### PR TITLE
refactor(orchestrator): C1 — explicit delegating methods replace the binding façade (ADR-0015)

### DIFF
--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -1,13 +1,23 @@
-"""MissionManager façade: deps, advisory state, and public method surface.
+"""MissionManager: DI container, advisory state, and the public verb surface.
 
-Implementation lives in sibling modules (ISSUES #36). Methods are bound from
-those modules onto the class (transitional façade bindings — free functions
-with ``self`` as first arg).
+Implementation lives in the sibling modules (schedule, dispatch, finalize,
+transitions, review, decomposition, sweeps, feed, mapper, deliver); this class
+holds explicit delegating methods with the modules' exact signatures. Binding
+attributes onto the class after its definition is forbidden (ADR-0015) and
+guarded by ``tests/test_structure_guards.py``.
+
+Advisory state is FLAT on the manager by design (ADR-0009/ADR-0015): the
+manager's identity is the state container — ``breakers`` is an injected dict
+shared across managers, and ``build_managers()`` reconciles managers in place
+on config reload precisely so this state survives. The advisory set:
+``_grace``/``_grace_next``, ``breakers``, ``blocked_reasons``, ``cycles``,
+``anomalies``, ``merge_handoffs``, ``rearm_merge_windows``, ``needs_human``,
+``_merge_window_closed``.
 
 Tests construct via the real ``__init__`` (``tests/fakes.make_mission_manager``
 with a real RunManager when a tmp path is given). Private-seam tests
-(``_transition``, ``_merge_sweep``, …) remain until a follow-up retargets them
-to public APIs — construction path is fixed; structure is not fully untangled.
+(``_transition``, ``_merge_sweep``, …) remain until ADR-0015's C2/C3 retarget
+them to the modules' public functions.
 """
 
 from __future__ import annotations
@@ -27,7 +37,11 @@ if _TC:
 from .markers import LEGAL_OUTCOMES  # noqa: F401  — public re-export
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from ...ports.messaging import MessagingPort
+    from ..model import Activity, Mission, MissionType
+    from ..run import Run
 
 
 class MissionManager:
@@ -56,6 +70,7 @@ class MissionManager:
         # prefix and the pmo_ref stamped on runs
         self.instance = instance if instance is not None else config.pmos[0]
         self.instance_name: str = self.instance.name
+        # ── advisory state (flat by design — see the module docstring) ──
         self._grace: set[str] = set()       # pmo_ids we transitioned last cycle
         self._grace_next: set[str] = set()
         # dev_type → reason (DEV_AUTH circuit breaker). Credentials are
@@ -93,156 +108,277 @@ class MissionManager:
         self._grace, self._grace_next = self._grace_next, set()
 
 
-# Bind collaborator implementations (functions with `self` as first arg).
-MissionManager._audit = feed._audit
-MissionManager._trip_breaker = feed._trip_breaker
-MissionManager._feed = feed._feed
-MissionManager._unquoted = staticmethod(feed._unquoted)
-MissionManager._is_devcake_comment = staticmethod(feed._is_devcake_comment)
-MissionManager._stage_of = staticmethod(feed._stage_of)
-MissionManager.gate_map = schedule.gate_map
-MissionManager.schedule = schedule.schedule
-MissionManager._open_blockers = schedule._open_blockers
-MissionManager.dispatch = dispatch.dispatch
-MissionManager._identifying_prompt = dispatch._identifying_prompt
-MissionManager._onboard_repo_options = dispatch._onboard_repo_options
-MissionManager._decomposition_rule = dispatch._decomposition_rule
-MissionManager._reference_repos_note = dispatch._reference_repos_note
-MissionManager._protocol_spec_env = dispatch._protocol_spec_env
-MissionManager._skill_payload = dispatch._skill_payload
-MissionManager.runspec_secret_payload = dispatch.runspec_secret_payload
-MissionManager._extra_repos_for = dispatch._extra_repos_for
-MissionManager._credential_spec = dispatch._credential_spec
-MissionManager._derive_seq = staticmethod(dispatch._derive_seq)
-MissionManager._unique_name = staticmethod(dispatch._unique_name)
-MissionManager._aware = staticmethod(dispatch._aware)
-MissionManager._last_giveup_at = classmethod(dispatch._last_giveup_at)
-MissionManager._attempt_number = dispatch._attempt_number
-MissionManager._give_up = dispatch._give_up
-MissionManager.activity_payload = dispatch.activity_payload
-MissionManager._push_activity_repo = dispatch._push_activity_repo
-MissionManager._checkpoint = finalize._checkpoint
-MissionManager.finalize = finalize.finalize
-MissionManager.dev_failure_error = finalize.dev_failure_error
-MissionManager.restore_after_failure = finalize.restore_after_failure
-MissionManager._post_transcript = finalize._post_transcript
-MissionManager._token_report_md = staticmethod(finalize._token_report_md)
-MissionManager._transition = transitions._transition
-MissionManager._flag_out_of_pipeline_merge = review._flag_out_of_pipeline_merge
-MissionManager._conflict_attempts = review._conflict_attempts
-MissionManager._maybe_route_conflict_to_execute = review._maybe_route_conflict_to_execute
-MissionManager._finalize_review = review._finalize_review
-MissionManager._finalize_decomposition = decomposition._finalize_decomposition
-MissionManager.dispatch_mapper = mapper.dispatch_mapper
-MissionManager.finalize_mapper = mapper.finalize_mapper
-MissionManager._apply_mapper_edges = mapper._apply_mapper_edges
-MissionManager._creates_cycle = staticmethod(mapper._creates_cycle)
-MissionManager.sweeps = sweeps.sweeps
-MissionManager._merge_sweep = sweeps._merge_sweep
-MissionManager._deferred_merge_retry = sweeps._deferred_merge_retry
-MissionManager._tracking_sweep = sweeps._tracking_sweep
-MissionManager.deliver_internal_zip = deliver.deliver_internal_zip
-MissionManager.deliver_internal_zip_for_mission = deliver.deliver_internal_zip_for_mission
+    # Delegating methods — implementation lives in the sibling modules
+    # (ADR-0015; signatures mirror the module functions exactly). Private
+    # `_x` delegators are transitional: C2/C3 retarget their callers and
+    # tests to the modules' public functions, then delete them.
+
+    # ── feed ──
+    def _audit(self, pmo_id: str, action: str, detail: str = ''):
+        return feed._audit(self, pmo_id, action, detail)
+
+    def _trip_breaker(self, name: str, reason: str):
+        return feed._trip_breaker(self, name, reason)
+
+    async def _feed(self, pmo_id: str, kind: str, markdown: str, *, externalize: bool = True):
+        return await feed._feed(self, pmo_id, kind, markdown, externalize=externalize)
+
+    @staticmethod
+    def _unquoted(body: str | None):
+        return feed._unquoted(body)
+
+    @staticmethod
+    def _is_devcake_comment(body: str | None):
+        return feed._is_devcake_comment(body)
+
+    @staticmethod
+    def _stage_of(mission: Mission):
+        return feed._stage_of(mission)
+
+    # ── schedule ──
+    async def gate_map(self, missions: list[Mission]):
+        return await schedule.gate_map(self, missions)
+
+    async def schedule(self, missions: list[Mission], gate: dict[str, str] | None = None):
+        return await schedule.schedule(self, missions, gate)
+
+    async def _open_blockers(self, m: Mission, by_id: dict[str, Mission],
+                             memo: dict[str, Mission | None]):
+        return await schedule._open_blockers(self, m, by_id, memo)
+
+    # ── dispatch ──
+    async def dispatch(self, mission: Mission, mtype: MissionType, dev_type: DevType):
+        return await dispatch.dispatch(self, mission, mtype, dev_type)
+
+    def _identifying_prompt(self, dev_type: DevType):
+        return dispatch._identifying_prompt(self, dev_type)
+
+    def _onboard_repo_options(self, primary: str):
+        return dispatch._onboard_repo_options(self, primary)
+
+    def _decomposition_rule(self, live: Mission):
+        return dispatch._decomposition_rule(self, live)
+
+    def _reference_repos_note(self, primary: str):
+        return dispatch._reference_repos_note(self, primary)
+
+    def _protocol_spec_env(self, *, mission_id: str, mission_key: str, mission_type: str,
+                           dev_type: DevType, seq: int, extra_args: str, repo, forge):
+        return dispatch._protocol_spec_env(
+            self, mission_id=mission_id, mission_key=mission_key,
+            mission_type=mission_type, dev_type=dev_type, seq=seq,
+            extra_args=extra_args, repo=repo, forge=forge)
+
+    async def _skill_payload(self, dev_type: DevType):
+        return await dispatch._skill_payload(self, dev_type)
+
+    def runspec_secret_payload(self, run: Run):
+        return dispatch.runspec_secret_payload(self, run)
+
+    def _extra_repos_for(self, run: Run):
+        return dispatch._extra_repos_for(self, run)
+
+    def _credential_spec(self, dev_type: DevType):
+        return dispatch._credential_spec(self, dev_type)
+
+    @staticmethod
+    def _derive_seq(activity):
+        return dispatch._derive_seq(activity)
+
+    @staticmethod
+    def _unique_name(name: str, used: set[str]):
+        return dispatch._unique_name(name, used)
+
+    @staticmethod
+    def _aware(ts: datetime):
+        return dispatch._aware(ts)
+
+    @classmethod
+    def _last_giveup_at(cls, pmo_id: str):
+        return dispatch._last_giveup_at(cls, pmo_id)
+
+    def _attempt_number(self, pmo_id: str, mission_type: str, activity: Activity | None = None):
+        return dispatch._attempt_number(self, pmo_id, mission_type, activity)
+
+    async def _give_up(self, mission: Mission, mtype: MissionType, attempts: int):
+        return await dispatch._give_up(self, mission, mtype, attempts)
+
+    async def activity_payload(self, pmo_id: str, kind: str = 'issue'):
+        return await dispatch.activity_payload(self, pmo_id, kind)
+
+    async def _push_activity_repo(self, mission, mtype, seq: int):
+        return await dispatch._push_activity_repo(self, mission, mtype, seq)
+
+    def _resolve_repo(self, mission: Mission, all_runs: list | None = None):
+        return dispatch._resolve_repo(self, mission, all_runs)
+
+    def _mapper_repo(self):
+        return dispatch._mapper_repo(self)
+
+    # ── finalize ──
+    async def _checkpoint(self, run: Run, key: str, fn):
+        return await finalize._checkpoint(self, run, key, fn)
+
+    async def finalize(self, run: Run, payload: dict):
+        return await finalize.finalize(self, run, payload)
+
+    def dev_failure_error(self, run: Run, payload: dict):
+        return finalize.dev_failure_error(self, run, payload)
+
+    async def restore_after_failure(self, run: Run):
+        return await finalize.restore_after_failure(self, run)
+
+    async def _post_transcript(self, run: Run, transcript: str, last_message: str | None = None):
+        return await finalize._post_transcript(self, run, transcript, last_message)
+
+    @staticmethod
+    def _token_report_md(run: Run, tr: dict):
+        return finalize._token_report_md(run, tr)
+
+    # ── transitions ──
+    async def _transition(self, run: Run, result: dict, plan_md: str | None):
+        return await transitions._transition(self, run, result, plan_md)
+
+    # ── review ──
+    async def _flag_out_of_pipeline_merge(self, run: Run):
+        return await review._flag_out_of_pipeline_merge(self, run)
+
+    async def _conflict_attempts(self, pmo_id: str):
+        return await review._conflict_attempts(self, pmo_id)
+
+    async def _maybe_route_conflict_to_execute(self, pmo_id: str, key: str, pr_url: str,
+                                               from_label: str):
+        return await review._maybe_route_conflict_to_execute(self, pmo_id, key, pr_url,
+                                                             from_label)
+
+    async def _finalize_review(self, run: Run, result: dict):
+        return await review._finalize_review(self, run, result)
+
+    # ── decomposition ──
+    async def _finalize_decomposition(self, run: Run, result: dict):
+        return await decomposition._finalize_decomposition(self, run, result)
+
+    # ── mapper ──
+    async def dispatch_mapper(self, dev_type: DevType, missions: list[Mission]):
+        return await mapper.dispatch_mapper(self, dev_type, missions)
+
+    async def finalize_mapper(self, run: Run, payload: dict):
+        return await mapper.finalize_mapper(self, run, payload)
+
+    async def _apply_mapper_edges(self, edges: list):
+        return await mapper._apply_mapper_edges(self, edges)
+
+    @staticmethod
+    def _creates_cycle(graph: dict[str, set[str]], blocker: str, blocked: str):
+        return mapper._creates_cycle(graph, blocker, blocked)
+
+    # ── sweeps ──
+    async def sweeps(self, missions: list[Mission]):
+        return await sweeps.sweeps(self, missions)
+
+    async def _merge_sweep(self, m: Mission):
+        return await sweeps._merge_sweep(self, m)
+
+    async def _deferred_merge_retry(self, m: Mission, pr, pr_url: str):
+        return await sweeps._deferred_merge_retry(self, m, pr, pr_url)
+
+    async def _tracking_sweep(self, m: Mission):
+        return await sweeps._tracking_sweep(self, m)
+
+    # ── deliver ──
+    async def deliver_internal_zip(self, run, pr):
+        return await deliver.deliver_internal_zip(self, run, pr)
+
+    async def deliver_internal_zip_for_mission(self, m, pr):
+        return await deliver.deliver_internal_zip_for_mission(self, m, pr)
+
+    # ── defined here (no module home yet) ──
+    def _attachment_cap(self) -> int:
+        """The PMO's attachment size cap (deliverable zip bound)."""
+        try:
+            return self.pmo.capabilities().attachment_max_bytes
+        except Exception:  # noqa: BLE001 — capability probe degrades to the conservative 25 MiB default cap; the zip builder still bounds the payload
+            return 25 * 1024 * 1024
+
+    def _run_is_ours(self, r) -> bool:
+        """Instance-scope a run record (schema v3). Vendor pmo_ids are UUIDs for
+        Linear, so the mission_pmo_id filters are already collision-free — this
+        is belt-and-braces for a future PMO with colliding ids. Legacy records
+        ("" / pre-v3 "main") always count: hiding them would silently reset
+        attempt counters on upgrade (count, don't hide)."""
+        return r.pmo_ref in ("", "main", self.instance_name)
 
 
-def _attachment_cap(self) -> int:
-    """The PMO's attachment size cap (deliverable zip bound)."""
-    try:
-        return self.pmo.capabilities().attachment_max_bytes
-    except Exception:  # noqa: BLE001 — capability probe degrades to the conservative 25 MiB default cap; the zip builder still bounds the payload
-        return 25 * 1024 * 1024
+    async def resolve_repo_live(self, mission, all_runs=None):
+        """(repo_name | None, gate_reason | None), UN-GATING zero-repo missions
+        onto the internal fallback forge (M11). Async — it may provision a repo.
 
+        Order: re-register any internal repo this mission already used (so the
+        sticky resolver finds it after an app restart), run the sticky resolver,
+        and if that returns the specific zero-repo gate, provision an internal
+        repo. Any OTHER gate (unknown marker, sticky-vanished external, mid-
+        mission change) is a real gate — never silently redirected internal."""
+        from ..repo_routing import REASON_ZERO_REPO
+        from ...ports.internal_forge import internal_repo_name
+        from ...adapters.registry import make_gitea_adapter
 
-MissionManager._attachment_cap = _attachment_cap
+        from ...config import RepoInstance
 
+        if all_runs is None:
+            all_runs = self.runs.store.all()
 
-def _run_is_ours(self, r) -> bool:
-    """Instance-scope a run record (schema v3). Vendor pmo_ids are UUIDs for
-    Linear, so the mission_pmo_id filters are already collision-free — this
-    is belt-and-braces for a future PMO with colliding ids. Legacy records
-    ("" / pre-v3 "main") always count: hiding them would silently reset
-    attempt counters on upgrade (count, don't hide)."""
-    return r.pmo_ref in ("", "main", self.instance_name)
+        async def _provision() -> str:
+            # ensure service accounts first (lazy retry — boot provisioning may
+            # have failed against a not-yet-ready Gitea; review finding #7)
+            svc = self.internal_forge.service_tokens()
+            if not svc:
+                await self.internal_forge.ensure_service_accounts()
+                svc = self.internal_forge.service_tokens() or {}
+            creds = await self.internal_forge.ensure_mission_repo(
+                self.instance_name, mission.key)
+            # the APP-SIDE adapter uses the devcake-app SERVICE token (org owner:
+            # write:issue for PR comments + write:repository for merge), NOT the
+            # mission's Dev write token (write:repository only → issue-scope 403s;
+            # review finding #1). The mission's write/read pair is the Dev's,
+            # delivered via runspec.
+            adapter = make_gitea_adapter(creds.clone_url, svc.get("app_token"),
+                                         svc.get("reviewer_token"))
+            # model_construct: internal repo names carry hyphens / exceed the
+            # operator-name pattern by design — they are synthesized, not input
+            inst = RepoInstance.model_construct(
+                name=creds.repo_name, forge="gitea", url=creds.clone_url,
+                default_branch="main", api_base=None)
+            self.forges.register_internal(creds.repo_name, inst, adapter)
+            return creds.repo_name
 
+        async def _ensure_registered(name: str) -> None:
+            # already registered this process → no per-cycle I/O (finding #8);
+            # else (re)provision — covers restart recovery + first intake
+            if name not in self.forges.instances:
+                await _provision()
 
-MissionManager._run_is_ours = _run_is_ours
-MissionManager._resolve_repo = dispatch._resolve_repo
-MissionManager._mapper_repo = dispatch._mapper_repo
+        expected = (internal_repo_name(self.instance_name, mission.key)
+                    if self.internal_forge is not None else None)
 
+        # a done/canceled mission must never (re-)provision: the poll loop sees
+        # terminal missions too, so without this guard the admin Clear endpoint
+        # was silently undone within one cycle — repo, svc user, and a fresh
+        # token pair resurrected (audit A4). Terminal missions are never
+        # scheduled (derivation row 5), so gating them is inert.
+        terminal = mission.status in ("done", "canceled")
 
-async def resolve_repo_live(self, mission, all_runs=None):
-    """(repo_name | None, gate_reason | None), UN-GATING zero-repo missions
-    onto the internal fallback forge (M11). Async — it may provision a repo.
+        # restart recovery: a prior run points at this mission's internal repo,
+        # but ForgeRuntime lost it on restart — re-register before resolving
+        if not terminal and expected is not None and any(
+                r.repo_ref == expected for r in all_runs
+                if r.mission_pmo_id == mission.pmo_id):
+            await _ensure_registered(expected)
 
-    Order: re-register any internal repo this mission already used (so the
-    sticky resolver finds it after an app restart), run the sticky resolver,
-    and if that returns the specific zero-repo gate, provision an internal
-    repo. Any OTHER gate (unknown marker, sticky-vanished external, mid-
-    mission change) is a real gate — never silently redirected internal."""
-    from ..repo_routing import REASON_ZERO_REPO
-    from ...ports.internal_forge import internal_repo_name
-    from ...adapters.registry import make_gitea_adapter
-
-    from ...config import RepoInstance
-
-    if all_runs is None:
-        all_runs = self.runs.store.all()
-
-    async def _provision() -> str:
-        # ensure service accounts first (lazy retry — boot provisioning may
-        # have failed against a not-yet-ready Gitea; review finding #7)
-        svc = self.internal_forge.service_tokens()
-        if not svc:
-            await self.internal_forge.ensure_service_accounts()
-            svc = self.internal_forge.service_tokens() or {}
-        creds = await self.internal_forge.ensure_mission_repo(
-            self.instance_name, mission.key)
-        # the APP-SIDE adapter uses the devcake-app SERVICE token (org owner:
-        # write:issue for PR comments + write:repository for merge), NOT the
-        # mission's Dev write token (write:repository only → issue-scope 403s;
-        # review finding #1). The mission's write/read pair is the Dev's,
-        # delivered via runspec.
-        adapter = make_gitea_adapter(creds.clone_url, svc.get("app_token"),
-                                     svc.get("reviewer_token"))
-        # model_construct: internal repo names carry hyphens / exceed the
-        # operator-name pattern by design — they are synthesized, not input
-        inst = RepoInstance.model_construct(
-            name=creds.repo_name, forge="gitea", url=creds.clone_url,
-            default_branch="main", api_base=None)
-        self.forges.register_internal(creds.repo_name, inst, adapter)
-        return creds.repo_name
-
-    async def _ensure_registered(name: str) -> None:
-        # already registered this process → no per-cycle I/O (finding #8);
-        # else (re)provision — covers restart recovery + first intake
-        if name not in self.forges.instances:
-            await _provision()
-
-    expected = (internal_repo_name(self.instance_name, mission.key)
-                if self.internal_forge is not None else None)
-
-    # a done/canceled mission must never (re-)provision: the poll loop sees
-    # terminal missions too, so without this guard the admin Clear endpoint
-    # was silently undone within one cycle — repo, svc user, and a fresh
-    # token pair resurrected (audit A4). Terminal missions are never
-    # scheduled (derivation row 5), so gating them is inert.
-    terminal = mission.status in ("done", "canceled")
-
-    # restart recovery: a prior run points at this mission's internal repo,
-    # but ForgeRuntime lost it on restart — re-register before resolving
-    if not terminal and expected is not None and any(
-            r.repo_ref == expected for r in all_runs
-            if r.mission_pmo_id == mission.pmo_id):
-        await _ensure_registered(expected)
-
-    name, reason = self._resolve_repo(mission, all_runs=all_runs)
-    if name is not None:
-        return name, reason
-    if (reason is REASON_ZERO_REPO and self.internal_forge is not None
-            and not terminal):
-        await _ensure_registered(expected)
-        return expected, None
-    return None, reason
-
-
-MissionManager.resolve_repo_live = resolve_repo_live
+        name, reason = self._resolve_repo(mission, all_runs=all_runs)
+        if name is not None:
+            return name, reason
+        if (reason is REASON_ZERO_REPO and self.internal_forge is not None
+                and not terminal):
+            await _ensure_registered(expected)
+            return expected, None
+        return None, reason

--- a/app/tests/test_structure_guards.py
+++ b/app/tests/test_structure_guards.py
@@ -1,0 +1,31 @@
+"""Structure ratchet (ADR-0015): the orchestrator god module must not return.
+
+C1 rule: ``domain/orchestrator/manager.py`` contains the class and nothing
+executable after it — no module-level ``MissionManager.<attr> = ...`` bindings
+(the old façade mechanism) and no module-level ``def`` below the class. The
+API route-body rule (every ``@app.<verb>`` body ≤ 4 statements, allowlist
+shrinking to ``{"dispatch_hello"}``) arrives with the C6 close-out.
+"""
+
+import ast
+from pathlib import Path
+
+MANAGER = (Path(__file__).parents[1] / "devcake" / "domain" / "orchestrator"
+           / "manager.py")
+
+
+def test_manager_has_no_post_class_bindings():
+    tree = ast.parse(MANAGER.read_text())
+    class_idx = next(i for i, n in enumerate(tree.body)
+                     if isinstance(n, ast.ClassDef) and n.name == "MissionManager")
+    offenders = []
+    for node in tree.body[class_idx + 1:]:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            offenders.append(f"module-level def {node.name} after the class")
+        for tgt in getattr(node, "targets", []):
+            if (isinstance(tgt, ast.Attribute) and isinstance(tgt.value, ast.Name)
+                    and tgt.value.id == "MissionManager"):
+                offenders.append(f"binding MissionManager.{tgt.attr}")
+    assert not offenders, (
+        "manager.py grew post-class bindings — ADR-0015 forbids resurrecting "
+        "the façade: " + "; ".join(offenders))

--- a/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
+++ b/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
@@ -1,0 +1,89 @@
+# ADR-0015 — Orchestrator module functions + API composition-root discipline
+
+- **Status:** accepted (2026-07-18); ships as the C1–C7 series of the pre-v0.2
+  structural plan. C1 (this ADR + the binding-block removal + the structure
+  guard test) is the normative anchor; C2/C3 finish the orchestrator, C4–C6
+  split the API composition root, C7 splits the admin ConfigPage.
+- **Context:** ISSUES #36 split the ~1.8k-line orchestrator god module into
+  `domain/orchestrator/` but left a *transitional façade*: ~50 free functions
+  taking `self`, bound onto `MissionManager` by module-level assignment after
+  the class body. Nothing was greppable as a method, `staticmethod()`/
+  `classmethod()` wrappers hid calling conventions, and the test suite grew
+  ~80 private-seam call sites (`mgr._transition(...)`) with no sanctioned
+  public seam. Meanwhile `api/main.py` accreted to ~1.8k lines: composition
+  root + poll loop + health probes + ~60 endpoint bodies. Both were flagged by
+  the 2026-07-18 skeptical review as "file split, not modularity."
+
+## Decision 1 — the manager is DI container + advisory state + verbs
+
+`MissionManager` holds: injected dependencies, flat advisory state, and
+**explicit delegating methods** whose signatures mirror the module functions
+exactly. Implementation lives in the sibling modules; module functions take
+`mgr` (né `self`) as an explicit first parameter; cross-module calls become
+explicit imports (acyclic: `finalize → transitions → {review, decomposition}`,
+`sweeps → review`). Six cross-cutting primitives stay methods forever —
+`_audit`, `_feed`, `_checkpoint`, `_trip_breaker`, `_run_is_ours`,
+`_attachment_cap` — because fakes override them per instance
+(`fakes.make_mission_manager` sets `mgr._audit`), `mission_actions` duck-types
+`_audit`, and routing every module through the manager for these removes the
+feed/finalize import fan-in that would otherwise cycle. **Never bind
+attributes onto the class after its definition** — the façade mechanism is
+forbidden and guard-tested (`tests/test_structure_guards.py`). No mixins; no
+re-inlining bodies into one class.
+
+## Decision 2 — advisory state stays flat on the manager
+
+Reaffirms ADR-0009. No `AdvisoryState` wrapper object: `breakers` is an
+injected dict aliased by `main.shared_breakers` and `OAuthManager`;
+`anomalies`/`rearm_merge_windows`/`_grace` are mutated from the composition
+root; and `build_managers()` reconciles managers **in place** on config reload
+precisely so advisory state survives — the manager's identity IS the state
+container. A wrapper is isomorphic to the manager and only endangers the
+aliasing. Shared state is shared by injection, never duplicated. State-bearing
+runtime objects (`FinalizerRouter`; `PollRuntime` from C4) hold the managers
+dict by live reference and are never rebuilt on config reload.
+
+## Decision 3 — main.py is composition root + route forwards, nothing else
+
+Endpoint behavior lives in `api/` application-service modules (the
+`mission_actions.py`/`clear.py` pattern: explicit parameters, raise
+`HTTPException`, never import `main.py`). Route decorators stay in `main.py`
+as forwards with **unchanged coroutine names and signatures** — tests call
+them directly (`app_main.save_profile(...)`), so the forward layer is the
+API's stable test seam. No `APIRouter`: it would be a second routing idiom for
+zero behavior. Every `@app.<verb>` body is ≤ 4 statements, AST-guarded with an
+allowlist that shrinks per PR and ends at `{"dispatch_hello"}` (the CI
+fixture). Poll machinery lives in `api/poll.py` as `PollRuntime`; health
+probes in `api/health.py`.
+
+## Decision 4 — module-public functions are the sanctioned test seam
+
+The dominant private seams are legitimized, not relocated:
+`transitions.transition`, `sweeps.merge_sweep`/`tracking_sweep`,
+`dispatch.attempt_number`/`resolve_repo`, `review.finalize_review`,
+`decomposition.finalize_decomposition`, `mapper.apply_mapper_edges` become
+their modules' public functions and the tests call them as such (AGENTS.md "no
+private tests / agree the seam first"). `_feed`/`_checkpoint` stay methods, so
+their test sites stand.
+
+## Rejected
+
+- **Mixins / one big class** — re-creates the god module with
+  multiple-inheritance opacity.
+- **A separate deps/state object** — isomorphic to the manager (the functions
+  need pmo, runs, config, forges *and* the advisory dicts); pure rename risk
+  against `build_managers()` and `shared_breakers` aliasing.
+- **APIRouter migration** — new idiom, breaks the direct-coroutine test seam,
+  zero behavior gained.
+- **Retargeting merge-sweep tests to `mgr.sweeps()`** — fabricated mission
+  lists, weaker assertions, more churn than legitimizing the module function.
+
+## Consequences
+
+- The structure guard test is the ratchet: the façade cannot quietly return,
+  and route bodies cannot quietly grow. Honest limit: module functions still
+  receive the whole `mgr` — state access is *explicit and greppable*, not
+  *narrow*. Per-module state slices were considered and rejected (Decision 2);
+  revisit only if a real bug traces to over-broad state access.
+- Behavior-preserving throughout: the full suite must stay green at every PR
+  boundary; C-series diffs move code byte-identically wherever possible.


### PR DESCRIPTION
Re-opened #19 (auto-closed when its stacked base branch was deleted by #18's merge). Same content, rebased onto main: binding block → exact-signature delegating methods, test_structure_guards.py, ADR-0015. Verified: ruff clean, 637 passed / 1 skipped via pytest_app.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)