### PR TITLE
feat(settings): settings bundle + config profiles (ADR-0013, part 1 of 2)

### DIFF
--- a/admin/spa/src/components/Modal.jsx
+++ b/admin/spa/src/components/Modal.jsx
@@ -58,16 +58,25 @@ export function Overlay({ children, className = "", onDismiss }) {
 }
 
 // No Escape/backdrop close on purpose: confirms guard consequential actions,
-// so only the explicit buttons may resolve the dialog.
-export function ConfirmDialog({ open, title, body, confirmLabel, busy, onConfirm, onCancel }) {
+// so only the explicit buttons may resolve the dialog. `children` renders
+// between body and buttons (e.g. an apply-preview diff); `error` keeps the
+// dialog open with the failure visible so the operator can retry or cancel.
+export function ConfirmDialog({ open, title, body, confirmLabel, busy, error,
+                                children, onConfirm, onCancel }) {
   if (!open) return null;
   return (
     <Overlay className="max-w-lg p-6">
       <h4 className="mb-2 text-base font-semibold tracking-tight">{title}</h4>
-      <p className="mb-5 whitespace-pre-line text-sm text-neutral-600 dark:text-neutral-300">
+      <p className="mb-4 whitespace-pre-line text-sm text-neutral-600 dark:text-neutral-300">
         {body}
       </p>
-      <div className="flex justify-end gap-2">
+      {children}
+      {error && (
+        <p className="mt-3 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/60 dark:text-red-300">
+          {error}
+        </p>
+      )}
+      <div className="mt-5 flex justify-end gap-2">
         <Button kind="ghost" disabled={busy} onClick={onCancel}>Cancel</Button>
         <Button kind="danger" disabled={busy} onClick={onConfirm}>
           {busy ? "Working…" : confirmLabel}

--- a/admin/spa/src/components/ProfilesSection.jsx
+++ b/admin/spa/src/components/ProfilesSection.jsx
@@ -1,0 +1,372 @@
+import React, { useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { get, send } from "../api.js";
+import { useSharedDraft } from "../lib/ConfigDraftContext.jsx";
+import { relTime } from "../lib/format.js";
+import Button from "./Button.jsx";
+import { Section } from "./Card.jsx";
+import { Select } from "./Field.jsx";
+import ImmediateBadge from "./ImmediateBadge.jsx";
+import InstantZone from "./InstantZone.jsx";
+import { ConfirmDialog, PromptDialog } from "./Modal.jsx";
+import MoreMenu from "./MoreMenu.jsx";
+import SettingRow from "./SettingRow.jsx";
+
+// Config profiles (ADR-0013): named snapshots of the runtime settings AND
+// secret values, applied as a whole. Everything here is Instant — a profile
+// carries secret values, which by design never enter the client-side draft;
+// destructive safety comes from ConfirmDialog previews, not the draft regime.
+// The UI deals in presence and counts only — a secret value never reaches
+// this component.
+
+const APPLY_BODY = (name) =>
+  `Replaces the runtime settings this profile contains: PMO connections, ` +
+  `repositories, Dev Types, prompt templates and active selections, limits — ` +
+  `and every stored secret value when the profile carries secrets. Current ` +
+  `settings are not kept anywhere unless you saved them as a profile first. ` +
+  `Run history, the skill store, internal repos, and .env values are ` +
+  `untouched. Blocked while runs are active.`;
+
+function countLine(counts) {
+  const bits = [];
+  if (counts.pmos) bits.push(`${counts.pmos} PMO${counts.pmos > 1 ? "s" : ""}`);
+  if (counts.repos) bits.push(`${counts.repos} repo${counts.repos > 1 ? "s" : ""}`);
+  if (counts.dev_types) bits.push(`${counts.dev_types} Dev Type${counts.dev_types > 1 ? "s" : ""}`);
+  if (counts.prompt_templates) bits.push(`${counts.prompt_templates} template${counts.prompt_templates > 1 ? "s" : ""}`);
+  if (counts.secrets) bits.push(`${counts.secrets} secret${counts.secrets > 1 ? "s" : ""}`);
+  return bits.length ? bits.join(" · ") : "empty snapshot";
+}
+
+// Compact apply-preview: the diff the backend computed — names and counts,
+// never values (ADR-0011).
+function DiffPreview({ diff }) {
+  if (!diff) return null;
+  const cfg = diff.sections?.config;
+  const sec = diff.sections?.secrets;
+  const rows = [];
+  if (cfg) {
+    if (cfg.app_changed?.length)
+      rows.push(["Settings", `${cfg.app_changed.length} value${cfg.app_changed.length > 1 ? "s" : ""} change (${cfg.app_changed.slice(0, 6).join(", ")}${cfg.app_changed.length > 6 ? ", …" : ""})`]);
+    const d = cfg.dev_types || {};
+    const devBits = [
+      d.added?.length && `+${d.added.length}`,
+      d.changed?.length && `${d.changed.length} changed`,
+      d.removed?.length && `removes ${d.removed.join(", ")}`,
+    ].filter(Boolean);
+    if (devBits.length) rows.push(["Dev Types", devBits.join(" · ")]);
+    const t = cfg.prompt_templates || {};
+    const tplBits = [
+      t.added?.length && `+${t.added.length}`,
+      t.removed?.length && `removes ${t.removed.length}`,
+    ].filter(Boolean);
+    if (tplBits.length) rows.push(["Prompt templates", tplBits.join(" · ")]);
+  }
+  if (sec) {
+    const flat = (g) => (g.added?.length || 0) + (g.replaced?.length || 0);
+    const dels = [...(sec.connections?.removed || []), ...(sec.harness?.removed || [])];
+    const writes = flat(sec.connections || {}) + flat(sec.harness || {});
+    const bits = [];
+    if (writes) bits.push(`${writes} value${writes > 1 ? "s" : ""} written`);
+    if (dels.length) bits.push(`deletes ${dels.join(", ")}`);
+    rows.push(["Secrets", bits.length ? bits.join(" · ") : "no changes"]);
+  }
+  return (
+    <div data-testid="apply-preview"
+      className="rounded-md border border-neutral-200 bg-stone-50 px-3 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-950">
+      {rows.length === 0 && (
+        <p className="text-neutral-500 dark:text-neutral-400">
+          No differences from the current settings.
+        </p>
+      )}
+      {rows.map(([k, v]) => (
+        <p key={k} className="py-0.5">
+          <span className="font-medium">{k}:</span>{" "}
+          <span className="text-neutral-600 dark:text-neutral-300">{v}</span>
+        </p>
+      ))}
+      {(diff.warnings || []).map((w) => (
+        <p key={w} className="py-0.5 text-amber-600 dark:text-amber-400">⚠ {w}</p>
+      ))}
+    </div>
+  );
+}
+
+export default function ProfilesSection() {
+  const { dr, reload } = useSharedDraft();
+  const [profiles, setProfiles] = useState(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [note, setNote] = useState(null);          // {kind: "ok"|"warn", text}
+  const [saveAs, setSaveAs] = useState(null);      // {busy, error}
+  const [overwrite, setOverwrite] = useState(null); // {name, busy, error}
+  const [applyPick, setApplyPick] = useState("");
+  const [applying, setApplying] = useState(null);  // {name, diff, busy, error}
+  const [renaming, setRenaming] = useState(null);  // {name, busy, error}
+  const [deleting, setDeleting] = useState(null);  // {name, busy, error}
+
+  const load = () =>
+    get("/profiles")
+      .then((d) => { setProfiles(d.profiles); setLoadFailed(false); })
+      .catch(() => setLoadFailed(true));
+  useEffect(() => { load(); }, []);
+
+  const dirty = dr.dirty;
+
+  const doSave = async (name, ow) => {
+    const setter = ow ? setOverwrite : setSaveAs;
+    setter((s) => ({ ...s, busy: true, error: "" }));
+    try {
+      const out = await send("POST", "/profiles",
+        ow ? { name, overwrite: true } : { name });
+      setSaveAs(null);
+      setOverwrite(null);
+      setNote(out.warnings?.length
+        ? { kind: "warn", text: `Saved “${out.name}” — ${out.warnings.join("; ")}` }
+        : { kind: "ok", text: `Saved “${out.name}”.` });
+      load();
+    } catch (e) {
+      if (!ow && e.status === 409) { setSaveAs(null); setOverwrite({ name }); }
+      else setter((s) => ({ ...s, busy: false, error: String(e.message || e) }));
+    }
+  };
+
+  const startApply = async (name) => {
+    setApplying({ name, diff: null, busy: false, error: "" });
+    try {
+      const detail = await get(`/profiles/${encodeURIComponent(name)}`);
+      setApplying((a) => (a && a.name === name ? { ...a, diff: detail.diff } : a));
+    } catch (e) {
+      setApplying((a) => (a && a.name === name
+        ? { ...a, error: String(e.message || e) } : a));
+    }
+  };
+
+  const doApply = async () => {
+    const name = applying.name;
+    setApplying((a) => ({ ...a, busy: true, error: "" }));
+    try {
+      const out = await send("POST", `/profiles/${encodeURIComponent(name)}/apply`);
+      setApplying(null);
+      setApplyPick("");
+      await reload();                       // the whole world changed
+      setNote(out.warnings?.length
+        ? { kind: "warn", text: `Applied “${name}” — ${out.warnings.join("; ")}` }
+        : { kind: "ok", text: `Applied “${name}”. Settings reloaded.` });
+      load();
+    } catch (e) {
+      setApplying((a) => ({ ...a, busy: false, error: String(e.message || e) }));
+    }
+  };
+
+  const doRename = async (newName) => {
+    setRenaming((s) => ({ ...s, busy: true, error: "" }));
+    try {
+      await send("POST",
+        `/profiles/${encodeURIComponent(renaming.name)}/rename`,
+        { new_name: newName });
+      setRenaming(null);
+      load();
+    } catch (e) {
+      setRenaming((s) => ({ ...s, busy: false, error: String(e.message || e) }));
+    }
+  };
+
+  const doDelete = async () => {
+    setDeleting((s) => ({ ...s, busy: true, error: "" }));
+    try {
+      await send("DELETE", `/profiles/${encodeURIComponent(deleting.name)}`);
+      setDeleting(null);
+      load();
+    } catch (e) {
+      setDeleting((s) => ({ ...s, busy: false, error: String(e.message || e) }));
+    }
+  };
+
+  const rows = profiles || [];
+
+  return (
+    <Section id="profiles" title="Profiles"
+      description="Named snapshots of your settings and secrets — save the current setup, switch between saved ones."
+      help="A profile captures the saved runtime settings (connections, repos, Dev Types, prompt templates, limits) and every stored secret value. Applying replaces the current settings with the snapshot; later edits never update a profile. Secret values are stored on the server and never shown here."
+      actions={
+        <>
+          <ImmediateBadge text="everything here applies immediately" />
+          <Button icon={Plus} onClick={() => setSaveAs({ busy: false, error: "" })}>
+            Save current as profile…
+          </Button>
+        </>
+      }>
+      {note && (
+        <p className={note.kind === "warn"
+          ? "rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+          : "rounded-md border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300"}>
+          {note.text}
+        </p>
+      )}
+      {dirty && (
+        <p className="text-xs text-amber-600 dark:text-amber-400">
+          You have unsaved changes — snapshots contain only saved settings,
+          and applying is disabled until you Save or Discard.
+        </p>
+      )}
+
+      <InstantZone note="applying replaces settings immediately">
+        <SettingRow label="Apply a profile"
+          desc="Replace the current settings with a saved snapshot."
+          help="Shows a preview of what changes before anything applies. Blocked while runs are active — pause intake and let runs finish first.">
+          <Select className="w-48" value={applyPick}
+            aria-label="Profile to apply"
+            disabled={!rows.length}
+            onChange={(e) => setApplyPick(e.target.value)}>
+            <option value="">choose a profile…</option>
+            {rows.filter((r) => !r.broken).map((r) => (
+              <option key={r.name} value={r.name}>{r.name}</option>
+            ))}
+          </Select>
+          <Button disabled={!applyPick || dirty}
+            title={dirty
+              ? "Save or discard your unsaved changes first — applying replaces the saved settings"
+              : undefined}
+            onClick={() => startApply(applyPick)}>
+            Apply profile…
+          </Button>
+        </SettingRow>
+      </InstantZone>
+
+      {profiles === null && (loadFailed ? (
+        <p className="text-sm text-red-700 dark:text-red-300">
+          Couldn&apos;t load the profiles.{" "}
+          <button type="button" onClick={load}
+            className="font-medium underline underline-offset-2">
+            Retry
+          </button>
+        </p>
+      ) : (
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">Loading profiles…</p>
+      ))}
+      {profiles !== null && rows.length === 0 && (
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          No profiles yet — save your current settings as your first profile.
+        </p>
+      )}
+      {rows.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[36rem] text-left text-sm">
+            <thead>
+              <tr className="border-b border-neutral-200 text-xs uppercase tracking-wide text-neutral-500 dark:border-neutral-800 dark:text-neutral-400">
+                <th className="py-2 pr-3 font-medium">Profile</th>
+                <th className="py-2 pr-3 font-medium">Captured</th>
+                <th className="py-2 pr-3 font-medium">Last applied</th>
+                <th className="py-2 font-medium"><span className="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-100 dark:divide-neutral-800">
+              {rows.map((r) => (
+                <tr key={r.name}>
+                  <td className="py-2.5 pr-3 align-top">
+                    <span className="font-mono text-sm font-medium">{r.name}</span>
+                    {r.broken && (
+                      <span className="ml-2 text-xs text-red-600 dark:text-red-400">
+                        unreadable snapshot
+                      </span>
+                    )}
+                    {!r.broken && !(r.sections || []).includes("secrets") && (
+                      <span className="ml-2 rounded bg-stone-100 px-1.5 py-0.5 text-[10px] font-medium text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
+                        configs only
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-2.5 pr-3 align-top text-neutral-600 dark:text-neutral-300">
+                    {r.broken ? "—" : (
+                      <>
+                        {r.created_at ? relTime(r.created_at) : "—"}
+                        <span className="block text-xs text-neutral-500 dark:text-neutral-400">
+                          {countLine(r.counts || {})}
+                        </span>
+                      </>
+                    )}
+                  </td>
+                  <td className="py-2.5 pr-3 align-top text-neutral-600 dark:text-neutral-300">
+                    {r.last_applied_at ? (
+                      <>
+                        {relTime(r.last_applied_at)}
+                        <span className="block text-xs text-neutral-500 dark:text-neutral-400">
+                          {r.diverged === true ? "settings changed since"
+                            : r.diverged === false ? "matches as of apply" : ""}
+                        </span>
+                      </>
+                    ) : "—"}
+                  </td>
+                  <td className="py-2.5 text-right align-top">
+                    <MoreMenu label={`More actions for profile ${r.name}`}
+                      items={[
+                        { label: "Rename",
+                          desc: "The snapshot is unchanged — only the name.",
+                          onClick: () => setRenaming({ name: r.name, busy: false, error: "" }) },
+                        { label: "Delete", danger: true,
+                          desc: "Removes the snapshot; current settings are untouched.",
+                          onClick: () => setDeleting({ name: r.name, busy: false, error: "" }) },
+                      ]} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <PromptDialog open={!!saveAs}
+        title="Save current settings as a profile"
+        label="Profile name"
+        hint="Snapshots the saved runtime settings and secret values. Letters/digits/spaces/dashes/underscores, ≤64 chars."
+        placeholder="e.g. staging"
+        confirmLabel="Save profile"
+        busy={saveAs?.busy}
+        error={saveAs?.error}
+        onConfirm={(name) => doSave(name, false)}
+        onCancel={() => setSaveAs(null)} />
+
+      <ConfirmDialog open={!!overwrite}
+        title={`Overwrite profile “${overwrite?.name}”?`}
+        body={"Its stored snapshot is replaced with the current settings. The old snapshot cannot be recovered."}
+        confirmLabel="Overwrite profile"
+        busy={overwrite?.busy}
+        error={overwrite?.error}
+        onConfirm={() => doSave(overwrite.name, true)}
+        onCancel={() => setOverwrite(null)} />
+
+      <ConfirmDialog open={!!applying}
+        title={`Apply profile “${applying?.name}”?`}
+        body={applying ? APPLY_BODY(applying.name) : ""}
+        confirmLabel="Apply profile"
+        busy={applying?.busy}
+        error={applying?.error}
+        onConfirm={doApply}
+        onCancel={() => setApplying(null)}>
+        {applying && !applying.diff && !applying.error && (
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">Computing preview…</p>
+        )}
+        {applying?.diff && <DiffPreview diff={applying.diff} />}
+      </ConfirmDialog>
+
+      <PromptDialog open={!!renaming}
+        title={`Rename profile “${renaming?.name}”`}
+        label="New name"
+        initial={renaming?.name || ""}
+        hint="The snapshot is unchanged — only the name."
+        confirmLabel="Rename"
+        busy={renaming?.busy}
+        error={renaming?.error}
+        onConfirm={doRename}
+        onCancel={() => setRenaming(null)} />
+
+      <ConfirmDialog open={!!deleting}
+        title={`Delete profile “${deleting?.name}”?`}
+        body="Deletes the stored snapshot, including its secret values. Your current live settings are not affected."
+        confirmLabel="Delete profile"
+        busy={deleting?.busy}
+        error={deleting?.error}
+        onConfirm={doDelete}
+        onCancel={() => setDeleting(null)} />
+    </Section>
+  );
+}

--- a/admin/spa/src/lib/nav.js
+++ b/admin/spa/src/lib/nav.js
@@ -6,6 +6,7 @@ export const CONFIG_SECTIONS = [
   { id: "skills", label: "Skills" },
   { id: "assignments", label: "Assignments" },
   { id: "prompts", label: "Prompts" },
+  { id: "profiles", label: "Profiles" },
   { id: "limits", label: "Limits" },
   { id: "traffic", label: "Traffic control" },
 ];

--- a/admin/spa/src/pages/ConfigPage.jsx
+++ b/admin/spa/src/pages/ConfigPage.jsx
@@ -11,6 +11,7 @@ import Toggle from "../components/Toggle.jsx";
 import { ConfirmDialog, Modal, PromptDialog } from "../components/Modal.jsx";
 import ImmediateBadge from "../components/ImmediateBadge.jsx";
 import MoreMenu from "../components/MoreMenu.jsx";
+import ProfilesSection from "../components/ProfilesSection.jsx";
 import PromptsSection from "../components/PromptsSection.jsx";
 import SelectionChips from "../components/SelectionChips.jsx";
 import { ADOPTION_COPY } from "../lib/configLabels.js";
@@ -985,6 +986,8 @@ export default function ConfigPage({ section }) {
       <PromptsSection cfg={cfg} setField={setField}
         devTypeNames={Object.keys(dr.draft.devTypes || {})} />
       )}
+
+      {section === "profiles" && <ProfilesSection />}
 
       {section === "limits" && (
       <Section id="limits" title="Limits"

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -22,8 +22,12 @@ from ..adapters.dagu import DAGU_URL, DaguExecutor, DuplicateRun
 from ..adapters.files import RunLogStore, RunStore
 from ..adapters.redis import Messaging
 from ..adapters.registry import make_forge, make_internal_forge, make_pmo
+from .. import profiles as profiles_store
 from .. import secrets as secrets_store
 from .. import security
+from ..settings_bundle import (BundleError, apply_bundle, audit_event,
+                               diff_bundle, dry_run_adapters,
+                               serialize_current, validate_config_semantics)
 from ..config import (HARNESS_VAR_PATTERN, AppConfig, Assignment, DevType,
                       _INSTANCE_NAME_RE, deep_merge, delete_dev_type,
                       load_config, load_dev_types, reject_stale_patch,
@@ -719,35 +723,17 @@ async def put_config(body: dict):
         merged = AppConfig.model_validate(deep_merge(config.model_dump(), body))
     except Exception as e:
         raise HTTPException(422, str(e))
-    rm = merged.relations_mapper
-    if rm.enabled and (not rm.dev_type or rm.dev_type not in dev_types):
-        raise HTTPException(422, "relations_mapper.dev_type must name an existing "
-                                 "Dev Type when the mapper is enabled")
-    if rm.interval_minutes < 1:
-        raise HTTPException(422, "relations_mapper.interval_minutes must be ≥ 1")
-    from ..prompts import PLAYBOOK_VARS
-    for mt, name in (merged.active_prompt_templates or {}).items():
-        if mt not in PLAYBOOK_VARS:
-            raise HTTPException(422, f"active_prompt_templates: unknown "
-                                     f"mission type {mt!r}")
-        if prompt_templates.resolve_playbook(mt, name)[1]:
-            raise HTTPException(422, f"active_prompt_templates: no stored "
-                                     f"template {mt}/{name}")
-    for dt_name, name in (merged.active_devtype_prompts or {}).items():
-        if dt_name not in dev_types:
-            raise HTTPException(422, f"active_devtype_prompts: unknown "
-                                     f"Dev Type {dt_name!r}")
-    # Dry-run adapter construction before persist (ISSUES #11): a bad URL or
-    # forge shape must not leave a broken config on disk. Unconfigured
-    # instances (empty team_key / repo URL) are valid-but-idle (schema v3).
+    # cross-store semantics + dry-run adapter construction (ISSUES #11) live
+    # in settings_bundle — ONE implementation shared with bundle apply
+    # (ADR-0013); the PUT resolves templates against disk
     try:
-        for inst in merged.pmos:
-            make_pmo(inst)
-        for repo in merged.repos:
-            if repo.configured:
-                make_forge(repo)
-    except Exception as e:
-        raise HTTPException(422, f"adapter construction failed: {e}") from e
+        validate_config_semantics(
+            merged, set(dev_types),
+            template_exists=lambda mt, name:
+                not prompt_templates.resolve_playbook(mt, name)[1])
+        dry_run_adapters(merged)
+    except BundleError as e:
+        raise HTTPException(e.status, str(e))
     previous = config.model_dump()
     # a removed instance's stored secrets go with it — otherwise a later
     # instance reusing the name silently inherits the dead credential
@@ -789,6 +775,148 @@ async def put_config(body: dict):
         log.info("auto_merge flipped ON — parked DEVCAKE-MERGE missions "
                  "re-armed for the deferred-merge sweep")
     return config.model_dump()
+
+
+# ── config profiles (ADR-0013): named snapshots of settings + secrets ────────
+
+def _require_no_active_runs(action: str) -> None:
+    """World-swaps are blocked while runs are in flight (founder decision) —
+    the internal-repo delete guard pattern, applied to whole-settings
+    replacement."""
+    n = len(store.active())
+    if n:
+        raise HTTPException(
+            409, f"{n} run(s) active — wait for them to finish or clear "
+                 f"runs before {action}")
+
+
+def _snapshot_warnings(bundle: dict) -> list[str]:
+    """A snapshot silently missing credentials its config expects is a trap
+    at apply time — name the gaps at save time instead."""
+    warns = []
+    sec = bundle.get("secrets") or {}
+    conns = sec.get("connections") or {}
+    cfg = bundle.get("config") or {}
+    for p in (cfg.get("app") or {}).get("pmos") or []:
+        if p.get("team_key") and not (conns.get(f"pmo-{p['name']}") or {}).get("api_key"):
+            warns.append(f"PMO {p['name']!r} is configured but has no stored "
+                         "API key — the snapshot carries none")
+    for r in (cfg.get("app") or {}).get("repos") or []:
+        stored = conns.get(f"repo-{r['name']}") or {}
+        if r.get("url") and not (stored.get("token") or stored.get("token_ro")):
+            warns.append(f"repo {r['name']!r} is configured but has no stored "
+                         "token — the snapshot carries none")
+    return warns
+
+
+@app.get("/api/v1/profiles")
+async def list_profiles():
+    """Profile rows for the admin table — counts and presence only. The
+    last-applied breadcrumb + divergence boolean ride the matching row
+    (dict compare + secret timestamps, never values — ADR-0011)."""
+    rows = profiles_store.list_profiles()
+    la = profiles_store.last_applied()
+    for row in rows:
+        row["last_applied_at"] = None
+        row["diverged"] = None
+        if la and la.get("name") == row["name"] and not row.get("broken"):
+            row["last_applied_at"] = la.get("at")
+            try:
+                bundle = profiles_store.read_profile(row["name"])
+                row["diverged"] = profiles_store.diverged_since(
+                    bundle, la.get("at") or "", config, dev_types)
+            except BundleError:
+                row["diverged"] = None
+    return {"profiles": rows}
+
+
+@app.get("/api/v1/profiles/{name}")
+async def get_profile(name: str):
+    """Full section A + a secrets PRESENCE map + the apply-preview diff.
+    Secret values never leave this endpoint."""
+    try:
+        bundle = profiles_store.read_profile(name)
+        diff = diff_bundle(bundle, config, dev_types)
+    except BundleError as e:
+        raise HTTPException(e.status, str(e))
+    presence = None
+    if "secrets" in (bundle.get("sections") or []):
+        sec = bundle.get("secrets") or {}
+        presence = {"connections": {k: sorted(f) for k, f in
+                                    (sec.get("connections") or {}).items()},
+                    "harness": sorted(sec.get("harness") or {})}
+    return {"name": bundle.get("name", name),
+            "created_at": bundle.get("created_at"),
+            "devcake_tag": bundle.get("devcake_tag", ""),
+            "sections": bundle.get("sections") or [],
+            "config": bundle.get("config"),
+            "secrets_present": presence,
+            "diff": diff}
+
+
+@app.post("/api/v1/profiles")
+async def save_profile(body: dict):
+    """Save-current-as: snapshot the live settings (A) + secret values (B)
+    under a name. 409 on collision unless overwrite — the UI chains an
+    explicit overwrite confirm."""
+    name = str(body.get("name") or "")
+    bundle = serialize_current(config, dev_types,
+                               include_config=True, include_secrets=True)
+    try:
+        profiles_store.save_profile(name, bundle,
+                                    overwrite=bool(body.get("overwrite")))
+    except BundleError as e:
+        raise HTTPException(e.status, str(e))
+    warnings = _snapshot_warnings(bundle)
+    sec = bundle.get("secrets") or {}
+    audit_event("profile_saved",
+                f"name={name} secrets="
+                f"{sum(len(f) for f in (sec.get('connections') or {}).values()) + len(sec.get('harness') or {})}")
+    return {"saved": True, "name": name, "warnings": warnings}
+
+
+@app.post("/api/v1/profiles/{name}/apply")
+async def apply_profile(name: str):
+    """THE world-swap: replaces the sections the profile contains (a profile
+    without secrets keeps the live ones). Blocked while runs are active;
+    rollback-by-reapply on reload failure (settings_bundle)."""
+    _require_no_active_runs("applying a profile")
+    try:
+        bundle = profiles_store.read_profile(name)
+        result = apply_bundle(bundle, config=config, dev_types=dev_types,
+                              reload=reload_connections)
+    except BundleError as e:
+        raise HTTPException(e.status, str(e))
+    if "secrets" in result["applied"]:
+        # fresh credentials clear latched auth state, same as the individual
+        # secret PUT endpoints do
+        shared_breakers.clear()
+        forge_runtime.breakers.clear()
+    profiles_store.record_applied(name)
+    audit_event("profile_applied",
+                f"name={name} sections={'+'.join(result['applied'])}")
+    return {"profile": name, **result}
+
+
+@app.post("/api/v1/profiles/{name}/rename")
+async def rename_profile(name: str, body: dict):
+    new = str(body.get("new_name") or "")
+    try:
+        profiles_store.rename_profile(name, new)
+    except BundleError as e:
+        raise HTTPException(e.status, str(e))
+    audit_event("profile_renamed", f"{name} -> {new}")
+    return {"renamed": True, "name": new}
+
+
+@app.delete("/api/v1/profiles/{name}")
+async def delete_profile(name: str):
+    try:
+        profiles_store.delete_profile(name)
+    except BundleError as e:
+        raise HTTPException(e.status, str(e))
+    audit_event("profile_deleted", f"name={name}")
+    return {"deleted": name}
 
 
 # ── per-Mission-Type prompt templates (v0.1.1) ───────────────────────────────
@@ -1004,11 +1132,11 @@ async def put_assignments(body: dict):
 
 # ── GUI-stored secrets (M12, F5): write-only VALUES, never echoed back ───────
 
-_SECRET_SCOPES = {"pmo", "repo"}
-# per-scope field allowlist — scope/instance/field all reach the filesystem
-# as path components, so every entry point validates against these (audit A5/A9)
-_SECRET_FIELDS = {"pmo": {"api_key"},
-                  "repo": {"token", "token_ro", "reviewer_token"}}
+_SECRET_SCOPES = set(secrets_store.CONNECTION_FIELDS)
+# per-scope field allowlist — ONE definition (secrets.CONNECTION_FIELDS,
+# shared with settings_bundle); scope/instance/field all reach the filesystem
+# as path components, so every entry point validates against it (audit A5/A9)
+_SECRET_FIELDS = secrets_store.CONNECTION_FIELDS
 _HARNESS_VAR_RE = re.compile(f"^{HARNESS_VAR_PATTERN}$")   # one definition: config.py
 
 

--- a/app/devcake/profiles.py
+++ b/app/devcake/profiles.py
@@ -1,0 +1,242 @@
+"""Config profiles (ADR-0013): named, fully independent snapshots of the
+deployment's runtime settings — section A (configs) and optionally section B
+(secret values) of a settings bundle.
+
+Storage splits a profile across the two stores it snapshots, preserving each
+store's invariants:
+    /data/config/profiles/{name}.yaml    section A + metadata (plain, diffable)
+    /data/secrets/profiles/{name}.json   section B (0600, redaction-glob level)
+
+A profile is fire-and-forget: applying one replaces the live world, but later
+edits do not update the profile, and there is no "active profile" — an honest
+match indicator would need value-derived secret fingerprints, which ADR-0011
+bans. What we track instead is the last-applied breadcrumb (a /data/state
+sidecar, deliberately outside bundles and harmlessly wiped by clear-runs) and
+a divergence boolean computed from non-secret dict comparison plus secret
+updated_at timestamps — never values.
+
+Profiles have no built-ins, no seeding, and no fallback pointer: deleting one
+breaks nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+
+import yaml
+
+from . import secrets as secrets_store
+from .config import AppConfig, DevType, _atomic_yaml
+from .settings_bundle import (BUNDLE_KIND, BUNDLE_SCHEMA_VERSION, BundleError,
+                              _utcnow, serialize_current)
+
+log = logging.getLogger("devcake.profiles")
+
+# prompt-template naming convention (templates.py) — locked after creation;
+# rename is an explicit endpoint. Validated BEFORE any path join (audit A5/A9).
+PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
+
+
+def _dir() -> Path:
+    return (Path(os.environ.get("DEVCAKE_DATA_DIR", "/data"))
+            / "config" / "profiles")
+
+
+def _path(name: str) -> Path:
+    return _dir() / f"{name}.yaml"
+
+
+def _state_path() -> Path:
+    return (Path(os.environ.get("DEVCAKE_DATA_DIR", "/data"))
+            / "state" / "profiles.json")
+
+
+def require_name(name: str) -> None:
+    if not PROFILE_NAME_RE.fullmatch(name or ""):
+        raise BundleError(422, "profile name must match "
+                               "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────────────
+
+def save_profile(name: str, bundle: dict, *, overwrite: bool = False) -> None:
+    """Persist a bundle as a named profile: section A + metadata to the yaml,
+    section B (when present) to the sibling secrets json."""
+    require_name(name)
+    if _path(name).exists() and not overwrite:
+        raise BundleError(409, f"a profile named {name!r} already exists")
+    doc = {k: v for k, v in bundle.items() if k != "secrets"}
+    doc["kind"] = BUNDLE_KIND
+    doc["name"] = name
+    _atomic_yaml(_path(name), doc)
+    if "secrets" in bundle:
+        secrets_store.write_profile_secrets(name, bundle["secrets"])
+    else:
+        secrets_store.delete_profile_secrets(name)   # overwrite may narrow
+
+
+def read_profile(name: str) -> dict:
+    """Recombine yaml + secrets json into one bundle dict. A profile whose
+    sections list promises secrets but whose json is missing REFUSES — a
+    silent A-only apply would delete every live secret's pairing."""
+    require_name(name)
+    p = _path(name)
+    if not p.exists():
+        raise BundleError(404, f"no profile named {name!r}")
+    doc = yaml.safe_load(p.read_text())
+    if not isinstance(doc, dict):
+        raise BundleError(422, f"profile {name!r} is unreadable")
+    if doc.get("bundle_schema_version") != BUNDLE_SCHEMA_VERSION:
+        raise BundleError(
+            422, f"profile {name!r} carries bundle_schema_version "
+                 f"{doc.get('bundle_schema_version')!r}, current is "
+                 f"{BUNDLE_SCHEMA_VERSION} — profiles are not auto-migrated; "
+                 "re-save the profile from current settings")
+    if "secrets" in (doc.get("sections") or []):
+        try:
+            sec = secrets_store.read_profile_secrets(name)
+        except ValueError as e:
+            raise BundleError(422, str(e))
+        if sec is None:
+            raise BundleError(
+                422, f"profile {name!r} promises a secrets section but its "
+                     "snapshot file is missing — re-save the profile")
+        doc["secrets"] = sec
+    return doc
+
+
+def delete_profile(name: str) -> None:
+    require_name(name)
+    p = _path(name)
+    if not p.exists():
+        raise BundleError(404, f"no profile named {name!r}")
+    p.unlink()
+    secrets_store.delete_profile_secrets(name)
+
+
+def rename_profile(name: str, new_name: str) -> None:
+    require_name(name)
+    require_name(new_name)
+    src = _path(name)
+    if not src.exists():
+        raise BundleError(404, f"no profile named {name!r}")
+    if _path(new_name).exists():
+        raise BundleError(409, f"a profile named {new_name!r} already exists")
+    doc = yaml.safe_load(src.read_text()) or {}
+    doc["name"] = new_name
+    _atomic_yaml(_path(new_name), doc)
+    src.unlink()
+    secrets_store.rename_profile_secrets(name, new_name)
+    state = _read_state()
+    if (state.get("last_applied") or {}).get("name") == name:
+        state["last_applied"]["name"] = new_name
+        _write_state(state)
+
+
+def list_profiles() -> list[dict]:
+    """Metadata rows for the admin table — counts and presence only, never a
+    secret value. Unreadable profile files list as broken rather than vanish."""
+    if not _dir().is_dir():
+        return []
+    out = []
+    for p in sorted(_dir().glob("*.yaml")):
+        name = p.stem
+        try:
+            doc = yaml.safe_load(p.read_text())
+            assert isinstance(doc, dict)
+        except Exception:
+            out.append({"name": name, "broken": True})
+            continue
+        cfg = doc.get("config") or {}
+        app = cfg.get("app") or {}
+        secret_count = 0
+        if "secrets" in (doc.get("sections") or []):
+            try:
+                sec = secrets_store.read_profile_secrets(name) or {}
+                secret_count = (
+                    sum(len(f) for f in (sec.get("connections") or {}).values())
+                    + len(sec.get("harness") or {}))
+            except ValueError:
+                out.append({"name": name, "broken": True})
+                continue
+        out.append({
+            "name": name,
+            "created_at": doc.get("created_at"),
+            "devcake_tag": doc.get("devcake_tag", ""),
+            "sections": doc.get("sections") or [],
+            "counts": {
+                "pmos": len(app.get("pmos") or []),
+                "repos": len(app.get("repos") or []),
+                "dev_types": len(cfg.get("dev_types") or {}),
+                "prompt_templates": sum(
+                    len(v) for v in (cfg.get("prompt_templates") or {}).values()),
+                "secrets": secret_count,
+            },
+        })
+    return out
+
+
+# ── last-applied breadcrumb + divergence ─────────────────────────────────────
+
+def _read_state() -> dict:
+    p = _state_path()
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+def _write_state(state: dict) -> None:
+    p = _state_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(state))
+
+
+def record_applied(name: str) -> None:
+    state = _read_state()
+    state["last_applied"] = {"name": name, "at": _utcnow()}
+    _write_state(state)
+
+
+def last_applied() -> dict | None:
+    return _read_state().get("last_applied")
+
+
+def diverged_since(bundle: dict, applied_at: str, config: AppConfig,
+                   dev_types: dict[str, DevType]) -> bool:
+    """Honest divergence: has the live world changed since this profile was
+    applied? Non-secret sections compare as dicts; secrets compare by NAME
+    SET and updated_at timestamps — never by value (ADR-0011)."""
+    if bundle.get("config") is not None:
+        cur = serialize_current(config, dev_types,
+                                include_config=True, include_secrets=False)
+        if cur.get("config") != bundle.get("config"):
+            return True
+    sec = bundle.get("secrets")
+    if sec is not None:
+        live = {(k, f) for k, fs in
+                secrets_store.list_connection_secrets().items() for f in fs}
+        snap = {(k, f) for k, fs in
+                (sec.get("connections") or {}).items() for f in fs}
+        if live != snap:
+            return True
+        live_h = set(secrets_store.list_harness_secrets())
+        if live_h != set(sec.get("harness") or {}):
+            return True
+        for key, fields in (sec.get("connections") or {}).items():
+            scope, _, instance = key.partition("-")
+            for field in fields:
+                st = secrets_store.connection_status(scope, instance, field)
+                if st["updated_at"] and st["updated_at"] > applied_at:
+                    return True
+        for var in sec.get("harness") or {}:
+            st = secrets_store.harness_status(var)
+            if st["updated_at"] and st["updated_at"] > applied_at:
+                return True
+    return False

--- a/app/devcake/prompts/templates.py
+++ b/app/devcake/prompts/templates.py
@@ -205,6 +205,14 @@ def _dev_dir(dev_type: str) -> Path:
     return CONFIG_PATH.parent / "devtype_prompt_templates" / dev_type
 
 
+def known_devtype_dirs() -> list[Path]:
+    """Every dev type that has a prompt-template dir on disk — the settings-
+    bundle apply prunes dirs of dev types the bundle removed (ADR-0013)."""
+    from ..config import CONFIG_PATH
+    root = CONFIG_PATH.parent / "devtype_prompt_templates"
+    return sorted(p for p in root.iterdir() if p.is_dir()) if root.is_dir() else []
+
+
 def seed_devtype_prompts(dev_types: dict) -> None:
     """Top-up seeding at boot and on dev-type create: Development ← the dev
     type's current identifying prompt (once); Customer Success ← the preset

--- a/app/devcake/secrets.py
+++ b/app/devcake/secrets.py
@@ -26,6 +26,15 @@ from . import security
 
 log = logging.getLogger("devcake.secrets")
 
+# ONE definition of the per-scope connection-secret field allowlist —
+# api.main validates endpoint input against it and settings_bundle validates
+# bundle shapes. scope/instance/field become path components everywhere, so
+# every entry point re-validates against this (audit A5/A9).
+CONNECTION_FIELDS: dict[str, set[str]] = {
+    "pmo": {"api_key"},
+    "repo": {"token", "token_ro", "reviewer_token"},
+}
+
 
 def _root() -> Path:
     return Path(os.environ.get("DEVCAKE_DATA_DIR", "/data")) / "secrets"
@@ -174,25 +183,81 @@ def _iso(mtime: float) -> str:
     return datetime.fromtimestamp(mtime, timezone.utc).isoformat()
 
 
+def list_connection_secrets() -> dict[str, dict[str, str]]:
+    """{"{scope}-{instance}": {field: value}} for every stored connection
+    secret. VALUE-BEARING — the settings-bundle serializer and boot
+    registration are the only consumers (ADR-0013); the API never echoes
+    these."""
+    out: dict[str, dict[str, str]] = {}
+    conn_dir = _root() / "connections"
+    if conn_dir.exists():
+        for p in sorted(conn_dir.glob("*.json")):
+            fields = {k: v for k, v in _read(p).items()
+                      if isinstance(v, str) and v}
+            if fields:
+                out[p.stem] = fields
+    return out
+
+
+def list_harness_secrets() -> dict[str, str]:
+    """{VAR: value} for every stored harness/model key. Value-bearing — same
+    consumers and same caveat as list_connection_secrets."""
+    out: dict[str, str] = {}
+    harness_dir = _root() / "harness"
+    if harness_dir.exists():
+        for p in sorted(harness_dir.glob("*.json")):
+            value = _read(p).get("value")
+            if isinstance(value, str) and value:
+                out[p.stem] = value
+    return out
+
+
 def register_all() -> None:
     """Register every stored secret with the redaction layer at boot (the
     glob scan already covers them, but explicit registration means immediate
     coverage for exact-match replacement even below the 16-char scan floor).
     Keys MUST match write_/delete_'s scheme or unregister leaves the
     boot-registered copy behind."""
-    root = _root()
-    conn_dir = root / "connections"
-    if conn_dir.exists():
-        for p in conn_dir.glob("*.json"):
-            # {scope}-{instance}.json; instance names can't contain hyphens
-            scope, _, instance = p.stem.partition("-")
-            for field, value in _read(p).items():
-                if isinstance(value, str) and value:
-                    security.register_runtime_secret(
-                        f"conn:{scope}:{instance}:{field}", value)
-    harness_dir = root / "harness"
-    if harness_dir.exists():
-        for p in harness_dir.glob("*.json"):
-            value = _read(p).get("value")
-            if isinstance(value, str) and value:
-                security.register_runtime_secret(f"harness:{p.stem}", value)
+    for key, fields in list_connection_secrets().items():
+        # {scope}-{instance}; instance names can't contain hyphens
+        scope, _, instance = key.partition("-")
+        for field, value in fields.items():
+            security.register_runtime_secret(
+                f"conn:{scope}:{instance}:{field}", value)
+    for var, value in list_harness_secrets().items():
+        security.register_runtime_secret(f"harness:{var}", value)
+
+
+# ── profile secret snapshots (ADR-0013) ─────────────────────────────────────
+# /data/secrets/profiles/{name}.json — ONE json per profile, 0600. The file
+# sits at glob level two, so security._known_values()'s glob("*/*") covers a
+# dormant snapshot with zero redaction changes (values <16 chars stay below
+# the scan floor until applied — the documented residual). Shape mirrors the
+# bundle secrets section: {"connections": {...}, "harness": {...}}.
+
+def _profile_path(name: str) -> Path:
+    return _root() / "profiles" / f"{name}.json"
+
+
+def write_profile_secrets(name: str, data: dict) -> None:
+    _atomic_write(_profile_path(name), data)
+
+
+def read_profile_secrets(name: str) -> dict | None:
+    """None when the profile stores no secrets. Corrupt files REFUSE (strict
+    read): silently applying half a snapshot would delete every live secret
+    the missing half once named."""
+    p = _profile_path(name)
+    if not p.exists():
+        return None
+    return _read_strict(p)
+
+
+def delete_profile_secrets(name: str) -> None:
+    _profile_path(name).unlink(missing_ok=True)
+
+
+def rename_profile_secrets(name: str, new_name: str) -> None:
+    p = _profile_path(name)
+    if p.exists():
+        os.replace(p, _profile_path(new_name))

--- a/app/devcake/settings_bundle.py
+++ b/app/devcake/settings_bundle.py
@@ -1,0 +1,716 @@
+"""The canonical settings-bundle representation (ADR-0013): ONE versioned
+serialization of the deployment's settings, consumed by both the config
+profiles store (profiles.py) and settings export/import.
+
+Sections (founder taxonomy):
+    config     (A) AppConfig + dev types + prompt templates + active pointers
+    secrets    (B) connection/harness secret VALUES (+ optional credential files)
+    setup_env  (C) .env bootstrap values, read from the app's own environment
+
+A bundle is a plain dict (YAML on the wire, `yaml.safe_load` ONLY — bundles
+are operator-uploaded input). Section A is always plaintext so a bundle stays
+diffable (ADR-0002); B and C travel in one encrypted envelope by default
+(settings_crypto, PR2). Applying a bundle is REPLACE-the-world for the
+sections it contains, routed through the same choke points as the config PUT
+(reject_stale_patch → model_validate → semantic checks → dry-run adapters).
+
+There are no transactions (ADR-0002): apply orders writes so any torn state
+is either pre-commit (old config.yaml authoritative, new files inert) or
+post-commit (new world authoritative, stale extras pruned by a re-apply).
+Rollback re-applies the pre-captured previous bundle through this same path.
+
+Validation errors NEVER echo input values — a malformed secrets section must
+not leak a value into a 422 detail or a log line (ADR-0013 hardening).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from opentelemetry import trace
+from pydantic import ValidationError
+
+from . import secrets as secrets_store
+from .config import (AppConfig, DevType, _INSTANCE_NAME_RE, delete_dev_type,
+                     reject_stale_patch, save_config, save_dev_type)
+from .prompts import PLAYBOOK_VARS
+from .prompts import templates as prompt_templates
+from .security import redact
+
+log = logging.getLogger("devcake.settings")
+tracer = trace.get_tracer("devcake")
+
+BUNDLE_KIND = "devcake-settings-bundle"
+BUNDLE_SCHEMA_VERSION = 1
+
+# Section C — the .env bootstrap set, mirroring .env.example (ONE place; a
+# tripwire test diffs this list against the file). (name, host_specific):
+# host-specific values ride the bundle but the generated .env flags them for
+# verification on the target host. DEVCAKE_ALLOW_INSECURE is deliberately
+# ABSENT: exporting an insecure-mode flag onto a production host would
+# silently disable its password checks.
+SETUP_ENV_VARS: list[tuple[str, bool]] = [
+    ("OO_ROOT_EMAIL", False),
+    ("OO_ROOT_PASSWORD", False),
+    ("OO_INGEST_EMAIL", False),
+    ("OO_INGEST_PASSWORD", False),
+    ("OO_ALERT_WEBHOOK", False),
+    ("OO_DAILY_COST_ALERT_USD", False),
+    ("GITEA_ADMIN_USER", False),
+    ("GITEA_ADMIN_PASSWORD", False),
+    ("GITEA_UI_URL", False),
+    ("DAGU_USER", False),
+    ("DAGU_PASSWORD", False),
+    ("REDIS_PASSWORD", False),
+    ("ADMIN_USER", False),
+    ("ADMIN_PASSWORD", False),
+    ("DAGU_UI_URL", False),
+    ("OO_UI_URL", False),
+    ("DOCKER_GID", True),
+    ("DEVCAKE_TAG", True),
+]
+_SETUP_ENV_NAMES = {name for name, _ in SETUP_ENV_VARS}
+
+# ~20 MB decoded — bundles are settings, not data; anything bigger is a
+# mistake or an attack, refused before parsing
+MAX_BUNDLE_BYTES = 20 * 1024 * 1024
+
+
+class BundleError(ValueError):
+    """Carries the HTTP status the API layer should map to (SkillStoreError
+    pattern). Messages must never contain secret material."""
+
+    def __init__(self, status: int, detail: str):
+        super().__init__(detail)
+        self.status = status
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── audit trail ──────────────────────────────────────────────────────────────
+
+def _audit_path() -> Path:
+    return Path(os.environ.get("DEVCAKE_DATA_DIR", "/data")) / "state" / "events.jsonl"
+
+
+def audit_event(action: str, detail: str = "") -> None:
+    """Settings-change audit record on the existing events.jsonl stream —
+    same shape as the mission audit (feed._audit) so readers need one parser.
+    Detail carries names/counts/section lists ONLY, never a value; redact()
+    is belt-and-braces, not the contract."""
+    path = _audit_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a") as f:
+        f.write(json.dumps({"ts": _utcnow(), "instance": "", "pmo_id": "",
+                            "action": action, "detail": redact(detail)}) + "\n")
+    with tracer.start_as_current_span("audit.event") as span:
+        span.set_attribute("devcake.audit.action", action)
+        span.set_attribute("devcake.audit.detail", redact(detail)[:500])
+
+
+# ── serialize ────────────────────────────────────────────────────────────────
+
+def serialize_current(config: AppConfig, dev_types: dict[str, DevType], *,
+                      include_config: bool = True,
+                      include_secrets: bool = True,
+                      include_credential_files: bool = False,
+                      include_setup_env: bool = False,
+                      skill_payloads: list[dict] | None = None) -> dict:
+    """Snapshot the live world into a bundle dict. dismissed_alerts is
+    STRIPPED (importing someone else's dismissals could hide active
+    advisories); credential files are export-only opt-in (host-migration
+    material, never profile material)."""
+    bundle: dict = {
+        "kind": BUNDLE_KIND,
+        "bundle_schema_version": BUNDLE_SCHEMA_VERSION,
+        "created_at": _utcnow(),
+        "devcake_tag": os.environ.get("DEVCAKE_TAG", ""),
+        "sections": [],
+    }
+    if include_config:
+        app = config.model_dump()
+        app.pop("dismissed_alerts", None)
+        operator_templates: dict[str, dict[str, str]] = {}
+        for mt, entries in prompt_templates.list_templates().items():
+            operator_templates[mt] = {e["name"]: e["template"]
+                                      for e in entries if not e["builtin"]}
+        devtype_prompts = {
+            dev: {e["name"]: e["template"] for e in entries}
+            for dev, entries in
+            prompt_templates.list_devtype_prompts(dev_types).items()}
+        bundle["config"] = {
+            "app": app,
+            "dev_types": {n: dt.model_dump() for n, dt in dev_types.items()},
+            "prompt_templates": operator_templates,
+            "devtype_prompts": devtype_prompts,
+        }
+        bundle["sections"].append("config")
+    if include_secrets:
+        sec: dict = {
+            "connections": secrets_store.list_connection_secrets(),
+            "harness": secrets_store.list_harness_secrets(),
+        }
+        if include_credential_files:
+            sec["credential_files"] = _read_credential_files(dev_types)
+        bundle["secrets"] = sec
+        bundle["sections"].append("secrets")
+    if include_setup_env:
+        values = {}
+        for name, _host in SETUP_ENV_VARS:
+            v = os.environ.get(name)
+            if v is not None:
+                values[name] = v
+        bundle["setup_env"] = {
+            "values": values,
+            "host_specific": [n for n, host in SETUP_ENV_VARS if host],
+        }
+        bundle["sections"].append("setup_env")
+    if skill_payloads:
+        bundle["skills"] = {"embedded": skill_payloads}
+    return bundle
+
+
+def _read_credential_files(dev_types: dict) -> dict[str, list[dict]]:
+    import base64
+    root = Path(os.environ.get("DEVCAKE_DATA_DIR", "/data")) / "secrets"
+    out: dict[str, list[dict]] = {}
+    for name in dev_types:
+        d = root / name
+        if not d.is_dir():
+            continue
+        files = [{"filename": p.name,
+                  "content_b64": base64.b64encode(p.read_bytes()).decode()}
+                 for p in sorted(d.iterdir()) if p.is_file()]
+        if files:
+            out[name] = files
+    return out
+
+
+# ── validate ─────────────────────────────────────────────────────────────────
+
+def _scrub_validation_error(e: ValidationError) -> str:
+    """Paths and reasons only — pydantic's default str() embeds the offending
+    INPUT, which for a secrets section would echo a value into the 422."""
+    parts = []
+    for err in e.errors(include_url=False, include_input=False):
+        loc = ".".join(str(p) for p in err.get("loc", ()))
+        parts.append(f"{loc or '<root>'}: {err.get('msg', 'invalid')}")
+    return "; ".join(parts[:20])
+
+
+_CONN_FIELDS = secrets_store.CONNECTION_FIELDS
+_INSTANCE_RE = re.compile(_INSTANCE_NAME_RE)
+_HARNESS_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
+
+
+def validate_bundle(bundle: dict, *, _strict: bool = True) -> dict:
+    """Structural + semantic validation. Returns the parsed world:
+    {config: AppConfig|None, dev_types: dict|None, prompt_templates,
+    devtype_prompts, secrets, setup_env, warnings}. Raises BundleError(422)
+    loudly on anything stale or malformed — never a silent drop, never an
+    echoed value. _strict=False (rollback only) parses shapes but skips the
+    cross-store semantic checks: restoring the world that WAS live must not
+    refuse over a consistency rule the live world never had to pass."""
+    if not isinstance(bundle, dict):
+        raise BundleError(422, "bundle must be a mapping")
+    if bundle.get("kind") != BUNDLE_KIND:
+        raise BundleError(422, f"not a {BUNDLE_KIND} file")
+    v = bundle.get("bundle_schema_version")
+    if v != BUNDLE_SCHEMA_VERSION:
+        raise BundleError(
+            422, f"bundle_schema_version {v!r} is not the current version "
+                 f"({BUNDLE_SCHEMA_VERSION}) — re-export from a matching "
+                 "DevCake version; the bundle format is not auto-migrated")
+    warnings: list[str] = []
+    out: dict = {"config": None, "dev_types": None, "prompt_templates": None,
+                 "devtype_prompts": None, "secrets": None, "setup_env": None,
+                 "warnings": warnings}
+
+    cfg_section = bundle.get("config")
+    if cfg_section is not None:
+        if not isinstance(cfg_section, dict) or not isinstance(
+                cfg_section.get("app"), dict):
+            raise BundleError(422, "config section must carry an 'app' mapping")
+        app = dict(cfg_section["app"])
+        try:
+            reject_stale_patch(app)
+        except ValueError as e:
+            raise BundleError(422, str(e))
+        # live dismissed_alerts is preserved on apply; a bundle-carried list
+        # is dropped here so serialize→apply round-trips are exact
+        app.pop("dismissed_alerts", None)
+        try:
+            cfg = AppConfig.model_validate(app)
+        except ValidationError as e:
+            raise BundleError(422, f"config.app invalid — "
+                                   f"{_scrub_validation_error(e)}")
+        dts: dict[str, DevType] = {}
+        for name, data in (cfg_section.get("dev_types") or {}).items():
+            if not isinstance(data, dict):
+                raise BundleError(422, f"dev_types[{name!r}] must be a mapping")
+            try:
+                dt = DevType.model_validate({**data, "name": name})
+            except ValidationError as e:
+                raise BundleError(422, f"dev_types[{name!r}] invalid — "
+                                       f"{_scrub_validation_error(e)}")
+            dts[name] = dt
+        templates = _validate_templates(cfg_section.get("prompt_templates"),
+                                        warnings)
+        dev_prompts = _validate_devtype_prompts(
+            cfg_section.get("devtype_prompts"), dts, warnings)
+        if _strict:
+            validate_config_semantics(
+                cfg, set(dts),
+                template_exists=lambda mt, name:
+                    name in prompt_templates._builtins() or name == "default"
+                    or name in templates.get(mt, {}),
+                check_assignments=True)
+        out.update(config=cfg, dev_types=dts, prompt_templates=templates,
+                   devtype_prompts=dev_prompts)
+
+    sec = bundle.get("secrets")
+    if sec is not None:
+        out["secrets"] = _validate_secrets(sec, out["config"], warnings)
+
+    env = bundle.get("setup_env")
+    if env is not None:
+        out["setup_env"] = _validate_setup_env(env, warnings)
+
+    skills = bundle.get("skills")
+    if skills is not None:
+        emb = skills.get("embedded")
+        if not isinstance(emb, list) or not all(
+                isinstance(s, dict) and isinstance(s.get("name"), str)
+                and isinstance(s.get("files"), list) for s in emb):
+            raise BundleError(422, "skills.embedded must be a list of "
+                                   "{name, files} entries")
+    return out
+
+
+def _validate_templates(section, warnings: list[str]) -> dict[str, dict[str, str]]:
+    out: dict[str, dict[str, str]] = {}
+    builtins = prompt_templates._builtins()
+    for mt, entries in (section or {}).items():
+        if mt not in PLAYBOOK_VARS:
+            raise BundleError(422, f"prompt_templates: unknown mission type {mt!r}")
+        out[mt] = {}
+        for name, text in (entries or {}).items():
+            if name in builtins or name == "default":
+                warnings.append(f"prompt_templates {mt}/{name}: built-in "
+                                "preset names are canonical — bundle copy ignored")
+                continue
+            if not isinstance(text, str):
+                raise BundleError(422, f"prompt_templates {mt}/{name}: "
+                                       "template must be a string")
+            try:
+                prompt_templates.validate_template(mt, text)
+                if not prompt_templates._NAME_RE.fullmatch(name):
+                    raise ValueError("template name must match "
+                                     "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
+            except ValueError as e:
+                raise BundleError(422, f"prompt_templates {mt}/{name}: {e}")
+            out[mt][name] = text
+    return out
+
+
+def _validate_devtype_prompts(section, dts: dict, warnings: list[str]
+                              ) -> dict[str, dict[str, str]]:
+    out: dict[str, dict[str, str]] = {}
+    for dev, entries in (section or {}).items():
+        if dev not in dts:
+            warnings.append(f"devtype_prompts[{dev!r}]: no such Dev Type in "
+                            "the bundle — entries dropped")
+            continue
+        out[dev] = {}
+        for name, text in (entries or {}).items():
+            if not isinstance(text, str):
+                raise BundleError(422, f"devtype_prompts {dev}/{name}: "
+                                       "template must be a string")
+            if not prompt_templates._NAME_RE.fullmatch(name):
+                raise BundleError(422, f"devtype_prompts {dev}/{name}: bad name")
+            if len(text.encode()) > 64 * 1024:
+                raise BundleError(422, f"devtype_prompts {dev}/{name}: "
+                                       "template exceeds 64 KB")
+            out[dev][name] = text
+    return out
+
+
+def _validate_secrets(sec, cfg: AppConfig | None, warnings: list[str]) -> dict:
+    """Shape checks; messages name keys and paths, NEVER values. Unknown-
+    instance entries are kept here (the target world may differ at apply
+    time) — apply/diff decide skip-with-warning against their live config."""
+    if not isinstance(sec, dict):
+        raise BundleError(422, "secrets section must be a mapping")
+    conns: dict[str, dict[str, str]] = {}
+    for key, fields in (sec.get("connections") or {}).items():
+        scope, _, instance = str(key).partition("-")
+        if scope not in _CONN_FIELDS or not _INSTANCE_RE.fullmatch(instance):
+            raise BundleError(422, f"secrets.connections[{key!r}]: key must be "
+                                   "{pmo|repo}-{instance}")
+        if not isinstance(fields, dict):
+            raise BundleError(422, f"secrets.connections[{key!r}] must be a mapping")
+        for field, value in fields.items():
+            if field not in _CONN_FIELDS[scope]:
+                raise BundleError(
+                    422, f"secrets.connections[{key!r}]: field {field!r} not in "
+                         f"{sorted(_CONN_FIELDS[scope])}")
+            if not isinstance(value, str) or not value:
+                raise BundleError(
+                    422, f"secrets.connections[{key!r}].{field}: value must be "
+                         "a non-empty string")
+        conns[key] = dict(fields)
+    harness: dict[str, str] = {}
+    for var, value in (sec.get("harness") or {}).items():
+        if not _HARNESS_RE.fullmatch(str(var)):
+            raise BundleError(422, f"secrets.harness[{var!r}]: var must match "
+                                   "^[A-Z][A-Z0-9_]{0,63}$")
+        if not isinstance(value, str) or not value:
+            raise BundleError(422, f"secrets.harness[{var}]: value must be a "
+                                   "non-empty string")
+        harness[var] = value
+    out: dict = {"connections": conns, "harness": harness}
+    cred = sec.get("credential_files")
+    if cred is not None:
+        if not isinstance(cred, dict):
+            raise BundleError(422, "secrets.credential_files must be a mapping")
+        for dev, files in cred.items():
+            for f in files or []:
+                fname = str((f or {}).get("filename") or "")
+                if not fname or os.path.basename(fname) != fname:
+                    raise BundleError(
+                        422, f"secrets.credential_files[{dev!r}]: filenames "
+                             "must be bare basenames")
+        out["credential_files"] = cred
+    if cfg is not None:
+        known = ({f"pmo-{p.name}" for p in cfg.pmos}
+                 | {f"repo-{r.name}" for r in cfg.repos})
+        for key in conns:
+            if key not in known:
+                warnings.append(f"secrets.connections[{key}]: no such instance "
+                                "in the bundle config — skipped at apply")
+    return out
+
+
+def _validate_setup_env(env, warnings: list[str]) -> dict:
+    if not isinstance(env, dict) or not isinstance(env.get("values"), dict):
+        raise BundleError(422, "setup_env section must carry a 'values' mapping")
+    values: dict[str, str] = {}
+    for name, value in env["values"].items():
+        if name == "DEVCAKE_ALLOW_INSECURE":
+            warnings.append("setup_env: DEVCAKE_ALLOW_INSECURE never rides a "
+                            "bundle — dropped")
+            continue
+        if name not in _SETUP_ENV_NAMES:
+            warnings.append(f"setup_env: unknown variable {name!r} — dropped")
+            continue
+        if not isinstance(value, str):
+            raise BundleError(422, f"setup_env.values[{name}]: must be a string")
+        values[name] = value
+    return {"values": values,
+            "host_specific": [n for n, host in SETUP_ENV_VARS if host]}
+
+
+# ── choke points shared with PUT /config (extracted from api.main) ───────────
+
+def validate_config_semantics(cfg: AppConfig, dev_type_names: set[str],
+                              template_exists: Callable[[str, str], bool],
+                              *, check_assignments: bool = False) -> None:
+    """Cross-store checks shared by PUT /config and bundle apply.
+    template_exists decides against the caller's template universe — disk
+    for the PUT, bundle ∪ builtins for an apply. check_assignments is
+    apply-only: the PUT keeps today's split where PUT /assignments owns that
+    validation (the SPA saves assignments separately, possibly before a new
+    Dev Type lands)."""
+    rm = cfg.relations_mapper
+    if rm.enabled and (not rm.dev_type or rm.dev_type not in dev_type_names):
+        raise BundleError(422, "relations_mapper.dev_type must name an "
+                               "existing Dev Type when the mapper is enabled")
+    for mt, name in (cfg.active_prompt_templates or {}).items():
+        if mt not in PLAYBOOK_VARS:
+            raise BundleError(422, f"active_prompt_templates: unknown "
+                                   f"mission type {mt!r}")
+        if not template_exists(mt, name):
+            raise BundleError(422, f"active_prompt_templates: no stored "
+                                   f"template {mt}/{name}")
+    for dt_name in (cfg.active_devtype_prompts or {}):
+        if dt_name not in dev_type_names:
+            raise BundleError(422, f"active_devtype_prompts: unknown "
+                                   f"Dev Type {dt_name!r}")
+    if check_assignments:
+        for mt, a in (cfg.assignments or {}).items():
+            if a.dev_type and a.dev_type not in dev_type_names:
+                raise BundleError(422, f"assignments[{mt}]: unknown Dev Type "
+                                       f"{a.dev_type!r}")
+
+
+def dry_run_adapters(cfg: AppConfig) -> None:
+    """Construct every adapter before anything persists (ISSUES #11): a bad
+    URL or forge shape must never land on disk. Unconfigured instances are
+    valid-but-idle."""
+    from .adapters.registry import make_forge, make_pmo  # lazy: import-light
+    try:
+        for inst in cfg.pmos:
+            make_pmo(inst)
+        for repo in cfg.repos:
+            if repo.configured:
+                make_forge(repo)
+    except Exception as e:
+        raise BundleError(422, f"adapter construction failed: {e}") from e
+
+
+# ── diff (preview) ───────────────────────────────────────────────────────────
+
+def diff_bundle(bundle: dict, config: AppConfig,
+                dev_types: dict[str, DevType]) -> dict:
+    """Preview payload for apply/import confirms. Secrets are PRESENCE AND
+    NAMES only — never a value, never a fingerprint (ADR-0011)."""
+    parsed = validate_bundle(bundle)
+    warnings = list(parsed["warnings"])
+    out: dict = {"sections": {}, "warnings": warnings}
+
+    if parsed["config"] is not None:
+        cur = config.model_dump()
+        cur.pop("dismissed_alerts", None)
+        new = parsed["config"].model_dump()
+        new.pop("dismissed_alerts", None)
+        changed = sorted(k for k in new if new[k] != cur.get(k))
+        cur_dts = {n: dt.model_dump() for n, dt in dev_types.items()}
+        new_dts = {n: dt.model_dump() for n, dt in parsed["dev_types"].items()}
+        cur_tpl = {(mt, e["name"])
+                   for mt, es in prompt_templates.list_templates().items()
+                   for e in es if not e["builtin"]}
+        new_tpl = {(mt, name) for mt, es in parsed["prompt_templates"].items()
+                   for name in es}
+        out["sections"]["config"] = {
+            "app_changed": changed,
+            "dev_types": _delta(cur_dts, new_dts),
+            "prompt_templates": {
+                "added": sorted(f"{mt}/{n}" for mt, n in new_tpl - cur_tpl),
+                "removed": sorted(f"{mt}/{n}" for mt, n in cur_tpl - new_tpl),
+            },
+        }
+        if new.get("intake_paused") != cur.get("intake_paused"):
+            state = "paused" if new.get("intake_paused") else "UNPAUSED"
+            warnings.append(f"applying changes intake to {state}")
+
+    if parsed["secrets"] is not None:
+        cur_conns = secrets_store.list_connection_secrets()
+        cur_flat = {f"{k}.{f}" for k, fs in cur_conns.items() for f in fs}
+        new_flat = {f"{k}.{f}" for k, fs in parsed["secrets"]["connections"].items()
+                    for f in fs}
+        cur_h = set(secrets_store.list_harness_secrets())
+        new_h = set(parsed["secrets"]["harness"])
+        out["sections"]["secrets"] = {
+            "connections": {"added": sorted(new_flat - cur_flat),
+                            "replaced": sorted(new_flat & cur_flat),
+                            "removed": sorted(cur_flat - new_flat)},
+            "harness": {"added": sorted(new_h - cur_h),
+                        "replaced": sorted(new_h & cur_h),
+                        "removed": sorted(cur_h - new_h)},
+        }
+        warnings.extend(_newer_secret_warnings(bundle, parsed))
+
+    if parsed["setup_env"] is not None:
+        out["sections"]["setup_env"] = {
+            "keys": sorted(parsed["setup_env"]["values"]),
+            "host_specific": parsed["setup_env"]["host_specific"],
+        }
+    if bundle.get("skills"):
+        out["sections"]["skills"] = {
+            "embedded": sorted(s["name"] for s in bundle["skills"]["embedded"])}
+    return out
+
+
+def _delta(cur: dict, new: dict) -> dict:
+    return {"added": sorted(set(new) - set(cur)),
+            "changed": sorted(k for k in set(new) & set(cur)
+                              if new[k] != cur[k]),
+            "removed": sorted(set(cur) - set(new))}
+
+
+def _newer_secret_warnings(bundle: dict, parsed: dict) -> list[str]:
+    """The rotation trap (ADR-0013): a live secret rotated AFTER the snapshot
+    was captured would be silently replaced by the older value. Timestamps
+    only — never values."""
+    created = str(bundle.get("created_at") or "")
+    if not created:
+        return []
+    warns = []
+    for key, fields in parsed["secrets"]["connections"].items():
+        scope, _, instance = key.partition("-")
+        for field in fields:
+            st = secrets_store.connection_status(scope, instance, field)
+            if st["present"] and st["updated_at"] and st["updated_at"] > created:
+                warns.append(f"secret {key}.{field} was updated after this "
+                             "snapshot was captured — applying restores the "
+                             "older value")
+    for var in parsed["secrets"]["harness"]:
+        st = secrets_store.harness_status(var)
+        if st["present"] and st["updated_at"] and st["updated_at"] > created:
+            warns.append(f"secret harness/{var} was updated after this "
+                         "snapshot was captured — applying restores the "
+                         "older value")
+    return warns
+
+
+# ── apply ────────────────────────────────────────────────────────────────────
+
+def apply_bundle(bundle: dict, *, config: AppConfig,
+                 dev_types: dict[str, DevType],
+                 reload: Callable[[], None],
+                 _is_rollback: bool = False) -> dict:
+    """REPLACE the live world with the bundle's sections. Synchronous end to
+    end — no awaits between validation and the in-memory swap, so the asyncio
+    poll loop can never observe a half-applied world. The caller holds the
+    runs-active guard.
+
+    Ordering (crash honesty, ADR-0013): additive file writes first, then the
+    config.yaml commit point, then deletions. A crash before the commit
+    leaves the old world authoritative with inert extra files; after it, the
+    new world is authoritative and a re-apply prunes the stale extras.
+    """
+    parsed = validate_bundle(bundle, _strict=not _is_rollback)
+    warnings = list(parsed["warnings"])
+    new_cfg: AppConfig | None = parsed["config"]
+    if new_cfg is not None and not _is_rollback:
+        dry_run_adapters(new_cfg)
+
+    previous = serialize_current(
+        config, dev_types,
+        include_config=new_cfg is not None,
+        include_secrets=parsed["secrets"] is not None)
+
+    applied: list[str] = []
+    try:
+        if new_cfg is not None:
+            _apply_config_files(parsed)
+        if parsed["secrets"] is not None:
+            warnings.extend(_apply_secrets(
+                parsed["secrets"],
+                new_cfg if new_cfg is not None else config,
+                restore_exact=_is_rollback))
+        if new_cfg is not None:
+            # commit point: config.yaml swaps the authoritative world
+            live_alerts = list(config.dismissed_alerts)
+            for field in type(new_cfg).model_fields:
+                setattr(config, field, getattr(new_cfg, field))
+            config.dismissed_alerts = live_alerts
+            save_config(config)
+            _prune_config_files(parsed, dev_types)
+            dev_types.clear()               # shared by reference with managers
+            dev_types.update(parsed["dev_types"])
+            prompt_templates.seed_devtype_prompts(dev_types)
+            applied.append("config")
+        if parsed["secrets"] is not None:
+            applied.append("secrets")
+        if _is_rollback:
+            # files restored is the load-bearing part — a rollback reload
+            # failure must not abort it (put_config's "restore reload also
+            # failed" semantics); adapters heal at the next config change
+            try:
+                reload()
+            except Exception:
+                log.exception("rollback reload failed — files restored")
+        else:
+            reload()
+    except BundleError:
+        raise
+    except Exception as e:
+        if _is_rollback:
+            raise
+        log.exception("bundle apply failed — restoring previous settings")
+        try:
+            apply_bundle(previous, config=config, dev_types=dev_types,
+                         reload=reload, _is_rollback=True)
+        except Exception:
+            log.exception("rollback also failed")
+            raise BundleError(
+                500, "apply failed AND the rollback failed — the deployment "
+                     "may hold a mix of old and new settings; re-apply "
+                     "either the profile or your last export to converge "
+                     f"(apply error: {e})")
+        raise BundleError(500, f"apply failed; previous settings restored: {e}")
+    return {"applied": applied, "warnings": warnings,
+            "untouched": ["runs", "dev-type credential files",
+                          "internal forge", "profiles"]}
+
+
+def _apply_config_files(parsed: dict) -> None:
+    """Additive writes through the existing per-store choke points — each
+    file individually atomic, validation stays load-bearing."""
+    for dt in parsed["dev_types"].values():
+        save_dev_type(dt)
+    for mt, entries in parsed["prompt_templates"].items():
+        for name, text in entries.items():
+            prompt_templates.save_template(mt, name, text)
+    for dev, entries in parsed["devtype_prompts"].items():
+        for name, text in entries.items():
+            prompt_templates.save_devtype_prompt(dev, name, text)
+
+
+def _prune_config_files(parsed: dict, old_dev_types: dict) -> None:
+    """Replace-the-world deletions, post-commit. Never touches dev-type
+    credential dirs, internal_forge/, profiles/, or /data/state. A pruned
+    seeded default Dev Type returns at next boot (load_dev_types top-up) —
+    documented, and the divergence indicator surfaces it honestly."""
+    import shutil
+    for name in set(old_dev_types) - set(parsed["dev_types"]):
+        delete_dev_type(name)
+    builtins = prompt_templates._builtins()
+    for mt, entries in prompt_templates.list_templates().items():
+        keep = set(parsed["prompt_templates"].get(mt, {}))
+        for e in entries:
+            if not e["builtin"] and e["name"] not in keep:
+                prompt_templates.delete_template(mt, e["name"])
+    for d in prompt_templates.known_devtype_dirs():
+        if d.name not in parsed["dev_types"]:
+            shutil.rmtree(d, ignore_errors=True)
+            continue
+        keep = set(parsed["devtype_prompts"].get(d.name, {})) | set(builtins)
+        keep.add("Development")             # seeded user data, never pruned
+        for p in d.glob("*.yaml"):
+            if p.stem not in keep:
+                p.unlink(missing_ok=True)
+
+
+def _apply_secrets(sec: dict, target_cfg: AppConfig, *,
+                   restore_exact: bool = False) -> list[str]:
+    """Replace the secret stores. Unknown-instance entries are SKIPPED with a
+    warning — never an orphan secret file on disk (ADR-0013 hardening).
+    restore_exact (rollback only) disables the skip: a live world may
+    legitimately hold a secret whose instance card isn't saved yet, and a
+    rollback must restore byte-exact, not editorialize."""
+    warnings: list[str] = []
+    known = ({f"pmo-{p.name}" for p in target_cfg.pmos}
+             | {f"repo-{r.name}" for r in target_cfg.repos})
+    wanted: dict[str, dict[str, str]] = {}
+    for key, fields in sec["connections"].items():
+        if key not in known and not restore_exact:
+            warnings.append(f"secrets.connections[{key}]: no such configured "
+                            "instance — skipped")
+            continue
+        wanted[key] = fields
+    current = secrets_store.list_connection_secrets()
+    for key in set(current) - set(wanted):
+        scope, _, instance = key.partition("-")
+        secrets_store.delete_connection_instance(scope, instance)
+    for key, fields in wanted.items():
+        scope, _, instance = key.partition("-")
+        for field in set(current.get(key, {})) - set(fields):
+            secrets_store.delete_connection_field(scope, instance, field)
+        for field, value in fields.items():
+            secrets_store.write_connection_secret(scope, instance, field, value)
+    cur_h = secrets_store.list_harness_secrets()
+    for var in set(cur_h) - set(sec["harness"]):
+        secrets_store.delete_harness_secret(var)
+    for var, value in sec["harness"].items():
+        secrets_store.write_harness_secret(var, value)
+    return warnings

--- a/app/tests/test_profiles.py
+++ b/app/tests/test_profiles.py
@@ -1,0 +1,262 @@
+"""Config profiles (ADR-0013): store CRUD across both files, name hygiene,
+divergence honesty, and the API surface (runs-active 409, presence-only
+responses, audit events)."""
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def run_coro(c):
+    return asyncio.new_event_loop().run_until_complete(c)
+
+
+def _env(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import config as config_mod
+    monkeypatch.setattr(config_mod, "CONFIG_PATH",
+                        tmp_path / "config" / "config.yaml")
+    from devcake import profiles, secrets, settings_bundle
+    from devcake.prompts import templates as prompt_templates
+    return settings_bundle, profiles, secrets, config_mod, prompt_templates
+
+
+def _small_world(config_mod, secrets):
+    cfg = config_mod.AppConfig(
+        repos=[config_mod.RepoInstance(name="main",
+                                       url="https://github.com/acme/app")],
+        assignments={mt: config_mod.Assignment(dev_type="senior-dev")
+                     for mt in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW")})
+    dts = {"senior-dev": config_mod.DevType(
+        name="senior-dev", harness_template="claude-code",
+        identifying_prompt="Senior.")}
+    secrets.write_connection_secret("repo", "main", "token",
+                                    "ghp_profile_secret_value_01")
+    return cfg, dts
+
+
+# ── store ────────────────────────────────────────────────────────────────────
+
+def test_save_read_roundtrip_splits_the_two_stores(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, _ = _env(monkeypatch, tmp_path)
+    cfg, dts = _small_world(config_mod, secrets)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+    profiles.save_profile("staging", bundle)
+    # A in config/, B in secrets/ — and the yaml never holds a value
+    yaml_text = (tmp_path / "config" / "profiles" / "staging.yaml").read_text()
+    assert "ghp_profile_secret_value_01" not in yaml_text
+    sec_file = tmp_path / "secrets" / "profiles" / "staging.json"
+    assert sec_file.stat().st_mode & 0o777 == 0o600
+    back = profiles.read_profile("staging")
+    assert back["config"] == bundle["config"]
+    assert back["secrets"] == bundle["secrets"]
+    assert back["name"] == "staging"
+
+
+def test_overwrite_semantics(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, _ = _env(monkeypatch, tmp_path)
+    cfg, dts = _small_world(config_mod, secrets)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+    profiles.save_profile("p", bundle)
+    with pytest.raises(sb.BundleError) as e:
+        profiles.save_profile("p", bundle)
+    assert e.value.status == 409
+    # overwrite with a config-only bundle narrows the profile — the stale
+    # secrets snapshot must not survive
+    slim = sb.serialize_current(cfg, dts, include_secrets=False)
+    profiles.save_profile("p", slim, overwrite=True)
+    assert not (tmp_path / "secrets" / "profiles" / "p.json").exists()
+    assert "secrets" not in profiles.read_profile("p").get("sections")
+
+
+def test_rename_moves_both_files_and_updates_breadcrumb(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, _ = _env(monkeypatch, tmp_path)
+    cfg, dts = _small_world(config_mod, secrets)
+    profiles.save_profile("old", sb.serialize_current(cfg, dts))
+    profiles.record_applied("old")
+    profiles.rename_profile("old", "new")
+    assert not (tmp_path / "config" / "profiles" / "old.yaml").exists()
+    assert not (tmp_path / "secrets" / "profiles" / "old.json").exists()
+    assert (tmp_path / "secrets" / "profiles" / "new.json").exists()
+    assert profiles.read_profile("new")["name"] == "new"
+    assert profiles.last_applied()["name"] == "new"
+    with pytest.raises(sb.BundleError) as e:
+        profiles.rename_profile("new", "new")
+    assert e.value.status == 409
+
+
+def test_delete_removes_both_files(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, _ = _env(monkeypatch, tmp_path)
+    cfg, dts = _small_world(config_mod, secrets)
+    profiles.save_profile("gone", sb.serialize_current(cfg, dts))
+    profiles.delete_profile("gone")
+    assert not (tmp_path / "config" / "profiles" / "gone.yaml").exists()
+    assert not (tmp_path / "secrets" / "profiles" / "gone.json").exists()
+    with pytest.raises(sb.BundleError) as e:
+        profiles.delete_profile("gone")
+    assert e.value.status == 404
+
+
+@pytest.mark.parametrize("bad", ["", "../evil", "a/b", ".hidden", "x" * 65,
+                                 "-leading-dash"])
+def test_name_hygiene_rejects_traversal_shapes(monkeypatch, tmp_path, bad):
+    sb, profiles, *_ = _env(monkeypatch, tmp_path)
+    with pytest.raises(sb.BundleError) as e:
+        profiles.require_name(bad)
+    assert e.value.status == 422
+
+
+def test_stale_profile_schema_refused(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, _ = _env(monkeypatch, tmp_path)
+    cfg, dts = _small_world(config_mod, secrets)
+    profiles.save_profile("old", sb.serialize_current(cfg, dts))
+    p = tmp_path / "config" / "profiles" / "old.yaml"
+    p.write_text(p.read_text().replace("bundle_schema_version: 1",
+                                       "bundle_schema_version: 99"))
+    with pytest.raises(sb.BundleError) as e:
+        profiles.read_profile("old")
+    assert "not auto-migrated" in str(e.value)
+
+
+def test_promised_secrets_file_missing_refuses(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, _ = _env(monkeypatch, tmp_path)
+    cfg, dts = _small_world(config_mod, secrets)
+    profiles.save_profile("p", sb.serialize_current(cfg, dts,
+                                                    include_secrets=True))
+    (tmp_path / "secrets" / "profiles" / "p.json").unlink()
+    with pytest.raises(sb.BundleError) as e:
+        profiles.read_profile("p")
+    assert "snapshot file is missing" in str(e.value)
+
+
+def test_list_profiles_counts_only(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, _ = _env(monkeypatch, tmp_path)
+    cfg, dts = _small_world(config_mod, secrets)
+    profiles.save_profile("p", sb.serialize_current(cfg, dts,
+                                                    include_secrets=True))
+    rows = profiles.list_profiles()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["counts"] == {"pmos": 0, "repos": 1, "dev_types": 1,
+                             "prompt_templates": 0, "secrets": 1}
+    assert "ghp_profile_secret_value_01" not in json.dumps(rows)
+
+
+# ── divergence ───────────────────────────────────────────────────────────────
+
+def test_divergence_flips_on_config_edit_and_secret_rewrite(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, _ = _env(monkeypatch, tmp_path)
+    cfg, dts = _small_world(config_mod, secrets)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+    profiles.save_profile("p", bundle)
+    profiles.record_applied("p")
+    applied_at = profiles.last_applied()["at"]
+
+    assert profiles.diverged_since(profiles.read_profile("p"), applied_at,
+                                   cfg, dts) is False
+    cfg.poll_interval_seconds = 99
+    assert profiles.diverged_since(profiles.read_profile("p"), applied_at,
+                                   cfg, dts) is True
+    cfg.poll_interval_seconds = 30
+    assert profiles.diverged_since(profiles.read_profile("p"), applied_at,
+                                   cfg, dts) is False
+    time.sleep(0.02)   # ensure the rewrite's mtime lands after applied_at
+    secrets.write_connection_secret("repo", "main", "token",
+                                    "ghp_profile_secret_value_01")
+    assert profiles.diverged_since(profiles.read_profile("p"), applied_at,
+                                   cfg, dts) is True
+
+
+# ── API surface (endpoint functions called directly, house pattern) ─────────
+
+def _wire_app(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    from devcake.api import main as app_main
+    cfg, dts = _small_world(config_mod, secrets)
+    tpl.seed_devtype_prompts(dts)
+    monkeypatch.setattr(app_main, "config", cfg)
+    monkeypatch.setattr(app_main, "dev_types", dts)
+    monkeypatch.setattr(app_main, "reload_connections", lambda: None)
+    monkeypatch.setattr(app_main, "store",
+                        SimpleNamespace(active=lambda: []))
+    monkeypatch.setattr(app_main, "shared_breakers", {})
+    monkeypatch.setattr(app_main.forge_runtime, "breakers", {})
+    return sb, profiles, secrets, config_mod, app_main
+
+
+def test_endpoint_flow_save_list_get_apply_rename_delete(monkeypatch, tmp_path):
+    from fastapi import HTTPException
+    sb, profiles, secrets, config_mod, app_main = _wire_app(monkeypatch, tmp_path)
+
+    out = run_coro(app_main.save_profile({"name": "base"}))
+    assert out["saved"] and out["warnings"] == []
+    with pytest.raises(HTTPException) as e:
+        run_coro(app_main.save_profile({"name": "base"}))
+    assert e.value.status_code == 409
+    run_coro(app_main.save_profile({"name": "base", "overwrite": True}))
+
+    rows = run_coro(app_main.list_profiles())["profiles"]
+    assert [r["name"] for r in rows] == ["base"]
+    assert rows[0]["last_applied_at"] is None
+
+    detail = run_coro(app_main.get_profile("base"))
+    text = json.dumps(detail)
+    assert "ghp_profile_secret_value_01" not in text
+    assert detail["secrets_present"]["connections"] == {"repo-main": ["token"]}
+    assert "diff" in detail
+
+    app_main.config.poll_interval_seconds = 77   # drift before the apply
+    out = run_coro(app_main.apply_profile("base"))
+    assert sorted(out["applied"]) == ["config", "secrets"]
+    assert app_main.config.poll_interval_seconds == 30
+    rows = run_coro(app_main.list_profiles())["profiles"]
+    assert rows[0]["last_applied_at"] and rows[0]["diverged"] is False
+
+    out = run_coro(app_main.rename_profile("base", {"new_name": "renamed"}))
+    assert out["name"] == "renamed"
+    out = run_coro(app_main.delete_profile("renamed"))
+    assert out["deleted"] == "renamed"
+
+    actions = [json.loads(line)["action"] for line in
+               (tmp_path / "state" / "events.jsonl").read_text().splitlines()]
+    assert actions.count("profile_saved") == 2
+    assert "profile_applied" in actions and "profile_renamed" in actions \
+        and "profile_deleted" in actions
+    log_text = (tmp_path / "state" / "events.jsonl").read_text()
+    assert "ghp_profile_secret_value_01" not in log_text
+
+
+def test_apply_blocked_while_runs_active(monkeypatch, tmp_path):
+    from fastapi import HTTPException
+    sb, profiles, secrets, config_mod, app_main = _wire_app(monkeypatch, tmp_path)
+    run_coro(app_main.save_profile({"name": "base"}))
+    monkeypatch.setattr(
+        app_main, "store",
+        SimpleNamespace(active=lambda: [SimpleNamespace(state="running")]))
+    with pytest.raises(HTTPException) as e:
+        run_coro(app_main.apply_profile("base"))
+    assert e.value.status_code == 409
+    assert "run(s) active" in e.value.detail
+    # save/list/get stay available while runs are active
+    assert run_coro(app_main.get_profile("base"))["name"] == "base"
+    run_coro(app_main.save_profile({"name": "second"}))
+
+
+def test_save_warns_on_configured_instance_without_secret(monkeypatch, tmp_path):
+    sb, profiles, secrets, config_mod, app_main = _wire_app(monkeypatch, tmp_path)
+    app_main.config.pmos = [config_mod.PMOInstance(
+        name="linear", team_key="ENG", repos=["main"])]
+    out = run_coro(app_main.save_profile({"name": "gappy"}))
+    assert any("no stored API key" in w for w in out["warnings"])
+
+
+def test_apply_missing_profile_404(monkeypatch, tmp_path):
+    from fastapi import HTTPException
+    sb, profiles, secrets, config_mod, app_main = _wire_app(monkeypatch, tmp_path)
+    with pytest.raises(HTTPException) as e:
+        run_coro(app_main.apply_profile("ghost"))
+    assert e.value.status_code == 404

--- a/app/tests/test_security.py
+++ b/app/tests/test_security.py
@@ -238,3 +238,21 @@ def test_read_only_repo_in_work_set_warns(tmp_path, monkeypatch):
                                        reference_repos=["docs"])])
     ids2 = {w["id"] for w in security.security_warnings(cfg2)}
     assert "repo-read-only:docs" not in ids2
+
+
+def test_profile_secret_snapshots_are_covered_by_the_redaction_glob(tmp_path, monkeypatch):
+    """ADR-0013 glob tripwire: /data/secrets/profiles/{name}.json sits at
+    scan level two, so a DORMANT profile's values must mask with ZERO
+    changes to security.py. If the profiles store ever moves deeper than
+    glob("*/*") reaches, this fails."""
+    import json as _json
+    from devcake import security
+    monkeypatch.setattr(security, "_SECRETS_DIR", tmp_path / "secrets")
+    d = tmp_path / "secrets" / "profiles"
+    d.mkdir(parents=True)
+    value = "profile-dormant-secret-abcdef123456"
+    (d / "staging.json").write_text(_json.dumps(
+        {"connections": {"repo-main": {"token": value}},
+         "harness": {"ANTHROPIC_API_KEY": value + "-h"}}))
+    out = security.redact(f"transcript {value} and {value}-h end")
+    assert value not in out and MASK in out

--- a/app/tests/test_settings_bundle.py
+++ b/app/tests/test_settings_bundle.py
@@ -1,0 +1,384 @@
+"""Settings bundle (ADR-0013): serialize/validate/diff/apply — replace-the-
+world semantics, rollback-by-reapply, scrubbed validation errors (a malformed
+secrets section must never echo a value), and the .env tripwire."""
+
+import copy
+from pathlib import Path
+
+import pytest
+
+
+def _env(monkeypatch, tmp_path: Path):
+    """Point every store at tmp_path (env resolves per call; CONFIG_PATH is
+    import-time, so monkeypatch the module attribute too — house pattern)."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import config as config_mod
+    monkeypatch.setattr(config_mod, "CONFIG_PATH",
+                        tmp_path / "config" / "config.yaml")
+    from devcake import profiles, secrets, settings_bundle
+    from devcake.prompts import templates as prompt_templates
+    return settings_bundle, profiles, secrets, config_mod, prompt_templates
+
+
+def _world(config_mod, secrets, prompt_templates):
+    """A small but full world: pmo + repo + custom dev type + operator
+    template + secrets."""
+    cfg = config_mod.AppConfig(
+        pmos=[config_mod.PMOInstance(name="linear", team_key="ENG",
+                                     repos=["main"])],
+        repos=[config_mod.RepoInstance(name="main",
+                                       url="https://github.com/acme/app")],
+        poll_interval_seconds=45,
+        active_prompt_templates={"PLAN": "tighter-plan"},
+        # a consistent world: every assignment names a dev type this world
+        # actually carries (live deployments guarantee this — remove_dev_type
+        # refuses while assigned)
+        assignments={mt: config_mod.Assignment(dev_type="senior-dev")
+                     for mt in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW")},
+        relations_mapper=config_mod.RelationsMapper(dev_type="senior-dev"),
+    )
+    dts = {
+        "senior-dev": config_mod.DevType(
+            name="senior-dev", harness_template="claude-code",
+            identifying_prompt="You are Senior Dev.", model="claude-fable-5"),
+        "extra-dev": config_mod.DevType(
+            name="extra-dev", harness_template="codex",
+            identifying_prompt="Extra.", secret_env=["DD_API_KEY"]),
+    }
+    prompt_templates.seed_devtype_prompts(dts)
+    prompt_templates.save_template("PLAN", "tighter-plan",
+                                   "Plan tightly for {title}.")
+    secrets.write_connection_secret("pmo", "linear", "api_key",
+                                    "lin_api_secret_value_0001")
+    secrets.write_connection_secret("repo", "main", "token",
+                                    "ghp_secret_value_0002")
+    secrets.write_harness_secret("ANTHROPIC_API_KEY", "sk-ant-secret-0003")
+    return cfg, dts
+
+
+def _comparable(bundle: dict) -> dict:
+    b = copy.deepcopy(bundle)
+    b.pop("created_at", None)
+    return b
+
+
+# ── round trip ───────────────────────────────────────────────────────────────
+
+def test_serialize_apply_roundtrip_onto_fresh_deployment(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path / "src")
+    cfg, dts = _world(config_mod, secrets, tpl)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+
+    # fresh deployment: repoint every store, apply, serialize again
+    dst = tmp_path / "dst"
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(dst))
+    monkeypatch.setattr(config_mod, "CONFIG_PATH",
+                        dst / "config" / "config.yaml")
+    cfg2, dts2 = config_mod.AppConfig(), {}
+    result = sb.apply_bundle(bundle, config=cfg2, dev_types=dts2,
+                             reload=lambda: None)
+    assert sorted(result["applied"]) == ["config", "secrets"]
+    again = sb.serialize_current(cfg2, dts2, include_secrets=True)
+    assert _comparable(again) == _comparable(bundle)
+    # the fresh world holds the values on disk, 0600
+    assert secrets.read_connection_secret("pmo", "linear", "api_key") \
+        == "lin_api_secret_value_0001"
+    assert (dst / "secrets" / "connections" / "pmo-linear.json").stat().st_mode & 0o777 == 0o600
+
+
+def test_apply_is_replace_the_world_and_spares_the_exclusions(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+
+    # target world: extras the bundle does not carry...
+    extra_dt = config_mod.DevType(name="doomed-dev", harness_template="codex")
+    config_mod.save_dev_type(extra_dt)
+    tpl.save_template("REVIEW", "doomed-template", "Review {title}.")
+    secrets.write_connection_secret("repo", "doomed", "token",
+                                    "doomed-token-value-0009")
+    secrets.write_harness_secret("DOOMED_KEY", "doomed-harness-value-0010")
+    # ...and the never-touched stores
+    cred = tmp_path / "secrets" / "senior-dev" / "creds.json"
+    cred.parent.mkdir(parents=True)
+    cred.write_text("{}")
+    forge_tok = tmp_path / "secrets" / "internal_forge" / "service.json"
+    forge_tok.parent.mkdir(parents=True)
+    forge_tok.write_text("{}")
+    prof = tmp_path / "secrets" / "profiles" / "keep.json"
+    prof.parent.mkdir(parents=True)
+    prof.write_text("{}")
+    run = tmp_path / "state" / "runs" / "r1.json"
+    run.parent.mkdir(parents=True)
+    run.write_text("{}")
+
+    live = config_mod.AppConfig()
+    live_dts = {"doomed-dev": extra_dt}
+    sb.apply_bundle(bundle, config=live, dev_types=live_dts,
+                    reload=lambda: None)
+
+    assert not (tmp_path / "config" / "dev_types" / "doomed-dev.yaml").exists()
+    assert "doomed-dev" not in live_dts and "senior-dev" in live_dts
+    assert not (tmp_path / "config" / "prompt_templates" / "REVIEW"
+                / "doomed-template.yaml").exists()
+    assert not (tmp_path / "secrets" / "connections" / "repo-doomed.json").exists()
+    assert not (tmp_path / "secrets" / "harness" / "DOOMED_KEY.json").exists()
+    for spared in (cred, forge_tok, prof, run):
+        assert spared.exists()
+    assert live.poll_interval_seconds == 45
+
+
+def test_config_only_bundle_keeps_live_secrets(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=False)
+    assert "secrets" not in bundle and bundle["sections"] == ["config"]
+    live = config_mod.AppConfig()
+    result = sb.apply_bundle(bundle, config=live, dev_types={},
+                             reload=lambda: None)
+    assert result["applied"] == ["config"]
+    assert secrets.read_harness_secret("ANTHROPIC_API_KEY") == "sk-ant-secret-0003"
+
+
+def test_orphan_secrets_are_skipped_with_warning_never_written(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+    bundle["secrets"]["connections"]["repo-ghost"] = {
+        "token": "ghost-token-value-4242"}
+    live, live_dts = config_mod.AppConfig(), {}
+    result = sb.apply_bundle(bundle, config=live, dev_types=live_dts,
+                             reload=lambda: None)
+    assert any("repo-ghost" in w for w in result["warnings"])
+    assert not (tmp_path / "secrets" / "connections" / "repo-ghost.json").exists()
+
+
+def test_dismissed_alerts_stripped_on_serialize_and_preserved_on_apply(
+        monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    cfg.dismissed_alerts = ["gui-secrets-basic-auth:sig"]
+    bundle = sb.serialize_current(cfg, dts, include_secrets=False)
+    assert "dismissed_alerts" not in bundle["config"]["app"]
+    live = config_mod.AppConfig(dismissed_alerts=["local-dismissal:sig2"])
+    sb.apply_bundle(bundle, config=live, dev_types={}, reload=lambda: None)
+    assert live.dismissed_alerts == ["local-dismissal:sig2"]
+
+
+# ── stale refusals ───────────────────────────────────────────────────────────
+
+def test_stale_bundle_version_refused_loudly(monkeypatch, tmp_path):
+    sb, *_ = _env(monkeypatch, tmp_path)
+    with pytest.raises(sb.BundleError) as e:
+        sb.validate_bundle({"kind": sb.BUNDLE_KIND, "bundle_schema_version": 2})
+    assert e.value.status == 422
+    assert "not auto-migrated" in str(e.value)
+
+
+def test_v3_env_shape_inside_bundle_gets_the_migration_string(monkeypatch, tmp_path):
+    sb, *_ = _env(monkeypatch, tmp_path)
+    bundle = {"kind": sb.BUNDLE_KIND, "bundle_schema_version": 1,
+              "config": {"app": {"repos": [{"name": "main",
+                                            "token_env": "GH_TOKEN"}]}}}
+    with pytest.raises(sb.BundleError) as e:
+        sb.validate_bundle(bundle)
+    assert "v3 *_env" in str(e.value)
+
+
+def test_wrong_kind_refused(monkeypatch, tmp_path):
+    sb, *_ = _env(monkeypatch, tmp_path)
+    with pytest.raises(sb.BundleError):
+        sb.validate_bundle({"bundle_schema_version": 1})
+
+
+# ── cross-refs + scrubbing ───────────────────────────────────────────────────
+
+def test_cross_ref_violations_are_422(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=False)
+    # assignment names a dev type the bundle does not carry
+    bad = copy.deepcopy(bundle)
+    bad["config"]["app"]["assignments"]["PLAN"]["dev_type"] = "missing-dev"
+    with pytest.raises(sb.BundleError) as e:
+        sb.validate_bundle(bad)
+    assert "missing-dev" in str(e.value)
+    # active template not in bundle ∪ builtins
+    bad = copy.deepcopy(bundle)
+    bad["config"]["app"]["active_prompt_templates"]["PLAN"] = "nowhere"
+    with pytest.raises(sb.BundleError) as e:
+        sb.validate_bundle(bad)
+    assert "nowhere" in str(e.value)
+
+
+def test_validation_errors_never_echo_secret_values(monkeypatch, tmp_path):
+    """The leak vector (ADR-0013 hardening): pydantic embeds input values in
+    its message; a malformed secrets section must not echo one."""
+    sb, *_ = _env(monkeypatch, tmp_path)
+    leaked = "sk-live-SUPER-SECRET-999999"
+    bundle = {"kind": sb.BUNDLE_KIND, "bundle_schema_version": 1,
+              "secrets": {"connections": {},
+                          "harness": {"GOOD_KEY": leaked,
+                                      "bad var!": leaked}}}
+    with pytest.raises(sb.BundleError) as e:
+        sb.validate_bundle(bundle)
+    assert leaked not in str(e.value)
+    # a config field carrying a secret-looking wrong-typed value
+    bundle = {"kind": sb.BUNDLE_KIND, "bundle_schema_version": 1,
+              "config": {"app": {"poll_interval_seconds": leaked}}}
+    with pytest.raises(sb.BundleError) as e:
+        sb.validate_bundle(bundle)
+    assert leaked not in str(e.value)
+
+
+# ── rollback ─────────────────────────────────────────────────────────────────
+
+def test_reload_failure_rolls_back_to_exact_pre_state(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    live = config_mod.AppConfig()
+    live_dts = dict(dts)
+    for dt in dts.values():
+        config_mod.save_dev_type(dt)
+    config_mod.save_config(live)
+    before = sb.serialize_current(live, live_dts, include_secrets=True)
+
+    incoming = sb.serialize_current(cfg, dts, include_secrets=True)
+    incoming["config"]["app"]["poll_interval_seconds"] = 77
+
+    calls = {"n": 0}
+
+    def failing_reload():
+        calls["n"] += 1
+        if calls["n"] == 1:            # the apply's reload fails...
+            raise RuntimeError("adapter exploded")
+        # ...the rollback's reload succeeds
+
+    with pytest.raises(sb.BundleError) as e:
+        sb.apply_bundle(incoming, config=live, dev_types=live_dts,
+                        reload=failing_reload)
+    assert e.value.status == 500
+    assert "previous settings restored" in str(e.value)
+    after = sb.serialize_current(live, live_dts, include_secrets=True)
+    assert _comparable(after) == _comparable(before)
+    assert live.poll_interval_seconds == 30    # never kept the bundle value
+
+
+def test_deterministic_reload_failure_still_restores_files(monkeypatch, tmp_path):
+    """The rollback's own reload failing must not abort the FILE restore —
+    put_config's 'restore reload also failed' semantics."""
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    live, live_dts = config_mod.AppConfig(), {}
+    before = sb.serialize_current(live, live_dts, include_secrets=True)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+
+    def always_failing_reload():
+        raise RuntimeError("always broken")
+
+    with pytest.raises(sb.BundleError) as e:
+        sb.apply_bundle(bundle, config=live, dev_types=live_dts,
+                        reload=always_failing_reload)
+    assert "previous settings restored" in str(e.value)
+    after = sb.serialize_current(live, live_dts, include_secrets=True)
+    assert _comparable(after) == _comparable(before)
+
+
+# ── diff (preview) ───────────────────────────────────────────────────────────
+
+def test_diff_reports_names_and_counts_never_values(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+    live, live_dts = config_mod.AppConfig(), {}
+    secrets.write_harness_secret("STALE_KEY", "stale-value-to-be-deleted-01")
+    diff = sb.diff_bundle(bundle, live, live_dts)
+    s = str(diff)
+    for value in ("lin_api_secret_value_0001", "ghp_secret_value_0002",
+                  "sk-ant-secret-0003", "stale-value-to-be-deleted-01"):
+        assert value not in s
+    sec = diff["sections"]["secrets"]
+    # the live store in this test already holds the values (same data dir),
+    # so they read as replaced, and the live-only key as removed
+    assert "pmo-linear.api_key" in sec["connections"]["replaced"]
+    assert "STALE_KEY" in sec["harness"]["removed"]
+    assert "poll_interval_seconds" in diff["sections"]["config"]["app_changed"]
+
+
+def test_diff_warns_when_live_secret_is_newer_than_snapshot(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+    bundle["created_at"] = "2000-01-01T00:00:00+00:00"   # ancient snapshot
+    diff = sb.diff_bundle(bundle, cfg, dts)
+    assert any("updated after this snapshot" in w for w in diff["warnings"])
+
+
+def test_diff_flags_intake_pause_change(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    bundle = sb.serialize_current(cfg, dts, include_secrets=False)
+    live = config_mod.AppConfig(intake_paused=True)
+    diff = sb.diff_bundle(bundle, live, {})
+    assert any("UNPAUSED" in w for w in diff["warnings"])
+
+
+# ── setup_env (section C plumbing; endpoints land in PR2) ───────────────────
+
+def test_setup_env_serialization_and_insecure_flag_exclusion(monkeypatch, tmp_path):
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    monkeypatch.setenv("ADMIN_PASSWORD", "hunter2-strong")
+    monkeypatch.setenv("DEVCAKE_ALLOW_INSECURE", "1")
+    cfg = config_mod.AppConfig()
+    bundle = sb.serialize_current(cfg, {}, include_config=False,
+                                  include_secrets=False,
+                                  include_setup_env=True)
+    values = bundle["setup_env"]["values"]
+    assert values.get("ADMIN_PASSWORD") == "hunter2-strong"
+    assert "DEVCAKE_ALLOW_INSECURE" not in values
+    assert "DOCKER_GID" in bundle["setup_env"]["host_specific"]
+    parsed = sb.validate_bundle(bundle)
+    assert parsed["setup_env"]["values"].get("ADMIN_PASSWORD") == "hunter2-strong"
+
+
+def test_setup_env_import_drops_insecure_and_unknown_vars(monkeypatch, tmp_path):
+    sb, *_ = _env(monkeypatch, tmp_path)
+    bundle = {"kind": sb.BUNDLE_KIND, "bundle_schema_version": 1,
+              "setup_env": {"values": {"DEVCAKE_ALLOW_INSECURE": "1",
+                                       "TOTALLY_UNKNOWN": "x",
+                                       "REDIS_PASSWORD": "r-pass"}}}
+    parsed = sb.validate_bundle(bundle)
+    assert parsed["setup_env"]["values"] == {"REDIS_PASSWORD": "r-pass"}
+    assert any("DEVCAKE_ALLOW_INSECURE" in w for w in parsed["warnings"])
+    assert any("TOTALLY_UNKNOWN" in w for w in parsed["warnings"])
+
+
+def test_setup_env_vars_tripwire_matches_env_example():
+    """SETUP_ENV_VARS mirrors .env.example — a var added to one without the
+    other is a drift bug. Skips when the repo root isn't available (the
+    app-test image copies only app/)."""
+    root = Path(__file__).resolve().parents[2] / ".env.example"
+    if not root.exists():
+        pytest.skip(".env.example not in the test image")
+    import re
+    from devcake.settings_bundle import SETUP_ENV_VARS
+    text = root.read_text()
+    declared = set(re.findall(r"^#?\s*([A-Z][A-Z0-9_]+)=", text, re.M))
+    declared -= {"DEVCAKE_ALLOW_INSECURE", "TAG"}
+    ours = {name for name, _ in SETUP_ENV_VARS}
+    assert ours == declared, (
+        f"SETUP_ENV_VARS drift — missing {sorted(declared - ours)}, "
+        f"extra {sorted(ours - declared)}")
+
+
+# ── audit events ─────────────────────────────────────────────────────────────
+
+def test_audit_event_appends_scrubbed_line(monkeypatch, tmp_path):
+    sb, *_ = _env(monkeypatch, tmp_path)
+    sb.audit_event("profile_saved", "name=staging secrets=3")
+    line = (tmp_path / "state" / "events.jsonl").read_text().strip()
+    import json
+    rec = json.loads(line)
+    assert rec["action"] == "profile_saved"
+    assert rec["detail"] == "name=staging secrets=3"
+    assert rec["pmo_id"] == "" and rec["instance"] == ""

--- a/docs/10-persistence.md
+++ b/docs/10-persistence.md
@@ -14,12 +14,20 @@ Run records are accessed through **`StatePort`** (`ports/state.py`); the product
   config/
     config.yaml                 # human-editable general config (§3)
     dev_types/{name}.yaml       # one file per Dev Type (admin-panel CRUD target)
+    prompt_templates/{TYPE}/{name}.yaml         # per-Mission-Type prompt templates (built-ins re-seeded at boot)
+    devtype_prompt_templates/{dev}/{name}.yaml  # per-Dev-Type identifying-prompt templates
+    profiles/{name}.yaml        # config profiles: section A of a settings bundle + metadata (ADR-0013)
   secrets/
+    connections/{scope}-{instance}.json  # GUI-stored PMO/repo secret VALUES (ADR-0011); 0600
+    harness/{VAR}.json          # GUI-stored harness/model keys; 0600
+    internal_forge/*.json       # bundled-Gitea service/mission tokens (ADR-0010); 0600
+    profiles/{name}.json        # a profile's secret snapshot (section B); 0600, covered by the redaction glob
     {dev_type}/creds.json       # uploaded credential JSONs; chmod 600, owner app
   state/
     runs/{run_id}.json          # Run records (02-domain-model.md §7), one file per run
     runs/quarantine/            # unreadable/model-invalid/pre-v2 records, moved aside at boot (§5)
-    events.jsonl                # append-only audit log of every PMO write the app performs
+    events.jsonl                # append-only audit log: every PMO write + settings changes (profile ops, exports)
+    profiles.json               # last-applied-profile breadcrumb (advisory; wiped harmlessly by clear-runs)
 ```
 
 (The poll snapshot served by `GET /api/v1/missions` is in-memory only — rebuilt
@@ -117,5 +125,6 @@ Direct file edits are tolerated but take effect on the next app start, when `loa
 | Deleted | Consequence |
 |---|---|
 | `/data/state` | Run history, attempt counters, and loop-warning dedupe reset. Mission state is untouched (it lives in the PMO); reconciliation (`04-orchestrator.md` §6) rebuilds the in-flight picture from the Dagu API and Redis. Legal at any time. |
-| `/data/secrets` | Dev Types with `credentials_json` mode fail auth (exit 12 → circuit breaker) until re-uploaded. |
+| `/data/secrets` | Dev Types with `credentials_json` mode fail auth (exit 12 → circuit breaker) until re-uploaded. GUI-stored connection/harness secrets and profile secret snapshots are gone — re-enter via the Config page or re-import a bundle. |
 | `/data/config` | The app blocks startup pending reconfiguration (admin panel first-run flow). |
+| `/data/config/profiles` + `/data/secrets/profiles` | Saved profile snapshots are gone; **live settings are untouched** (profiles are fire-and-forget snapshots, ADR-0013). |

--- a/docs/11-admin-panel.md
+++ b/docs/11-admin-panel.md
@@ -38,6 +38,11 @@ Simple but beautiful: a static SPA (React + Vite + Tailwind, `admin/spa/`) serve
 | `GET /api/v1/runs/{run_id}/log/stream` | SSE follow of the same log: replays the stored lines, then streams new ones until the run reaches a terminal state (`event: end`). Sends `X-Accel-Buffering: no` so nginx doesn't buffer; 15 s `: ping` heartbeats stay under nginx's 60 s read timeout |
 | `POST /api/v1/system/clear-runs` | Operator wipe: stop in-flight Devs, delete local run records + audit log, purge Dagu run history, delete OpenObserve log/trace streams. Config + secrets + PMO/forge untouched (`10-persistence.md` §5) |
 | `POST /api/v1/relations-mapper/run` | Manually dispatch a Relations Mapper run (`03-mission-lifecycle.md` §4b). Works regardless of the `enabled` toggle (which governs only the interval service); 422 without a valid `dev_type`, 409 while a mapper run is active |
+| `GET /api/v1/profiles` | Config profile rows (ADR-0013): counts + presence only, plus the last-applied breadcrumb and the divergence boolean. Never a secret value |
+| `GET /api/v1/profiles/{name}` | One profile: metadata, full section A, a secrets **presence map**, and the apply-preview `diff` vs current settings |
+| `POST /api/v1/profiles` | Save-current-as: snapshots the live settings + secret values under `{"name": …}`. 409 on collision unless `overwrite: true`; warnings name configured instances whose secret is missing from the snapshot |
+| `POST /api/v1/profiles/{name}/apply` | THE world-swap: replaces the sections the profile contains through the config choke points (a configs-only profile keeps live secrets). **409 while runs are active**; rollback-by-reapply on reload failure; appends an audit event |
+| `POST /api/v1/profiles/{name}/rename` · `DELETE /api/v1/profiles/{name}` | Rename (moves both snapshot files, keeps the breadcrumb honest) / delete a snapshot — live settings untouched |
 | `GET /api/v1/missions` | Current derived Missions + types (poll-cycle snapshot, advisory — INV-1); includes `blocked_by` keys, and the reason string names open blockers |
 | `POST /api/v1/debug/dispatch-hello` | Dispatches the hello stub Dev through the full pipeline (Dagu → container → Redis → finalize). Permanent debug/CI fixture — `scripts/ci_suite.sh` |
 
@@ -137,6 +142,14 @@ Both validate server-side (name shape, required description, per-file 200 KB / t
 
 ### Assignments
 Matrix: four Mission Types × (Dev-Type dropdown + **extra CLI args** textbox). The args are appended verbatim to the harness invocation for runs of that Mission Type — the mechanism for per-Mission-Type tuning like bounded-effort ONBOARD (`--max-turns 15` is the seeded default there for the claude-code harness). The textbox shows a hint naming the assigned Dev Type's harness; **reassigning a Mission Type to a Dev Type with a different harness triggers a warning offering to keep or clear the args** (they are harness-specific by nature). Same trust class as the MCP command area: admin-only, executed in the Dev container. Inline validation (every type assigned; a Dev Type may hold several).
+
+### Profiles (anchor `#/config/profiles`)
+Named snapshots of the runtime settings AND secret values (ADR-0013). **Entirely Instant** — profiles carry secret values, which never enter the client draft, so the section header carries the ImmediateBadge and the apply panel sits in an InstantZone. The UI deals in presence and counts only; a secret value never reaches the SPA.
+
+- **Save current as profile…** (the one primary): PromptDialog for the name; a 409 collision chains into an explicit red **Overwrite** confirm. Save warnings name configured instances whose secret is missing from the snapshot.
+- **Apply a profile**: dropdown + "Apply profile…" (the Prompts workflow-switcher lineage). The ConfirmDialog **renders the backend's diff preview** — per-section change counts, secret deletions by name, "updated after this snapshot" rotation warnings, intake-pause changes — plus honest destroyed/survives copy ("Run history, the skill store, internal repos, and .env values are untouched"). Disabled while the page draft is dirty (Save or Discard first); a 409 while runs are active renders inside the dialog for retry.
+- Rows: mono name (+ "configs only" badge for A-only profiles), capture time + counts, last-applied breadcrumb with the honest divergence note ("settings changed since" / "matches as of apply" — dict compare + secret timestamps, never value fingerprints). Rename/Delete live in the row ⋯ menu; delete states that live settings are unaffected.
+- Applying reloads the whole shared draft (everything changed). Profiles are fire-and-forget: later edits never update a snapshot.
 
 ### Limits
 - **Global max Devs** integer (help text: effective ceiling = min(global, sum of per-type caps)).

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -34,6 +34,7 @@ If that contract is wrong for your environment, do not run DevCake there.
 | Linear API key | Read/write of the team's project data |
 | `docker.sock` (via Dagu) | **Root-equivalent on the host** |
 | `ADMIN_PASSWORD` / GUI secret store | All operator secrets on the volume |
+| Config profile snapshots (`/data/secrets/profiles/`) | A saved profile's full secret set — same class as the live store; dormant copies survive live rotation/deletion until the profile is deleted (ADR-0013) |
 | `/data` volume (or its backups) | Full secret dump — treat backups like a password-manager export |
 | Mission content + repo content | Feeds agent prompts (trust zone B, §2) |
 
@@ -139,6 +140,15 @@ a capable agent from pushing bad code to a feature branch or exfiltrating tokens
    Config; stored `0600` under `/data/secrets/connections/` and
    `/data/secrets/harness/`. Never echoed (`GET /config` has no secret material;
    `secrets-check` = presence + timestamp only). `.env` = **bootstrap only**.
+6a. **Config profile snapshots (ADR-0013):** saving a profile copies the
+   current secret VALUES to `/data/secrets/profiles/{name}.json` (`0600`, at
+   redaction-glob level — dormant values ≥16 chars are masked by the scan;
+   shorter ones aren't until applied, the same residual as any `/data`
+   backup). The API stays presence-and-counts only for profiles: list/read
+   endpoints and apply previews never emit a value or a fingerprint. Note the
+   rotation caveat: a profile holds the values **as of its save** — rotating
+   a live secret does not touch snapshots, and applying an old profile
+   restores the old value (the apply preview warns).
 7. **Dev-Type secret env (`DevType.secret_env`):** mission-tooling credentials
    (e.g. a log-platform key for an MCP plugin) are the same harness-namespace
    secret class — GUI-stored, `0600`, redaction-registered on write and at boot.
@@ -262,7 +272,9 @@ dismiss.
 7. Strong bootstrap passwords in `.env` (empty/`change-me*` refuse boot unless
    `DEVCAKE_ALLOW_INSECURE=1` — local sandbox only).
 8. Read `/health` **security_warnings**; do not dismiss unread.
-9. Treat **`/data` backups** as secret material.
+9. Treat **`/data` backups** as secret material — including the config
+   profile snapshots under `/data/secrets/profiles/`, which hold every
+   secret value as of each save.
 
 Tutorials: `docs/tutorials/01-first-mission.md`, `13-deployment.md`.
 

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -238,6 +238,10 @@ Fixes from the founder's first post-v0.1.1 live pass, plus the multi-repo design
 
 ## Post-v0.1 backlog
 
+### Shipped post-v0.1
+
+- **Config profiles + settings bundle** (2026-07-18, ADR-0013): ONE versioned bundle format over the four settings stores; named profile snapshots (A + B) with save/apply/rename/delete, apply = replace-the-world through the config choke points (409 while runs active, rollback-by-reapply, diff preview with rotation warnings), scrubbed-error hardening, settings audit events on `events.jsonl`, and the `#/config/profiles` admin section. **Remaining in the ADR-0013 line:** single-file export/import (encrypted-by-default, import-lands-as-profile), setup-env (`.env`) export + generated-file import, `backup_gitea.sh`/`restore_gitea.sh`, and the `profiles.mjs` UI suite (after the check:ui branch merges).
+
 ### Deferred (v0.2+)
 
 - **Webhook ingestion** — a PMO `watch()`/webhook `ChangeEvent` seam replacing polling (+ tunnel guide). Deliberately sequenced *after* F2: the multi-PMO port reshapes the exact surface the seam attaches to. Top candidate once v0.1 ships — multi-PMO instances multiply polling cost.

--- a/docs/adr/0013-settings-bundle-profiles-and-export.md
+++ b/docs/adr/0013-settings-bundle-profiles-and-export.md
@@ -1,0 +1,48 @@
+# ADR-0013 — Settings bundle, config profiles, and export/import
+
+- **Status:** accepted (2026-07-18; profiles + bundle core shipped first, export/import + setup-env + Gitea scripts follow in the same feature line)
+- **Context:** A deployment's settings span four stores (`config.yaml`, `dev_types/*.yaml`, the two prompt-template trees, `/data/secrets/**`) plus `.env`, each with per-entity CRUD only. There was no way to save, load, import, or export a setup as a whole — the only backup story was "copy `/data`". Setting up a new run configuration, or a second deployment, meant re-entering everything by hand.
+
+## Decision 1 — ONE canonical bundle format
+
+`settings_bundle.py` defines a single versioned serialization (`kind: devcake-settings-bundle`, `bundle_schema_version: 1`) with three sections in the founder's taxonomy: **config** (A — AppConfig, dev types, operator prompt templates, active pointers, per-DevType skill *names*), **secrets** (B — connection/harness secret values, optional dev-type credential files), **setup_env** (C — the `.env` bootstrap values). Profiles and export/import are two consumers of the same serializer — a profile IS a stored bundle; an export file IS a serialized profile.
+
+- Section A is always plaintext YAML — bundles stay diffable (ADR-0002 ethos).
+- Sections B and C travel in ONE passphrase-encrypted envelope by default (scrypt KDF + AESGCM via the `cryptography` package; plaintext export exists behind an explicit `acknowledge_plaintext` gate with password-manager-export framing).
+- Versioning matches the house stance: `bundle_schema_version` is refused loudly on mismatch with no auto-migration; the embedded `config.app` goes through the **existing** `reject_stale_patch`, so stale v1/v3 shapes get the existing migration strings. Additive fields with defaults need no bump. **Consequence: profiles and bundles die on a config schema bump** — the refusal names it; "re-save profiles after upgrading" is runbook material.
+- Exclusions ledger — never in a bundle: internal-forge service tokens (re-provisioned at boot), run state, `dismissed_alerts` (imported dismissals could hide live advisories; live value survives apply), `DEVCAKE_ALLOW_INSECURE` (an exported insecure flag must never disable a production host's password checks), the last-applied sidecar. Dev-type credential files are export-only opt-in — host-migration material, never profile material.
+
+## Decision 2 — narrow never-echo exception
+
+ADR-0011's never-echo contract stands everywhere except ONE deliberate, operator-initiated egress: settings export. Previews, profile reads, and list endpoints stay presence-and-counts only (no values, no fingerprints). The security contract records the posture change honestly: **admin basic auth now includes one-request secret read-out** (docs/14 §2/§4). Guardrails: export is POST-only (no values in URLs/access logs), encrypted by default, plaintext acknowledged explicitly, and every export appends an audit event recording sections + encryption mode.
+
+Import hardening: bundles are operator-supplied input — `yaml.safe_load` only, ~20 MB cap, and **scrubbed validation errors** (pydantic embeds offending input in its messages; a malformed secrets section must not echo a value into a 422 detail or a log line — `_scrub_validation_error` strips inputs, and the secrets validators name keys/paths only).
+
+## Decision 3 — profiles: named snapshots across the two stores
+
+`/data/config/profiles/{name}.yaml` holds section A + metadata (diffable); `/data/secrets/profiles/{name}.json` holds section B (0600). The secrets file sits at glob level two, so `security._known_values()`'s `glob("*/*")` covers a dormant snapshot with **zero redaction changes** (tripwire-tested). Residual, documented: dormant values under the 16-char scan floor aren't masked until applied — the same exposure class as a `/data` backup, which the snapshot is.
+
+Profiles are **fire-and-forget**: no built-ins, no seeding, no active pointer — deleting one breaks nothing. There is deliberately no "active profile" indicator: an honest one needs value-derived secret fingerprints, which ADR-0011 bans. Instead: a last-applied breadcrumb (`/data/state/profiles.json`, outside bundles, harmlessly wiped by clear-runs) plus a divergence boolean computed from non-secret dict comparison and secret `updated_at` timestamps.
+
+**Rejected alternative — profiles/settings history in the internal Gitea.** (1) docs/14 §4: secrets "never in git"; git history is append-only, so rotated-out values would persist in `gitea_data`'s object store outside the 0600 + redaction discipline, gated by a bootstrap password. (2) Settings are boot-critical while the internal forge is optional (`GITEA_ADMIN_PASSWORD` unset ⇒ no forge) and sometimes down — the skill-store tolerates that only because skills are lazy enhancement content with a bundled fallback. (3) A git copy of file-based live settings recreates the rejected activity-mirror pattern (docs/16 discarded list: cache-coherence vs single source of truth). The salvaged kernel is the settings **audit trail**: profile save/apply/rename/delete, import, and export append scrubbed events (action, names, counts, encrypted flag — never values) to the existing `events.jsonl`. A one-way, scrubbed, A-only mirror push to Gitea remains a possible future roadmap item — advisory only, never read back.
+
+## Decision 4 — apply = replace-the-world through the existing choke points
+
+Applying a bundle (the ONLY world-swap path — imports land as profiles first, then apply like any other) replaces the sections it contains: full-document `AppConfig.model_validate` (not deep-merge), per-store writes through `save_dev_type`/`save_template`/`write_connection_secret` (validation stays load-bearing), then deletion of files the bundle doesn't carry. A profile without B keeps live secrets. Cross-store semantic checks are ONE implementation shared with `PUT /config` (`validate_config_semantics` + `dry_run_adapters`, extracted from the PUT).
+
+- **Runs-active guard:** apply 409s while runs are dispatched/running/finalizing (the internal-repo delete pattern). Save/list/read/export stay available.
+- **Crash honesty:** no transactions (ADR-0002). Ordering — additive writes, `config.yaml` commit point, deletions — makes any torn state either pre-commit (old world authoritative, new files inert) or post-commit (new world authoritative, stale extras pruned by re-apply). Recovery = re-apply. A staging-dir swap was rejected: `os.replace` cannot atomically swap non-empty directories.
+- **Rollback-by-reapply:** failure after the commit point re-applies the pre-captured previous bundle through the same code path — with three deliberate relaxations, because restoring what WAS live must not editorialize: semantic cross-checks are skipped, the orphan-secret skip is disabled (a live world may hold a secret whose instance card isn't saved yet), and a rollback reload failure logs instead of aborting the file restore. A double fault (rollback file writes failing too) raises 500 naming both worlds; every file write is individually atomic, so the disk is a consistent mix recoverable by any full re-apply.
+- Unknown-instance secrets in a normal apply are **skipped with a warning, never written** — no orphan secret files. The boot top-up interplay is accepted: applying a profile that lacks a seeded default dev type deletes it, and the next boot re-seeds it (the divergence indicator surfaces this honestly).
+- The apply confirm is a **preview**, not just a warning: `diff_bundle` reports per-section adds/changes/removals, flags `intake_paused` changes, and defuses the rotation trap by warning when a live secret's `updated_at` post-dates the snapshot ("applying restores the older value") — timestamps, never values.
+
+## Decision 5 — setup config (C) and internal Gitea (D)
+
+- **C:** the app container reads `.env` values from its own environment (compose `env_file`) but cannot write the host's `.env` and cannot restart the stack. So C exports in-app (with a staleness note: `os.environ` reflects container-start values) and **imports as a generated `.env` download** plus a documented host step (`docker compose up -d`). `DOCKER_GID`/`DEVCAKE_TAG` ride as values flagged host-specific with verify-comments in the generated file.
+- **D:** the app has no git binary and never shells out; API snapshots of internal work repos would discard the history/branches/PRs that ADR-0010's retention exists to keep, and break at Gitea's ~1000-entry tree truncation. So work repos get **host-side full-fidelity scripts** (`scripts/backup_gitea.sh` / `restore_gitea.sh`, a `gitea_data` volume tar — handled like a `/data` backup, since it contains repo content and Gitea's credential DB). The skill-store — HEAD-only by design — travels in bundles via the optional skills embedding (the existing base64 `files[]` shape).
+
+## Consequences
+
+- The persistence layout gains `config/profiles/`, `secrets/profiles/`, `state/profiles.json` (docs/10). Deleting the profiles dirs loses snapshots only; live settings are untouched.
+- Bundles/`/data`-grade material: an export containing B or C is a password-manager export; docs/14 gains the asset row, the Zone-A read-out sentence, and the operator-checklist item; the `gui-secrets-basic-auth` health warning copy now mentions export capability.
+- The full backup story becomes: `/data` volume + `gitea_data` volume (scripts), with settings bundles as the portable, selective layer on top.

--- a/docs/tutorials/02-operating-devcake.md
+++ b/docs/tutorials/02-operating-devcake.md
@@ -64,6 +64,27 @@ cumulative recorded cost — that's your cue to intervene or SKIP.
   open (`14` §2 zone C). Independent REVIEW Dev Type is **recommended**, not
   enforced.
 
+## Config profiles — save and switch whole setups
+
+Config → **Profiles** snapshots your entire saved setup — connections, repos,
+Dev Types, prompt templates, limits, **and every stored secret value** — under
+a name, and applies one back in a single click (ADR-0013):
+
+1. Get a setup working, then **Save current as profile…** (e.g. `baseline`).
+2. Reconfigure freely for a different task; save that as `docs-sprint`.
+3. Switch back anytime with **Apply a profile** → the confirm shows exactly
+   what changes (counts and names, never secret values) before anything
+   applies. Applying is blocked while runs are active — pause intake and let
+   them drain first.
+
+Honesty rules worth knowing: profiles are snapshots, not live links — later
+edits never update a profile (the row shows "settings changed since" when
+you've drifted from the last-applied one); applying an old profile restores
+its **old** secret values, and the preview warns when a live secret is newer
+than the snapshot; run history, the skill store, internal repos, and `.env`
+are never touched by a profile. Profile snapshots live on `/data` and hold
+secret values — they are part of why backups are a password export.
+
 ## Security warnings and daily hygiene
 
 - Read **security_warnings** on Overview/health (write token on all stages,


### PR DESCRIPTION
## What this is

Part 1 of the ADR-0013 line (planned with the founder 2026-07-18): ONE canonical, versioned **settings bundle** representation over the four settings stores, and **config profiles** — named, fully independent snapshots of runtime configs (A) + runtime secrets (B) that can be saved, applied, renamed, and deleted from the admin panel. Part 2 (same ADR) adds single-file export/import with encryption, setup-env (C) export + generated-`.env` import, and the `gitea_data` backup/restore scripts (D).

## Backend

- **`settings_bundle.py`** — serialize/validate/diff/apply of the bundle format (`bundle_schema_version: 1`, refuse-loudly, no auto-migration; embedded config goes through the existing `reject_stale_patch` so stale v1/v3 shapes get the existing migration strings). Apply is **replace-the-world** through the same choke points as `PUT /config` — the semantic checks + dry-run adapter construction are now extracted and shared (`validate_config_semantics`/`dry_run_adapters`; PUT behavior unchanged, pinned by the existing suite).
- **`profiles.py`** — profiles split across the two stores they snapshot: `/data/config/profiles/{name}.yaml` (diffable A + metadata) and `/data/secrets/profiles/{name}.json` (0600, **at redaction-glob level two — zero security.py changes**, tripwire-tested). Fire-and-forget semantics + an honest last-applied breadcrumb with a divergence boolean (dict compare + secret timestamps — never value fingerprints, ADR-0011 intact).
- **Six endpoints** under `/api/v1/profiles*`: list/get (presence + counts + apply-preview diff, never a value), save-current-as (409→overwrite), apply (**409 while runs are active**, internal-repo-delete guard pattern), rename, delete. Profile ops append scrubbed **audit events** to `events.jsonl` (the salvaged kernel of the considered-and-rejected profiles-in-Gitea idea — see the ADR).
- **Hardening** (from the plan's adversarial pass): validation errors are scrubbed — a malformed secrets section can never echo a value into a 422 or a log; unknown-instance secrets skip-with-warning (no orphan files); rollback-by-reapply restores **byte-exact** (lenient semantics, no orphan-skip, reload failure never aborts the file restore); `dismissed_alerts` never ride a bundle; profile names validate before any path join.

## Admin UI

New **Config → Profiles** section (`#/config/profiles`): Instant regime (profiles carry secret values — nothing rides the draft), apply panel in an InstantZone with a ConfirmDialog that renders the backend diff preview (change counts, secret deletions by name, rotation warnings, intake-pause flags) and honest destroyed/survives copy; apply disabled while the draft is dirty; save-as 409 chains an explicit overwrite confirm; rename/delete in the row ⋯ menu; configs-only badge; last-applied + divergence breadcrumb. `ConfirmDialog` gains additive `error` + `children` props.

## Docs

ADR-0013 (bundle format, narrow never-echo exception, profiles layout + scan-floor residual, apply/rollback/crash honesty, C/D decisions, rejected Gitea alternative), docs/10 layout (also fixes the pre-existing staleness — the prompt-template trees and GUI secret stores were missing), docs/11 endpoints + section spec, docs/14 (snapshot asset row, §4 6a, checklist), docs/16 shipped line, tutorial 2 walkthrough.

## Tests

**530 passed, 1 skipped** (was 455 functions; +75 collected): bundle round-trip onto a fresh deployment, replace-the-world + exclusions sparing, config-only apply keeps live secrets, orphan-skip, rollback to exact pre-state (incl. deterministic-reload-failure), scrubbed-error leak tests, `.env.example` tripwire, profiles CRUD/rename/divergence, endpoint 409/presence-only/audit assertions, and the redaction-glob tripwire for `/data/secrets/profiles/`. SPA builds clean. The `profiles.mjs` check:ui suite lands after PR #9 (the committed UI-suite branch) merges, as planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)