### PR TITLE
fix(errors): blanket-except policy (BLE001) + grok-auth exit-12 classifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Design and refactors must respect SOLID. Prefer **deep modules** (small interfac
 - Typing domain code against concrete `DaguExecutor` / `Messaging` / `RunStore` instead of ports
 - Duplicating the ACL → digest → save → start spine outside `RunBootstrap`
 - Giant untested functions in `orchestrator.py` without a public-seam test
-- `except Exception: pass` that swallows real failures without logging
+- `except Exception: pass` that swallows real failures without logging — lint-enforced: ruff `BLE001`; every blanket catch is narrowed or carries `# noqa: BLE001 — <justification>` naming its contract (docs/15 §7)
 - Mutating production modules only “to make the test pass” by weakening invariants
 
 ## Docker images: Bake only

--- a/app/devcake/adapters/files/owner_store.py
+++ b/app/devcake/adapters/files/owner_store.py
@@ -35,7 +35,7 @@ class OwnerStore:
         try:
             data = json.loads(self.path.read_text())
             return {str(k): str(v) for k, v in data.items()}
-        except Exception:
+        except Exception:  # noqa: BLE001 — unreadable owner store starts empty (logged); ownership is advisory
             log.error("unreadable owner store %s — starting empty (a shared "
                       "mission may need its duplicate-claim anomaly resolved "
                       "by hand)", self.path)

--- a/app/devcake/adapters/files/run_store.py
+++ b/app/devcake/adapters/files/run_store.py
@@ -67,8 +67,8 @@ class RunStore:
                     raw["spec_env"] = {k: v for k, v in env.items()
                                        if not self._sensitive_env_name(k)}
                 self._write_text(path, json.dumps(raw, indent=2, default=str))
-        except Exception:
-            pass  # not valid JSON: preserve the bytes under 0600
+        except Exception:  # noqa: BLE001 — not valid JSON: preserve the bytes under 0600
+            log.debug("quarantine: %s not parseable; preserving raw bytes", path.name)
         qdir = self.root / "quarantine"
         qdir.mkdir(mode=0o700, exist_ok=True)
         dest = qdir / path.name
@@ -87,7 +87,7 @@ class RunStore:
         for p in sorted(self.root.glob("*.json")):
             try:
                 runs.append(Run.model_validate_json(p.read_text()))
-            except Exception:
+            except Exception:  # noqa: BLE001 — corrupt run JSON is skipped, never crashes the listing; the boot sweep quarantines it
                 continue  # unreadable file: skip, never crash the loop
         return runs
 
@@ -110,7 +110,7 @@ class RunStore:
                 run = Run.model_validate_json(path.read_text())
                 if run.schema_version < 2:
                     raise ValueError("pre-v2 run record (may carry credentials)")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 — any parse/validation failure quarantines the record rather than blocking boot
                 self._quarantine(path, str(e))
                 moved.append(path.stem)
         return moved

--- a/app/devcake/adapters/gitea/adapter.py
+++ b/app/devcake/adapters/gitea/adapter.py
@@ -200,7 +200,7 @@ class GiteaForge:
         try:
             state = await self.pr_state(pr_number)
             return bool(state.merged)
-        except Exception:
+        except Exception:  # noqa: BLE001 — probe contract: failure → False, caller re-raises the original merge error
             return False
 
     async def mergeable(self, pr_number: int) -> Optional[bool]:

--- a/app/devcake/adapters/gitea/provision.py
+++ b/app/devcake/adapters/gitea/provision.py
@@ -145,7 +145,7 @@ class GiteaProvisioner:
         try:
             toks = await self._req("GET", f"/users/{user}/tokens",
                                    tolerate=(404,)) or []
-        except Exception:
+        except Exception:  # noqa: BLE001 — probe contract: failure → False → token treated as dead and re-minted; never raises into boot provisioning
             return False
         return any(t.get("name") == name
                    and t.get("token_last_eight") == token[-8:] for t in toks)
@@ -525,7 +525,7 @@ class GiteaProvisioner:
                 r = await client.get(
                     f"{self.url}/api/v1/repos/{ORG}/{repo}",
                     headers={"Authorization": f"token {token}"})
-        except Exception:
+        except Exception:  # noqa: BLE001 — tri-state probe contract (A13): network failure → None; caller must not re-mint on None
             return None
         if r.status_code == 200:
             return True
@@ -573,7 +573,7 @@ class GiteaProvisioner:
                 return {"ok": False, "ui_url": self.public_url,
                         "detail": "org not provisioned yet (boot pending?)"}
             return {"ok": True, "detail": "", "ui_url": self.public_url}
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — health probe contract: any failure → {"ok": False} payload; health must never raise
             return {"ok": False, "detail": str(e)[:200],
                     "ui_url": self.public_url}
 
@@ -592,7 +592,7 @@ class GiteaProvisioner:
             return None
         try:
             return json.loads(path.read_text())
-        except Exception:
+        except Exception:  # noqa: BLE001 — unreadable secret reads as absent (logged); provisioning re-mints from absence
             log.error("unreadable internal-forge secret %s", path)
             return None
 

--- a/app/devcake/adapters/github/adapter.py
+++ b/app/devcake/adapters/github/adapter.py
@@ -151,7 +151,7 @@ class GitHubForge:
         try:
             state = await self.pr_state(pr_number)
             return bool(state.merged)
-        except Exception:
+        except Exception:  # noqa: BLE001 — probe contract: failure → False, caller re-raises the original merge error
             return False
 
     async def mergeable(self, pr_number: int) -> Optional[bool]:

--- a/app/devcake/adapters/gitlab/adapter.py
+++ b/app/devcake/adapters/gitlab/adapter.py
@@ -156,7 +156,7 @@ class GitLabForge:
                         state = await self.pr_state(pr_number)
                         if state.merged:
                             return
-                    except Exception:
+                    except Exception:  # noqa: BLE001 — best-effort merged check; original error re-raised
                         pass
                 raise
 
@@ -194,7 +194,7 @@ class GitLabForge:
             if e.status == 404:
                 return BranchProtection(protected=False, requires_reviews=None)
             return None
-        except Exception:
+        except Exception:  # noqa: BLE001 — probe contract: failure → None (protection unknown); never raises into the poll loop
             return None
 
     async def pr_files(self, pr_number: int) -> list[PRFile]:

--- a/app/devcake/adapters/redis/messaging.py
+++ b/app/devcake/adapters/redis/messaging.py
@@ -102,7 +102,9 @@ class Messaging:
             try:
                 if json.loads(fields.get("m", "{}")).get("kind") == "runspec.result":
                     await self.redis.xdel(stream, entry_id)
-            except Exception:
+            except Exception:  # noqa: BLE001 — best-effort secret-entry sweep; skip is logged
+                log.warning("delete_runspec_result: skipping unparseable entry %s on %s",
+                            entry_id, stream)
                 continue
 
     async def delete_reply_stream(self, run_id: str) -> None:
@@ -170,7 +172,8 @@ class Messaging:
                 try:
                     envelope = json.loads((fields or {}).get("m", "{}"))
                     run_id = str(envelope.get("run_id", ""))
-                except Exception:
+                except Exception:  # noqa: BLE001 — scan must finish; skip is logged
+                    log.warning("ingress run-id scan: skipping unparseable entry %s", _entry_id)
                     continue
                 if run_id:
                     out.add(run_id)
@@ -229,7 +232,7 @@ class Messaging:
             envelope = json.loads(fields.get("m", "{}"))
             if not isinstance(envelope, dict):
                 envelope = {}
-        except Exception:
+        except Exception:  # noqa: BLE001 — a malformed body must still be dead-letterable; empty envelope, poison path proceeds
             envelope = {}
         key = self._chunk_identity(envelope)
         assembly = self._chunks.get(key) if key else None

--- a/app/devcake/api/clear.py
+++ b/app/devcake/api/clear.py
@@ -124,13 +124,13 @@ async def clear_redis(messaging: Messaging) -> dict[str, Any]:
         try:
             await r.delete(key)
             reply_deleted += 1
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — clear-runs teardown is best-effort per key; failure logged, sweep continues
             log.warning("redis delete %s: %s", key, e)
     # trim ingress rather than drop it (keeps consumer group)
     try:
         await r.xtrim(INGRESS, maxlen=0, approximate=False)
         ingress_trimmed = True
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — best-effort teardown; failure logged and recorded as ingress_trimmed=False, sweep continues
         log.warning("redis xtrim ingress: %s", e)
         ingress_trimmed = False
     # revoke any leftover per-run ACL users (dev-*)
@@ -141,7 +141,7 @@ async def clear_redis(messaging: Messaging) -> dict[str, Any]:
             if name.startswith("dev-"):
                 await r.execute_command("ACL", "DELUSER", name)
                 users_deleted += 1
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — clear-runs teardown is best-effort per subsystem; failure logged, sweep continues
         log.warning("redis ACL cleanup: %s", e)
     # in-process chunk reassembly
     messaging._chunks.clear()

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -260,7 +260,7 @@ async def _poll_instance(mgr: MissionManager,
         try:
             m.repo, m.repo_reason = await mgr.resolve_repo_live(
                 m, all_runs=run_snapshot)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — poll guard: a forge outage gates THIS mission only (reason recorded + logged); it must never abort the whole cycle
             m.repo, m.repo_reason = None, (
                 f"internal forge unreachable — mission gated: {str(e)[:150]}")
             log.warning("repo resolution failed for %s: %s", m.key, e)
@@ -509,7 +509,7 @@ async def _check_redis() -> bool:
             return bool(await r.ping())
         finally:
             await r.aclose()
-    except Exception:
+    except Exception:  # noqa: BLE001 — probe contract: any failure → False; /health must never 500
         return False
 
 
@@ -533,7 +533,7 @@ async def _branch_protection() -> dict:
                 prot = await f.default_branch_protection(
                     inst.default_branch if inst else "main")
                 out[name] = prot.model_dump() if prot else None
-            except Exception:
+            except Exception:  # noqa: BLE001 — probe contract: failure → None (advisory omitted); /health must never 500
                 out[name] = None
         _protection_cache["value"] = out
     return _protection_cache["value"]
@@ -543,7 +543,7 @@ async def _check_http(url: str) -> bool:
     try:
         async with httpx.AsyncClient(timeout=3) as client:
             return (await client.get(url)).status_code < 500
-    except Exception:
+    except Exception:  # noqa: BLE001 — probe contract: any failure → False; /health must never 500
         return False
 
 
@@ -567,7 +567,7 @@ async def _oo_ingest_check() -> dict:
                   "detail": "" if r.status_code == 200 else
                   f"HTTP {r.status_code} — the OO service account cannot "
                   f"authenticate; run scripts/provision_oo.py (ISSUES #13)"}
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — probe contract: any failure → ok:False + detail; /health must never 500
         result = {"ok": False, "detail": f"probe failed: {str(e)[:150]}"}
     _oo_ingest_cache.update(ts=now, result=result)
     return result
@@ -592,7 +592,7 @@ async def health():
         mgr = managers.get(inst.name)
         try:
             ok = bool(mgr) and (await mgr.pmo.health_probe(inst.team_key)).ok
-        except Exception:
+        except Exception:  # noqa: BLE001 — probe contract: any failure → ok:False for this instance; /health must never 500
             ok = False
         pmo_instances[inst.name] = {"ok": ok, "configured": True,
                                     "team": inst.team_key}
@@ -834,7 +834,7 @@ async def put_config(body: dict):
     try:
         reject_stale_patch(body)
         merged = AppConfig.model_validate(deep_merge(config.model_dump(), body))
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — validation contract: whatever the merge/model raises on a bad patch surfaces as 422, never a 500
         raise HTTPException(422, str(e))
     # cross-store semantics + dry-run adapter construction (ISSUES #11) live
     # in settings_bundle — ONE implementation shared with bundle apply
@@ -1047,14 +1047,14 @@ def _open_uploaded_bundle(body: dict) -> dict:
     protected-envelope unwrap when a passphrase rides along."""
     try:
         raw = base64.b64decode(str(body.get("content_b64") or ""), validate=True)
-    except Exception:
+    except Exception:  # noqa: BLE001 — upload-parsing contract: any decode failure is the client's 422, never a 500
         raise HTTPException(422, "content_b64 must be valid base64")
     if len(raw) > MAX_BUNDLE_BYTES:
         raise HTTPException(422, f"bundle exceeds "
                                  f"{MAX_BUNDLE_BYTES // (1024 * 1024)} MB")
     try:
         doc = yaml.safe_load(raw.decode("utf-8"))
-    except Exception:
+    except Exception:  # noqa: BLE001 — upload-parsing contract: any decode/parse failure is the client's 422, never a 500
         raise HTTPException(422, "not a readable YAML bundle")
     if not isinstance(doc, dict):
         raise HTTPException(422, "not a settings bundle")
@@ -1157,7 +1157,7 @@ async def export_summary():
     harness_n = len(secrets_store.list_harness_secrets())
     try:
         skills_n = len((await skill_service.list_skills())[0])
-    except Exception:
+    except Exception:  # noqa: BLE001 — advisory count: a skill-store outage shows 0, the export dialog must still render
         skills_n = 0
     return {"secrets": {"total": sum(by_scope.values()) + harness_n,
                         "by_scope": by_scope, "harness": harness_n,
@@ -1350,7 +1350,7 @@ async def list_dev_types():
 async def upsert_dev_type(body: dict, name: str | None = None):
     try:
         dt = DevType.model_validate(body if name is None else {**body, "name": name})
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — validation contract: whatever model_validate raises on a bad body surfaces as 422, never a 500
         raise HTTPException(422, str(e))
     dev_types[dt.name] = dt
     save_dev_type(dt)
@@ -1436,7 +1436,7 @@ async def get_assignments():
 async def put_assignments(body: dict):
     try:
         new = {k: Assignment.model_validate(v) for k, v in body.items()}
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — validation contract: whatever model_validate raises on a bad body surfaces as 422, never a 500
         raise HTTPException(422, str(e))
     missing = {"ONBOARD", "PLAN", "EXECUTE", "REVIEW"} - set(new)
     if missing:
@@ -1609,7 +1609,7 @@ async def test_pmo(name: str):
                 "labels": h.managed_labels_present,
                 "labels_expected": h.managed_labels_expected,
                 "missions_visible": len(missions)}
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — connection-test contract: any probe failure → ok:False + error in the response, never a 500
         return {"ok": False, "error": str(e)[:300]}
 
 
@@ -1655,7 +1655,7 @@ async def test_forge(name: str):
                 "reference_only": inst.reference_only,
                 "reviewer_token_configured": reviewer, "probe_pr": pr is None,
                 "branch_protection": protection.model_dump() if protection else None}
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — connection-test contract: any probe failure → ok:False + error in the response, never a 500
         return {"ok": False, "error": str(e)[:300]}
 
 
@@ -1667,7 +1667,7 @@ async def list_internal_repos():
         return {"repos": [], "ui_url": None}
     try:
         repos = await internal_forge.list_repos()
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — upstream-error contract: any forge failure surfaces as 502 with detail, never a raw 500
         raise HTTPException(502, f"internal forge unreachable: {str(e)[:200]}")
     return {"repos": [r.model_dump() for r in repos],
             "ui_url": os.environ.get("GITEA_UI_URL", "http://localhost:3300")}
@@ -1691,7 +1691,7 @@ async def create_internal_repo(body: dict):
         return await internal_forge.create_operator_repo(name)
     except ValueError as e:
         raise HTTPException(409, str(e))
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — upstream-error contract: any forge failure surfaces as 502 with detail, never a raw 500
         raise HTTPException(502, f"internal forge: {str(e)[:200]}")
 
 
@@ -1759,7 +1759,7 @@ async def sync_skills():
                                  "(GITEA_ADMIN_PASSWORD unset)")
     try:
         await internal_forge.ensure_skill_store(skill_service.builtin_seed())
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — upstream-error contract: any forge failure surfaces as 502 with detail, never a raw 500
         raise HTTPException(502, f"internal forge: {str(e)[:200]}")
     return {"ok": True}
 
@@ -1777,7 +1777,7 @@ async def delete_internal_repo(name: str):
                                  "to finish before clearing")
     try:
         await internal_forge.delete_repo(name)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — upstream-error contract: any forge failure surfaces as 502 with detail, never a raw 500
         raise HTTPException(502, f"delete failed: {str(e)[:200]}")
     forge_runtime.forges.pop(name, None)
     forge_runtime.instances.pop(name, None)

--- a/app/devcake/api/mission_actions.py
+++ b/app/devcake/api/mission_actions.py
@@ -23,7 +23,10 @@ Precondition discipline:
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
+
+log = logging.getLogger("devcake.missions")
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Protocol
@@ -104,8 +107,8 @@ def _try_audit(mgr: Any, pmo_id: str, action: str, detail: str = "") -> None:
         return
     try:
         fn(pmo_id, action, detail)
-    except Exception:  # pragma: no cover - defensive
-        pass
+    except Exception:  # noqa: BLE001 — audit is advisory; failure is logged, never surfaced
+        log.debug("audit write failed for %s/%s", pmo_id, action, exc_info=True)
 
 
 # ── 1) label actions: retry / park / unpark / resume ────────────────────────

--- a/app/devcake/domain/forge_runtime.py
+++ b/app/devcake/domain/forge_runtime.py
@@ -145,7 +145,7 @@ class ForgeRuntime:
         else:
             try:
                 data = (await forge.health_probe()).model_dump()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 — probe contract: any failure → ok:False + transient detail, never raises into the poll loop
                 # a probe that could not run says nothing about the credential
                 data = {"ok": False, "repository": inst.url if inst else "",
                         "can_push": False, "transient": True,

--- a/app/devcake/domain/orchestrator/decomposition.py
+++ b/app/devcake/domain/orchestrator/decomposition.py
@@ -267,7 +267,7 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
             try:
                 await self.pmo.append_description(
                     MissionRef(pmo_id, "issue"), note)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 — lineage note is best-effort BY DESIGN (comment above); failure recorded in the audit, the cancel proceeds
                 self._audit(pmo_id, "lineage_note_failed", str(e)[:200])
         await self._checkpoint(run, "decomp:parent_note", _parent_note)
 

--- a/app/devcake/domain/orchestrator/deliver.py
+++ b/app/devcake/domain/orchestrator/deliver.py
@@ -52,7 +52,7 @@ async def deliver_internal_zip_for_mission(self, m, pr) -> None:
         act = await self.pmo.get_activity(m.ref)
         if any(marker in self._unquoted(e.body) for e in act.entries):
             return                               # already delivered
-    except Exception:
+    except Exception:  # noqa: BLE001 — idempotency probe is advisory; failure logged and delivery proceeds (a double attach beats a lost deliverable)
         log.warning("deliverable idempotency check failed for %s — proceeding",
                     m.key)
     await _deliver_core(self, m.repo, m.key, m.pmo_id, m.pmo_kind, pr)
@@ -104,7 +104,7 @@ async def _merge_sha(forge, pr_number: int) -> str:
     try:
         raw = await forge._req("GET", f"/pulls/{pr_number}")
         return raw.get("merge_commit_sha") or "main"
-    except Exception:
+    except Exception:  # noqa: BLE001 — best-effort probe per docstring: any failure falls back to zipping at the "main" ref
         return "main"
 
 
@@ -118,7 +118,7 @@ async def _build_zip(forge, files: list[PRFile], ref: str,
     for f in files:
         try:
             fetched.append((f.path, await forge.file_content(f.path, ref)))
-        except Exception:
+        except Exception:  # noqa: BLE001 — fetch failure is logged and recorded as a real omission (MANIFEST.txt); the zip build continues
             # a fetch failure is a REAL omission — count it (review finding
             # #4: else the feed note over-claims the delivered file count and
             # MANIFEST.txt never mentions it → silent data loss)

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -161,7 +161,7 @@ async def dispatch(self, mission: Mission, mtype: MissionType,
         return None
     try:
         live = await self.pmo.get(mission.ref)                 # live re-read
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — any PMO failure gates this ONE mission (reason recorded + logged); escaping would abort the whole poll segment (audit A1)
         # a PMO failure here (transient or permanent) gates the ONE mission —
         # letting it escape would abort the whole poll segment (audit A1)
         self.blocked_reasons[mission.pmo_id] = (
@@ -309,7 +309,7 @@ async def _skill_payload(self, dev_type: DevType) -> list[dict]:
         return []
     try:
         payload, warnings = await self.skills.payload_for(dev_type.skills)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — skills are additive and must never refuse a run; dispatch proceeds without them (logged)
         # payload_for swallows STORE errors, but a bundled-copy read can
         # still raise — skills are additive and must never refuse a run
         log.warning("skills for %s unavailable — dispatching without them "
@@ -508,8 +508,9 @@ def _last_giveup_at(cls, pmo_id: str) -> datetime | None:
                     if e.get("pmo_id") == pmo_id \
                             and e.get("action") == "devcake_failed":
                         ts = cls._aware(datetime.fromisoformat(e["ts"]))
-                except Exception:
-                    continue  # one bad audit line must never halt scheduling
+                except Exception:  # noqa: BLE001 — one bad audit line must never halt scheduling
+                    log.debug("_last_giveup_at: skipping unparseable audit line")
+                    continue
         return ts
     except FileNotFoundError:
         return None
@@ -635,7 +636,7 @@ async def activity_payload(self, pmo_id: str, kind: str = "issue") -> dict:
         never parses vendor asset URLs."""
         try:
             data = await self.pmo.download_asset(att.url)
-        except Exception:
+        except Exception:  # noqa: BLE001 — attachment fetch degrades to an inline "unavailable" marker; the mirror build continues
             return f"[attachment unavailable: {att.url}]"
         # basename BEFORE dedupe: a slash-bearing link text ([v1/r.md](…))
         # must yield the same name in the index, the snapshot commit, and

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -149,7 +149,7 @@ def _attachment_cap(self) -> int:
     """The PMO's attachment size cap (deliverable zip bound)."""
     try:
         return self.pmo.capabilities().attachment_max_bytes
-    except Exception:
+    except Exception:  # noqa: BLE001 — capability probe degrades to the conservative 25 MiB default cap; the zip builder still bounds the payload
         return 25 * 1024 * 1024
 
 

--- a/app/devcake/domain/orchestrator/review.py
+++ b/app/devcake/domain/orchestrator/review.py
@@ -48,7 +48,7 @@ async def _flag_out_of_pipeline_merge(self, run: Run) -> None:
             f"{run.mission_key}: PR merged outside the pipeline ({state.url})")
         log.warning("out-of-pipeline merge on %s (%s)", run.mission_key,
                     state.url)
-    except Exception:
+    except Exception:  # noqa: BLE001 — anomaly probe is best-effort; failure logged (debug), the review flow is unaffected
         log.debug("out-of-pipeline merge check failed for %s",
                   run.mission_key, exc_info=True)
 
@@ -165,7 +165,7 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                         self._audit(pmo_id, "review_approve_merged", pr_url)
                     await self._checkpoint(run, "review:done", _done)
                     await self.deliver_internal_zip(run, pr)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 — every merge failure, whatever its type, must enter the re-probe → conflict-route → merge-failed recovery ladder; escaping would strand the mission mid-REVIEW
                     # Capture for nested async defs (static F821 + safe if
                     # await order changes later); not a known production 500.
                     merge_err = e

--- a/app/devcake/domain/orchestrator/schedule.py
+++ b/app/devcake/domain/orchestrator/schedule.py
@@ -125,7 +125,7 @@ async def _open_blockers(self, m: Mission, by_id: dict[str, Mission],
             if bid not in memo:
                 try:
                     memo[bid] = await self.pmo.get(MissionRef(bid, "issue"))
-                except Exception:
+                except Exception:  # noqa: BLE001 — fail-safe per ADR-0007: an unreadable blocker counts as open (logged); self-heals next cycle
                     log.warning("blocker %s of %s unreadable — treated as open",
                                 bid, m.key)
                     memo[bid] = None

--- a/app/devcake/domain/orchestrator/sweeps.py
+++ b/app/devcake/domain/orchestrator/sweeps.py
@@ -180,7 +180,7 @@ async def _deferred_merge_retry(self, m: Mission, pr,
         span.set_attribute("devcake.merge.verdict", str(verdict))
         try:
             await forge.merge(pr.number)
-        except Exception:
+        except Exception:  # noqa: BLE001 — a failed merge IS the signal here: a real conflict routes/hands off, anything else is logged transient and next cycle retries
             if verdict is False:
                 span.set_attribute("devcake.outcome", "conflict")
                 if not await self._maybe_route_conflict_to_execute(

--- a/app/devcake/domain/orchestrator/transitions.py
+++ b/app/devcake/domain/orchestrator/transitions.py
@@ -198,7 +198,7 @@ async def _transition(self, run: Run, result: dict, plan_md: str | None) -> None
                     await self.pmo.post_feed(
                         MissionRef(pmo_id, "project"),
                         redact(baton) + "\n\n" + COMMENT_SENTINEL)
-                except Exception:
+                except Exception:  # noqa: BLE001 — project-update mirror is best-effort; failure logged, the hand-off is already recorded on the feed + audit
                     log.warning("project-update hand-off failed for %s — "
                                 "summary lives in the audit log only",
                                 run.mission_key, exc_info=True)

--- a/app/devcake/domain/reconcile.py
+++ b/app/devcake/domain/reconcile.py
@@ -33,7 +33,7 @@ async def reconcile_runs(manager) -> None:
                     or label in ("failed", "aborted", "error", "cancelled"):
                 try:
                     node_errors = await executor.node_errors(r.run_id) if status else []
-                except Exception:
+                except Exception:  # noqa: BLE001 — error-detail probe is optional enrichment; empty detail is the safe default, the orphan kill proceeds
                     node_errors = []
                 await manager.kill(r, "orphaned", "reconciliation: dagu run not alive")
                 detail = " ".join(str(item.get("error") or "") for item in node_errors)

--- a/app/devcake/domain/runs.py
+++ b/app/devcake/domain/runs.py
@@ -303,7 +303,7 @@ class RunManager:
         from ..telemetry import push_oo_log
         try:
             errors = await self.executor.node_errors(run.run_id)
-        except Exception:
+        except Exception:  # noqa: BLE001 — detail probe is best-effort (logged); the failure record must still ship to OpenObserve
             log.warning("no dagu node errors for %s", run.run_id, exc_info=True)
             errors = []
         record = failure_record(run, new_state, reason, errors)

--- a/app/devcake/domain/skills.py
+++ b/app/devcake/domain/skills.py
@@ -57,7 +57,7 @@ def parse_frontmatter(text: str) -> dict:
         end = text.index("\n---", 3)
         data = yaml.safe_load(text[3:end])
         return data if isinstance(data, dict) else {}
-    except Exception:
+    except Exception:  # noqa: BLE001 — lenient by contract (docstring): any broken shape yields {}; a malformed SKILL.md must never take the listing down
         return {}
 
 
@@ -152,7 +152,7 @@ class SkillService:
                     builtin=name in builtin_names))
             return skills, {"enabled": True, "ok": True, "detail": "",
                             "html_url": self.forge.skill_store_url()}
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — skill store degrades to the bundled listing; failure logged + surfaced in store_status detail
             log.warning("skill store unreachable — serving bundled list: %s", e)
             return self._builtin_listing(), {
                 "enabled": True, "ok": False, "detail": str(e),
@@ -196,7 +196,7 @@ class SkillService:
         try:
             text = base64.b64decode(skill_md.get("content_b64") or "",
                                     validate=True).decode("utf-8")
-        except Exception:
+        except Exception:  # noqa: BLE001 — any decode failure maps to a typed SkillStoreError(422) refusal the API surfaces
             raise SkillStoreError(422, "SKILL.md is not valid base64/UTF-8")
         fm = parse_frontmatter(text)
         name = str(fm.get("name") or "")
@@ -240,7 +240,7 @@ class SkillService:
             try:
                 data = base64.b64decode(f.get("content_b64") or "",
                                         validate=True)
-            except Exception:
+            except Exception:  # noqa: BLE001 — any decode failure maps to a typed SkillStoreError(422) refusal the API surfaces
                 raise SkillStoreError(422, f"{rel}: not valid base64")
             if len(data) > MAX_FILE_BYTES:
                 raise SkillStoreError(422, f"{rel} exceeds the "
@@ -253,7 +253,7 @@ class SkillService:
                                        f"{MAX_TOTAL_BYTES}-byte total cap")
         try:
             existing = {t["path"] for t in await self._store_tree()}
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — store I/O failure maps to a typed SkillStoreError(503) the API surfaces
             raise SkillStoreError(503, f"skill store unreachable: {e}")
         if not overwrite and (f"{name}/SKILL.md" in existing
                               or name in self._builtin_skills()):
@@ -269,7 +269,7 @@ class SkillService:
             if orphans:
                 await self.forge.delete_skill_paths(
                     sorted(orphans), f"devcake admin: prune skill {name}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — store I/O failure maps to a typed SkillStoreError(502) the API surfaces
             raise SkillStoreError(502, f"skill store write failed: {e}")
         self._invalidate()
 
@@ -286,14 +286,14 @@ class SkillService:
         try:
             paths = [t["path"] for t in await self._store_tree()
                      if t["path"].startswith(f"{name}/")]
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — store I/O failure maps to a typed SkillStoreError(503) the API surfaces
             raise SkillStoreError(503, f"skill store unreachable: {e}")
         if not paths:
             raise SkillStoreError(404, f"skill {name!r} is not in the store")
         try:
             await self.forge.delete_skill_paths(
                 paths, f"devcake admin: delete skill {name}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — store I/O failure maps to a typed SkillStoreError(502) the API surfaces
             raise SkillStoreError(502, f"skill store delete failed: {e}")
         self._invalidate()
 
@@ -320,7 +320,7 @@ class SkillService:
             try:
                 store_index = {t["path"]: int(t.get("size") or 0)
                                for t in await self._store_tree()}
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 — skills are additive: store failure degrades to the bundled copies, recorded in warnings
                 warnings.append(f"skill store unreachable ({e}) — "
                                 "using bundled copies")
         builtin = self._builtin_skills()
@@ -335,7 +335,7 @@ class SkillService:
                 try:
                     entry, size_used, warns = await self._collect(
                         name, sized, total, self._store_file)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 — skills are additive: store read failure falls back to the bundled copy, recorded in warnings
                     warnings.append(f"skill {name!r}: store read failed ({e}) "
                                     "— trying the bundled copy")
                     entry, size_used, warns = [], 0, []

--- a/app/devcake/profiles.py
+++ b/app/devcake/profiles.py
@@ -148,7 +148,7 @@ def list_profiles() -> list[dict]:
         try:
             doc = yaml.safe_load(p.read_text())
             assert isinstance(doc, dict)
-        except Exception:
+        except Exception:  # noqa: BLE001 — a broken profile renders as broken in the list; listing must not 500
             out.append({"name": name, "broken": True})
             continue
         cfg = doc.get("config") or {}
@@ -188,7 +188,7 @@ def _read_state() -> dict:
         return {}
     try:
         return json.loads(p.read_text())
-    except Exception:
+    except Exception:  # noqa: BLE001 — corrupt last-applied breadcrumb reads as empty; it is an advisory divergence hint only
         return {}
 
 

--- a/app/devcake/prompts/templates.py
+++ b/app/devcake/prompts/templates.py
@@ -94,7 +94,7 @@ def _load(path: Path) -> dict | None:
     try:
         data = yaml.safe_load(path.read_text())
         return data if isinstance(data, dict) else None
-    except Exception:
+    except Exception:  # noqa: BLE001 — unreadable template logged and read as absent; seeded defaults still serve
         log.error("unreadable prompt template %s", path)
         return None
 

--- a/app/devcake/secrets.py
+++ b/app/devcake/secrets.py
@@ -80,7 +80,7 @@ def _read(path: Path) -> dict:
         return {}
     try:
         return json.loads(path.read_text())
-    except Exception:
+    except Exception:  # noqa: BLE001 — lenient-read contract: corrupt file reads as absent (logged); redaction scanner alarms separately
         log.error("unreadable secret file %s", path)
         return {}
 

--- a/app/devcake/security.py
+++ b/app/devcake/security.py
@@ -154,7 +154,7 @@ def _known_values() -> list[str]:
         try:
             live_paths.add(str(p))
             values.extend(_file_values(p))
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 — redaction-source scan must cover the rest; unreadable file reported once
             _report_unreadable(p, exc)
             continue
     for stale in set(_scan_cache) - live_paths:      # deleted files drop out

--- a/app/devcake/settings_bundle.py
+++ b/app/devcake/settings_bundle.py
@@ -442,7 +442,7 @@ def unprotect_bundle(bundle: dict, passphrase: str) -> dict:
     try:
         sections = json.loads(plaintext)
         assert isinstance(sections, dict)
-    except Exception:
+    except Exception:  # noqa: BLE001 — any parse/shape failure of decrypted bytes maps to one typed 422; never leaks internals
         raise BundleError(422, "decrypted payload is not a bundle section map")
     out = {k: v for k, v in bundle.items() if k != "protected"}
     out.update(sections)

--- a/app/devcake/telemetry/__init__.py
+++ b/app/devcake/telemetry/__init__.py
@@ -46,7 +46,7 @@ async def push_oo_log(stream: str, record: dict) -> bool:
                 json=[record])
             resp.raise_for_status()
         return True
-    except Exception:
+    except Exception:  # noqa: BLE001 — telemetry shipping is fire-and-forget; failure logged, must never break kill/finalize
         log.warning("could not ship record to OO stream %s", stream, exc_info=True)
         return False
 

--- a/app/ruff.toml
+++ b/app/ruff.toml
@@ -5,8 +5,12 @@ target-version = "py312"
 line-length = 100
 
 [lint]
-# Narrow: syntax / undefined names only (caught the review.py merge_err capture).
-select = ["E9", "F63", "F7", "F82"]
+# Narrow: syntax / undefined names only (caught the review.py merge_err capture),
+# plus BLE001 (blind except). Policy (docs/15 §7): every production
+# `except Exception` is narrowed or carries `# noqa: BLE001` with a one-line
+# justification. Silent swallows (bare pass/continue, no log) are never OK.
+select = ["E9", "F63", "F7", "F82", "BLE001"]
 
 [lint.per-file-ignores]
-"tests/*" = []
+# Test code legitimately catches broadly.
+"tests/*" = ["BLE001"]

--- a/app/tests/test_entrypoint_classify.py
+++ b/app/tests/test_entrypoint_classify.py
@@ -1,0 +1,65 @@
+"""classify_harness_failure units (docs/15 §1, §4): a nonzero harness exit is
+DEV_AUTH (12) only on credential wording, else DEV_CRASH (10). The grok CLI's
+revoked-session wording ("Not signed in", "run `grok login`") must map to 12 —
+the historical miss made revoked grok creds burn three DEV_CRASH attempts
+instead of tripping the DEV_AUTH breaker once."""
+
+import importlib.util
+import os
+from pathlib import Path
+
+# host checkout: repo/app/tests → repo/images/common; app container: /srv/tests
+# → /srv/images/common (read-only compose mount)
+_CANDIDATES = [Path(__file__).parents[2] / "images" / "common" / "dev_entrypoint.py",
+               Path(__file__).parents[1] / "images" / "common" / "dev_entrypoint.py"]
+ENTRYPOINT = next((p for p in _CANDIDATES if p.exists()), _CANDIDATES[0])
+
+# module reads these at import; redis.from_url is lazy (no connection until
+# use). Restore the env afterwards — leaking REDIS_URL here would repoint the
+# live messaging tests (same pytest process) at a nonexistent server.
+_ENV_KEYS = ("DEVCAKE_RUN_ID", "REDIS_URL", "REDIS_USER", "REDIS_PASSWORD")
+_saved = {k: os.environ.get(k) for k in _ENV_KEYS}
+os.environ.setdefault("DEVCAKE_RUN_ID", "T-1-1-EXECUTE-AAAAAA")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6399/0")
+os.environ.setdefault("REDIS_USER", "test")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+
+spec = importlib.util.spec_from_file_location("dev_entrypoint_classify", ENTRYPOINT)
+ep = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ep)
+
+for _k, _v in _saved.items():
+    if _v is None:
+        os.environ.pop(_k, None)
+    else:
+        os.environ[_k] = _v
+
+
+def test_grok_revoked_session_is_auth():
+    assert ep.classify_harness_failure("Error: Not signed in.") == 12
+    assert ep.classify_harness_failure(
+        "You are signed out. Run `grok login` to continue.") == 12
+    assert ep.classify_harness_failure("Please sign in to continue") == 12
+
+
+def test_legacy_markers_still_auth():
+    assert ep.classify_harness_failure("401 Unauthorized") == 12
+    assert ep.classify_harness_failure("authentication failed for user") == 12
+    assert ep.classify_harness_failure("please log in again") == 12
+
+
+def test_generic_crash_is_not_auth():
+    assert ep.classify_harness_failure("Traceback (most recent call last): ...") == 10
+    assert ep.classify_harness_failure("segmentation fault") == 10
+    assert ep.classify_harness_failure("") == 10
+
+
+def test_precision_no_bare_login_or_sign_in_substrings():
+    # "login"/"sign in" alone are NOT markers — a crash while *processing* such
+    # text must stay DEV_CRASH; a false 12 pauses the whole Dev Type (docs/15 §4)
+    assert ep.classify_harness_failure("error rendering the login page fixture") == 10
+    assert ep.classify_harness_failure("failed test: sign in button missing") == 10
+
+
+def test_case_insensitive():
+    assert ep.classify_harness_failure("NOT SIGNED IN") == 12

--- a/docs/15-errors-and-retries.md
+++ b/docs/15-errors-and-retries.md
@@ -15,7 +15,7 @@
 | `DEV_CRASH` | exit 10 (harness crash), 20 (entrypoint); vanished container | counted attempt |
 | `DEV_MCP_SETUP` | exit 14: an `mcp_setup_commands` entry failed or hit the 300 s per-command cap; `run.error` carries the command + stderr tail | counted attempt |
 | `DEV_TIMEOUT` | exit 124 / watchdog kill | counted attempt |
-| `DEV_AUTH` | exit 12 | circuit breaker (§4) — **not** a counted attempt |
+| `DEV_AUTH` | exit 12 — harness credential wording per the §4 marker contract | circuit breaker (§4) — **not** a counted attempt |
 | `DEV_FORGE_AUTH` | exit 13 with GitHub/GitLab auth/permission evidence | global forge circuit breaker; no run dispatch until the configured token can push |
 | `DEV_BAD_OUTPUT` | exit 11: `result.json` missing/invalid; app-side: structurally invalid payload behind a legal outcome (empty decomposition, bad `blocked_by`) | counted attempt |
 | `ILLEGAL_OUTCOME` | outcome not in `LEGAL_OUTCOMES` for the run type (`03` §6) — includes forged outcomes (e.g. EXECUTE claiming `reviewed`) | park with `DEVCAKE-SKIP` + comment; audit `illegal_outcome`; never acted on, never retried |
@@ -76,6 +76,8 @@ Contrast: `DEVCAKE-FAILED` = involuntary give-up after repeated errors; `DEVCAKE
 
 Exit 12 trips a **per-Dev-Type breaker**: all scheduling for that Dev Type pauses (its Missions stay queued, unharmed), the health strip shows the tripped state, and a PMO comment is posted on the mission that tripped it. Half-open probe: the next config write touching that Dev Type's credentials (or a manual "retry" from the admin panel health strip) closes the breaker. Rationale: auth failures burn nothing but fail everything — retrying without new credentials is pure waste.
 
+**Harness-auth marker contract** (the Dev entrypoint's `classify_harness_failure`, mirrored by `test_entrypoint_classify.py`): a nonzero harness exit maps to 12 only when the stderr tail carries credential wording — `authentication`, `unauthorized`, `log in`, plus the grok CLI's revoked-session phrases `not signed in`, `please sign in`, `signed out`, `grok login`. Markers are **precise phrases by design**: a false 12 pauses the entire Dev Type until a human re-uploads credentials, while a false 10 merely burns one attempt — when extending the list, err toward 10. (Bare `login`/`sign in` are deliberately absent.)
+
 Exit 13 trips the **global forge breaker** only when the Dev's clone-failure classification is the structured `DEV_FORGE_AUTH` class, which itself requires git's credential wording ("returned error: 403/401", "Authentication failed", "could not read Username", …) — a bare "403" in stderr (rate limit, URL fragment) never halts dispatch. Probes latch the breaker only on **definitive** credential/permission failures (HTTP 401/403/404; a GitHub rate-limit 403 is exempt): 5xx/network/probe errors are marked *transient* and neither latch nor clear it. While the breaker is latched, the poll loop re-probes every cycle — a false latch or a restored token self-heals within one poll interval, while a genuinely revoked token stays latched (and alerted) until fixed. Startup and the Forge connection test run the same probe and require push permission, so a private repository omitted from a fine-grained PAT is rejected before another Dev starts.
 
 ## 5. Poison messages
@@ -94,3 +96,31 @@ there is no metrics pipeline in v0 (`12-observability.md` §4):
 3. `PMO_TRANSIENT`/`FORGE_TRANSIENT` persistent > 15 min — `poll.cycle` outcome attribute plus `forge.probe_transient` spans;
 4. poison message — `ingress.poison` spans;
 5. daily cost threshold — SUM of `devcake.cost.usd` over `run.finalize` spans (`OO_DAILY_COST_ALERT_USD`, default 50).
+
+## 7. Blanket-exception policy
+
+Silent partial failure — a swallowed exception in a loop that keeps looking
+healthy — is this system's most dangerous failure mode: poll cycles, sweeps,
+and teardown paths all deliberately outlive individual errors. The policy that
+keeps that deliberate without becoming sloppy:
+
+- **Lint-enforced** (`app/ruff.toml`, rule `BLE001`; runs in CI and
+  `scripts/ci_suite.sh`): every production `except Exception` is either
+  **narrowed** to the types the code can actually handle, or carries
+  `# noqa: BLE001 — <one-line justification>` naming the contract that makes a
+  blanket catch correct. The justification lives **inline at the site** — this
+  section defines the vocabulary, never a site inventory (it would drift).
+- **Sanctioned contracts** (the justification should name one):
+  *loop guard* (a poll/sweep/consumer cycle must survive any single item's
+  failure — the failure is logged and, where one exists, surfaced via
+  `poll_degraded`/`blocked_reasons`/a breaker); *probe* (health and connection
+  probes map any failure to `ok: False` — `/health` must never 500);
+  *best-effort teardown/rollback* (cleanup continues past individual failures,
+  each logged; the original error, not the cleanup's, surfaces); *degrade with
+  record* (fall back to a default and record it — bundled skill copy, warnings
+  list, quarantine).
+- **Never sanctioned:** a blanket catch whose handler neither logs, records,
+  falls back visibly, nor re-raises. There are none in the tree; the lint keeps
+  it that way.
+- Test code is exempt (`tests/*` per-file ignore) — tests legitimately catch
+  broadly.

--- a/images/common/dev_entrypoint.py
+++ b/images/common/dev_entrypoint.py
@@ -201,6 +201,25 @@ def clone_error_class(stderr: str) -> str:
     return "DEV_FORGE_AUTH" if any(m in lowered for m in auth_markers) else "DEV_FORGE"
 
 
+HARNESS_AUTH_MARKERS = (
+    # generic credential wording (any harness)
+    "authentication", "unauthorized", "log in",
+    # grok CLI revoked/expired-session wording — without these a revoked grok
+    # cred exits 10 (DEV_CRASH, three burned attempts) instead of 12 (DEV_AUTH
+    # breaker trip)
+    "not signed in", "please sign in", "signed out", "grok login",
+)
+
+
+def classify_harness_failure(err_text: str) -> int:
+    """Exit code for a nonzero harness exit: 12 (DEV_AUTH) only on credential
+    wording, else 10 (DEV_CRASH). Markers are precise phrases on purpose — a
+    false 12 pauses the whole Dev Type until a human re-uploads credentials;
+    a false 10 merely burns one attempt (docs/15 §4)."""
+    lowered = err_text.lower()
+    return 12 if any(m in lowered for m in HARNESS_AUTH_MARKERS) else 10
+
+
 # ── live output relay (docs/08 §4, docs/09 §2) ──────────────────────────────
 # The harness's stdout is pumped line-by-line: the raw line is accumulated for
 # end-of-run parsing, and a condensed human-readable rendering is (a) printed
@@ -897,9 +916,7 @@ def main() -> None:
 
     if harness_exit != 0:
         err = err_text[-1500:]
-        auth_fail = "authentication" in err.lower() or "unauthorized" in err.lower() \
-            or "log in" in err.lower()
-        code = 12 if auth_fail else 10
+        code = classify_harness_failure(err)
         send_artifacts({"result": None, "exit_code": code,
                         "transcript_md": with_session(
                             f"harness exited {harness_exit}\n\n```\n{err}\n```", dump),

--- a/scripts/ci_suite.sh
+++ b/scripts/ci_suite.sh
@@ -26,6 +26,10 @@ python3 scripts/check_image_pins.py
 echo "── bake app-test (prod image has no pytest)"
 docker buildx bake -f docker-bake.hcl app-test
 
+echo "── ruff (syntax / undefined names / blanket-except policy, docs/15 §7)"
+docker run --rm -e RUFF_CACHE_DIR=/tmp/ruff-cache -w /srv \
+  "devcake/app-test:${DEVCAKE_TAG:-latest}" ruff check devcake tests
+
 echo "── unit + live-redis tests (INV-1..6 coverage) via app-test image"
 # Same Docker network as compose so redis://redis resolves; prod app stays lean.
 # Mount images/common for test_entrypoint_render (same path as compose: /srv/images/common).


### PR DESCRIPTION
## What

**PR B** of the skeptic-review response plan (pre-v0.2). Two things: a lint-enforced blanket-exception policy, and the deferred grok-auth misclassification fix.

### Blanket-except policy (docs/15 §7, new)

The review counted ~119 `except Exception` sites and feared silent partial failure. The response is not blanket-narrowing — poll cycles, sweeps, and teardown paths *deliberately* outlive individual errors. It is making every blanket catch carry its contract:

- **ruff `BLE001` enabled** (`app/ruff.toml`; `tests/*` exempt). Ruff auto-exempts re-raising handlers, leaving 71 flagged sites; every one is now either fixed or annotated `# noqa: BLE001 — <justification>` naming one of the sanctioned contracts (*loop guard / probe / best-effort teardown-rollback / degrade-with-record*). Justifications live **at the site** — docs/15 §7 defines the vocabulary and deliberately contains no site inventory (it would drift).
- **Silent swallows fixed** (the actual risk class): the `runspec.result` **secret-entry sweep** and ingress run-id scan in `redis/messaging.py` silently skipped unparseable entries (now `log.warning`); `dispatch.py`'s bad-audit-line skip, `mission_actions.py`'s defensive audit pass (module had no logger), and `run_store.py`'s quarantine parse fallback now log. Zero unlogged swallows remain in the tree, and the lint keeps it that way.
- `scripts/ci_suite.sh` gains the ruff step (CI already lints via `ci.yml`; local scripts previously ran no lint). AGENTS.md's anti-pattern bullet now points at the enforced rule.

### Grok-auth classifier (deferred fix; docs/15 §4 "harness-auth marker contract")

xAI intermittently revokes stored grok credentials. The failure wording ("Not signed in", "run `grok login`") matched none of the entrypoint's auth markers, so revoked creds exited **10** — three burned DEV_CRASH attempts and a `DEVCAKE-FAILED` — instead of **12**, one DEV_AUTH breaker trip visible in `/health` and cleared by re-uploading credentials.

- `images/common/dev_entrypoint.py`: extracted `classify_harness_failure()` (mirrors the existing `git_error_class()` shape) with the grok phrases added. **Markers are precise on purpose**: a false 12 pauses the entire Dev Type until a human re-uploads credentials, so bare "login"/"sign in" are deliberately excluded; the asymmetry is documented at the function and in docs/15 §4.
- App side needs no change — exit 12 already trips the breaker (`finalize.py`), pauses that Dev Type's scheduling, and surfaces in `/health` `circuit_breakers`.
- New `tests/test_entrypoint_classify.py` (5 tests, same `/images`-mount loader as `test_entrypoint_mcp.py`) pins wording → exit code, including precision cases that must stay 10.

## Verification

- `ruff check devcake tests` clean with the new config.
- Full suite via `./scripts/pytest_app.sh`: **636 passed, 1 skipped**.
- Branch-diff audit: outside the deliberate fixes above, every changed line in `app/devcake` is a comment-only `except` annotation.
- ⚠️ **Lockstep**: `images/` changed — deploy requires the harness-image rebake per the runbook. Live proof of the fix: next time a grok cred is revoked, expect one `DEV_AUTH` breaker in `/health` instead of 3× DEV_CRASH → FAILED.

## Context

Series: PR A #16 (positioning/docs) → **B (this)** → C1–C7 (structure) → D (live E2Es, Clear-Runs stop hardening, audit, v0.2 tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)