### PR TITLE
fix(admin): redesign follow-ups — a11y polish + committed behavioral suite

### DIFF
--- a/admin/spa/DESIGN.md
+++ b/admin/spa/DESIGN.md
@@ -200,8 +200,13 @@ A UI change is done when you have personally seen:
    and actually look at them. Note: the app scrolls inside `<main>` (fullPage
    screenshots won't capture it) and hash-only `page.goto` does **not** remount
    the app — reload for fresh-mount behavior.
-3. Behavioral assertions for new interactions (menu opens, dialog reached,
-   draft counts edits), not just screenshots.
+3. `npm --prefix admin/spa run check:ui` green — the committed behavioral
+   suite (`admin/spa/tests/`: settings model, action hierarchy, redesign
+   invariants; it boots vite itself and needs the live backend on :8080).
+   It never confirms a Save and cancels every destructive dialog, so it is
+   safe against live config. New interactions get assertions added here
+   (menu opens, dialog reached, draft counts edits), not just screenshots.
+   Local-only for now — CI has no live stack to run it against.
 4. For prod: `docker buildx bake admin && docker compose up -d admin` + load.
 
 Name anything left unproven (OAuth wizard, real save-PUT, etc.) instead of

--- a/admin/spa/package-lock.json
+++ b/admin/spa/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
         "@vitejs/plugin-react": "^4.3.4",
+        "playwright-core": "^1.61.1",
         "tailwindcss": "^4.0.0",
         "vite": "^6.0.0"
       }
@@ -2190,6 +2191,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/admin/spa/package.json
+++ b/admin/spa/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "check:ui": "node tests/run.mjs"
   },
   "dependencies": {
     "@fontsource-variable/bricolage-grotesque": "^5.2.10",
@@ -15,6 +16,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "playwright-core": "^1.61.1",
     "tailwindcss": "^4.0.0",
     "vite": "^6.0.0"
   }

--- a/admin/spa/src/components/Modal.jsx
+++ b/admin/spa/src/components/Modal.jsx
@@ -6,8 +6,11 @@ const FOCUSABLE =
 
 // Shared overlay: dialog semantics, focus trap, scroll lock on <main>.
 // `onDismiss` enables Esc + backdrop close — omit it for confirms, which
-// must be resolved by their explicit buttons only.
-export function Overlay({ children, className = "", onDismiss }) {
+// must be resolved by their explicit buttons only. `surfaceClass` swaps the
+// default white-card surface wholesale (border + background) — pass it
+// instead of stacking conflicting utilities in `className` (Tailwind
+// resolves duplicate properties by stylesheet order, not class order).
+export function Overlay({ children, className = "", surfaceClass, onDismiss, ariaLabel }) {
   const ref = useRef(null);
   useEffect(() => {
     const node = ref.current;
@@ -48,8 +51,11 @@ export function Overlay({ children, className = "", onDismiss }) {
         ref={ref}
         role="dialog"
         aria-modal="true"
+        aria-label={ariaLabel}
         tabIndex={-1}
-        className={`w-full rounded-card border border-neutral-200 bg-white shadow-2xl focus:outline-none dark:border-neutral-800 dark:bg-neutral-900 ${className}`}
+        className={`w-full rounded-card shadow-2xl focus:outline-none ${
+          surfaceClass || "border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
+        } ${className}`}
       >
         {children}
       </div>

--- a/admin/spa/src/components/MoreMenu.jsx
+++ b/admin/spa/src/components/MoreMenu.jsx
@@ -8,8 +8,12 @@ import { ExternalLink, MoreHorizontal } from "lucide-react";
 export default function MoreMenu({ label = "More actions", items }) {
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
+  const btnRef = useRef(null);
+  const menuRef = useRef(null);
   useEffect(() => {
     if (!open) return;
+    // menu-button pattern: focus enters the menu when it opens
+    menuRef.current?.querySelector('[role="menuitem"]')?.focus();
     const away = (e) => ref.current && !ref.current.contains(e.target) && setOpen(false);
     const esc = (e) => e.key === "Escape" && setOpen(false);
     document.addEventListener("pointerdown", away);
@@ -19,9 +23,29 @@ export default function MoreMenu({ label = "More actions", items }) {
       document.removeEventListener("keydown", esc);
     };
   }, [open]);
+  // Roving focus: the trigger is the only tab stop; arrows move within the
+  // menu, Esc returns focus to the trigger, Tab closes and moves on from it.
+  const onKey = (e) => {
+    if (!open) {
+      if (e.key === "ArrowDown" && document.activeElement === btnRef.current) {
+        e.preventDefault();
+        setOpen(true);
+      }
+      return;
+    }
+    const f = [...(menuRef.current?.querySelectorAll('[role="menuitem"]') || [])];
+    const i = f.indexOf(document.activeElement);
+    if (e.key === "ArrowDown") { e.preventDefault(); f[(i + 1) % f.length]?.focus(); }
+    else if (e.key === "ArrowUp") { e.preventDefault(); f[(i - 1 + f.length) % f.length]?.focus(); }
+    else if (e.key === "Home") { e.preventDefault(); f[0]?.focus(); }
+    else if (e.key === "End") { e.preventDefault(); f[f.length - 1]?.focus(); }
+    else if (e.key === "Escape") { setOpen(false); btnRef.current?.focus(); }
+    else if (e.key === "Tab") { setOpen(false); btnRef.current?.focus(); }
+  };
   return (
-    <span ref={ref} className="relative inline-block">
+    <span ref={ref} onKeyDown={onKey} className="relative inline-block">
       <button
+        ref={btnRef}
         type="button"
         title={label}
         aria-label={label}
@@ -34,7 +58,9 @@ export default function MoreMenu({ label = "More actions", items }) {
       </button>
       {open && (
         <div
+          ref={menuRef}
           role="menu"
+          aria-label={label}
           className="absolute right-0 top-full z-40 mt-1 w-64 rounded-md border border-neutral-200 bg-white py-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
         >
           {items.map((it) => (
@@ -42,6 +68,7 @@ export default function MoreMenu({ label = "More actions", items }) {
               key={it.label}
               type="button"
               role="menuitem"
+              tabIndex={-1}
               onClick={() => { setOpen(false); it.onClick(); }}
               className="block w-full px-3 py-2 text-left text-sm transition hover:bg-stone-50 focus-visible:bg-stone-50 focus-visible:outline-none dark:hover:bg-neutral-800 dark:focus-visible:bg-neutral-800"
             >

--- a/admin/spa/src/components/RunTerminal.jsx
+++ b/admin/spa/src/components/RunTerminal.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Copy, Check } from "lucide-react";
+import { Overlay } from "./Modal.jsx";
 import { getText } from "../api.js";
 
 export const TERMINAL_STATES = ["finished", "failed", "timed_out", "orphaned"];
@@ -14,12 +15,6 @@ export default function RunTerminal({ run, onClose }) {
   const [copied, setCopied] = useState(false);
   const preRef = useRef(null);
   const stickRef = useRef(true);
-
-  useEffect(() => {
-    const onKey = (e) => e.key === "Escape" && onClose();
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
 
   useEffect(() => {
     let es;
@@ -61,11 +56,12 @@ export default function RunTerminal({ run, onClose }) {
   const note = run.error || run.verdict; // app-level judgment, when present
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-[2px]"
-      onClick={onClose}>
-      <div role="dialog" aria-modal="true" aria-label={`Run terminal ${run.run_id}`}
-        className="flex h-[75vh] w-full max-w-5xl flex-col overflow-hidden rounded-card border border-neutral-700 bg-neutral-950 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}>
+    // Overlay supplies the focus trap, Esc/backdrop close, <main> scroll
+    // lock and focus restore; the terminal keeps its always-dark chrome.
+    <Overlay onDismiss={onClose}
+      ariaLabel={`Run terminal ${run.run_id}`}
+      surfaceClass="border border-neutral-700 bg-neutral-950"
+      className="flex h-[75vh] max-w-5xl flex-col overflow-hidden">
         <div className="flex items-center gap-2 border-b border-neutral-800 bg-neutral-900 px-4 py-2.5">
           <span className="h-3 w-3 rounded-full bg-red-500" />
           <span className="h-3 w-3 rounded-full bg-yellow-500" />
@@ -103,7 +99,6 @@ export default function RunTerminal({ run, onClose }) {
               : lines.join("\n")}
           {live && <span className="animate-pulse text-neutral-400">{lines.length ? "\n" : ""}▊</span>}
         </pre>
-      </div>
-    </div>
+    </Overlay>
   );
 }

--- a/admin/spa/src/pages/ConfigPage.jsx
+++ b/admin/spa/src/pages/ConfigPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Play, Plus, Trash2, KeyRound, Upload } from "lucide-react";
 import { get, send } from "../api.js";
 import PageHeader from "../components/PageHeader.jsx";
@@ -231,7 +231,7 @@ function DevTypeCard({ name, draftDt, serverDt, harnesses, setField, onDelete, o
         </InstantZone>
       )}
       <SelectionChips label="Skills"
-        help={`Skill-store skills installed to ~/${h.skills_dir || ".claude/skills"} inside the Dev container before the agent starts. The catalog lives in the Skills section below.`}
+        help={`Skill-store skills installed to ~/${h.skills_dir || ".claude/skills"} inside the Dev container before the agent starts. The catalog lives in the Skills section.`}
         options={(skillsCatalog?.skills || []).map((s) => ({
           name: s.name, title: s.description || undefined }))}
         selected={d.skills || []}
@@ -240,7 +240,7 @@ function DevTypeCard({ name, draftDt, serverDt, harnesses, setField, onDelete, o
           !h.skills_dir && (d.skills || []).length
             ? ` — ${d.skills.length} selected skill(s) will be skipped`
             : ""}.`}
-        emptyNote="no skills in the catalog yet — see the Skills section below"
+        emptyNote="no skills in the catalog yet — see the Skills section"
         staleNote="not in the skill store — skipped at dispatch; click to remove"
         onChange={(next) => {
           // write back in CATALOG order (unknown names last): uncheck-then-
@@ -537,11 +537,24 @@ export default function ConfigPage({ section }) {
   const [skillsCatalog, setSkillsCatalog] = useState({ skills: [], store: null });
   const [skillsErr, setSkillsErr] = useState(false);
   const [skillsMsg, setSkillsMsg] = useState("");
+  const skillsMsgTimer = useRef(null);
+  useEffect(() => () => clearTimeout(skillsMsgTimer.current), []);
   const loadSkills = () =>
     get("/skills")
       .then((r) => { setSkillsCatalog(r); setSkillsErr(false); })
       .catch(() => setSkillsErr(true));
   useEffect(() => { loadSkills(); }, []);
+  const restoreBuiltins = async () => {
+    try {
+      await send("POST", "/skills/sync");
+      await loadSkills();
+      setSkillsMsg("✓ built-in skills restored");
+      clearTimeout(skillsMsgTimer.current);
+      skillsMsgTimer.current = setTimeout(() => setSkillsMsg(""), 4000);
+    } catch (e) {
+      setPageErr(`restoring built-ins failed: ${String(e.message || e)}`);
+    }
+  };
   const [addSkill, setAddSkill] = useState(false);
   const [addDev, setAddDev] = useState(false);
   const [renameFor, setRenameFor] = useState(null);
@@ -812,28 +825,27 @@ export default function ConfigPage({ section }) {
             <Button icon={Plus} onClick={() => setAddSkill(true)}>
               Add skill
             </Button>
-            <MoreMenu label="More skill-store actions" items={[
-              ...(skillsCatalog.store?.html_url ? [{
-                label: "Open the store in Gitea",
-                desc: "Skills live in a Git repo — edit them there directly.",
-                external: true,
-                onClick: () => window.open(skillsCatalog.store.html_url, "_blank", "noopener"),
-              }] : []),
-              {
-                label: "Restore built-in skills",
-                desc: "Re-adds any missing bundled skills. Never overwrites your edits.",
-                onClick: async () => {
-                  try {
-                    await send("POST", "/skills/sync");
-                    await loadSkills();
-                    setSkillsMsg("✓ built-in skills restored");
-                    setTimeout(() => setSkillsMsg(""), 4000);
-                  } catch (e) {
-                    setPageErr(`restoring built-ins failed: ${String(e.message || e)}`);
-                  }
+            {/* no html_url → the menu would hold a single item; DESIGN §3
+                says a lone action stays a visible ghost button instead */}
+            {skillsCatalog.store?.html_url ? (
+              <MoreMenu label="More skill-store actions" items={[
+                {
+                  label: "Open the store in Gitea",
+                  desc: "Skills live in a Git repo — edit them there directly.",
+                  external: true,
+                  onClick: () => window.open(skillsCatalog.store.html_url, "_blank", "noopener"),
                 },
-              },
-            ]} />
+                {
+                  label: "Restore built-in skills",
+                  desc: "Re-adds any missing bundled skills. Never overwrites your edits.",
+                  onClick: restoreBuiltins,
+                },
+              ]} />
+            ) : (
+              <Button kind="ghost" onClick={restoreBuiltins}>
+                Restore built-in skills
+              </Button>
+            )}
           </>
         )}>
         {skillsCatalog.store && !skillsCatalog.store.enabled && (

--- a/admin/spa/tests/harness.mjs
+++ b/admin/spa/tests/harness.mjs
@@ -1,0 +1,77 @@
+// Shared harness for the behavioral UI suite (DESIGN.md §8): playwright-core
+// driving the locally cached Chromium headless shell — never downloads a
+// browser. Target the vite dev server by default; point UI_BASE at
+// http://127.0.0.1:8080 (with ADMIN_USER/ADMIN_PASSWORD exported) to run the
+// same checks against the prod container.
+import { chromium } from "playwright-core";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const BASE = process.env.UI_BASE || "http://127.0.0.1:5199";
+
+function chromePath() {
+  if (process.env.UI_CHROME) return process.env.UI_CHROME;
+  const root = join(homedir(), ".cache", "ms-playwright");
+  const revs = existsSync(root)
+    ? readdirSync(root).filter((d) => d.startsWith("chromium_headless_shell-")).sort().reverse()
+    : [];
+  for (const rev of revs) {
+    const p = join(root, rev, "chrome-linux", "headless_shell");
+    if (existsSync(p)) return p;
+  }
+  throw new Error(
+    "no cached Chromium headless shell under ~/.cache/ms-playwright — " +
+    "set UI_CHROME to a Chrome/Chromium executable",
+  );
+}
+
+let passes = 0, failures = 0, skips = 0;
+
+export function check(name, ok, detail = "") {
+  if (ok) { passes += 1; console.log(`  ✓ ${name}`); }
+  else { failures += 1; console.error(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`); }
+}
+
+export function skip(name, why) {
+  skips += 1;
+  console.log(`  - ${name} (skipped: ${why})`);
+}
+
+export async function withPage(fn, { width = 1280, height = 900 } = {}) {
+  const browser = await chromium.launch({ executablePath: chromePath() });
+  const auth = process.env.ADMIN_USER && process.env.ADMIN_PASSWORD
+    ? { username: process.env.ADMIN_USER, password: process.env.ADMIN_PASSWORD }
+    : undefined;
+  const ctx = await browser.newContext({
+    viewport: { width, height },
+    httpCredentials: auth,
+    colorScheme: "light",
+  });
+  const page = await ctx.newPage();
+  // Native window.confirm/prompt/alert are banned (DESIGN.md §5) — any one
+  // that fires is an instant failure, wherever it came from.
+  page.on("dialog", (d) => {
+    check(`no native dialog (got ${d.type()}: "${d.message()}")`, false);
+    d.dismiss().catch(() => {});
+  });
+  try {
+    await fn(page);
+  } finally {
+    await browser.close();
+  }
+}
+
+// Fresh-mount navigation: hash-only page.goto does NOT remount the app
+// (DESIGN.md §8), so land on the URL and reload for a clean mount.
+export async function gotoFresh(page, hash) {
+  await page.goto(`${BASE}/${hash}`);
+  await page.reload();
+  await page.waitForSelector("main", { timeout: 10000 });
+}
+
+export function summary(suite) {
+  const tail = skips ? `, ${skips} skipped` : "";
+  console.log(`${suite}: ${passes} passed, ${failures} failed${tail}`);
+  process.exitCode = failures ? 1 : 0;
+}

--- a/admin/spa/tests/hierarchy.mjs
+++ b/admin/spa/tests/hierarchy.mjs
@@ -1,0 +1,89 @@
+// Action-hierarchy suite (DESIGN.md §3): one primary per header/card, the
+// rest behind a ⋯ MoreMenu whose items still reach their confirm/prompt
+// dialogs, and full keyboard operation of the menu. All dialogs are
+// cancelled — nothing destructive ever runs.
+import { check, gotoFresh, skip, summary, withPage } from "./harness.mjs";
+
+await withPage(async (page) => {
+  // 1: no bare secondary/destructive buttons on the redesigned surfaces
+  for (const [hash, waitFor] of [
+    ["#/config/dev-types", "#dev-types"],
+    ["#/config/skills", "#skills"],
+    ["#/runs", 'h1:has-text("Runs")'],
+  ]) {
+    await gotoFresh(page, hash);
+    await page.waitForSelector(waitFor);
+    for (const label of ["Rename", "Delete", "Clear runs"]) {
+      check(`${hash} has no bare "${label}" button`,
+        (await page.locator(`button:visible:text-is("${label}")`).count()) === 0);
+    }
+  }
+
+  // 2-3: Dev Type card ⋯ reaches the Rename prompt and Delete confirm
+  await gotoFresh(page, "#/config/dev-types");
+  await page.waitForSelector("#dev-types");
+  const devMenu = page.locator('button[aria-label^="More actions for"]').first();
+  if (!(await devMenu.count())) {
+    skip("Dev Type ⋯ menu flows", "no Dev Type cards on this stack");
+  } else {
+    await devMenu.click();
+    await page.click('[role="menuitem"]:has-text("Rename")');
+    await page.waitForSelector('[role="dialog"]:has-text("Rename Dev Type")');
+    check("⋯ → Rename reaches the prompt dialog", true);
+    await page.click('[role="dialog"] button:has-text("Cancel")');
+
+    await devMenu.click();
+    await page.click('[role="menuitem"]:has-text("Delete Dev Type")');
+    await page.waitForSelector('[role="dialog"]:has-text("Delete dev type")');
+    check("⋯ → Delete reaches the confirm dialog", true);
+    await page.click('[role="dialog"] button:has-text("Cancel")');
+
+    // 4: keyboard operation — open, arrows move focus, Esc returns to trigger
+    await devMenu.focus();
+    await page.keyboard.press("Enter");
+    await page.waitForSelector('[role="menu"]');
+    const focusedItem = () => page.evaluate(() => {
+      const el = document.activeElement;
+      return el?.getAttribute("role") === "menuitem" ? el.textContent.trim() : null;
+    });
+    const first = await focusedItem();
+    check("opening the menu focuses the first item", first !== null);
+    await page.keyboard.press("ArrowDown");
+    const second = await focusedItem();
+    check("ArrowDown moves focus to the next item", second !== null && second !== first);
+    await page.keyboard.press("ArrowUp");
+    check("ArrowUp moves focus back", (await focusedItem()) === first);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(100);
+    check("Esc closes the menu and refocuses the trigger",
+      (await page.locator('[role="menu"]').count()) === 0 &&
+      (await page.evaluate(() =>
+        document.activeElement?.getAttribute("aria-label")?.startsWith("More actions for"))));
+  }
+
+  // 5: Runs header — primary link + destructive action behind ⋯, confirmed
+  await gotoFresh(page, "#/runs");
+  await page.waitForSelector('h1:has-text("Runs")');
+  check("Runs header keeps Open Dagu as the visible primary",
+    (await page.locator('a:has-text("Open Dagu")').count()) === 1);
+  await page.click('button[aria-label="More run actions"]');
+  await page.click('[role="menuitem"]:has-text("Clear run history")');
+  await page.waitForSelector('[role="dialog"]:has-text("Clear all run history?")');
+  check("⋯ → Clear run history still confirms", true);
+  await page.click('[role="dialog"] button:has-text("Cancel")');
+
+  // 6: Skills header — one primary; secondary actions in ⋯ or a lone ghost
+  await gotoFresh(page, "#/config/skills");
+  await page.waitForSelector("#skills");
+  const addSkill = await page.locator('button:has-text("Add skill")').count();
+  if (!addSkill) {
+    skip("Skills header hierarchy", "skill store disabled on this stack");
+  } else {
+    const menu = await page.locator('button[aria-label="More skill-store actions"]').count();
+    const ghost = await page.locator('button:text-is("Restore built-in skills")').count();
+    check("Skills header: primary + (⋯ menu XOR lone ghost restore)",
+      addSkill === 1 && ((menu === 1 && ghost === 0) || (menu === 0 && ghost === 1)));
+  }
+});
+
+summary("hierarchy");

--- a/admin/spa/tests/redesign.mjs
+++ b/admin/spa/tests/redesign.mjs
@@ -39,9 +39,11 @@ await withPage(async (page) => {
 
   // 5: RunTerminal — focus-trapped dialog, Esc closes, focus returns
   await gotoFresh(page, "#/runs");
-  await page.waitForSelector('h1:has-text("Runs")');
+  // the empty-state row renders before the first /runs fetch resolves —
+  // give real rows time to arrive before concluding the stack has none
   const runBtn = page.locator('td button[title="Open the run terminal"]').first();
-  if (!(await runBtn.count())) {
+  const hasRuns = await runBtn.waitFor({ timeout: 8000 }).then(() => true, () => false);
+  if (!hasRuns) {
     skip("RunTerminal dialog behavior", "no runs recorded on this stack");
   } else {
     await runBtn.click();

--- a/admin/spa/tests/redesign.mjs
+++ b/admin/spa/tests/redesign.mjs
@@ -1,0 +1,60 @@
+// Redesign suite: masthead answers first, oven strip, manual dark mode,
+// click-popover help, and the RunTerminal dialog behavior (when the stack
+// has runs). Read-only — no config edits, no destructive actions.
+import { check, gotoFresh, skip, summary, withPage } from "./harness.mjs";
+
+await withPage(async (page) => {
+  // 1: Overview opens with the answer masthead + eyebrow, not a status dump
+  await gotoFresh(page, "#/overview");
+  await page.waitForSelector("main h1");
+  const h1 = (await page.locator("main h1").first().textContent()).trim();
+  check("masthead is an answer sentence",
+    /(needs? you|critical warning|DevCake)/.test(h1), `got "${h1}"`);
+
+  // 2: the four-stage oven strip renders every pipeline stage
+  for (const stage of ["ONBOARD", "PLAN", "EXECUTE", "REVIEW"]) {
+    check(`oven strip shows ${stage}`,
+      (await page.locator(`a[href="#/runs"]:has-text("${stage}")`).count()) === 1);
+  }
+
+  // 3: dark mode is manual (.dark on <html>) and the toggle drives it
+  await page.click('button[aria-label="Dark theme"]');
+  check("Dark theme toggle sets .dark on the root",
+    await page.evaluate(() => document.documentElement.classList.contains("dark")));
+  await page.click('button[aria-label="Light theme"]');
+  check("Light theme toggle removes .dark",
+    await page.evaluate(() => !document.documentElement.classList.contains("dark")));
+  await page.click('button[aria-label="System theme"]');   // leave as found
+
+  // 4: help is a click-popover (works on touch/keyboard), Esc closes it
+  await gotoFresh(page, "#/config/pmo");
+  await page.waitForSelector("#pmo");
+  const help = page.locator('button[aria-label="Help"]').first();
+  await help.click();
+  check("help ? opens a popover on click",
+    (await page.locator('[role="tooltip"]:visible').count()) === 1);
+  await page.keyboard.press("Escape");
+  check("Esc closes the help popover",
+    (await page.locator('[role="tooltip"]:visible').count()) === 0);
+
+  // 5: RunTerminal — focus-trapped dialog, Esc closes, focus returns
+  await gotoFresh(page, "#/runs");
+  await page.waitForSelector('h1:has-text("Runs")');
+  const runBtn = page.locator('td button[title="Open the run terminal"]').first();
+  if (!(await runBtn.count())) {
+    skip("RunTerminal dialog behavior", "no runs recorded on this stack");
+  } else {
+    await runBtn.click();
+    await page.waitForSelector('[role="dialog"][aria-label^="Run terminal"]');
+    check("run id opens the terminal dialog", true);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(100);
+    check("Esc closes the terminal",
+      (await page.locator('[role="dialog"]').count()) === 0);
+    check("focus returns to the run-id button",
+      await page.evaluate(() =>
+        document.activeElement?.getAttribute("title") === "Open the run terminal"));
+  }
+});
+
+summary("redesign");

--- a/admin/spa/tests/run.mjs
+++ b/admin/spa/tests/run.mjs
@@ -1,0 +1,57 @@
+// Suite runner: boots vite (unless UI_BASE points elsewhere), reads
+// ADMIN_USER/ADMIN_PASSWORD from the repo-root .env so the dev proxy can
+// authenticate against the nginx container, runs every suite, aggregates.
+//   npm run check:ui              → vite on :5199 against the live backend
+//   UI_BASE=http://127.0.0.1:8080 npm run check:ui   → prod container direct
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const spa = join(here, "..");
+const SUITES = ["settings.mjs", "hierarchy.mjs", "redesign.mjs"];
+
+// pick up admin credentials from the repo-root .env when not already set
+try {
+  const env = readFileSync(join(spa, "..", "..", ".env"), "utf8");
+  for (const key of ["ADMIN_USER", "ADMIN_PASSWORD"]) {
+    if (!process.env[key]) {
+      const m = env.match(new RegExp(`^${key}=(.*)$`, "m"));
+      if (m) process.env[key] = m[1].trim().replace(/^["']|["']$/g, "");
+    }
+  }
+} catch { /* no .env — the proxy runs unauthenticated */ }
+
+let vite = null;
+const base = process.env.UI_BASE || "http://127.0.0.1:5199";
+
+if (!process.env.UI_BASE) {
+  vite = spawn("npx", ["vite", "--port", "5199", "--strictPort"], {
+    cwd: spa, stdio: "ignore", env: process.env,
+  });
+  const deadline = Date.now() + 30000;
+  let up = false;
+  while (Date.now() < deadline) {
+    try { up = (await fetch(base)).ok; if (up) break; }
+    catch { await new Promise((r) => setTimeout(r, 300)); }
+  }
+  if (!up) {
+    console.error("vite did not come up on :5199 within 30s");
+    vite.kill();
+    process.exit(1);
+  }
+}
+
+let failed = false;
+for (const suite of SUITES) {
+  console.log(`\n── ${suite}`);
+  const code = await new Promise((resolve) => {
+    spawn(process.execPath, [join(here, suite)], { stdio: "inherit", env: process.env })
+      .on("close", resolve);
+  });
+  if (code !== 0) failed = true;
+}
+
+vite?.kill();
+process.exit(failed ? 1 : 0);

--- a/admin/spa/tests/settings.mjs
+++ b/admin/spa/tests/settings.mjs
@@ -1,0 +1,91 @@
+// Settings-model suite: one config section per view, route-driven nav, the
+// unified draft across sections, nav guard, mobile chips. Never confirms a
+// Save — every flow ends in Cancel/Discard so live config is untouched.
+import { BASE, check, gotoFresh, summary, withPage } from "./harness.mjs";
+
+const POLL = 'input[aria-label="Poll interval (seconds)"]';
+const GLOBAL_MAX = 'input[aria-label="Global max Devs"]';
+
+await withPage(async (page) => {
+  // 1-2: bare and unknown #/config land on the first section
+  await gotoFresh(page, "#/config");
+  await page.waitForSelector("#pmo");
+  check("bare #/config redirects to #/config/pmo", page.url().endsWith("#/config/pmo"));
+  await gotoFresh(page, "#/config/definitely-not-a-section");
+  await page.waitForSelector("#pmo");
+  check("unknown section redirects to #/config/pmo", page.url().endsWith("#/config/pmo"));
+
+  // 3: exactly one section per view
+  check("PMO view renders only the PMO section",
+    await page.locator("#pmo").count() === 1 && await page.locator("#limits").count() === 0);
+  await gotoFresh(page, "#/config/limits");
+  await page.waitForSelector("#limits");
+  check("Limits view renders only the Limits section",
+    await page.locator("#limits").count() === 1 && await page.locator("#pmo").count() === 0);
+
+  // 4: sidebar sub-nav highlight is route-driven
+  const activeLink = page.locator('aside a[href="#/config/limits"]');
+  check("sidebar sub-nav highlights the routed section",
+    ((await activeLink.getAttribute("class")) || "").includes("font-semibold"));
+
+  // 5: one draft across sections — edit in two sections, count reaches 2
+  const dirtyCount = async () => {
+    const bar = page.locator('span:has-text("Unsaved changes")').first();
+    return (await bar.count()) ? ((await bar.textContent()).match(/\((\d+)\)/) || [])[1] : null;
+  };
+  await gotoFresh(page, "#/config/pmo");
+  const poll = page.locator(POLL);
+  const pollBefore = await poll.inputValue();
+  await poll.fill(String(Number(pollBefore) + 1));
+  await page.waitForSelector('span:has-text("Unsaved changes")');
+  check("edit in PMO section marks the draft dirty (1)", (await dirtyCount()) === "1");
+  await page.click('aside a[href="#/config/limits"]');   // same-page section switch
+  await page.waitForSelector(GLOBAL_MAX);
+  const gmax = page.locator(GLOBAL_MAX);
+  const gmaxBefore = await gmax.inputValue();
+  await gmax.fill(String(Number(gmaxBefore) + 1));
+  check("edit in Limits section joins the same draft (2)", (await dirtyCount()) === "2");
+
+  // 6: Save opens the review dialog listing both edits — then Cancel
+  await page.click('button:has-text("Save changes…")');
+  await page.waitForSelector('[role="dialog"]');
+  const review = page.locator('[role="dialog"]');
+  check("save review lists both edits",
+    (await review.locator("text=Review 2 changes").count()) === 1);
+  check("review shows the Poll interval row",
+    (await review.locator("text=Poll interval").count()) >= 1);
+  await review.locator('button:has-text("Cancel")').click();
+  check("cancelling the review keeps the draft dirty", (await dirtyCount()) === "2");
+
+  // 7: nav guard on leaving Config dirty; Esc = Stay
+  await page.click('aside a[href="#/runs"]');
+  await page.waitForSelector("text=You have 2 unsaved changes");
+  check("nav guard appears when leaving Config dirty", true);
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(150);
+  check("Esc on the nav guard stays on Config",
+    page.url().includes("#/config/") &&
+    (await page.locator("text=You have 2 unsaved changes").count()) === 0);
+
+  // cleanup: discard the draft, verify clean
+  await page.click('button:has-text("Discard changes")');
+  await page.waitForTimeout(150);
+  check("discard clears the dirty bar",
+    (await page.locator("text=Unsaved changes").count()) === 0);
+  check("discard restored the edited value",
+    (await page.locator(GLOBAL_MAX).inputValue()) === gmaxBefore);
+});
+
+// 8: mobile — chip row switches sections, active chip highlighted
+await withPage(async (page) => {
+  await gotoFresh(page, "#/config/skills");
+  const chip = page.locator('a[href="#/config/skills"]:visible', { hasText: "Skills" }).first();
+  check("mobile chip row shows the active section",
+    ((await chip.getAttribute("class")) || "").includes("border-accent"));
+  await page.locator('a[href="#/config/limits"]:visible', { hasText: "Limits" }).first().click();
+  await page.waitForSelector("#limits");
+  check("mobile chip switches sections",
+    await page.locator("#limits").count() === 1 && await page.locator("#skills").count() === 0);
+}, { width: 390, height: 844 });
+
+summary("settings");


### PR DESCRIPTION
Follow-ups from the PR #8 review, plus the verification that PR honestly listed as missing.

## Fixes
- **Stale copy**: two "Skills section *below*" strings in ConfigPage predated the one-section-per-view split.
- **MoreMenu keyboard support** (WAI-ARIA menu-button): focus enters the menu on open; ArrowUp/Down/Home/End move with roving tabIndex; Esc/Tab close and return focus to the trigger; ArrowDown on the closed trigger opens.
- **RunTerminal** now uses the shared `Overlay` (new `surfaceClass` prop keeps its always-dark chrome) — gains the focus trap, Esc close, `<main>` scroll lock and focus restore.
- **Skills header edge**: with no store `html_url` the ⋯ menu held a single non-destructive item; a lone action stays a visible ghost button (DESIGN §3).
- `skillsMsg` dismiss timer cleaned up on unmount.

## Committed behavioral suite — `npm run check:ui`
PR #8's 37 checks were run ad-hoc and never committed; `admin/spa/tests/` makes them reproducible: **settings model** (redirects, one-section-per-view, cross-section draft, nav guard Esc=Stay), **action hierarchy** (no bare destructive buttons, every ⋯ item reaches its dialog, full keyboard operation), **redesign invariants** (masthead, oven strip, manual dark mode, help popover, RunTerminal dialog). playwright-core drives the cached Chromium headless shell; the runner boots vite itself; native dialogs are an instant failure; no flow ever confirms a Save. Local-only for now (CI has no live stack); DESIGN.md §8 now names it in the definition of done.

## Evidence (Always Works™)
- `npm run build` green; suite **46/46 against vite** and **46/46 against the freshly baked prod container** (`docker buildx bake admin && docker compose up -d admin`, now serving the redesign).
- Screens (dev-types ⋯ menu, skills, config) inspected light + dark + 390 px.
- **The four flows PR #8 left unproven, now driven for real** on the live stack:
  - Real Save PUT: poll interval 15→16, verified server-side, then 16→15 — config ends exactly as found.
  - Restore built-in skills: success note shown, catalog unchanged.
  - Skill folder import: throwaway `devcake-import-probe` uploaded via the Import files tab, appeared in the table, deleted through the row action + confirm — store back as found.
  - OAuth wizard: dialog reaches its states honestly — on this stack the harness login exits 1 (`Login failed: login exited 1` surfaced in-dialog), so the device-code screen itself still awaits a stack with a working harness login. That failure is backend-side, not the wizard UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)