### PR TITLE
docs(positioning): "Your board is the interface" + operator contract + roadmap honesty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DevCake 🍰
 
-**You never babysit a chat UI. You run your board.**
+**Your board is the interface. Tickets in, pull requests out.**
 
 DevCake staffs the task board you already use with AI developers. You write a
 ticket in plain language; disposable containers triage, plan, implement, and
@@ -29,9 +29,15 @@ Product voice and pitch variants: [`docs/17-positioning.md`](docs/17-positioning
   Bake, your forge, your models) — not multi-tenant SaaS
 - People who want **receipts** (transcripts, costs, traces) more than a chat copilot
 
-**Not for:** shared Docker hosts, exposing the admin UI to the open internet on
-basic auth alone, or expecting injection-proof agents. Prompt injection is in
-scope of “ticket writers are trusted,” not a product defect to be papered over.
+**Not for:** anyone wanting a hosted, zero-ops service (self-hosting *is* the
+trust model); boards without discipline (DevCake amplifies your board — it
+cannot invent one); shared Docker hosts; exposing the admin UI to the open
+internet on basic auth alone; or expecting injection-proof agents. Prompt
+injection is in scope of “ticket writers are trusted,” not a product defect to
+be papered over.
+
+What you own as the operator — once at setup, and recurring — fits on one page:
+[`docs/18-operator-contract.md`](docs/18-operator-contract.md).
 
 ---
 
@@ -183,7 +189,9 @@ must not exceed [`docs/14-security.md`](docs/14-security.md).
 | I want to… | Start here |
 |---|---|
 | Understand the product and invariants | [`docs/00-overview.md`](docs/00-overview.md) |
+| Onboard as a new engineer (reading path) | [`docs/00-overview.md`](docs/00-overview.md) §6a |
 | Understand the security deal | [`docs/14-security.md`](docs/14-security.md) |
+| Know what you own as operator | [`docs/18-operator-contract.md`](docs/18-operator-contract.md) |
 | Run a first mission / operate daily | [`docs/tutorials/`](docs/tutorials/) |
 | Deploy, networks, runbook | [`docs/13-deployment.md`](docs/13-deployment.md) |
 | Labels, lifecycle, orchestrator | [`docs/02`](docs/02-domain-model.md) · [`03`](docs/03-mission-lifecycle.md) · [`04`](docs/04-orchestrator.md) |

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -122,6 +122,27 @@ A concrete end-to-end pass, naming the governing document at each hop:
 9. **REVIEW:** by **recommended** config, a *different* Dev Type than EXECUTE reviews the PR (warned if shared — not a hard gate; `14` §8). On approval, the app removes the stage label and approves the PR (second reviewer token if configured); then **merge precedes Done**: with `auto_merge` **off** (default) the Mission carries `DEVCAKE-MERGE` until a **human** merges; with it on the app merges and only then marks **Done**. On rejection, the report is posted and the label swaps back to `DEVCAKE-EXECUTE`.
 10. **Throughout**, every hop is one connected OpenTelemetry trace (dispatch → container → finalization), visible in OpenObserve (`12-observability.md`).
 
+## 6a. Onboarding path (30 minutes for a new engineer)
+
+Read in this order — each doc assumes the ones before it:
+
+1. This overview, §1–§6 — what it is, the invariants, one Mission's life.
+2. [`02-domain-model.md`](02-domain-model.md) — the entities and the label
+   state machine everything else speaks in.
+3. [`03-mission-lifecycle.md`](03-mission-lifecycle.md) — what each Mission
+   Type actually does.
+4. **[`14-security.md`](14-security.md)** — the trust contract; nothing you
+   build or operate may outclaim it.
+5. [`04-orchestrator.md`](04-orchestrator.md) — scheduling, dispatch,
+   finalization, crash recovery.
+6. [`13-deployment.md`](13-deployment.md) — the stack you'll actually touch,
+   plus the runbook.
+7. [`tutorials/01-first-mission.md`](tutorials/01-first-mission.md) — drive one
+   mission end to end.
+
+Operating duties — once at setup and recurring — live in
+[`18-operator-contract.md`](18-operator-contract.md).
+
 ## 7. Document map
 
 | Doc | Governs |
@@ -143,5 +164,6 @@ A concrete end-to-end pass, naming the governing document at each hop:
 | `15-errors-and-retries.md` | Error taxonomy, retry matrix, `DEVCAKE-FAILED` |
 | `16-roadmap.md` | Milestones with exit criteria |
 | `17-positioning.md` | Outward voice — must not outclaim `14` |
+| `18-operator-contract.md` | What the operator owns — setup pointer + recurring duties + rotation |
 | `adr/` | Records of significant architectural decisions |
 | `tutorials/` | Operator path (includes supply-chain checklist) |

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -238,10 +238,37 @@ Fixes from the founder's first post-v0.1.1 live pass, plus the multi-repo design
 
 ## Post-v0.1 backlog
 
+> **Status vocabulary** (applies below; the honesty rule: a feature is not
+> *done* until the live box proves it): **built** = merged, full suite + CI
+> green · **live-verified (date)** = exercised on the live stack, evidence
+> noted · **⏳ live-pending** = built, live end-to-end still owed. Milestone
+> checkboxes `[x]` above mark exit criteria verified at that milestone's close.
+
 ### Shipped post-v0.1
 
-- **Config profiles + settings bundle** (2026-07-18, ADR-0013): ONE versioned bundle format over the four settings stores; named profile snapshots (A + B) with save/apply/rename/delete, apply = replace-the-world through the config choke points (409 while runs active, rollback-by-reapply, diff preview with rotation warnings), scrubbed-error hardening, settings audit events on `events.jsonl`, and the `#/config/profiles` admin section.
-- **Settings export/import + setup-env + Gitea backup** (2026-07-18, ADR-0013 part 2): single-file export (source = current or a profile; sections A/B/C; scrypt+AESGCM encrypted by default, plaintext behind explicit acknowledgment; optional skill embedding; audited), stateless import that **lands as a profile** (apply remains the one world-swap path), section C as a generated ready-to-place `.env` download, `scripts/backup_gitea.sh`/`restore_gitea.sh` for full-fidelity internal-forge backups, and the Export…/Import… transfer UI. **Remaining in the ADR-0013 line:** the `profiles.mjs` UI suite (after the check:ui branch merges).
+- **MCP plugins — core ports** (2026-07-17, PR #6): `DevType.secret_env` +
+  live `mcp_setup_commands` runspec wire, referenced-missing-secret dispatch
+  gate, exit-14 `DEV_MCP_SETUP` reporting, `tutorials/03-mcp-plugins.md`;
+  connectors live out-of-repo (vendor segregation). **built** · ⏳ live plugin
+  round pending the founder-owned `LOGS_MCP_GIT_TOKEN` PAT.
+- **Decomposition depth + fail-closed edge inheritance** (2026-07-18,
+  ADR-0012, PR #10): depth-tagged markers, `max_decomposition_depth` +
+  Traffic-control UI, strict inherited edges, scheduler family gate, lineage
+  notes on canceled parents. **built** (493 tests at merge) ·
+  **⏳ live-pending** — live E2E plan on file.
+- **Missions board** (2026-07-18, PR #11, rflpazini): Hermes-style kanban with
+  steering comments + stop-run; pre-merge review fixed priority-validation
+  500, stop-of-finalizing 409, `create_mission` 502. **built** · deployed live
+  2026-07-18 (UI suite green).
+- **Config profiles + settings bundle** (2026-07-18, ADR-0013): ONE versioned bundle format over the four settings stores; named profile snapshots (A + B) with save/apply/rename/delete, apply = replace-the-world through the config choke points (409 while runs active, rollback-by-reapply, diff preview with rotation warnings), scrubbed-error hardening, settings audit events on `events.jsonl`, and the `#/config/profiles` admin section. **built** (530 tests at merge) · **⏳ live-pending** — profile save/apply round-trip on the live stack owed.
+- **Settings export/import + setup-env + Gitea backup** (2026-07-18, ADR-0013 part 2): single-file export (source = current or a profile; sections A/B/C; scrypt+AESGCM encrypted by default, plaintext behind explicit acknowledgment; optional skill embedding; audited), stateless import that **lands as a profile** (apply remains the one world-swap path), section C as a generated ready-to-place `.env` download, `scripts/backup_gitea.sh`/`restore_gitea.sh` for full-fidelity internal-forge backups, and the Export…/Import… transfer UI. **built** (548 tests at merge) · **⏳ live-pending** — encrypted export/import round-trip + `restore_gitea.sh` drill owed; the `profiles.mjs` UI suite owed (check:ui branch has merged — unblocked).
+- **Activity-feed fidelity + per-mission activity repos** (2026-07-18,
+  ADR-0014, PR #15): last-message-inline + full-dump flip, `MISSION.md`
+  faithful mirror, per-mission `activity-*` repos swept on Clear, quoting
+  quarantine, `executed_trivially` removed. **live-verified 2026-07-18**
+  (missions DEV-126/DEV-127 on the live sandbox).
+- **Missions "Poll now"** (2026-07-18, PR #14, rflpazini): INV-1-aligned poll
+  CTA; "New mission" dropped from the board. **live-verified 2026-07-18**.
 
 ### Deferred (v0.2+)
 

--- a/docs/17-positioning.md
+++ b/docs/17-positioning.md
@@ -2,7 +2,8 @@
 
 > **Audience:** anyone writing outward-facing words about this project — README,
 > website, pitch, launch post. The README is the applied version of this doc.
-> **Status:** adopted at v0 close; **aligned with the product security contract**
+> **Status:** adopted at v0 close; motto and fit criteria revised 2026-07-18
+> (pre-v0.2) — §1, §1b. **Aligned with the product security contract**
 > in [`14-security.md`](14-security.md). Outward copy must not claim a stronger
 > posture than `14`. The product name is **provisional** (§6).
 
@@ -14,13 +15,15 @@ control surface is the task board you already run. You manage AI developers
 exactly the way you manage human ones: write a ticket, get work back on a pull
 request, approve it or send it back with notes.
 
-**Motto: "You never operate it."**  
-(Long form: *You never operate it. You write a ticket; finished work comes back
-on a PR — with a receipt.*)
+**Motto: "Your board is the interface."**  
+(Long form: *Your board is the interface. Tickets dispatch work; labels steer
+it; finished work comes back on a PR — with a receipt.*)
 
-“Never operate it” means **no day-to-day chat babysitting** — not “no trust
-decisions.” You still choose who can write tickets, protect the default branch,
-and whether auto-merge is on. Those are operator duties (`14` §9).
+There is no second place of work — and no pretense that the work runs itself.
+You self-host it, you decide who writes tickets, you protect the default
+branch, and you hold the merge button. That ownership is the deal, stated
+plainly: it is *why* the output can be trusted, not fine print to walk back
+(`14` §9; recurring duties in [`18-operator-contract.md`](18-operator-contract.md)).
 
 The second pillar is **autonomy with receipts.** Every step posts its transcript
 and token bill to the ticket; dispatches, kills, sweeps, and PMO writes are
@@ -48,10 +51,37 @@ Forbidden overclaims:
 - “Independent review by default” as a hard product guarantee.
 - Implying sandboxed multi-customer isolation.
 
+### 1b. When to use it — and when not (normative for all outward copy)
+
+Fit is part of the pitch. Every outward description of the product should make
+both lists recognizable within the first minute.
+
+**Use DevCake when:**
+
+- Your team already runs real work through a task board (Linear in-tree today)
+  and the board has discipline: tickets are written to be picked up, and
+  labels mean things.
+- One adult operator can own a dedicated machine and the trust envelope that
+  comes with it — team membership, branch protection, credentials, backups
+  ([`18-operator-contract.md`](18-operator-contract.md)).
+- You want **delegation with receipts** — transcripts, token bills, traces —
+  more than a chat copilot at your elbow.
+
+**Don't use DevCake when:**
+
+- You want a hosted, zero-ops service. There isn't one; self-hosting on your
+  own box *is* the trust model (`14` §2).
+- There is no board discipline to inherit. DevCake amplifies the board you
+  run; it cannot invent one for you.
+- You need multi-tenant isolation, or agents that stay safe under malicious
+  ticket writers — ticket writers are inside the trust boundary (`14` §3).
+- You want pair programming in an editor. This is delegation, not
+  companionship.
+
 ## 2. The pitches
 
 **The hero line (10 words):**
-> You never operate it. Your task board just gets done.
+> Your board is the interface. Tickets in, pull requests out.
 
 **One-liner (for "what is this repo?"):**
 > DevCake staffs your task board with AI developers whose work arrives on a
@@ -71,9 +101,9 @@ Forbidden overclaims:
 > looks at the work skeptically before you merge. What comes back is a pull
 > request plus a receipt for every step and what it cost. It runs on a machine
 > you control, with your own AI subscriptions. Nothing reaches main without
-> your green light unless you turn on auto-merge and accept that path. You
-> don't babysit a chat UI. You run your board — and you still own branch
-> protection and who can write tickets.
+> your green light unless you turn on auto-merge and accept that path. Your
+> board is the interface — no chat UI to babysit. And you own the shop:
+> branch protection, who can write tickets, and the merge button.
 
 **The kitchen-table version (zero tech vocabulary):**
 > It's a robot work crew for my to-do list. I write down what I want in plain
@@ -101,10 +131,10 @@ Forbidden overclaims:
 
 | | |
 |---|---|
-| **Roof (motto)** | *You never operate it.* (no chat babysitting — not “no trust work”) |
-| **Pillar 1 — No new interface** | Your task board is the product. Labels are the controls; tickets are the conversations; your merge (or auto-merge) is the deploy button. |
+| **Roof (motto)** | *Your board is the interface.* (no new place of work — and you own the trust envelope) |
+| **Pillar 1 — No new place of work** | Your task board is the product. Labels are the controls; tickets are the conversations; your merge (or auto-merge) is the deploy button. |
 | **Pillar 2 — Autonomy with receipts** | Every step posts transcript + token bill. Traced and audited. Independent AI review is **recommended config** (warned if violated). “Done” never lies about merge. |
-| **Pillar 3 — Your models, your box** | Self-hosted on a **dedicated** machine. Mix Claude/Grok/Codex per role. Control plane does not ship your secrets to us; agents with open egress can still exfiltrate if injected — defend the supply chain (`14`). |
+| **Pillar 3 — Your box, your rules** | Self-hosted on a **dedicated** machine; you own the trust envelope — team membership, branch protection, the merge button, backups (`18`). Mix Claude/Grok/Codex per role. Control plane does not ship your secrets to us; agents with open egress can still exfiltrate if injected — defend the supply chain (`14`). |
 | **Foundation** | Verified, not vibed: acceptance path tickets → PRs, GitHub and GitLab, invariant tests, redaction of app-mediated posts. Security contract in `14`. |
 
 ## 4. Tone guide

--- a/docs/18-operator-contract.md
+++ b/docs/18-operator-contract.md
@@ -1,0 +1,82 @@
+# 18 — Operator Contract: What You Own
+
+> **Audience:** the person who runs a DevCake host — before the first real
+> EXECUTE and every week after. **Status:** adopted pre-v0.2 (2026-07-18).
+> **Zero-drift rule:** this page consolidates *what* you own and *when*; the
+> linked docs stay the single source for *how*. If this page and a linked doc
+> disagree, the linked doc wins — then fix this page.
+
+## 1. The deal in one paragraph
+
+DevCake automates the work, not the trust. Your board is the interface for
+delegation (`17`); this page is the other half of that sentence: you host the
+stack, you decide who can write tickets, you protect the default branch, you
+hold the merge button, and you keep the secrets and the backups. None of that
+is busywork the product forgot to automate — it is the control that makes
+autonomous work trustworthy (`14` §0). The app **warns** on weak posture; it
+does not gate you (`14` §8). It assumes an adult operator.
+
+## 2. Once, before the first real EXECUTE
+
+The checklist is [`14-security.md`](14-security.md) §9 — ten items, from
+dedicated host and loopback-only control ports to treating `/data` backups as
+secret material. Do not start real work without it. The GUI-only path for
+proving a fresh machine works is the
+[operator drill](tutorials/operator-drill.md).
+
+## 3. Recurring duties
+
+| Duty | When | How (normative source) |
+|---|---|---|
+| **Read `/health`** — `security_warnings`, `circuit_breakers`, `poll_degraded`, merge queue, needs-human | Routinely; always when something feels off | Admin Overview renders it ([`11`](11-admin-panel.md)); OpenObserve alerts back it ([`12`](12-observability.md) §5–6) |
+| **Acknowledge breakers** | When tripped | `DEV_AUTH`: re-upload that Dev Type's credentials — the write clears the breaker ([`15`](15-errors-and-retries.md) §4). Repo breakers clear on a green probe: fix the token, wait a poll |
+| **Back up `/data`** | Before every upgrade; weekly otherwise | Volume copy; it is a **secret dump** — store accordingly ([`10`](10-persistence.md), [`13`](13-deployment.md) §8) |
+| **Back up `gitea_data`** | Same cadence, if the internal forge holds real work | `scripts/backup_gitea.sh` / `restore_gitea.sh` ([`13`](13-deployment.md) §8) |
+| **Export a settings bundle** | Before risky config surgery | Admin Settings export — encrypted by default; store like a credential dump ([`11`](11-admin-panel.md)) |
+| **Rotate secrets** | On a schedule you choose; immediately on suspicion or a team departure | §4 below |
+| **Pause intake** | Before maintenance, upgrades, or anything that shouldn't dispatch new work | Sidebar master switch; in-flight runs finish ([`02`](02-domain-model.md), [`11`](11-admin-panel.md)) |
+| **Re-run the fresh-`/data` drill** | Each release you adopt; quarterly otherwise | [operator drill](tutorials/operator-drill.md) — the standing stranger-operability proof |
+| **Rebuild in lockstep on upgrade** | Every time `app/`, `admin/`, or `images/` change | `docker buildx bake all && docker compose up -d` ([`13`](13-deployment.md) §8, `AGENTS.md`) |
+
+## 4. Secret rotation (the procedure, in one place)
+
+Rotation is four different motions depending on the secret:
+
+1. **PMO and forge tokens** — mint the new token at the provider, paste it
+   into the Config card's secret field, **Save**, then run the connection
+   test. The write path hot-reloads adapters ([`11`](11-admin-panel.md)).
+2. **Model / harness credentials** — upload via the Dev Type card (OAuth
+   wizard, credential upload, or `scripts/grok_login.sh`). The write clears
+   any `DEV_AUTH` breaker for Dev Types using that credential
+   ([`15`](15-errors-and-retries.md) §4).
+3. **Stack bootstrap passwords** (`ADMIN_*`, `REDIS_*`, `DAGU_*`, `OO_*`,
+   `GITEA_ADMIN_*`) — edit `.env`, then restart the stack; services take
+   their passwords from `.env` at boot ([`13`](13-deployment.md) §8).
+4. **After any rotation: re-save your profiles.** A profile snapshot holds
+   secret values *as of its save*; applying a stale one resurrects the old
+   secret. The apply preview warns on secrets “updated after this snapshot”
+   ([`11`](11-admin-panel.md)) — treat that warning as a stop sign unless you
+   mean it.
+
+Old settings exports and old `/data` backups still contain the pre-rotation
+secrets. Rotation is not complete until you have re-exported and re-backed-up —
+or accepted that the old artifacts must now be guarded like the old secret.
+
+## 5. What the app will not do for you
+
+The app warns; **you** gate (`14` §8):
+
+- **Branch protection** on every work repo's default branch — the forge
+  enforces; the app only surfaces an advisory ([`13`](13-deployment.md) §8a).
+- **Team membership** — every ticket writer steers agents that hold your
+  credentials (`14` §0).
+- **Auto-merge** — off by default; turning it on is a judgment call the app
+  will never make for you.
+- **REVIEW separation** — a different Dev Type for REVIEW than EXECUTE is
+  recommended configuration; the app warns when shared, nothing more.
+
+## 6. Ownership map
+
+[`14-security.md`](14-security.md) §10 assigns every residual risk an owner —
+Design, Operator, or Engineering. The rows marked **Operator** are this page's
+justification. Read them once; they are the honest edges of the product.

--- a/docs/tutorials/02-operating-devcake.md
+++ b/docs/tutorials/02-operating-devcake.md
@@ -1,7 +1,7 @@
 # Tutorial 2 — Operating DevCake Day to Day
 
-You never **babysit** DevCake through a chat UI — you operate work **through
-Linear**. Labels and statuses are the control surface; DevCake reads them as
+Your board is the interface — you operate work **through Linear**, not a chat
+UI. Labels and statuses are the control surface; DevCake reads them as
 instructions and reports back the same way. The admin panel is for config,
 health, secrets, and runs — keep it on **localhost** (or SSH tunnel); it is
 host-equivalent power (`14-security.md` §4).


### PR DESCRIPTION
## What

**PR A** of the skeptic-review response plan (pre-v0.2). Docs-only.

Replaces the stale **"You never operate it"** motto with the frame the product can state plainly — **"Your board is the interface"** — and turns the "what you still own" critique into product surface instead of fine print.

- **`docs/17-positioning.md`**: new roof; hero line → *"Your board is the interface. Tickets in, pull requests out."*; 30-second pitch and message house realigned (Pillar 3 → *Your box, your rules — you own the trust envelope*); ownership stated affirmatively — the walk-back construction is gone. New **§1b "When to use it — and when not"**, normative for all outward copy.
- **NEW `docs/18-operator-contract.md`**: one page for what the operator owns — pre-first-EXECUTE pointer (`14` §9), recurring-duties table (health, breakers, backups, bundles, intake pause, drill, lockstep rebuild), the **secret-rotation procedure** consolidated for the first time (incl. the stale-profile-resurrects-old-secret trap), warns-vs-gates list, ownership-map pointer (`14` §10). Zero-drift: linked, not duplicated.
- **`docs/16-roadmap.md`**: status legend (**built / live-verified (date) / ⏳ live-pending**) and a completed "Shipped post-v0.1" record — ADR-0012, the Missions board (#11), ADR-0014 (#15), and Poll-now (#14) were missing from it entirely. ADR-0012/0013 are now honestly marked ⏳ live-pending (their live E2Es are v0.2 tag gates, per plan).
- **`docs/00-overview.md`**: §6a onboarding path (30-minute read order for a second engineer) + doc-map row for 18.
- **`README.md`**: new tagline; "Not for" extended with the zero-ops-SaaS and no-board-discipline anti-fits; docs table rows for the operator contract and the onboarding path.
- **`tutorials/02`**: opening sentence aligned.

## Verification

- `grep -rni "never operate|never babysit|run your board"` over the repo → zero hits (agent-persona prompts untouched — they never used the motto phrases).
- All new/edited relative links resolve to existing files.

## Context

First of the A→B→C→D series agreed for the v0.2 release candidate: A (this) → B (exception policy + grok-auth exit-12 classifier) → C1–C7 (orchestrator de-façade, main.py split, ConfigPage split) → D (live E2Es, Clear-Runs stop hardening, audit, tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)