### PR TITLE
fix: close suite/CI boundary gaps — hermetic HTTP, auth 401s, real dispatch smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,14 @@ jobs:
             "devcake/app-test:${DEVCAKE_TAG}" \
             python -m pytest tests/ -q --tb=short
 
-      # Free the control network before compose claims it.
+      # Free the control network before compose claims it. Unit-test Redis creates
+      # a bare `devcake_control` network (no compose labels); compose refuses to
+      # adopt it unless we remove both the container and the network.
       - name: Cleanup unit-test Redis
         if: always()
-        run: docker rm -f devcake-ci-redis 2>/dev/null || true
+        run: |
+          docker rm -f devcake-ci-redis 2>/dev/null || true
+          docker network rm devcake_control 2>/dev/null || true
 
       # Minimal compose (no Gitea) + hard readiness — scripts/ci_compose_for_dispatch.sh
       # then real Dagu → hello → Redis → finalize (scripts/ci_dispatch_hello.sh).
@@ -106,6 +110,7 @@ jobs:
         run: |
           set -euo pipefail
           docker rm -f devcake-ci-redis 2>/dev/null || true
+          docker network rm devcake_control 2>/dev/null || true
           export DEVCAKE_TAG="${DEVCAKE_TAG}"
           export DOCKER_GID
           DOCKER_GID="$(stat -c %g /var/run/docker.sock)"
@@ -127,3 +132,4 @@ jobs:
         run: |
           docker compose down -v --remove-orphans 2>/dev/null || true
           docker rm -f devcake-ci-redis 2>/dev/null || true
+          docker network rm devcake_control 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-# DevCake CI — Bake control-plane images (GHA BuildKit cache) + pytest.
-# Compose never builds; see docker-bake.hcl + docker-bake.ci.hcl.
+# DevCake CI — Bake control-plane images (GHA BuildKit cache) + pytest +
+# minimal compose hello-dispatch smoke. Compose never builds; see docker-bake.hcl.
 name: CI
 
 on:
@@ -19,9 +19,9 @@ env:
 
 jobs:
   bake-and-test:
-    name: Bake (ci) + pytest
+    name: Bake (ci) + pytest + dispatch smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -39,12 +39,9 @@ jobs:
             ./docker-bake.hcl
             ./docker-bake.ci.hcl
           targets: ci
-          # Load into the local docker store for pytest / smoke steps.
           load: true
-          # Provenance attestations break multi-target load on some runners.
           provenance: false
           sbom: false
-          # Force GHA cache only (override local .buildx-cache from docker-bake.hcl).
           set: |
             *.cache-from=type=gha,scope=devcake-ci
             *.cache-to=type=gha,mode=max,scope=devcake-ci
@@ -79,6 +76,13 @@ jobs:
           docker logs devcake-ci-redis || true
           exit 1
 
+      - name: Ruff (syntax / undefined names)
+        run: |
+          set -euo pipefail
+          docker run --rm -e RUFF_CACHE_DIR=/tmp/ruff-cache -w /srv \
+            "devcake/app-test:${DEVCAKE_TAG}" \
+            ruff check devcake tests
+
       - name: Pytest via app-test on compose network
         run: |
           set -euo pipefail
@@ -91,34 +95,35 @@ jobs:
             "devcake/app-test:${DEVCAKE_TAG}" \
             python -m pytest tests/ -q --tb=short
 
-      - name: Admin nginx health smoke
-        run: |
-          set -euo pipefail
-          docker rm -f devcake-ci-admin 2>/dev/null || true
-          docker run -d --name devcake-ci-admin -p 18080:80 \
-            -e ADMIN_USER=admin \
-            -e ADMIN_PASSWORD=Admin-test1! \
-            -e DAGU_UI_URL=http://localhost:8525 \
-            -e OO_UI_URL=http://localhost:5080 \
-            "devcake/admin:${DEVCAKE_TAG}"
-          for i in $(seq 1 30); do
-            if curl -sf http://127.0.0.1:18080/nginx-health | grep -q ok; then
-              echo "admin health OK"
-              docker rm -f devcake-ci-admin
-              exit 0
-            fi
-            sleep 1
-          done
-          docker logs devcake-ci-admin || true
-          docker rm -f devcake-ci-admin || true
-          exit 1
-
-      - name: Hello image entrypoint smoke
-        run: |
-          set -euo pipefail
-          docker run --rm --entrypoint python "devcake/dev-hello:${DEVCAKE_TAG}" \
-            -c 'import redis; print("hello image ok")'
-
-      - name: Cleanup Redis
+      # Free the control network before compose claims it.
+      - name: Cleanup unit-test Redis
         if: always()
         run: docker rm -f devcake-ci-redis 2>/dev/null || true
+
+      # Minimal compose (no Gitea) + hard readiness — scripts/ci_compose_for_dispatch.sh
+      # then real Dagu → hello → Redis → finalize (scripts/ci_dispatch_hello.sh).
+      - name: Compose stack for dispatch smoke
+        run: |
+          set -euo pipefail
+          docker rm -f devcake-ci-redis 2>/dev/null || true
+          export DEVCAKE_TAG="${DEVCAKE_TAG}"
+          export DOCKER_GID
+          DOCKER_GID="$(stat -c %g /var/run/docker.sock)"
+          chmod +x scripts/ci_compose_for_dispatch.sh scripts/ci_dispatch_hello.sh
+          ./scripts/ci_compose_for_dispatch.sh
+
+      - name: Hello dispatch pipeline smoke
+        run: |
+          set -euo pipefail
+          export ADMIN_USER=admin
+          export ADMIN_PASSWORD=Ci-admin-Pass1!
+          export DEVCAKE_BASE_URL=http://127.0.0.1:8080
+          # Cold CI: allow more polls (30 × 3s default may be tight under load)
+          export DEVCAKE_HELLO_POLLS=40
+          ./scripts/ci_dispatch_hello.sh
+
+      - name: Teardown compose stack
+        if: always()
+        run: |
+          docker compose down -v --remove-orphans 2>/dev/null || true
+          docker rm -f devcake-ci-redis 2>/dev/null || true

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -73,6 +73,7 @@ jobs:
             "id | grep -q uid=1000 && codex --version | grep -F \"$CODEX_PIN\" && test -f /dev_entrypoint.py"
           docker run --rm --entrypoint sh "devcake/dev-grok-build:${DEVCAKE_TAG}" -ec \
             'id | grep -q uid=1000 && grok --version && test -f /dev_entrypoint.py'
+          # Layer presence only — full Dagu→hello→finalize smoke is ci.yml.
           docker run --rm --entrypoint python "devcake/dev-hello:${DEVCAKE_TAG}" -c \
-            'import redis; print("hello ok")'
+            'import redis; print("hello redis import ok")'
           echo "harness smoke OK"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,12 @@ injection, hard-gated branch protection) than that file. Design choices
 | Change type | Minimum proof |
 |---|---|
 | Docker / Bake / Compose | `docker buildx bake …` succeeds **and** `docker compose up -d` + healthchecks pass |
-| App / API | Bake (or restart) app **and** pytest in container **or** real HTTP to the changed path |
+| App / API | **`docker buildx bake app-test`** (or `scripts/pytest_app.sh`) **then** pytest in that image, **or** `PYTHONPATH=app` on Python **3.12** against the working tree; **and** bake/restart prod `app` when the run path changed |
 | Admin SPA | `bake admin` **and** load UI / nginx-health |
 | Dev harness / entrypoint | `bake images` (or affected target) **and** smoke CLI + import entrypoint |
 | Docs-only | No runtime required; still re-read for accuracy |
+
+**Stale `app-test` trap:** the `devcake/app-test` image **COPY**s `app/devcake` and `app/tests` at bake time. Re-running pytest on an old `devcake/app-test:latest` grades the last bake, not your working tree — a silent false green. Always rebake after `app/` edits, or use `PYTHONPATH=app` on 3.12, or `./scripts/pytest_app.sh` (always bakes first). CI rebakes on every run; local agent loops often forget.
 
 Never claim done from "build succeeded" alone when the user-facing path is run/up. Name anything still unproven.
 
@@ -38,7 +40,7 @@ Never claim done from "build succeeded" alone when the user-facing path is run/u
 | **Agree the seam first** | Before the first test: state the public interface under test (function, port Protocol, HTTP path). Tests hit that seam only. |
 | **No private tests** | Do not assert on private helpers, call counts of internal collaborators, or implementation structure. Prefer fakes at **port** seams (`ports/*`). |
 | **Independent expected values** | Assertions use known literals / domain rules — not recomputing the same algorithm as production. |
-| **Where tests live** | `app/tests/test_*.py`. Run with Python **3.12** (prod image). Prefer `docker buildx bake app-test` then pytest in that image, or `PYTHONPATH=app` locally on 3.12. |
+| **Where tests live** | `app/tests/test_*.py`. Run with Python **3.12** (prod image). Prefer `./scripts/pytest_app.sh` (rebakes `app-test` then pytest), or `PYTHONPATH=app` locally on 3.12. |
 | **When TDD does not apply** | Pure renames, docs-only, config/copy, or mechanical follow-the-existing-pattern refactors with no behavior change — still run existing tests (Always Works™). |
 
 ### SOLID (always)
@@ -102,11 +104,13 @@ docker buildx bake -f docker-bake.hcl -f docker-bake.ci.hcl all
 
 | Workflow | When | What |
 |---|---|---|
-| `ci.yml` | every PR + `main` | Bake group `ci` (GHA cache) → assert prod has no pytest → Redis + `app-test` pytest → admin/hello smoke |
-| `docker-images.yml` | `images/**` changes + `main` + manual | Bake group `images` → harness CLI smoke (pinned versions) |
+| `ci.yml` | every PR + `main` | Bake group `ci` → ruff → Redis + `app-test` pytest → minimal compose (no Gitea) via `scripts/ci_compose_for_dispatch.sh` → `scripts/ci_dispatch_hello.sh` |
+| `docker-images.yml` | `images/**` changes + `main` + manual | Bake group `images` → harness CLI smoke + hello redis-import smoke (layer only; full dispatch is `ci.yml`) |
 | `docker-publish.yml` | **manual** (`workflow_dispatch`) | Bake `all` + push to GHCR (`ghcr.io/<owner>/devcake/<name>`) |
 
-**Local CI suite:** `scripts/ci_suite.sh` bakes `app-test` and runs pytest on `devcake_control` (prod `app` image has no pytest). Needs a running compose stack for the hello dispatch half.
+**Local unit path:** `./scripts/pytest_app.sh` (always rebakes `app-test`, then pytest).  
+**Local full suite:** `scripts/ci_suite.sh` — pin gate + bake app-test + pytest + Gitea forge battery + dispatch smoke.  
+**Clean-room dispatch compose:** `scripts/ci_compose_for_dispatch.sh` (minimal services; set `CI_COMPOSE_WRITE_ENV=1` only when you intend to overwrite `.env`).
 
 ### Do
 

--- a/README.md
+++ b/README.md
@@ -158,10 +158,13 @@ and [`docs/13-deployment.md`](docs/13-deployment.md).
 ## Verify
 
 ```bash
-# CI-shaped checks (Docker): see .github/workflows/ci.yml
+# Unit suite only (always rebakes app-test so the image matches the tree):
+./scripts/pytest_app.sh
+
+# CI-shaped bake (Docker): see .github/workflows/ci.yml
 docker buildx bake -f docker-bake.hcl -f docker-bake.ci.hcl ci
 
-# Full local suite (stack up; includes harness smoke):
+# Full local suite (stack up; forge battery + dispatch-hello smoke):
 ./scripts/ci_suite.sh
 ```
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -69,6 +69,7 @@ LABEL org.opencontainers.image.title="devcake-app-test" \
 USER root
 COPY --from=deps-dev /opt/venv /opt/venv
 COPY --chown=app:app tests/ ./tests/
+COPY --chown=app:app ruff.toml ./ruff.toml
 USER app
 
 # Default for `docker run devcake/app-test` — override as needed.

--- a/app/devcake/adapters/dagu/executor.py
+++ b/app/devcake/adapters/dagu/executor.py
@@ -35,11 +35,23 @@ def extract_node_errors(status: Optional[dict]) -> list[dict[str, str]]:
 
 
 class DaguExecutor:
-    def __init__(self, base_url: str = DAGU_URL):
+    def __init__(
+        self,
+        base_url: str = DAGU_URL,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+        auth: tuple[str, str] | None = None,
+    ):
         self.base = base_url
+        self._transport = transport        # tests inject MockTransport
+        self._auth = _AUTH if auth is None else auth
+
+    def _client(self, timeout: float = 10) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=timeout, auth=self._auth, transport=self._transport)
 
     async def start(self, params: dict[str, str], dag_run_id: str) -> None:
-        async with httpx.AsyncClient(timeout=10, auth=_AUTH) as client:
+        async with self._client(10) as client:
             resp = await client.post(
                 f"{self.base}/api/v1/dags/{DAG_NAME}/start",
                 json={"params": json.dumps(params), "dagRunId": dag_run_id},
@@ -49,14 +61,14 @@ class DaguExecutor:
             resp.raise_for_status()
 
     async def stop(self, dag_run_id: str) -> bool:
-        async with httpx.AsyncClient(timeout=10, auth=_AUTH) as client:
+        async with self._client(10) as client:
             resp = await client.post(
                 f"{self.base}/api/v1/dag-runs/{DAG_NAME}/{dag_run_id}/stop"
             )
             return resp.status_code < 300
 
     async def status(self, dag_run_id: str) -> Optional[dict[str, Any]]:
-        async with httpx.AsyncClient(timeout=10, auth=_AUTH) as client:
+        async with self._client(10) as client:
             resp = await client.get(f"{self.base}/api/v1/dag-runs/{DAG_NAME}/{dag_run_id}")
             if resp.status_code == 404:
                 return None
@@ -69,7 +81,7 @@ class DaguExecutor:
 
     async def stop_all(self) -> list[str]:
         """Stop every in-flight run of the dev-run DAG. Returns any error strings."""
-        async with httpx.AsyncClient(timeout=30, auth=_AUTH) as client:
+        async with self._client(30) as client:
             resp = await client.post(f"{self.base}/api/v1/dags/{DAG_NAME}/stop-all")
             if resp.status_code == 404:
                 return []
@@ -80,7 +92,7 @@ class DaguExecutor:
         """Paginate through every historical dagRunId for the dev-run DAG."""
         ids: list[str] = []
         cursor: Optional[str] = None
-        async with httpx.AsyncClient(timeout=30, auth=_AUTH) as client:
+        async with self._client(30) as client:
             while True:
                 params: dict[str, Any] = {"limit": 500}
                 if cursor:
@@ -101,7 +113,7 @@ class DaguExecutor:
 
     async def delete(self, dag_run_id: str) -> bool:
         """Permanently remove one DAG-run record. True if deleted (or already gone)."""
-        async with httpx.AsyncClient(timeout=15, auth=_AUTH) as client:
+        async with self._client(15) as client:
             resp = await client.delete(
                 f"{self.base}/api/v1/dag-runs/{DAG_NAME}/{dag_run_id}"
             )

--- a/app/devcake/adapters/gitea/adapter.py
+++ b/app/devcake/adapters/gitea/adapter.py
@@ -74,7 +74,8 @@ class GiteaForge:
         branch_protection_read="admin", pr_list_head_filter=False)
 
     def __init__(self, repo_url: str, token: str, reviewer_token: str | None = None,
-                 api_base: str | None = None):
+                 api_base: str | None = None,
+                 transport: httpx.AsyncBaseTransport | None = None):
         origin, url_path = "", repo_url
         if repo_url:
             parts = urlsplit(repo_url)
@@ -94,14 +95,19 @@ class GiteaForge:
                 f"invalid Gitea repository URL {repo_url!r}: need a host")
         self.token = token
         self.reviewer_token = reviewer_token or None
+        self._transport = transport        # tests inject MockTransport
 
     def _headers(self, reviewer: bool = False) -> dict[str, str]:
         token = self.reviewer_token if reviewer else self.token
+        if not (token or "").strip():
+            raise ForgeError(
+                "Gitea token missing; configure a write token for this repo",
+                status=401)
         return {"Authorization": f"token {token}"}
 
     async def _req(self, method: str, path: str, *, reviewer: bool = False,
                    **kwargs) -> Any:
-        async with httpx.AsyncClient(timeout=20) as client:
+        async with httpx.AsyncClient(timeout=20, transport=self._transport) as client:
             resp = await client.request(
                 method,
                 f"{self.api}/api/v1/repos/{self.owner}/{self.repo}{path}",

--- a/app/devcake/adapters/github/adapter.py
+++ b/app/devcake/adapters/github/adapter.py
@@ -41,7 +41,8 @@ class GitHubForge:
         branch_protection_read="admin", pr_list_head_filter=True)
 
     def __init__(self, repo_url: str, token: str, reviewer_token: str | None = None,
-                 api_base: str | None = None):
+                 api_base: str | None = None,
+                 transport: httpx.AsyncBaseTransport | None = None):
         # https://github.com/{owner}/{repo}
         parts = [p for p in repo_url.rstrip("/").removesuffix(".git").split("/") if p]
         if len(parts) < 2 or not parts[-1] or not parts[-2]:
@@ -52,15 +53,21 @@ class GitHubForge:
         self.api = api_base or API          # override unlocks GitHub Enterprise
         self.token = token
         self.reviewer_token = reviewer_token or None
+        self._transport = transport        # tests inject MockTransport
 
     def _headers(self, reviewer: bool = False) -> dict[str, str]:
         token = self.reviewer_token if reviewer else self.token
+        if not (token or "").strip():
+            # Avoid illegal empty Authorization values (ADR-0011 class)
+            raise ForgeError(
+                "GitHub token missing; configure a write token for this repo",
+                status=401)
         return {"Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json"}
 
     async def _req(self, method: str, path: str, *, reviewer: bool = False,
                    **kwargs) -> Any:
-        async with httpx.AsyncClient(timeout=20) as client:
+        async with httpx.AsyncClient(timeout=20, transport=self._transport) as client:
             resp = await client.request(
                 method, f"{self.api}/repos/{self.owner}/{self.repo}{path}",
                 headers=self._headers(reviewer), **kwargs)

--- a/app/devcake/adapters/gitlab/adapter.py
+++ b/app/devcake/adapters/gitlab/adapter.py
@@ -44,7 +44,8 @@ class GitLabForge:
         branch_protection_read="maintainer", pr_list_head_filter=True)
 
     def __init__(self, repo_url: str, token: str, reviewer_token: str | None = None,
-                 api_base: str | None = None):
+                 api_base: str | None = None,
+                 transport: httpx.AsyncBaseTransport | None = None):
         # api_base overrides; otherwise the instance is the repo URL's origin
         # (identical to the old https://gitlab.com default for gitlab.com repos,
         # and makes self-hosted instances work without extra config)
@@ -63,13 +64,19 @@ class GitLabForge:
         self.project = quote(path, safe="")
         self.token = token
         self.reviewer_token = reviewer_token or None
+        self._transport = transport        # tests inject MockTransport
 
     def _headers(self, reviewer: bool = False) -> dict[str, str]:
-        return {"PRIVATE-TOKEN": self.reviewer_token if reviewer else self.token}
+        token = self.reviewer_token if reviewer else self.token
+        if not (token or "").strip():
+            raise ForgeError(
+                "GitLab token missing; configure a write token for this repo",
+                status=401)
+        return {"PRIVATE-TOKEN": token}
 
     async def _req(self, method: str, path: str, *, reviewer: bool = False,
                    raw: bool = False, **kwargs) -> Any:
-        async with httpx.AsyncClient(timeout=20) as client:
+        async with httpx.AsyncClient(timeout=20, transport=self._transport) as client:
             resp = await client.request(
                 method, f"{self.base}/api/v4/projects/{self.project}{path}",
                 headers=self._headers(reviewer), **kwargs)

--- a/app/devcake/api/auth.py
+++ b/app/devcake/api/auth.py
@@ -22,6 +22,18 @@ def credentials_configured() -> bool:
     return bool(user and password)
 
 
+def _const_eq(a: str, b: str) -> bool:
+    """Constant-time string equality that never raises (auth must stay 401).
+
+    secrets.compare_digest on str rejects non-ASCII (TypeError → 500).
+    Compare UTF-8 bytes instead; length mismatch returns False, not an exception.
+    """
+    try:
+        return secrets.compare_digest(a.encode("utf-8"), b.encode("utf-8"))
+    except (TypeError, ValueError):
+        return False
+
+
 def _valid_basic_auth(value: str) -> bool:
     if not value.startswith("Basic "):
         return False
@@ -33,8 +45,8 @@ def _valid_basic_auth(value: str) -> bool:
     expected_user, expected_password = admin_credentials()
     return (
         bool(expected_user and expected_password)
-        and secrets.compare_digest(supplied_user, expected_user)
-        and secrets.compare_digest(supplied_password, expected_password)
+        and _const_eq(supplied_user, expected_user)
+        and _const_eq(supplied_password, expected_password)
     )
 
 

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -743,7 +743,7 @@ async def put_config(body: dict):
                if p["name"] not in {i.name for i in merged.pmos}]
     removed += [("repo", r["name"]) for r in previous["repos"]
                 if r["name"] not in {i.name for i in merged.repos}]
-    for field in merged.model_fields:
+    for field in type(merged).model_fields:
         setattr(config, field, getattr(merged, field))
     save_config(config)
     try:
@@ -751,7 +751,7 @@ async def put_config(body: dict):
     except Exception as e:
         log.exception("reload_connections failed — restoring previous config")
         restored = AppConfig.model_validate(previous)
-        for field in restored.model_fields:
+        for field in type(restored).model_fields:
             setattr(config, field, getattr(restored, field))
         save_config(config)
         try:

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -1,8 +1,13 @@
 """MissionManager façade: deps, advisory state, and public method surface.
 
 Implementation lives in sibling modules (ISSUES #36). Methods are bound from
-those modules so `MissionManager.__new__` test patterns and attribute
-monkeypatches keep working.
+those modules onto the class (transitional façade bindings — free functions
+with ``self`` as first arg).
+
+Tests construct via the real ``__init__`` (``tests/fakes.make_mission_manager``
+with a real RunManager when a tmp path is given). Private-seam tests
+(``_transition``, ``_merge_sweep``, …) remain until a follow-up retargets them
+to public APIs — construction path is fixed; structure is not fully untangled.
 """
 
 from __future__ import annotations

--- a/app/devcake/domain/orchestrator/review.py
+++ b/app/devcake/domain/orchestrator/review.py
@@ -166,6 +166,9 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                     await self._checkpoint(run, "review:done", _done)
                     await self.deliver_internal_zip(run, pr)
                 except Exception as e:
+                    # Capture for nested async defs (static F821 + safe if
+                    # await order changes later); not a known production 500.
+                    merge_err = e
                     # Already-merged treated as success by forge.merge; if we
                     # still fail, re-probe before posting merge-failed (ISSUES #6).
                     try:
@@ -230,14 +233,14 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                                 await self._feed(
                                     pmo_id, "issue",
                                     f"⏳ REVIEW approved but the merge is not "
-                                    f"possible yet ({e}) — DevCake keeps "
+                                    f"possible yet ({merge_err}) — DevCake keeps "
                                     f"retrying for up to "
                                     f"{self.config.merge_retry_window_minutes} "
                                     f"minutes (mergeability computing / CI "
                                     f"pipeline running). You can merge {pr_url} "
                                     f"manually at any time. {MERGE_RETRY_MARKER}")
                                 self._audit(pmo_id, "merge_deferred",
-                                            str(e)[:120])
+                                            str(merge_err)[:120])
                                 self._merge_window_closed.discard(pmo_id)
                                 run.finalized_steps.append(
                                     "review:merge_deferred")
@@ -245,11 +248,12 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                                 await self._feed(
                                     pmo_id, "issue",
                                     f"⚠️ REVIEW approved but auto-merge failed "
-                                    f"({e}); awaiting human merge of {pr_url} "
-                                    f"(`DEVCAKE-MERGE`). {MERGE_HANDOFF_MARKER}")
+                                    f"({merge_err}); awaiting human merge of "
+                                    f"{pr_url} (`DEVCAKE-MERGE`). "
+                                    f"{MERGE_HANDOFF_MARKER}")
                                 self._audit(pmo_id,
                                             "review_approve_merge_failed",
-                                            str(e)[:120])
+                                            str(merge_err)[:120])
                                 run.finalized_steps.append(
                                     "review:merge_failed")
                             self.runs.store.save(run)

--- a/app/requirements-dev.txt
+++ b/app/requirements-dev.txt
@@ -1,3 +1,4 @@
 # Test-only deps — installed only into the `test` image target (docker-bake app-test).
 # Runtime image uses requirements.txt alone.
 pytest==8.3.4
+ruff==0.12.2

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.6
+pydantic==2.13.4
 uvicorn[standard]==0.34.0
 redis==5.2.1
 httpx==0.28.1

--- a/app/ruff.toml
+++ b/app/ruff.toml
@@ -1,0 +1,12 @@
+# Lightweight hygiene gate — expand select set as the tree is cleaned.
+# Broader rules (F401 unused imports, style, complexity) are intentionally
+# deferred; do not treat this file as a full lint program yet.
+target-version = "py312"
+line-length = 100
+
+[lint]
+# Narrow: syntax / undefined names only (caught the review.py merge_err capture).
+select = ["E9", "F63", "F7", "F82"]
+
+[lint.per-file-ignores]
+"tests/*" = []

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -1,6 +1,13 @@
 """Shared test fakes (not a test module)."""
 
-from devcake.config import RepoInstance
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from devcake.config import AppConfig, DevType, PMOInstance, RepoInstance
+from devcake.domain.orchestrator import MissionManager
 
 
 class FakeForgeRuntime:
@@ -39,3 +46,85 @@ class FakeForgeRuntime:
             self.breakers.pop(name, None)
         elif not data.get("transient"):
             self.breakers[name] = data.get("detail", "")
+
+
+class NullMessaging:
+    """Minimal MessagingPort stand-in for MissionManager construction."""
+
+    async def create_run_user(self, rid):
+        return "pw"
+
+    async def delete_run_user(self, rid):
+        pass
+
+    async def delete_reply_stream(self, rid):
+        pass
+
+
+class FakeExecutor:
+    """No-op ExecutorPort for constructing a real RunManager in tests."""
+
+    def __init__(self):
+        self.starts: list[tuple] = []
+
+    async def start(self, params, dag_run_id):
+        self.starts.append((params, dag_run_id))
+
+    async def stop(self, dag_run_id):
+        return True
+
+    async def status(self, dag_run_id):
+        return None
+
+
+DEFAULT_INSTANCE = PMOInstance(name="linear", team_key="DEV")
+
+
+def make_mission_manager(
+    tmp_path: Path | None = None,
+    *,
+    pmo: Any = None,
+    forge: Any = None,
+    forge_runtime: Any = None,
+    config: AppConfig | None = None,
+    dev_types: dict[str, DevType] | None = None,
+    messaging: Any = None,
+    runs: Any = None,
+    instance: PMOInstance | None = None,
+    breakers: dict[str, str] | None = None,
+    internal_forge: Any = None,
+    noop_audit: bool = False,
+) -> MissionManager:
+    """Construct MissionManager via the real ``__init__`` (DI constructor).
+
+    When ``tmp_path`` is given and ``runs`` is omitted, builds a real
+    ``RunManager`` over a RunStore (not a SimpleNamespace). Opt into
+    ``noop_audit=True`` only when a test needs to silence PMO audit feeds.
+
+    Transitional: many tests still call private façade methods; construction
+    path matches production. Full private-seam retarget is a follow-up epic.
+    """
+    from devcake.adapters.files.run_store import RunStore
+    from devcake.domain.runs import RunManager
+
+    cfg = config if config is not None else AppConfig()
+    inst = instance if instance is not None else DEFAULT_INSTANCE
+    dts = dev_types if dev_types is not None else {
+        "senior-dev": DevType(name="senior-dev", harness_template="claude-code"),
+    }
+    fr = forge_runtime if forge_runtime is not None else FakeForgeRuntime(forge)
+    msg = messaging if messaging is not None else NullMessaging()
+    if runs is None:
+        if tmp_path is not None:
+            store = RunStore(Path(tmp_path) / "runs")
+            runs = RunManager(store, msg, FakeExecutor())
+        else:
+            # No store path: lightweight stand-in for pure helper tests
+            runs = SimpleNamespace(store=None, finalizer=None)
+    mgr = MissionManager(
+        cfg, dts, pmo, fr, runs, msg,
+        instance=inst, breakers=breakers, internal_forge=internal_forge,
+    )
+    if noop_audit:
+        mgr._audit = lambda *a, **k: None  # type: ignore[method-assign]
+    return mgr

--- a/app/tests/test_api_auth.py
+++ b/app/tests/test_api_auth.py
@@ -97,3 +97,21 @@ def test_correct_credentials_still_200(monkeypatch):
     client = _auth_app(monkeypatch, "operator", "correct-horse")
     auth = {"Authorization": _basic("operator", "correct-horse")}
     assert client.get("/api/v1/config", headers=auth).status_code == 200
+
+
+def test_non_ascii_admin_password_accepts_and_rejects(monkeypatch):
+    """Configured ADMIN_PASSWORD may be non-ASCII — must not 500 (bricking)."""
+    client = _auth_app(monkeypatch, "operator", "sëcret-🔐-pass")
+    good = {"Authorization": _basic("operator", "sëcret-🔐-pass")}
+    bad = {"Authorization": _basic("operator", "wrong")}
+    assert client.get("/api/v1/config", headers=good).status_code == 200
+    assert client.get("/api/v1/config", headers=bad).status_code == 401
+
+
+def test_non_ascii_admin_username_accepts_and_rejects(monkeypatch):
+    """Configured ADMIN_USER may be non-ASCII — same compare_digest trap."""
+    client = _auth_app(monkeypatch, "оператор", "correct-horse")
+    good = {"Authorization": _basic("оператор", "correct-horse")}
+    bad = {"Authorization": _basic("operator", "correct-horse")}
+    assert client.get("/api/v1/config", headers=good).status_code == 200
+    assert client.get("/api/v1/config", headers=bad).status_code == 401

--- a/app/tests/test_api_auth.py
+++ b/app/tests/test_api_auth.py
@@ -55,3 +55,45 @@ def test_malformed_basic_auth_is_rejected(monkeypatch):
     assert client.get(
         "/api/v1/config", headers={"Authorization": "Basic not-base64"}
     ).status_code == 401
+
+
+def _auth_app(monkeypatch, user: str, password: str) -> TestClient:
+    monkeypatch.setenv("ADMIN_USER", user)
+    monkeypatch.setenv("ADMIN_PASSWORD", password)
+    app = FastAPI()
+    app.middleware("http")(enforce_control_plane_auth)
+
+    @app.get("/api/v1/config")
+    async def read_config():
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def test_wrong_password_same_length_is_401(monkeypatch):
+    """Mismatched password of equal length must be 401, never 500."""
+    client = _auth_app(monkeypatch, "operator", "correct-horse")
+    bad = {"Authorization": _basic("operator", "correct-xxxxx")}  # same len
+    assert client.get("/api/v1/config", headers=bad).status_code == 401
+
+
+def test_wrong_password_different_length_is_401(monkeypatch):
+    """Length mismatch must stay 401 (never an uncaught compare_digest error)."""
+    client = _auth_app(monkeypatch, "operator", "correct-horse")
+    bad = {"Authorization": _basic("operator", "nope")}  # shorter
+    resp = client.get("/api/v1/config", headers=bad)
+    assert resp.status_code == 401, f"expected 401, got {resp.status_code}"
+
+
+def test_wrong_password_unicode_is_401(monkeypatch):
+    """Historical 500: secrets.compare_digest on str rejects non-ASCII (TypeError)."""
+    client = _auth_app(monkeypatch, "operator", "correct-horse")
+    bad = {"Authorization": _basic("operator", "пароль-неверный")}
+    resp = client.get("/api/v1/config", headers=bad)
+    assert resp.status_code == 401, f"expected 401, got {resp.status_code}"
+
+
+def test_correct_credentials_still_200(monkeypatch):
+    client = _auth_app(monkeypatch, "operator", "correct-horse")
+    auth = {"Authorization": _basic("operator", "correct-horse")}
+    assert client.get("/api/v1/config", headers=auth).status_code == 200

--- a/app/tests/test_crash_recovery.py
+++ b/app/tests/test_crash_recovery.py
@@ -397,8 +397,11 @@ def test_checkpoint_skips_without_unawaited_coro(tmp_path):
     run.finalized_steps = ["already"]
     store.save(run)
 
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.runs = type("R", (), {"store": store})()
+    from fakes import make_mission_manager
+    mgr = make_mission_manager(
+        runs=type("R", (), {"store": store})(),
+        noop_audit=False,
+    )
     calls = []
 
     async def side():
@@ -436,29 +439,18 @@ def test_human_needed_baton_posted_once(tmp_path):
             m.status = status
 
     store = RunStore(tmp_path / "runs")
+    runs = type("Runs", (), {"store": store})()
 
-    class Runs:
-        pass
-    runs = Runs()
-    runs.store = store
-
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = 'linear'
-    mgr.instance = PMOInstance(name='linear', team_key='DEV')
-    mgr.config = AppConfig()
-    mgr.dev_types = {}
-    mgr.pmo = FakePMO()
+    from fakes import make_mission_manager
     from types import SimpleNamespace
-    mgr.forges = FakeForgeRuntime(SimpleNamespace(descriptor=SimpleNamespace(pr_noun="pull request")))
-    mgr.runs = runs
-    mgr.messaging = FakeMessaging()
-    mgr._grace = set()
-    mgr._grace_next = set()
-    mgr.breakers = {}
-    mgr.merge_handoffs = {}
-    mgr._merge_window_closed = set()
-    mgr.needs_human = {}
-    mgr._audit = lambda *a, **k: None
+    mgr = make_mission_manager(
+        pmo=FakePMO(),
+        forge=SimpleNamespace(descriptor=SimpleNamespace(pr_noun="pull request")),
+        config=AppConfig(),
+        dev_types={},
+        runs=runs,
+        messaging=FakeMessaging(),
+    )
 
     run = Run(
         run_id="T-1-1-EXECUTE-AAAAAA", mission_key="T-1", mission_pmo_id="p1",
@@ -509,29 +501,18 @@ def test_redelivery_own_label_swap_is_not_external_transition(tmp_path):
             m.status = status
 
     store = RunStore(tmp_path / "runs")
+    runs = type("Runs", (), {"store": store})()
 
-    class Runs:
-        pass
-    runs = Runs()
-    runs.store = store
-
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = 'linear'
-    mgr.instance = PMOInstance(name='linear', team_key='DEV')
-    mgr.config = AppConfig()
-    mgr.dev_types = {}
-    mgr.pmo = FakePMO()
+    from fakes import make_mission_manager
     from types import SimpleNamespace
-    mgr.forges = FakeForgeRuntime(SimpleNamespace(descriptor=SimpleNamespace(pr_noun="pull request")))
-    mgr.runs = runs
-    mgr.messaging = FakeMessaging()
-    mgr._grace = set()
-    mgr._grace_next = set()
-    mgr.breakers = {}
-    mgr.merge_handoffs = {}
-    mgr._merge_window_closed = set()
-    mgr.needs_human = {}
-    mgr._audit = lambda *a, **k: None
+    mgr = make_mission_manager(
+        pmo=FakePMO(),
+        forge=SimpleNamespace(descriptor=SimpleNamespace(pr_noun="pull request")),
+        config=AppConfig(),
+        dev_types={},
+        runs=runs,
+        messaging=FakeMessaging(),
+    )
     mgr._flag_out_of_pipeline_merge = AsyncMock()
 
     run = Run(

--- a/app/tests/test_dagu_executor.py
+++ b/app/tests/test_dagu_executor.py
@@ -1,0 +1,120 @@
+"""Hermetic HTTP contract for DaguExecutor (URL + method + body).
+
+Unit suite otherwise only uses FakeExecutor — a production start() no-op
+would pass. MockTransport makes the real adapter path fail closed.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from devcake.adapters.dagu.executor import DAG_NAME, DaguExecutor, DuplicateRun
+
+
+def run_coro(c):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(c)
+    finally:
+        loop.close()
+
+
+def _executor(handler) -> DaguExecutor:
+    return DaguExecutor(
+        "http://dagu.test:8080",
+        transport=httpx.MockTransport(handler),
+        auth=("", ""),
+    )
+
+
+def test_start_posts_dag_start_with_params_and_run_id():
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        assert request.method == "POST"
+        assert str(request.url) == (
+            f"http://dagu.test:8080/api/v1/dags/{DAG_NAME}/start")
+        body = json.loads(request.content.decode())
+        assert body["dagRunId"] == "run-abc"
+        assert json.loads(body["params"]) == {"IMAGE": "devcake/dev-hello:latest"}
+        return httpx.Response(200, json={})
+
+    run_coro(_executor(handler).start(
+        {"IMAGE": "devcake/dev-hello:latest"}, "run-abc"))
+    assert len(seen) == 1
+
+
+def test_start_409_raises_duplicate_run():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, json={"message": "already_exists"})
+
+    with pytest.raises(DuplicateRun):
+        run_coro(_executor(handler).start({}, "dup-id"))
+
+
+def test_status_get_path_and_404_is_none():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert str(request.url) == (
+            f"http://dagu.test:8080/api/v1/dag-runs/{DAG_NAME}/missing")
+        return httpx.Response(404, json={})
+
+    assert run_coro(_executor(handler).status("missing")) is None
+
+
+def test_status_returns_json():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"status": "running", "dagRunId": "r1"})
+
+    body = run_coro(_executor(handler).status("r1"))
+    assert body == {"status": "running", "dagRunId": "r1"}
+
+
+def test_stop_posts_dag_run_stop():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert str(request.url) == (
+            f"http://dagu.test:8080/api/v1/dag-runs/{DAG_NAME}/run-x/stop")
+        return httpx.Response(200, json={})
+
+    assert run_coro(_executor(handler).stop("run-x")) is True
+
+
+def test_start_must_issue_http_request():
+    """Mutation bar: a no-op start() leaves seen empty → fail."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={})
+
+    run_coro(_executor(handler).start({"k": "v"}, "must-hit-http"))
+    assert len(seen) == 1
+    assert seen[0].method == "POST"
+
+
+def test_start_sends_basic_auth():
+    """Load-bearing Dagu API auth must appear on the wire."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={})
+
+    ex = DaguExecutor(
+        "http://dagu.test:8080",
+        transport=httpx.MockTransport(handler),
+        auth=("dagu-user", "dagu-secret"),
+    )
+    run_coro(ex.start({"x": "1"}, "auth-run"))
+    assert len(seen) == 1
+    # httpx encodes basic auth on the request
+    auth = seen[0].headers.get("Authorization", "")
+    assert auth.startswith("Basic ")
+    import base64
+    decoded = base64.b64decode(auth.split(" ", 1)[1]).decode()
+    assert decoded == "dagu-user:dagu-secret"

--- a/app/tests/test_dependencies.py
+++ b/app/tests/test_dependencies.py
@@ -4,11 +4,8 @@ import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
-from devcake.config import PMOInstance, AppConfig, DevType
-from fakes import FakeForgeRuntime
-from devcake.domain.orchestrator import MissionManager
+from devcake.config import AppConfig, DevType
 from devcake.domain.model import Mission
-from devcake.adapters.files.run_store import RunStore
 
 NOW = datetime.now(timezone.utc)
 
@@ -33,21 +30,16 @@ class DepPMO:
 
 
 def make_mgr(tmp_path, pmo):
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = 'linear'
-    mgr.instance = PMOInstance(name='linear', team_key='DEV')
-    mgr.forges = FakeForgeRuntime(SimpleNamespace(descriptor=SimpleNamespace(pr_noun='pull request')))
-    mgr.internal_forge = None
-    mgr.config = AppConfig()
-    mgr.dev_types = {
-        "senior-dev": DevType(name="senior-dev", harness_template="claude-code"),
-        "main-dev": DevType(name="main-dev", harness_template="grok-build"),
-    }
-    mgr.pmo = pmo
-    mgr.runs = SimpleNamespace(store=RunStore(tmp_path / "runs"))
-    mgr._grace, mgr._grace_next, mgr.breakers = set(), set(), {}
-    mgr.blocked_reasons = {}
-    mgr._audit = lambda *a, **k: None
+    from fakes import make_mission_manager
+    mgr = make_mission_manager(
+        tmp_path, pmo=pmo,
+        forge=SimpleNamespace(descriptor=SimpleNamespace(pr_noun='pull request')),
+        dev_types={
+            "senior-dev": DevType(name="senior-dev", harness_template="claude-code"),
+            "main-dev": DevType(name="main-dev", harness_template="grok-build"),
+        },
+        noop_audit=True,
+    )
     dispatched = []
 
     async def fake_dispatch(mission, mtype, dev_type):

--- a/app/tests/test_forge_http.py
+++ b/app/tests/test_forge_http.py
@@ -1,0 +1,185 @@
+"""Hermetic HTTP contract for ForgePort adapters (auth headers + URL assembly).
+
+Domain tables in test_forge.py stub _req and never exercise vendor HTTP.
+These tests inject httpx.MockTransport so empty _headers() or a broken
+URL f-string fails the suite. Precedent: test_pmo_contract.py,
+test_internal_forge_provision.py.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from devcake.adapters.github.adapter import GitHubForge
+from devcake.adapters.gitea.adapter import GiteaForge
+from devcake.adapters.gitlab.adapter import GitLabForge
+
+
+def run_coro(c):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(c)
+    finally:
+        loop.close()
+
+
+def test_github_health_probe_sends_bearer_and_repo_url():
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        assert str(request.url) == "https://api.github.com/repos/o/r"
+        assert request.headers.get("Authorization") == "Bearer gh-write-tok"
+        assert request.headers.get("Accept") == "application/vnd.github+json"
+        return httpx.Response(200, json={"permissions": {"push": True}})
+
+    forge = GitHubForge(
+        "https://github.com/o/r", "gh-write-tok",
+        transport=httpx.MockTransport(handler),
+    )
+    health = run_coro(forge.health_probe())
+    assert health.ok is True
+    assert health.can_push is True
+    assert len(seen) == 1
+
+
+def test_github_reviewer_token_on_approve():
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        assert request.method == "POST"
+        assert str(request.url).endswith("/pulls/8/reviews")
+        assert request.headers.get("Authorization") == "Bearer gh-reviewer-tok"
+        return httpx.Response(200, json={"id": 1})
+
+    forge = GitHubForge(
+        "https://github.com/o/r", "gh-write-tok", "gh-reviewer-tok",
+        transport=httpx.MockTransport(handler),
+    )
+    assert run_coro(forge.approve(8)) is True
+    assert len(seen) == 1
+
+
+def test_github_enterprise_api_base_in_url():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url).startswith("https://ghe.example/api/v3/repos/o/r")
+        assert request.headers.get("Authorization") == "Bearer tok"
+        return httpx.Response(200, json={"permissions": {"push": True}})
+
+    forge = GitHubForge(
+        "https://github.com/o/r", "tok",
+        api_base="https://ghe.example/api/v3",
+        transport=httpx.MockTransport(handler),
+    )
+    assert run_coro(forge.health_probe()).ok is True
+
+
+def test_gitlab_health_probe_sends_private_token_and_project_url():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == (
+            "https://gitlab.com/api/v4/projects/group%2Fproj")
+        assert request.headers.get("PRIVATE-TOKEN") == "gl-write-tok"
+        return httpx.Response(200, json={
+            "permissions": {
+                "project_access": {"access_level": 40},
+                "group_access": None,
+            },
+        })
+
+    forge = GitLabForge(
+        "https://gitlab.com/group/proj", "gl-write-tok",
+        transport=httpx.MockTransport(handler),
+    )
+    health = run_coro(forge.health_probe())
+    assert health.ok is True
+
+
+def test_gitlab_reviewer_token_header():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers.get("PRIVATE-TOKEN") == "gl-reviewer"
+        return httpx.Response(200, json={"id": 1})
+
+    forge = GitLabForge(
+        "https://gitlab.com/group/proj", "gl-write", "gl-reviewer",
+        transport=httpx.MockTransport(handler),
+    )
+    assert run_coro(forge.approve(3)) is True
+
+
+def test_gitea_health_probe_sends_token_auth_and_url():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://git.example/api/v1/repos/o/r"
+        assert request.headers.get("Authorization") == "token gitea-tok"
+        return httpx.Response(200, json={"permissions": {"push": True}})
+
+    forge = GiteaForge(
+        "https://git.example/o/r", "gitea-tok",
+        transport=httpx.MockTransport(handler),
+    )
+    health = run_coro(forge.health_probe())
+    assert health.ok is True
+    assert health.can_push is True
+
+
+def test_gitea_reviewer_token_header():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers.get("Authorization") == "token gitea-reviewer"
+        return httpx.Response(200, json={"id": 1})
+
+    forge = GiteaForge(
+        "https://git.example/o/r", "gitea-tok", "gitea-reviewer",
+        transport=httpx.MockTransport(handler),
+    )
+    assert run_coro(forge.approve(2)) is True
+
+
+def test_github_request_asserts_auth_header_on_wire():
+    """Mutant bar: assert the Authorization header on the request itself
+    (not only health.ok). Empty _headers() fails here without relying on
+    health_probe mapping 401 → ok=False."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("Authorization", ""))
+        return httpx.Response(200, json={"permissions": {"push": True}})
+
+    forge = GitHubForge(
+        "https://github.com/o/r", "must-be-sent",
+        transport=httpx.MockTransport(handler),
+    )
+    assert run_coro(forge.health_probe()).ok is True
+    assert seen == ["Bearer must-be-sent"]
+
+
+def test_github_post_pr_comment_is_write_path_with_auth():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert str(request.url).endswith("/issues/3/comments")
+        assert request.headers.get("Authorization") == "Bearer gh-write"
+        return httpx.Response(201, json={"id": 1})
+
+    forge = GitHubForge(
+        "https://github.com/o/r", "gh-write",
+        transport=httpx.MockTransport(handler),
+    )
+    run_coro(forge.post_pr_comment(3, "hello"))
+
+
+def test_github_empty_token_does_not_send_illegal_bearer():
+    """ADR-0011 class: empty token must not build Authorization: Bearer <empty>.
+    Fail closed before send; health_probe maps the error to ok=False."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={})
+
+    forge = GitHubForge(
+        "https://github.com/o/r", "",
+        transport=httpx.MockTransport(handler),
+    )
+    health = run_coro(forge.health_probe())
+    assert seen == [], "must not hit the wire with an empty Bearer token"
+    assert health.ok is False

--- a/app/tests/test_harness.py
+++ b/app/tests/test_harness.py
@@ -109,7 +109,8 @@ def test_credential_spec_derives_from_registry(tmp_path, monkeypatch):
     secrets.mkdir(parents=True)
     (secrets / "grok-auth.json").write_text('{"grok": true}')
 
-    mgr = MissionManager.__new__(MissionManager)
+    from fakes import make_mission_manager
+    mgr = make_mission_manager(noop_audit=False)
     env, files = mgr._credential_spec(DevType(name="main-dev",
                                               harness_template="grok-build"))
     assert env == {"XAI_API_KEY": "xai-test-000000000000000000000"}
@@ -136,18 +137,20 @@ def test_runspec_secret_payload_built_on_request(tmp_path, monkeypatch):
     secrets.mkdir(parents=True)
     (secrets / "grok-auth.json").write_text('{"grok": true}')
 
+    from fakes import make_mission_manager
     from devcake.domain.run import Run
     from devcake.config import RepoInstance
-    mgr = MissionManager.__new__(MissionManager)
     cfg = AppConfig()
     cfg.repos = [RepoInstance(name="main", url="https://github.com/o/r")]
-    mgr.config = cfg
-    mgr.instance = PMOInstance(name="linear", team_key="DEV", repos=["main"])
-    mgr.forges = FakeForgeRuntime(object(), inst=cfg.repos[0])
-    mgr.dev_types = {"main-dev": DevType(name="main-dev",
-                                         harness_template="grok-build"),
-                     "senior-dev": DevType(name="senior-dev",
-                                           harness_template="claude-code")}
+    mgr = make_mission_manager(
+        config=cfg,
+        instance=PMOInstance(name="linear", team_key="DEV", repos=["main"]),
+        forge_runtime=FakeForgeRuntime(object(), inst=cfg.repos[0]),
+        dev_types={
+            "main-dev": DevType(name="main-dev", harness_template="grok-build"),
+            "senior-dev": DevType(name="senior-dev", harness_template="claude-code"),
+        },
+    )
     run = Run(run_id="T-1-1-EXECUTE-AAAAAA", mission_key="T-1",
               mission_type="EXECUTE", dev_type="main-dev", seq=1)
     payload = mgr.runspec_secret_payload(run)
@@ -231,15 +234,13 @@ def test_dispatch_mapper_uses_registry_image_and_sends_harness(tmp_path, monkeyp
     store = RunStore(tmp_path / "runs")
     runs = RunManager(store, NullMessaging(), FakeExecutor())
 
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = 'linear'
-    mgr.instance = PMOInstance(name='linear', team_key='DEV')
-    mgr.config = AppConfig()
-    mgr.runs = runs
-    mgr.messaging = NullMessaging()
-    # dispatch reads the forge descriptor for the dev-side dialect spec_env
+    from fakes import make_mission_manager
     from devcake.adapters.github import GitHubForge
-    mgr.forges = FakeForgeRuntime(GitHubForge("https://github.com/o/r", "tok"))
+    mgr = make_mission_manager(
+        runs=runs, messaging=NullMessaging(),
+        forge=GitHubForge("https://github.com/o/r", "tok"),
+        config=AppConfig(),
+    )
 
     dt = DevType(name="senior-dev", harness_template="grok-build",
                  model="grok-4.5")   # the user's exact scenario
@@ -263,12 +264,10 @@ def test_dispatch_mapper_uses_registry_image_and_sends_harness(tmp_path, monkeyp
 def test_protocol_spec_env_points_devs_at_collector(monkeypatch):
     """ISSUES #13: Dev OTLP export targets the collector on devcake_runtime —
     never OpenObserve directly (which would need credentials in the runspec)."""
+    from fakes import make_mission_manager
     from devcake.adapters.registry import make_forge
     from devcake.config import RepoInstance
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = 'linear'
-    mgr.instance = PMOInstance(name='linear', team_key='DEV')
-    mgr.config = AppConfig()
+    mgr = make_mission_manager(config=AppConfig(), noop_audit=False)
     repo = RepoInstance(url="https://github.com/o/r")
     env = mgr._protocol_spec_env(
         mission_id="p1", mission_key="T-1", mission_type="EXECUTE",

--- a/app/tests/test_mapper.py
+++ b/app/tests/test_mapper.py
@@ -9,9 +9,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from devcake.config import PMOInstance
-from fakes import FakeForgeRuntime
-
 from devcake.config import AppConfig, DevType
 from devcake.domain.orchestrator import (MapperBusy, MapperService, MapperUnconfigured,
                               MissionManager)
@@ -49,17 +46,12 @@ class MapPMO:
 
 
 def make_mgr(tmp_path, pmo):
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = 'linear'
-    mgr.instance = PMOInstance(name='linear', team_key='DEV')
-    mgr.forges = FakeForgeRuntime(SimpleNamespace(descriptor=SimpleNamespace(pr_noun='pull request')))
-    mgr.config = AppConfig()
-    mgr.pmo = pmo
-    mgr.runs = SimpleNamespace(store=RunStore(tmp_path / "runs"))
-    mgr._grace, mgr._grace_next, mgr.breakers = set(), set(), {}
-    mgr.merge_handoffs, mgr._merge_window_closed = {}, set()
-    mgr._audit = lambda *a, **k: None
-    return mgr
+    from fakes import make_mission_manager
+    return make_mission_manager(
+        tmp_path, pmo=pmo,
+        forge=SimpleNamespace(descriptor=SimpleNamespace(pr_noun='pull request')),
+        noop_audit=True,
+    )
 
 
 def run_coro(c):

--- a/app/tests/test_multi_instance.py
+++ b/app/tests/test_multi_instance.py
@@ -19,12 +19,12 @@ def run_coro(c):
 
 
 def _mgr(name: str, breakers=None) -> MissionManager:
-    m = MissionManager.__new__(MissionManager)
-    m.instance = PMOInstance(name=name, team_key=name.upper())
-    m.instance_name = name
-    m.anomalies = {}
-    m.breakers = breakers if breakers is not None else {}
-    return m
+    from fakes import make_mission_manager
+    return make_mission_manager(
+        instance=PMOInstance(name=name, team_key=name.upper()),
+        breakers=breakers if breakers is not None else {},
+        noop_audit=False,
+    )
 
 
 def _mission(pmo_id: str, key: str, instance: str) -> Mission:

--- a/app/tests/test_repo_routing.py
+++ b/app/tests/test_repo_routing.py
@@ -112,15 +112,9 @@ def test_malformed_marker_gates_instead_of_silent_default():
 def test_vanished_repo_contract_in_sweeps_and_review(tmp_path):
     """A DEVCAKE-MERGE-parked mission whose repo vanished must surface a
     visible reason (sweeps) / fail the run cleanly (review) — never crash."""
-    from fakes import FakeForgeRuntime
-    from devcake.domain.orchestrator import MissionManager
+    from fakes import FakeForgeRuntime, make_mission_manager
 
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = "linear"
-    mgr.blocked_reasons = {}
-    mgr.merge_handoffs = {}
-    mgr._merge_window_closed = set()
-    mgr.forges = FakeForgeRuntime(None)          # nothing resolves
+    mgr = make_mission_manager(forge_runtime=FakeForgeRuntime(None))
     m = _m()
     m.repo, m.repo_reason = None, "repo 'beta' no longer configured"
     run_coro(mgr._merge_sweep(m))                # must not raise
@@ -135,26 +129,17 @@ def test_vanished_repo_contract_in_sweeps_and_review(tmp_path):
 def test_zero_repo_mission_visible_but_gated(tmp_path):
     """Zero-repo missions derive fully but never dispatch; the reason is
     surfaced through blocked_reasons for /health and the missions API."""
-    from fakes import FakeForgeRuntime
+    from fakes import FakeForgeRuntime, make_mission_manager
     from devcake.adapters.files.run_store import RunStore
     from devcake.config import AppConfig, DevType
-    from devcake.domain.orchestrator import MissionManager
 
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = "linear"
-    mgr.instance = INST
-    mgr.config = AppConfig()
-    mgr.dev_types = {"senior-dev": DevType(name="senior-dev",
-                                           harness_template="claude-code")}
-    mgr.pmo = None
-    mgr.forges = FakeForgeRuntime(None)
-    mgr.breakers, mgr.blocked_reasons, mgr.cycles = {}, {}, []
-    mgr._grace, mgr._grace_next = set(), set()
-
-    class Runs:
-        pass
-    mgr.runs = Runs()
-    mgr.runs.store = RunStore(tmp_path / "runs")
+    mgr = make_mission_manager(
+        tmp_path, pmo=None, forge_runtime=FakeForgeRuntime(None),
+        config=AppConfig(), instance=INST,
+        dev_types={"senior-dev": DevType(name="senior-dev",
+                                         harness_template="claude-code")},
+        runs=type("Runs", (), {"store": RunStore(tmp_path / "runs")})(),
+    )
 
     m = _m()
     m.labels = {"DEVCAKE"}
@@ -183,13 +168,15 @@ def test_two_repos_route_tokens_and_dialects_per_run(tmp_path, monkeypatch):
     rt.rebuild([gh, gl], make_forge)
     assert set(rt.forges) == {"ghrepo", "glrepo"}
 
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.config = AppConfig()
-    mgr.forges = rt
-    mgr.instance = PMOInstance(name="linear", team_key="DEV",
-                               repos=["ghrepo", "glrepo"])
-    mgr.dev_types = {"senior-dev": DevType(name="senior-dev",
-                                           harness_template="claude-code")}
+    from fakes import make_mission_manager
+    mgr = make_mission_manager(
+        config=AppConfig(),
+        forge_runtime=rt,
+        instance=PMOInstance(name="linear", team_key="DEV",
+                             repos=["ghrepo", "glrepo"]),
+        dev_types={"senior-dev": DevType(name="senior-dev",
+                                         harness_template="claude-code")},
+    )
     dt = mgr.dev_types["senior-dev"]
 
     env_gh = mgr._protocol_spec_env(
@@ -236,16 +223,14 @@ def test_resolve_repo_history_assembly(tmp_path):
     for r in (mine_old, mine_new, mapper, other_mission, other_instance):
         store.save(r)
 
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = "linear"
-    mgr.instance = INST
-
-    class Runs:
-        pass
-    mgr.runs = Runs()
-    mgr.runs.store = store
-    mgr.forges = FakeForgeRuntime(object())   # instances: {"main"} — irrelevant
-    mgr.forges._inst.name = "main"
+    from fakes import make_mission_manager
+    fr = FakeForgeRuntime(object())   # instances: {"main"} — irrelevant
+    fr._inst.name = "main"
+    mgr = make_mission_manager(
+        instance=INST,
+        forge_runtime=fr,
+        runs=type("Runs", (), {"store": store})(),
+    )
     # repo names must include beta for sticky to resolve
     from devcake.config import RepoInstance
     import devcake.domain.repo_routing as rr
@@ -311,18 +296,15 @@ def test_resolve_repo_live_ungates_zero_repo_to_internal(tmp_path, monkeypatch):
         def instances(self, v):
             self._insts = v
 
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = "linear"
-    mgr.instance = INST                                    # no default_repo
+    from fakes import make_mission_manager
     rt = RT(None)
     rt._insts = {}
-    mgr.forges = rt
-    mgr.internal_forge = FakeInternal()
-
-    class Runs:
-        pass
-    mgr.runs = Runs()
-    mgr.runs.store = RunStore(tmp_path / "runs")
+    mgr = make_mission_manager(
+        instance=INST,                                    # no default_repo
+        forge_runtime=rt,
+        internal_forge=FakeInternal(),
+        runs=type("Runs", (), {"store": RunStore(tmp_path / "runs")})(),
+    )
 
     # zero-repo mission → internal
     name, reason = run_coro(mgr.resolve_repo_live(_m()))
@@ -424,19 +406,17 @@ def test_internal_zip_delivery(tmp_path, monkeypatch):
         internal = {"linear-t-1"}
         def get(self, name): return FakeForge()
 
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.forges = RT()
-    mgr.pmo = FakePMO()
+    from fakes import make_mission_manager
+    from devcake.adapters.files.run_store import RunStore
+    mgr = make_mission_manager(
+        pmo=FakePMO(),
+        forge_runtime=RT(),
+        runs=type("Runs", (), {"store": RunStore(tmp_path / "runs")})(),
+    )
 
     async def _feed(pmo_id, kind, md): feed.append(md)
     mgr._feed = _feed
-    from devcake.domain.orchestrator import deliver
     mgr._attachment_cap = lambda: 10*1024*1024
-
-    class Runs: pass
-    mgr.runs = Runs()
-    from devcake.adapters.files.run_store import RunStore
-    mgr.runs.store = RunStore(tmp_path / "runs")
 
     run = _run("linear-t-1"); run.mission_pmo_id = "p1"; run.mission_key = "T-1"
     run.finalized_steps = []

--- a/app/tests/test_run_bootstrap.py
+++ b/app/tests/test_run_bootstrap.py
@@ -11,9 +11,6 @@ import asyncio
 
 import pytest
 
-from devcake.config import PMOInstance
-from fakes import FakeForgeRuntime
-
 from devcake.domain.run import Run, auth_digest
 from devcake.domain.run_bootstrap import RunBootstrap
 
@@ -176,21 +173,18 @@ def test_dispatch_mapper_uses_bootstrap_spine(tmp_path, monkeypatch):
     from devcake.adapters.github import GitHubForge
     from devcake.config import AppConfig, DevType
     from devcake.domain.model import Mission
-    from devcake.domain.orchestrator import MissionManager
     from devcake.domain.runs import RunManager
     from devcake.harness import HARNESSES
-
+    from fakes import make_mission_manager
     monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
     store = InMemoryStore()
     executor = FakeExecutor(store)
     runs = RunManager(store, FakeMessaging(), executor)
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = 'linear'
-    mgr.instance = PMOInstance(name='linear', team_key='DEV')
-    mgr.config = AppConfig()
-    mgr.runs = runs
-    mgr.messaging = FakeMessaging()
-    mgr.forges = FakeForgeRuntime(GitHubForge("https://github.com/o/r", "tok"))
+    mgr = make_mission_manager(
+        runs=runs, messaging=FakeMessaging(),
+        forge=GitHubForge("https://github.com/o/r", "tok"),
+        config=AppConfig(),
+    )
 
     dt = DevType(name="senior-dev", harness_template="grok-build", model="grok-4.5")
     m = Mission(pmo_id="p1", pmo_kind="issue", key="T-1", title="t",

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -7,9 +7,6 @@ from datetime import datetime, timezone
 
 import pytest
 
-from devcake.config import PMOInstance
-from fakes import FakeForgeRuntime
-
 from devcake.config import AppConfig, DevType
 from devcake.ports.forge import ForgeError, PullRequest
 from devcake.domain.orchestrator import MissionManager
@@ -147,37 +144,17 @@ class FakeForge:
 
 
 def make_mgr(tmp_path, m, forge=None):
+    from fakes import make_mission_manager
     cfg = AppConfig()
     fake = FakePMO(m)
-    store = RunStore(tmp_path / "runs")
-
-    class Runs:
-        pass
-    runs = Runs()
-    runs.store = store
-    runs.finalizer = None
-    mgr = MissionManager.__new__(MissionManager)
-    mgr.instance_name = 'linear'
-    mgr.instance = PMOInstance(name='linear', team_key='DEV')
-    mgr.config = cfg
-    mgr.dev_types = {"senior-dev": DevType(name="senior-dev",
-                                           harness_template="claude-code")}
-    mgr.pmo = fake
-    mgr.runs = runs
-    mgr.messaging = NullMessaging()
-    mgr._grace, mgr._grace_next, mgr.breakers = set(), set(), {}
-    mgr.blocked_reasons = {}
-    mgr.merge_handoffs, mgr._merge_window_closed = {}, set()
-    mgr.rearm_merge_windows = False
-    mgr.needs_human = {}
-    mgr._audit = lambda *a, **k: None
-    if forge is not None:
-        mgr.forges = FakeForgeRuntime(forge)
-    else:
-        # no forge: any resolution returns None — the clean-fail paths
-        # (rather than an AttributeError) are the trust boundary under test
-        mgr.forges = FakeForgeRuntime(None)
-    return mgr, fake, store
+    mgr = make_mission_manager(
+        tmp_path, pmo=fake, forge=forge, config=cfg,
+        dev_types={"senior-dev": DevType(name="senior-dev",
+                                         harness_template="claude-code")},
+        messaging=NullMessaging(),
+        noop_audit=True,  # transition tests assert labels/feed, not audit
+    )
+    return mgr, fake, mgr.runs.store
 
 
 def run_coro(c):

--- a/docs/06-forge-adapter.md
+++ b/docs/06-forge-adapter.md
@@ -150,7 +150,9 @@ GitLab < 15.6 has no `detailed_merge_status`; the adapter falls back to the lega
 
 ## 8. Adapter contract tests
 
-What `app/tests/test_forge.py` covers (no network — `_req` is stubbed):
+Two layers:
+
+**Domain / port tables** (`app/tests/test_forge.py`) — no network; `_req` is stubbed so mergeable maps, merge retries, and DTO parity stay fast and independent of HTTP:
 
 | # | Scenario |
 |---|---|
@@ -164,6 +166,8 @@ What `app/tests/test_forge.py` covers (no network — `_req` is stubbed):
 | 8 | Registry: `forges()` covers exactly `{github, gitlab}` with real descriptors; `make_forge` constructs each (passing `api_base`); an unknown forge is rejected by `RepoInstance` validation |
 | 9 | Descriptor completeness: every field non-empty; `pr_instructions` renders against `{key}/{title}/{default}/{branch}` without `KeyError`; `token_patterns` compile |
 | 10 | `mission_branch()` single definition: `devcake/` prefix |
+
+**HTTP contract** (`app/tests/test_forge_http.py`) — hermetic `httpx.MockTransport` injected via optional constructor `transport=` (same seam as Linear / Gitea provisioner). Asserts auth header shape and full URL assembly for GitHub, GitLab, and Gitea so empty `_headers()` or a broken `_req` URL fails the suite. Live Gitea battery remains `scripts/contract_tests_forge.py` (vendor drift).
 
 ## 9. Adding a forge (checklist)
 

--- a/scripts/ci_compose_for_dispatch.sh
+++ b/scripts/ci_compose_for_dispatch.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Bring up the minimal compose set for hello dispatch smoke (no Gitea).
+# Used by GHA ci.yml and optionally for local clean-room proof.
+#
+# Service set (transitive deps for app + Dagu spawning hello):
+#   fluentbit  — redis/dagu depend_on + fluentd log driver
+#   openobserve — app depends_on service_started
+#   otel-collector — hello OTLP export target
+#   redis, dagu, app, admin
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+TAG="${DEVCAKE_TAG:-latest}"
+DOCKER_GID="${DOCKER_GID:-$(stat -c %g /var/run/docker.sock 2>/dev/null || echo 0)}"
+
+# On GHA always write synthetic .env. Locally: only if CI_COMPOSE_WRITE_ENV=1
+# (never clobber a developer's real .env by default).
+WRITE_ENV="${CI_COMPOSE_WRITE_ENV:-0}"
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  WRITE_ENV=1
+fi
+
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-Ci-admin-Pass1!}"
+REDIS_PASSWORD="${REDIS_PASSWORD:-Ci-redis-Pass1!}"
+DAGU_USER="${DAGU_USER:-devcake}"
+DAGU_PASSWORD="${DAGU_PASSWORD:-Ci-dagu-Pass1!}"
+OO_ROOT_EMAIL="${OO_ROOT_EMAIL:-ci@example.com}"
+OO_ROOT_PASSWORD="${OO_ROOT_PASSWORD:-Ci-oo-root-Pass1!}"
+OO_INGEST_EMAIL="${OO_INGEST_EMAIL:-ingest@example.com}"
+OO_INGEST_PASSWORD="${OO_INGEST_PASSWORD:-Ci-oo-ingest-Pass1!}"
+
+if [[ "$WRITE_ENV" == "1" ]]; then
+  echo "── write ephemeral .env for dispatch compose (CI workspace only)"
+  cat > .env <<EOF
+DEVCAKE_TAG=${TAG}
+OO_ROOT_EMAIL=${OO_ROOT_EMAIL}
+OO_ROOT_PASSWORD=${OO_ROOT_PASSWORD}
+OO_INGEST_EMAIL=${OO_INGEST_EMAIL}
+OO_INGEST_PASSWORD=${OO_INGEST_PASSWORD}
+GITEA_ADMIN_USER=devcakeadmin
+GITEA_ADMIN_PASSWORD=Ci-gitea-unused-Pass1!
+DAGU_USER=${DAGU_USER}
+DAGU_PASSWORD=${DAGU_PASSWORD}
+REDIS_PASSWORD=${REDIS_PASSWORD}
+ADMIN_USER=${ADMIN_USER}
+ADMIN_PASSWORD=${ADMIN_PASSWORD}
+DOCKER_GID=${DOCKER_GID}
+DAGU_UI_URL=http://localhost:8525
+OO_UI_URL=http://localhost:5080
+EOF
+elif [[ ! -f .env ]]; then
+  echo "no .env present; set CI_COMPOSE_WRITE_ENV=1 to generate a synthetic one, or copy .env.example" >&2
+  exit 1
+else
+  echo "── reusing existing .env (CI_COMPOSE_WRITE_ENV not set)"
+  # shellcheck disable=SC1091
+  set -a
+  # load only what readiness curls need
+  while IFS= read -r line; do
+    case "$line" in
+      ADMIN_USER=*|ADMIN_PASSWORD=*|REDIS_PASSWORD=*|DAGU_USER=*|DAGU_PASSWORD=*|DEVCAKE_TAG=*)
+        export "${line?}" ;;
+    esac
+  done < <(grep -E '^(ADMIN_USER|ADMIN_PASSWORD|REDIS_PASSWORD|DAGU_USER|DAGU_PASSWORD|DEVCAKE_TAG)=' .env || true)
+  set +a
+  ADMIN_USER="${ADMIN_USER:-admin}"
+  ADMIN_PASSWORD="${ADMIN_PASSWORD:?ADMIN_PASSWORD missing in .env}"
+fi
+
+export DEVCAKE_TAG="$TAG"
+export ADMIN_USER ADMIN_PASSWORD REDIS_PASSWORD DAGU_USER DAGU_PASSWORD
+
+SERVICES=(fluentbit openobserve redis dagu otel-collector app admin)
+
+echo "── pull third-party images for dispatch set"
+docker compose pull fluentbit openobserve redis dagu otel-collector
+
+echo "── compose up: ${SERVICES[*]}"
+docker compose up -d "${SERVICES[@]}"
+
+# status via docker inspect: Health.Status if present, else State.Status
+_container_status() {
+  local svc="$1" cid
+  cid=$(docker compose ps -q "$svc" 2>/dev/null | head -1)
+  [[ -n "$cid" ]] || { echo missing; return; }
+  docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$cid" 2>/dev/null || echo missing
+}
+
+wait_service() {
+  local svc="$1" want="$2" max="${3:-60}" i st
+  for i in $(seq 1 "$max"); do
+    st=$(_container_status "$svc")
+    if [[ "$st" == "$want" ]]; then
+      echo "  $svc → $st (attempt $i)"
+      return 0
+    fi
+    # services without healthchecks: "running" is enough
+    if [[ "$want" == "running" && "$st" == "running" ]]; then
+      echo "  $svc → running (attempt $i)"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "  $svc NOT $want (last=$st) after ${max} attempts" >&2
+  return 1
+}
+
+echo "── wait for service readiness"
+wait_service fluentbit running 30
+wait_service openobserve running 45
+wait_service redis healthy 40
+wait_service dagu healthy 40
+wait_service app healthy 60
+wait_service admin healthy 40
+
+echo "── wait for authenticated control plane via admin :8080"
+BASE_URL="${DEVCAKE_BASE_URL:-http://127.0.0.1:8080}"
+for i in $(seq 1 60); do
+  if curl -sf "${BASE_URL}/nginx-health" | grep -q ok; then
+    code=$(curl -s -o /dev/null -w '%{http_code}' -u "${ADMIN_USER}:${ADMIN_PASSWORD}" \
+      "${BASE_URL}/api/v1/runs" || echo 000)
+    if [[ "$code" == "200" ]]; then
+      echo "  authenticated GET /api/v1/runs → 200 (attempt $i)"
+      echo "── compose stack ready for dispatch"
+      exit 0
+    fi
+    echo "  nginx ok; /api/v1/runs → ${code} (attempt $i)"
+  else
+    echo "  nginx-health not ready (attempt $i)"
+  fi
+  sleep 2
+done
+
+echo "compose stack failed readiness" >&2
+docker compose ps || true
+docker compose logs --tail=80 app admin dagu redis fluentbit || true
+exit 1

--- a/scripts/ci_dispatch_hello.sh
+++ b/scripts/ci_dispatch_hello.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Stub-harness smoke: full dispatch pipeline (Dagu → container → Redis → finalize).
+# Preconditions: compose stack up (app + admin + redis + dagu + …), hello image
+# baked as devcake/dev-hello:${DEVCAKE_TAG:-latest}, ADMIN_* credentials set.
+# Used by scripts/ci_suite.sh and .github/workflows/ci.yml.
+set -euo pipefail
+
+: "${ADMIN_USER:?ADMIN_USER must be set}"
+: "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set}"
+
+BASE_URL="${DEVCAKE_BASE_URL:-http://localhost:8080}"
+SLEEP_SECS="${DEVCAKE_HELLO_SLEEP:-2}"
+MAX_POLLS="${DEVCAKE_HELLO_POLLS:-30}"
+POLL_SLEEP="${DEVCAKE_HELLO_POLL_SLEEP:-3}"
+
+echo "── stub-harness smoke: POST ${BASE_URL}/api/v1/debug/dispatch-hello"
+RUN=$(curl -sf -u "$ADMIN_USER:$ADMIN_PASSWORD" -H 'X-DevCake-Request: 1' -X POST \
+  "${BASE_URL}/api/v1/debug/dispatch-hello?sleep=${SLEEP_SECS}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['run_id'])")
+echo "hello run_id=${RUN}"
+
+STATE=""
+for i in $(seq 1 "$MAX_POLLS"); do
+  STATE=$(curl -sf -u "$ADMIN_USER:$ADMIN_PASSWORD" \
+    "${BASE_URL}/api/v1/runs/${RUN}" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['state'])")
+  echo "  poll ${i}/${MAX_POLLS}: state=${STATE}"
+  [ "$STATE" = "finished" ] && break
+  [ "$STATE" = "failed" ] || [ "$STATE" = "timed_out" ] && {
+    echo "hello run $STATE" >&2
+    exit 1
+  }
+  sleep "$POLL_SLEEP"
+done
+[ "$STATE" = "finished" ] || {
+  echo "hello run stuck in ${STATE:-unknown}" >&2
+  exit 1
+}
+echo "hello run finished ✓"

--- a/scripts/ci_suite.sh
+++ b/scripts/ci_suite.sh
@@ -41,16 +41,6 @@ docker run --rm \
 echo "── forge contract battery (gitea lane — bundled instance, no external tokens)"
 docker compose exec -T app python - < scripts/contract_tests_forge.py
 
-echo "── stub-harness smoke: full dispatch pipeline (Dagu → container → Redis → finalize)"
-RUN=$(curl -sf -u "$ADMIN_USER:$ADMIN_PASSWORD" -H 'X-DevCake-Request: 1' -X POST \
-  "http://localhost:8080/api/v1/debug/dispatch-hello?sleep=2" | python3 -c "import json,sys; print(json.load(sys.stdin)['run_id'])")
-for i in $(seq 1 30); do
-  STATE=$(curl -sf -u "$ADMIN_USER:$ADMIN_PASSWORD" \
-    "http://localhost:8080/api/v1/runs/$RUN" | python3 -c "import json,sys; print(json.load(sys.stdin)['state'])")
-  [ "$STATE" = "finished" ] && break
-  [ "$STATE" = "failed" ] || [ "$STATE" = "timed_out" ] && { echo "hello run $STATE"; exit 1; }
-  sleep 3
-done
-[ "$STATE" = "finished" ] || { echo "hello run stuck in $STATE"; exit 1; }
-echo "hello run finished ✓"
+# Full Dagu → hello container → Redis → finalize (also wired into GHA ci.yml)
+./scripts/ci_dispatch_hello.sh
 echo "── CI suite green"

--- a/scripts/pytest_app.sh
+++ b/scripts/pytest_app.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Always-fresh unit suite: rebake app-test (COPY'd tree) then pytest.
+# Avoids the stale-image false green when app/ or tests/ changed since last bake.
+# For the full local suite (forge battery + dispatch smoke) use ci_suite.sh.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Optional Redis for live messaging tests (compose network). If the network
+# is missing, pytest still runs; live-redis tests skip or fail on connection.
+REDIS_PASSWORD="${REDIS_PASSWORD:-}"
+if [[ -f .env ]]; then
+  # shellcheck disable=SC1091
+  while IFS= read -r line; do
+    case "$line" in
+      REDIS_PASSWORD=*) export "${line?}" ;;
+    esac
+  done < <(grep -E '^REDIS_PASSWORD=' .env || true)
+fi
+
+echo "── bake app-test (ensures image matches working tree)"
+docker buildx bake -f docker-bake.hcl app-test
+
+TAG="${DEVCAKE_TAG:-latest}"
+NET_ARGS=()
+ENV_ARGS=()
+if docker network inspect devcake_control >/dev/null 2>&1; then
+  NET_ARGS=(--network devcake_control)
+  if [[ -n "${REDIS_PASSWORD:-}" ]]; then
+    ENV_ARGS=(-e "REDIS_URL=redis://redis:6379/0" -e "REDIS_PASSWORD=${REDIS_PASSWORD}")
+  fi
+fi
+
+echo "── pytest via devcake/app-test:${TAG}"
+docker run --rm \
+  "${NET_ARGS[@]}" \
+  "${ENV_ARGS[@]}" \
+  -v "$(pwd)/images/common:/srv/images/common:ro" \
+  -w /srv \
+  "devcake/app-test:${TAG}" \
+  python -m pytest tests/ -q "$@"


### PR DESCRIPTION
## Summary

Closes verification gaps from a critical WIP review: the suite proved domain decisions well but under-tested process boundaries (forge auth, Dagu HTTP, hello entrypoint), and CI “entrypoint smoke” only imported `redis`. This PR raises **verification quality** only — it does not claim a stronger security posture than `docs/14-security.md`.

### Auth
- Basic auth compares credentials as UTF-8 bytes so non-ASCII passwords never raise `TypeError` from `secrets.compare_digest` (was a **500**).
- Pin `pydantic==2.13.4` (resolved under `fastapi==0.115.6`).
- Expand `test_api_auth` for wrong password (same length, different length, unicode).

### ForgePort HTTP contract
- Optional `httpx` `transport=` on GitHub / GitLab / Gitea adapters (same seam as Linear / Gitea provisioner).
- New `test_forge_http.py`: auth header shapes, reviewer token, URL assembly, write path (`post_pr_comment`), empty-token fail-closed (no illegal `Bearer `).
- Empty token raises `ForgeError` before send on all three forges (ADR-0011 class).
- Domain tables in `test_forge.py` still stub `_req` (unchanged dual-layer design).
- `docs/06` documents stubbed domain tables vs MockTransport HTTP.

### DaguExecutor
- `transport=` + injectable auth; shared `_client` helper.
- New `test_dagu_executor.py`: start URL/body, 409 → `DuplicateRun`, status/stop, no-op start mutant bar, basic auth on the wire.

### MissionManager tests
- `make_mission_manager()` uses real `__init__`; with `tmp_path` builds a real `RunManager` + `FakeExecutor`.
- All `MissionManager.__new__` test sites migrated.
- `noop_audit` opt-in for legacy private-seam tests. Full private-method retarget / class-binding removal remains a follow-up.

### CI / scripts
- `scripts/ci_dispatch_hello.sh` — extract full Dagu → hello → Redis → finalize poll.
- `scripts/ci_compose_for_dispatch.sh` — minimal compose (**no Gitea**), hard readiness (service health + nginx-health + authenticated `GET /api/v1/runs`). Writes `.env` only under `GITHUB_ACTIONS` or `CI_COMPOSE_WRITE_ENV=1`.
- `ci.yml`: bake → ruff → pytest (+ unit redis) → compose dispatch → teardown. Removes standalone admin throwaway and redis-import “entrypoint” theater.
- `docker-images.yml`: honest hello redis-import label (full dispatch is `ci.yml`).
- `scripts/pytest_app.sh` always rebakes `app-test`; AGENTS/README document the stale-image trap.

### Tooling
- Narrow `ruff` (E9/F63/F7/F82) in app-test + CI; `ruff.toml` notes broader lint is deferred.
- `review.py`: capture merge exception as `merge_err` for nested async / static F821.

## Test plan

- [x] `docker buildx bake app-test` + ruff + hermetic pytest (live Redis tests need compose network)
- [x] Local `scripts/ci_compose_for_dispatch.sh` readiness (reuse existing stack / minimal up)
- [x] Local `scripts/ci_dispatch_hello.sh` → `hello run finished`
- [ ] **GHA:** this PR’s job must show compose ready + `hello run finished ✓` (first full proof of the new path on `ubuntu-latest`)
- [ ] Spot-check: empty forge token does not send illegal `Bearer `; wrong unicode Basic password → 401

## Follow-ups (out of scope)

- Retarget private orchestrator tests (`_transition`, etc.) to public APIs; drop class-level method bindings.
- Optional Gitea live forge battery in GHA after dispatch is stable.
- Broader ruff / measured cov floor / mypy on `ports/`.