### PR TITLE
refactor(orchestrator): C2 — transition-family seams go module-public (ADR-0015)

### DIFF
--- a/app/devcake/domain/orchestrator/decomposition.py
+++ b/app/devcake/domain/orchestrator/decomposition.py
@@ -16,33 +16,33 @@ from .markers import (COMMENT_SENTINEL, at_decomposition_limit,
 log = logging.getLogger("devcake.missions")
 
 
-async def _finalize_decomposition(self, run: Run, result: dict) -> None:
+async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
     pmo_id = run.mission_pmo_id
-    live = await self.pmo.get(MissionRef(pmo_id, run.pmo_kind))
+    live = await mgr.pmo.get(MissionRef(pmo_id, run.pmo_kind))
     # depth is PMO state — the mission's own label + marker (ADR-0012);
     # unknown (label without a readable marker) counts as at-limit, fail-safe.
     # Replay-stable: once any child checkpoint exists the decision was taken
     # under the limit of that moment — a config change mid-resume must finish
     # the wiring, not strand live children behind a SKIP park.
-    limit = self.config.max_decomposition_depth
+    limit = mgr.config.max_decomposition_depth
     committed = any(s.startswith("decomp:child:") for s in run.finalized_steps)
     if not committed and at_decomposition_limit(live, limit):
         depth = decomposition_depth(live)
         async def _depth_limit():
-            await self.pmo.swap_labels(MissionRef(pmo_id, run.pmo_kind),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, run.pmo_kind),
                                    remove=set(), add={LABEL_SKIP})
             if live.status == "in_progress":
-                await self.pmo.set_status(
+                await mgr.pmo.set_status(
                     MissionRef(pmo_id, run.pmo_kind), "backlog")
-            await self._feed(
+            await mgr._feed(
                 pmo_id, run.pmo_kind,
                 f"⛔ Depth limit: this mission is at decomposition depth "
                 f"{depth if depth is not None else 'unknown'} of the "
                 f"configured limit {limit} and may not be decomposed "
                 f"again. Parked with `DEVCAKE-SKIP` for a human to "
                 f"re-scope.")
-            self._audit(pmo_id, "depth_limit_rejected", run.run_id)
-        await self._checkpoint(run, "decomp:depth_limit", _depth_limit)
+            mgr._audit(pmo_id, "depth_limit_rejected", run.run_id)
+        await mgr._checkpoint(run, "decomp:depth_limit", _depth_limit)
         run.verdict = "handed off: decomposition depth limit"
         return
     # children of an unknown-depth parent (unlimited mode) record depth 2 —
@@ -81,7 +81,7 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
     existing: dict[int, str] = {}
     existing_keys: dict[int, str] = {}
     conflicts: list[str] = []
-    for mission in await self.pmo.list_all(self.instance.team_key):
+    for mission in await mgr.pmo.list_all(mgr.instance.team_key):
         if LABEL_CREATED not in mission.labels:
             continue
         marker = decomposition_marker(mission.description)
@@ -108,11 +108,11 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
     if conflicts:
         detail = "; ".join(conflicts[:8])
         async def _decomp_conflict():
-            await self.pmo.swap_labels(
+            await mgr.pmo.swap_labels(
                 MissionRef(pmo_id, live.pmo_kind), remove=set(),
                 add={LABEL_NEEDS_HUMAN})
             if live.status == "in_progress":
-                await self.pmo.set_status(
+                await mgr.pmo.set_status(
                     MissionRef(pmo_id, live.pmo_kind), "backlog")
             baton = (
                 "Decomposition replay conflict: no children were created. "
@@ -120,18 +120,18 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
                 + ". Reconcile the existing `DEVCAKE-CREATED` missions, "
                   "then remove `DEVCAKE-NEEDS-HUMAN` to retry."
             )
-            await self._feed(pmo_id, live.pmo_kind, baton)
+            await mgr._feed(pmo_id, live.pmo_kind, baton)
             if live.pmo_kind == "project":
-                await self.pmo.post_feed(
+                await mgr.pmo.post_feed(
                     MissionRef(pmo_id, "project"),
                     redact(baton) + "\n\n" + COMMENT_SENTINEL)
-            self._audit(pmo_id, "decomposition_conflict", detail)
-        await self._checkpoint(run, "decomp:conflict", _decomp_conflict)
+            mgr._audit(pmo_id, "decomposition_conflict", detail)
+        await mgr._checkpoint(run, "decomp:conflict", _decomp_conflict)
         run.verdict = "handed off: decomposition replay conflict"
         return
 
     labels = {LABEL_CREATED}
-    if self.config.adoption_mode == "opt_in":
+    if mgr.config.adoption_mode == "opt_in":
         labels.add(LABEL_OPTIN)
     created = []
     child_ids: dict[int, str] = {}                            # part index → issue id
@@ -140,7 +140,7 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
     async def _resolve_existing_child(part: int) -> tuple[str, str] | None:
         if part in existing:
             return existing[part], existing_keys[part]
-        for mission in await self.pmo.list_all(self.instance.team_key):
+        for mission in await mgr.pmo.list_all(mgr.instance.team_key):
             marker = decomposition_marker(mission.description)
             if marker and marker.group(1) == pmo_id \
                     and int(marker.group(3)) == part:
@@ -171,8 +171,8 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
                 # Appended AFTER the manifest hash is computed, like the
                 # rest of the footer, so replay idempotency is unaffected.
                 footer += f"\n`devcake-repo:{parent_repo_marker}`"
-            key, child_id = await self.pmo.create_mission(
-                self.instance.team_key, title,
+            key, child_id = await mgr.pmo.create_mission(
+                mgr.instance.team_key, title,
                 d["description"] + footer,
                 d["priority"], labels,
                 # an issue's children stay in its containing project so the
@@ -180,7 +180,7 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
                 parent_ref=pmo_id if is_project else live.parent_ref)
             created.append(key)
             run.finalized_steps.append(key_child)
-            self.runs.store.save(run)
+            mgr.runs.store.save(run)
         child_ids[i] = child_id
         child_key_by_part[i] = key
         # edges wired immediately per child (crash-safe resume; duplicate
@@ -190,10 +190,10 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
             if blocker_id:
                 rel_key = f"decomp:rel:{j}->{i}"
                 async def _rel(blocker_id=blocker_id, child_id=child_id, j=j):
-                    await self.pmo.create_relation(blocker_id, child_id)
-                    self._audit(child_id, "relation_created",
+                    await mgr.pmo.create_relation(blocker_id, child_id)
+                    mgr._audit(child_id, "relation_created",
                                 f"blocked by part {j} ({blocker_id})")
-                await self._checkpoint(run, rel_key, _rel)
+                await mgr._checkpoint(run, rel_key, _rel)
     # all children in part order, reused parts included — key sources are
     # authoritative (create_mission return / marker scan), never a snapshot,
     # so the lineage note below renders identically on every replay
@@ -214,18 +214,18 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
         # The snapshot is deliberately taken AFTER child creation (a second
         # team read): relations a human added while the children were being
         # created are honored on both sides.
-        snapshot = await self.pmo.list_all(self.instance.team_key)
+        snapshot = await mgr.pmo.list_all(mgr.instance.team_key)
         by_id = {sm.pmo_id: sm for sm in snapshot}
         child_id_set = set(child_ids.values())
 
         async def _inherit(blocker_id: str, blocked_id: str) -> None:
             try:
-                await self.pmo.create_relation(blocker_id, blocked_id)
+                await mgr.pmo.create_relation(blocker_id, blocked_id)
             except Exception:
-                self._audit(blocked_id, "relation_inherit_failed",
+                mgr._audit(blocked_id, "relation_inherit_failed",
                             f"{blocker_id} blocks {blocked_id}")
                 raise
-            self._audit(blocked_id, "relation_inherited",
+            mgr._audit(blocked_id, "relation_inherited",
                         f"{blocker_id} blocks {blocked_id}")
 
         # the original's blockers re-read from the post-creation snapshot;
@@ -247,11 +247,11 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
             for b in open_blockers:
                 async def _in(b=b, child_id=child_id):
                     await _inherit(b, child_id)
-                await self._checkpoint(run, f"decomp:inherit:in:{b}->{i}", _in)
+                await mgr._checkpoint(run, f"decomp:inherit:in:{b}->{i}", _in)
             for dep in dependents:
                 async def _out(child_id=child_id, dep=dep):
                     await _inherit(child_id, dep)
-                await self._checkpoint(run, f"decomp:inherit:out:{i}->{dep}",
+                await mgr._checkpoint(run, f"decomp:inherit:out:{i}->{dep}",
                                        _out)
 
         # lineage note (ADR-0012 hygiene): best-effort BY DESIGN — the note
@@ -265,23 +265,23 @@ async def _finalize_decomposition(self, run: Run, result: dict) -> None:
             if note in (live.description or ""):
                 return
             try:
-                await self.pmo.append_description(
+                await mgr.pmo.append_description(
                     MissionRef(pmo_id, "issue"), note)
             except Exception as e:  # noqa: BLE001 — lineage note is best-effort BY DESIGN (comment above); failure recorded in the audit, the cancel proceeds
-                self._audit(pmo_id, "lineage_note_failed", str(e)[:200])
-        await self._checkpoint(run, "decomp:parent_note", _parent_note)
+                mgr._audit(pmo_id, "lineage_note_failed", str(e)[:200])
+        await mgr._checkpoint(run, "decomp:parent_note", _parent_note)
 
     links = ", ".join(created) or "(all already existed)"
     async def _tracking():
         if is_project:
-            await self.pmo.swap_labels(MissionRef(pmo_id, "project"),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, "project"),
                                        remove=set(), add={LABEL_TRACKING})
-            self._audit(pmo_id, "decomposed_project", links)
+            mgr._audit(pmo_id, "decomposed_project", links)
         else:
-            await self._feed(
+            await mgr._feed(
                 pmo_id, "issue",
                 f"🧩 Decomposed into {len(normalized)} standalone issues: "
                 f"{links}. This issue is canceled in their favor.")
-            await self.pmo.cancel_mission(MissionRef(pmo_id, "issue"))
-            self._audit(pmo_id, "decomposed_canceled", links)
-    await self._checkpoint(run, "decomp:tracking", _tracking)
+            await mgr.pmo.cancel_mission(MissionRef(pmo_id, "issue"))
+            mgr._audit(pmo_id, "decomposed_canceled", links)
+    await mgr._checkpoint(run, "decomp:tracking", _tracking)

--- a/app/devcake/domain/orchestrator/finalize.py
+++ b/app/devcake/domain/orchestrator/finalize.py
@@ -10,7 +10,8 @@ from opentelemetry.trace import SpanKind, Status, StatusCode
 from ...security import redact, redact_value
 from ..model import MissionRef
 from ..run import Run, utcnow
-from .feed import _blockquote
+from . import transitions
+from .feed import _blockquote, _stage_of
 from .markers import FEED_INLINE_MAX
 
 log = logging.getLogger("devcake.missions")
@@ -97,7 +98,7 @@ async def finalize(self, run: Run, payload: dict) -> None:
         # instead of stranding in `finalizing` until the watchdog timeout.
         if "transition" not in run.finalized_steps:
             try:
-                await self._transition(run, result, plan_md)
+                await transitions.transition(self, run, result, plan_md)
             except ValueError as e:
                 await self.messaging.delete_run_user(run.run_id)
                 await self.messaging.delete_reply_stream(run.run_id)
@@ -169,7 +170,7 @@ async def restore_after_failure(self, run: Run) -> None:
         return  # only ONBOARD dispatches from backlog change the status
     try:
         live = await self.pmo.get(MissionRef(run.mission_pmo_id, run.pmo_kind))
-        if live.status == "in_progress" and self._stage_of(live) is None:
+        if live.status == "in_progress" and _stage_of(live) is None:
             await self.pmo.set_status(
                 MissionRef(run.mission_pmo_id, run.pmo_kind), "backlog")
             self._audit(run.mission_pmo_id, "set_status",

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -235,28 +235,17 @@ class MissionManager:
     def _token_report_md(run: Run, tr: dict):
         return finalize._token_report_md(run, tr)
 
-    # ── transitions ──
-    async def _transition(self, run: Run, result: dict, plan_md: str | None):
-        return await transitions._transition(self, run, result, plan_md)
-
-    # ── review ──
+    # ── review ── (transition/finalize seams are module-public since C2:
+    # transitions.transition, review.finalize_review,
+    # decomposition.finalize_decomposition)
     async def _flag_out_of_pipeline_merge(self, run: Run):
+        # stays a method: instance-overridable (tests suppress it per-manager)
         return await review._flag_out_of_pipeline_merge(self, run)
-
-    async def _conflict_attempts(self, pmo_id: str):
-        return await review._conflict_attempts(self, pmo_id)
 
     async def _maybe_route_conflict_to_execute(self, pmo_id: str, key: str, pr_url: str,
                                                from_label: str):
         return await review._maybe_route_conflict_to_execute(self, pmo_id, key, pr_url,
                                                              from_label)
-
-    async def _finalize_review(self, run: Run, result: dict):
-        return await review._finalize_review(self, run, result)
-
-    # ── decomposition ──
-    async def _finalize_decomposition(self, run: Run, result: dict):
-        return await decomposition._finalize_decomposition(self, run, result)
 
     # ── mapper ──
     async def dispatch_mapper(self, dev_type: DevType, missions: list[Mission]):

--- a/app/devcake/domain/orchestrator/review.py
+++ b/app/devcake/domain/orchestrator/review.py
@@ -14,16 +14,16 @@ from .markers import (CONFLICT_MARKER, MAX_CONFLICT_RESOLVES, MERGE_HANDOFF_MARK
 log = logging.getLogger("devcake.missions")
 
 
-async def _flag_out_of_pipeline_merge(self, run: Run) -> None:
+async def _flag_out_of_pipeline_merge(mgr, run: Run) -> None:
     """Detection tripwire (docs/14, ADR-0007 addendum): the Dev's forge token
     can merge unless branch protection forbids it. If the mission's PR turns
     up merged while the mission is still mid-pipeline, say so loudly —
     detection only; a human decides (they may have merged early themselves)."""
-    forge = self.forges.get(run.repo_ref)
+    forge = mgr.forges.get(run.repo_ref)
     if forge is None:
         # repo vanished: the detection cannot run — say so instead of going
         # silently blind (an out-of-pipeline merge could slip past unseen)
-        self.anomalies[run.mission_pmo_id] = (
+        mgr.anomalies[run.mission_pmo_id] = (
             f"{run.mission_key}: out-of-pipeline-merge detection suspended — "
             f"repo '{run.repo_ref}' is no longer configured")
         log.warning("out-of-pipeline check skipped for %s: repo %r vanished",
@@ -36,15 +36,15 @@ async def _flag_out_of_pipeline_merge(self, run: Run) -> None:
         state = await forge.pr_state(pr.number)
         if not state.merged:
             return
-        await self._feed(
+        await mgr._feed(
             run.mission_pmo_id, run.pmo_kind,
             f"⚠️ **Out-of-pipeline merge detected:** {state.url} is already "
             f"merged, but this mission is still mid-pipeline "
             f"({run.mission_type}). If you merged it yourself on purpose, "
             f"mark the mission Done (or add `DEVCAKE-SKIP`); otherwise check "
             f"who merged it — DevCake did not.")
-        self._audit(run.mission_pmo_id, "out_of_pipeline_merge", state.url)
-        self.anomalies[run.mission_pmo_id] = (
+        mgr._audit(run.mission_pmo_id, "out_of_pipeline_merge", state.url)
+        mgr.anomalies[run.mission_pmo_id] = (
             f"{run.mission_key}: PR merged outside the pipeline ({state.url})")
         log.warning("out-of-pipeline merge on %s (%s)", run.mission_key,
                     state.url)
@@ -53,17 +53,17 @@ async def _flag_out_of_pipeline_merge(self, run: Run) -> None:
                   run.mission_key, exc_info=True)
 
 
-async def _conflict_attempts(self, pmo_id: str) -> int:
+async def _conflict_attempts(mgr, pmo_id: str) -> int:
     """Prior auto-resolve attempts, derived from feed markers — the PMO is
     the source of truth (docs/03), so the count survives restarts and a
     human deleting directive comments deliberately resets it."""
-    act = await self.pmo.get_activity(MissionRef(pmo_id, "issue"))
+    act = await mgr.pmo.get_activity(MissionRef(pmo_id, "issue"))
     hits = [int(mt.group(1)) for e in act.entries
-            for mt in CONFLICT_MARKER.finditer(self._unquoted(e.body))]
+            for mt in CONFLICT_MARKER.finditer(mgr._unquoted(e.body))]
     return max(hits) if hits else 0
 
 
-async def _maybe_route_conflict_to_execute(self, pmo_id: str, key: str,
+async def _maybe_route_conflict_to_execute(mgr, pmo_id: str, key: str,
                                            pr_url: str,
                                            from_label: str) -> bool:
     """docs/03 §4.1 — on an auto-resolvable merge failure (conflict or
@@ -71,28 +71,28 @@ async def _maybe_route_conflict_to_execute(self, pmo_id: str, key: str,
     directive, max MAX_CONFLICT_RESOLVES attempts per mission. Returns
     True when routed; any failure or decline returns False so the caller's
     human fallback (DEVCAKE-MERGE) is never blocked."""
-    if not self.config.auto_resolve_merge_conflicts:
+    if not mgr.config.auto_resolve_merge_conflicts:
         return False
     try:
-        n = await self._conflict_attempts(pmo_id)
+        n = await _conflict_attempts(mgr, pmo_id)
         if n >= MAX_CONFLICT_RESOLVES:
-            self._audit(pmo_id, "conflict_resolve_exhausted", pr_url)
+            mgr._audit(pmo_id, "conflict_resolve_exhausted", pr_url)
             return False
         # directive FIRST, then swap (mirrors the reject path): if the
         # post fails the mission stays put and the marker count never
         # undercounts. The EXECUTE playbook tells the Dev a 🧩 resolve
         # directive overrides its normal implement-the-mission job (🧩 is
         # reserved for this directive — 🔀 already means "PR opened").
-        await self._feed(
+        await mgr._feed(
             pmo_id, "issue",
             f"🧩 Auto-merge hit a merge conflict on {pr_url} (auto-resolve "
             f"attempt {n + 1}/{MAX_CONFLICT_RESOLVES}) — back to EXECUTE. "
-            f"Next Dev: sync `{mission_branch(self.instance_name, key)}` with the default branch, "
+            f"Next Dev: sync `{mission_branch(mgr.instance_name, key)}` with the default branch, "
             f"resolve the conflicts, and push; the PR then returns to "
             f"REVIEW. `devcake:conflict-resolve:{n + 1}`")
-        await self.pmo.swap_labels(MissionRef(pmo_id, "issue"),
+        await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                    remove={from_label}, add={LABEL_EXECUTE})
-        self._audit(pmo_id, "conflict_resolve_dispatched",
+        mgr._audit(pmo_id, "conflict_resolve_dispatched",
                     f"attempt {n + 1} ({pr_url})")
         return True
     except Exception:
@@ -100,11 +100,11 @@ async def _maybe_route_conflict_to_execute(self, pmo_id: str, key: str,
         return False
 
 
-async def _finalize_review(self, run: Run, result: dict) -> None:
+async def finalize_review(mgr, run: Run, result: dict) -> None:
     pmo_id = run.mission_pmo_id
     verdict = result.get("verdict")
     report = result.get("report_md") or result.get("summary") or ""
-    forge = self.forges.get(run.repo_ref)
+    forge = mgr.forges.get(run.repo_ref)
     if forge is None:
         # the run's repo vanished from config mid-flight: fail CLEANLY —
         # transcripts/report are already posted; no transition is applied
@@ -127,7 +127,7 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                     pr.number,
                     "## DevCake REVIEW: APPROVED-BY-DEVCAKE ✅\n\n"
                     + report + footer)
-            await self._checkpoint(run, "review:pr_comment", _pr_comment)
+            await mgr._checkpoint(run, "review:pr_comment", _pr_comment)
 
             async def _formal():
                 try:
@@ -140,12 +140,12 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                 run.finalized_steps.append("review:formal_approve")
                 if formal:
                     run.finalized_steps.append("review:formal_approve_ok")
-                self.runs.store.save(run)
+                mgr.runs.store.save(run)
             else:
                 # redelivery: only claim formal approval if it succeeded
                 formal = "review:formal_approve_ok" in run.finalized_steps
 
-        if self.config.auto_merge and pr:
+        if mgr.config.auto_merge and pr:
             if "review:done" not in run.finalized_steps \
                     and "review:merge_failed" not in run.finalized_steps \
                     and "review:merge_deferred" not in run.finalized_steps \
@@ -153,18 +153,18 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                 try:
                     async def _merge():
                         await forge.merge(pr.number)
-                    await self._checkpoint(run, "review:merge", _merge)
+                    await mgr._checkpoint(run, "review:merge", _merge)
                     async def _done():
-                        await self.pmo.swap_labels(MissionRef(pmo_id, "issue"),
+                        await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                              remove={LABEL_REVIEW}, add=set())
-                        await self.pmo.set_status(MissionRef(pmo_id, "issue"), "done")
-                        await self._feed(
+                        await mgr.pmo.set_status(MissionRef(pmo_id, "issue"), "done")
+                        await mgr._feed(
                             pmo_id, "issue",
                             f"✅ REVIEW approved; PR merged ({pr_url}). "
                             f"Mission done.")
-                        self._audit(pmo_id, "review_approve_merged", pr_url)
-                    await self._checkpoint(run, "review:done", _done)
-                    await self.deliver_internal_zip(run, pr)
+                        mgr._audit(pmo_id, "review_approve_merged", pr_url)
+                    await mgr._checkpoint(run, "review:done", _done)
+                    await mgr.deliver_internal_zip(run, pr)
                 except Exception as e:  # noqa: BLE001 — every merge failure, whatever its type, must enter the re-probe → conflict-route → merge-failed recovery ladder; escaping would strand the mission mid-REVIEW
                     # Capture for nested async defs (static F821 + safe if
                     # await order changes later); not a known production 500.
@@ -177,19 +177,19 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                             async def _done_merged():
                                 if "review:merge" not in run.finalized_steps:
                                     run.finalized_steps.append("review:merge")
-                                    self.runs.store.save(run)
-                                await self.pmo.swap_labels(
+                                    mgr.runs.store.save(run)
+                                await mgr.pmo.swap_labels(
                                     MissionRef(pmo_id, "issue"),
                                     remove={LABEL_REVIEW}, add=set())
-                                await self.pmo.set_status(
+                                await mgr.pmo.set_status(
                                     MissionRef(pmo_id, "issue"), "done")
-                                await self._feed(
+                                await mgr._feed(
                                     pmo_id, "issue",
                                     f"✅ REVIEW approved; PR merged ({pr_url}). "
                                     f"Mission done.")
-                                self._audit(pmo_id, "review_approve_merged", pr_url)
-                            await self._checkpoint(run, "review:done", _done_merged)
-                            await self.deliver_internal_zip(run, pr)
+                                mgr._audit(pmo_id, "review_approve_merged", pr_url)
+                            await mgr._checkpoint(run, "review:done", _done_merged)
+                            await mgr.deliver_internal_zip(run, pr)
                             return
                     except Exception:
                         log.exception("pr_state probe after merge fail for %s",
@@ -212,7 +212,7 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                         if "review:conflict_routed" in run.finalized_steps:
                             return
                         try:
-                            routed = await self._maybe_route_conflict_to_execute(
+                            routed = await _maybe_route_conflict_to_execute(mgr, 
                                 pmo_id, run.mission_key, pr_url, LABEL_REVIEW)
                         except Exception:
                             log.exception("conflict route failed for %s",
@@ -220,60 +220,60 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                             routed = False
                         if routed:
                             run.finalized_steps.append("review:conflict_routed")
-                            self.runs.store.save(run)
+                            mgr.runs.store.save(run)
                             return
                     if "review:merge_failed" not in run.finalized_steps \
                             and "review:merge_deferred" not in run.finalized_steps:
                         async def _fail_path():
-                            await self.pmo.swap_labels(
+                            await mgr.pmo.swap_labels(
                                 MissionRef(pmo_id, "issue"),
                                 remove={LABEL_REVIEW}, add={LABEL_MERGE})
                             if mstate is not False and \
-                                    self.config.merge_retry_window_minutes > 0:
-                                await self._feed(
+                                    mgr.config.merge_retry_window_minutes > 0:
+                                await mgr._feed(
                                     pmo_id, "issue",
                                     f"⏳ REVIEW approved but the merge is not "
                                     f"possible yet ({merge_err}) — DevCake keeps "
                                     f"retrying for up to "
-                                    f"{self.config.merge_retry_window_minutes} "
+                                    f"{mgr.config.merge_retry_window_minutes} "
                                     f"minutes (mergeability computing / CI "
                                     f"pipeline running). You can merge {pr_url} "
                                     f"manually at any time. {MERGE_RETRY_MARKER}")
-                                self._audit(pmo_id, "merge_deferred",
+                                mgr._audit(pmo_id, "merge_deferred",
                                             str(merge_err)[:120])
-                                self._merge_window_closed.discard(pmo_id)
+                                mgr._merge_window_closed.discard(pmo_id)
                                 run.finalized_steps.append(
                                     "review:merge_deferred")
                             else:
-                                await self._feed(
+                                await mgr._feed(
                                     pmo_id, "issue",
                                     f"⚠️ REVIEW approved but auto-merge failed "
                                     f"({merge_err}); awaiting human merge of "
                                     f"{pr_url} (`DEVCAKE-MERGE`). "
                                     f"{MERGE_HANDOFF_MARKER}")
-                                self._audit(pmo_id,
+                                mgr._audit(pmo_id,
                                             "review_approve_merge_failed",
                                             str(merge_err)[:120])
                                 run.finalized_steps.append(
                                     "review:merge_failed")
-                            self.runs.store.save(run)
+                            mgr.runs.store.save(run)
                         await _fail_path()
         elif "review:awaiting_merge" not in run.finalized_steps:
             async def _await_merge():
-                await self.pmo.swap_labels(MissionRef(pmo_id, "issue"),
+                await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                            remove={LABEL_REVIEW}, add={LABEL_MERGE})
-                await self._feed(
+                await mgr._feed(
                     pmo_id, "issue",
                     f"✅ REVIEW approved "
                     f"({'formal approval filed' if formal else 'APPROVED-BY-DEVCAKE marker'}). "
                     f"Awaiting human merge of {pr_url} — the merge sweep completes "
                     f"this mission once it merges." + footer)
-                self._audit(pmo_id, "review_approve_awaiting_merge", pr_url)
-            await self._checkpoint(run, "review:awaiting_merge", _await_merge)
+                mgr._audit(pmo_id, "review_approve_awaiting_merge", pr_url)
+            await mgr._checkpoint(run, "review:awaiting_merge", _await_merge)
     else:  # reject
         rejections = 1 + sum(
-            1 for r in self.runs.store.all()
-            if r.mission_pmo_id == pmo_id and self._run_is_ours(r) and r.mission_type == "REVIEW"
+            1 for r in mgr.runs.store.all()
+            if r.mission_pmo_id == pmo_id and mgr._run_is_ours(r) and r.mission_type == "REVIEW"
             and r.state == "finished"
             and (r.result or {}).get("verdict") == "reject")
 
@@ -283,7 +283,7 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
             if report:
                 try:
                     name = f"{run.seq}_REVIEW_REPORT.md"
-                    url = await self.pmo.upload_attachment(
+                    url = await mgr.pmo.upload_attachment(
                         pmo_id, name, redact(report).encode())
                     feed_body = (
                         f"🔁 REVIEW rejected (round {rejections}) — back "
@@ -291,7 +291,7 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                         f"[{name}]({url})")
                 except Exception:
                     log.exception("review report upload failed — posting inline")
-            await self._feed(pmo_id, "issue", feed_body)
+            await mgr._feed(pmo_id, "issue", feed_body)
 
         async def _reject_pr_comment():
             if pr:
@@ -301,35 +301,35 @@ async def _finalize_review(self, run: Run, result: dict) -> None:
                     + report + footer)
 
         async def _reject_labels():
-            await self.pmo.swap_labels(MissionRef(pmo_id, "issue"),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                    remove={LABEL_REVIEW}, add={LABEL_EXECUTE})
-            self._audit(pmo_id, "label_swap",
+            mgr._audit(pmo_id, "label_swap",
                         f"{LABEL_REVIEW}→{LABEL_EXECUTE}")
 
         async def _reject_loop_warn():
-            every = self.config.review_loop_warning_every
+            every = mgr.config.review_loop_warning_every
             if every < 1 or rejections % every != 0:
                 return
             cost = sum((r.token_report or {}).get("cost_usd") or 0
-                       for r in self.runs.store.all()
-                       if r.mission_pmo_id == pmo_id and self._run_is_ours(r))
+                       for r in mgr.runs.store.all()
+                       if r.mission_pmo_id == pmo_id and mgr._run_is_ours(r))
             warn = (f"⚠️ **Loop warning:** this mission has been through "
                     f"{rejections} REVIEW rejections. Cumulative recorded "
                     f"cost so far: ${cost:.2f} (runs without cost data not "
                     f"included). Add `DEVCAKE-SKIP` to stop DevCake, or "
                     f"intervene on the PR directly.")
-            await self._feed(pmo_id, "issue", warn)
+            await mgr._feed(pmo_id, "issue", warn)
             if pr:
                 await forge.post_pr_comment(pr.number, warn)
-            self._audit(pmo_id, "loop_warning", f"{rejections} rejections")
+            mgr._audit(pmo_id, "loop_warning", f"{rejections} rejections")
 
-        await self._checkpoint(run, "review:reject:feed", _reject_feed)
-        await self._checkpoint(run, "review:reject:pr_comment",
+        await mgr._checkpoint(run, "review:reject:feed", _reject_feed)
+        await mgr._checkpoint(run, "review:reject:pr_comment",
                                _reject_pr_comment)
-        await self._checkpoint(run, "review:reject:labels", _reject_labels)
-        await self._checkpoint(run, "review:reject:loop_warn",
+        await mgr._checkpoint(run, "review:reject:labels", _reject_labels)
+        await mgr._checkpoint(run, "review:reject:loop_warn",
                                _reject_loop_warn)
         if "review:reject" not in run.finalized_steps:
             run.finalized_steps.append("review:reject")
-            self.runs.store.save(run)
+            mgr.runs.store.save(run)
 

--- a/app/devcake/domain/orchestrator/transitions.py
+++ b/app/devcake/domain/orchestrator/transitions.py
@@ -8,42 +8,43 @@ from ...security import redact
 from ..model import (LABEL_EXECUTE, LABEL_NEEDS_HUMAN, LABEL_PLAN, LABEL_REVIEW,
                      LABEL_SKIP, MissionRef)
 from ..run import Run
+from . import decomposition, feed, review
 from .markers import COMMENT_SENTINEL, LEGAL_OUTCOMES, _SWAP_MARKER_STAGE
 
 log = logging.getLogger("devcake.missions")
 
 
-async def _transition(self, run: Run, result: dict, plan_md: str | None) -> None:
+async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
     outcome = result.get("outcome", "")
     pmo_id = run.mission_pmo_id
     if outcome not in LEGAL_OUTCOMES.get(run.mission_type, frozenset()):
         # illegal (or unknown) outcome for this step — the trust boundary.
         # Park for a human; never act on it (docs/03 §6, docs/15).
         async def _illegal():
-            await self.pmo.swap_labels(MissionRef(pmo_id, run.pmo_kind),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, run.pmo_kind),
                                    remove=set(), add={LABEL_SKIP})
-            await self._feed(
+            await mgr._feed(
                 pmo_id, run.pmo_kind,
                 f"⛔ DevCake received outcome `{outcome or '(empty)'}` from a "
                 f"**{run.mission_type}** run — not a legal outcome for that step. "
                 f"No transition was applied; parked with `DEVCAKE-SKIP` for a "
                 f"human to inspect.")
-            self._audit(pmo_id, "illegal_outcome",
+            mgr._audit(pmo_id, "illegal_outcome",
                         f"{outcome or '(empty)'} from {run.mission_type}")
-        await self._checkpoint(run, "transition:illegal", _illegal)
+        await mgr._checkpoint(run, "transition:illegal", _illegal)
         run.verdict = redact(
             f"rejected: outcome {outcome or '(empty)'} is illegal "
             f"for {run.mission_type} — parked with DEVCAKE-SKIP")
         log.warning("illegal outcome %r from %s run %s — parked",
                     outcome, run.mission_type, run.run_id)
         return
-    live = await self.pmo.get(MissionRef(pmo_id, run.pmo_kind))               # live re-read
+    live = await mgr.pmo.get(MissionRef(pmo_id, run.pmo_kind))               # live re-read
     if run.pmo_kind == "project" and outcome not in ("decomposed", "human_needed"):
         async def _proj_park():
-            await self.pmo.swap_labels(MissionRef(pmo_id, "project"),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, "project"),
                                        remove=set(), add={LABEL_SKIP})
-            self._audit(pmo_id, "project_bad_outcome_parked", outcome)
-        await self._checkpoint(run, "transition:project_park", _proj_park)
+            mgr._audit(pmo_id, "project_bad_outcome_parked", outcome)
+        await mgr._checkpoint(run, "transition:project_park", _proj_park)
         run.verdict = redact(
             f"rejected: project returned {outcome} (only decomposed "
             f"is legal) — parked with DEVCAKE-SKIP")
@@ -63,110 +64,110 @@ async def _transition(self, run: Run, result: dict, plan_md: str | None) -> None
     expected_stages.update(
         stage for marker, stage in _SWAP_MARKER_STAGE.items()
         if marker in run.finalized_steps)
-    if self._stage_of(live) not in expected_stages:
+    if feed._stage_of(live) not in expected_stages:
         async def _external():
-            await self._feed(
+            await mgr._feed(
                 pmo_id, run.pmo_kind,
                 f"ℹ️ DevCake completed a **{run.mission_type}** run (`{run.run_id}`), but "
                 f"this mission's state was changed externally while it ran. The output is "
                 f"posted above; **no status or label changes were applied**.")
-            self._audit(pmo_id, "external_transition", run.run_id)
-        await self._checkpoint(run, "transition:external", _external)
+            mgr._audit(pmo_id, "external_transition", run.run_id)
+        await mgr._checkpoint(run, "transition:external", _external)
         run.verdict = ("skipped: mission state changed externally while the "
                        "run was in flight — no transition applied")
         log.warning("EXTERNAL_TRANSITION on %s — no labels applied", run.run_id)
         return
 
     if outcome in ("executed", "reviewed"):
-        await self._flag_out_of_pipeline_merge(run)
+        await mgr._flag_out_of_pipeline_merge(run)
 
     if outcome == "planned":
         plan_name = f"PLAN_{run.seq}.md"
         plan_url_box: list[str] = []
 
         async def _plan_upload():
-            url = await self.pmo.upload_attachment(
+            url = await mgr.pmo.upload_attachment(
                 pmo_id, plan_name, redact(plan_md or "").encode())
             plan_url_box.clear()
             plan_url_box.append(url)
 
         async def _plan_feed():
             url = plan_url_box[0] if plan_url_box else f"(see attachment {plan_name})"
-            await self._feed(
+            await mgr._feed(
                 pmo_id, run.pmo_kind,
                 f"📋 DevCake plan for this mission: [{plan_name}]({url})")
 
         async def _plan_labels():
-            await self.pmo.swap_labels(MissionRef(pmo_id, "issue"),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                        remove={LABEL_PLAN}, add={LABEL_EXECUTE})
-            self._audit(pmo_id, "label_swap", f"{LABEL_PLAN}→{LABEL_EXECUTE}")
+            mgr._audit(pmo_id, "label_swap", f"{LABEL_PLAN}→{LABEL_EXECUTE}")
 
-        await self._checkpoint(run, "transition:planned:upload", _plan_upload)
-        await self._checkpoint(run, "transition:planned:feed", _plan_feed)
-        await self._checkpoint(run, "transition:planned:labels", _plan_labels)
+        await mgr._checkpoint(run, "transition:planned:upload", _plan_upload)
+        await mgr._checkpoint(run, "transition:planned:feed", _plan_feed)
+        await mgr._checkpoint(run, "transition:planned:labels", _plan_labels)
         if "transition:planned" not in run.finalized_steps:
             run.finalized_steps.append("transition:planned")
-            self.runs.store.save(run)
+            mgr.runs.store.save(run)
     elif outcome == "executed":
         async def _executed_labels():
-            await self.pmo.swap_labels(MissionRef(pmo_id, "issue"),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                        remove={LABEL_EXECUTE}, add={LABEL_REVIEW})
-            self._audit(pmo_id, "label_swap", f"{LABEL_EXECUTE}→{LABEL_REVIEW}")
+            mgr._audit(pmo_id, "label_swap", f"{LABEL_EXECUTE}→{LABEL_REVIEW}")
 
         async def _executed_feed():
-            _f = self.forges.get(run.repo_ref)
+            _f = mgr.forges.get(run.repo_ref)
             noun = _f.descriptor.pr_noun if _f else "pull request"
-            await self._feed(
+            await mgr._feed(
                 pmo_id, run.pmo_kind,
                 f"🔀 DevCake opened/updated the {noun}: "
                 f"{result.get('pr_url', '(no url reported)')} — awaiting REVIEW.")
 
-        await self._checkpoint(run, "transition:executed:labels", _executed_labels)
-        await self._checkpoint(run, "transition:executed:feed", _executed_feed)
+        await mgr._checkpoint(run, "transition:executed:labels", _executed_labels)
+        await mgr._checkpoint(run, "transition:executed:feed", _executed_feed)
         if "transition:executed" not in run.finalized_steps:
             run.finalized_steps.append("transition:executed")
-            self.runs.store.save(run)
+            mgr.runs.store.save(run)
     elif outcome == "reviewed":
-        await self._finalize_review(run, result)
+        await review.finalize_review(mgr, run, result)
     elif outcome == "decomposed":
-        await self._finalize_decomposition(run, result)
+        await decomposition.finalize_decomposition(mgr, run, result)
     elif outcome == "plan_needed" and plan_md:
         plan_name = f"PLAN_{run.seq}.md"
         plan_url_box: list[str] = []
 
         async def _plan_attach_upload():
-            url = await self.pmo.upload_attachment(
+            url = await mgr.pmo.upload_attachment(
                 pmo_id, plan_name, redact(plan_md).encode())
             plan_url_box.clear()
             plan_url_box.append(url)
 
         async def _plan_attach_feed():
             url = plan_url_box[0] if plan_url_box else f"(see {plan_name})"
-            await self._feed(
+            await mgr._feed(
                 pmo_id, run.pmo_kind,
                 f"📋 DevCake attached an opportunistic plan from triage: "
                 f"[{plan_name}]({url}) — skipping the PLAN step.")
 
         async def _plan_attach_labels():
-            await self.pmo.swap_labels(MissionRef(pmo_id, "issue"),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                        remove=set(), add={LABEL_EXECUTE})
-            self._audit(pmo_id, "label_add", LABEL_EXECUTE)
+            mgr._audit(pmo_id, "label_add", LABEL_EXECUTE)
 
-        await self._checkpoint(run, "transition:plan_needed_attach:upload",
+        await mgr._checkpoint(run, "transition:plan_needed_attach:upload",
                                _plan_attach_upload)
-        await self._checkpoint(run, "transition:plan_needed_attach:feed",
+        await mgr._checkpoint(run, "transition:plan_needed_attach:feed",
                                _plan_attach_feed)
-        await self._checkpoint(run, "transition:plan_needed_attach:labels",
+        await mgr._checkpoint(run, "transition:plan_needed_attach:labels",
                                _plan_attach_labels)
         if "transition:plan_needed_attach" not in run.finalized_steps:
             run.finalized_steps.append("transition:plan_needed_attach")
-            self.runs.store.save(run)
+            mgr.runs.store.save(run)
     elif outcome == "plan_needed":
         async def _plan_needed():
-            await self.pmo.swap_labels(MissionRef(pmo_id, "issue"),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                        remove=set(), add={LABEL_PLAN})
-            self._audit(pmo_id, "label_add", LABEL_PLAN)
-        await self._checkpoint(run, "transition:plan_needed", _plan_needed)
+            mgr._audit(pmo_id, "label_add", LABEL_PLAN)
+        await mgr._checkpoint(run, "transition:plan_needed", _plan_needed)
     elif outcome == "human_needed":
         # deliberate hand-off (docs/03 §4a, ADR-0007): the run finished
         # cleanly, so it never counts toward max_attempts; the stage label
@@ -174,14 +175,14 @@ async def _transition(self, run: Run, result: dict, plan_md: str | None) -> None
         # DEVCAKE-NEEDS-HUMAN. Checkpointed so redelivery never re-posts
         # the baton (ISSUES #5).
         async def _human():
-            await self.pmo.swap_labels(MissionRef(pmo_id, run.pmo_kind),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, run.pmo_kind),
                                        remove=set(), add={LABEL_NEEDS_HUMAN})
             if run.stage_label_at_dispatch is None and live.status == "in_progress":
-                await self.pmo.set_status(MissionRef(pmo_id, run.pmo_kind), "backlog")
-                self._audit(pmo_id, "set_status", "backlog (human hand-off)")
+                await mgr.pmo.set_status(MissionRef(pmo_id, run.pmo_kind), "backlog")
+                mgr._audit(pmo_id, "set_status", "backlog (human hand-off)")
             nth = 1 + sum(
-                1 for r in self.runs.store.all()
-                if r.mission_pmo_id == pmo_id and self._run_is_ours(r) and r.state == "finished"
+                1 for r in mgr.runs.store.all()
+                if r.mission_pmo_id == pmo_id and mgr._run_is_ours(r) and r.state == "finished"
                 and (r.result or {}).get("outcome") == "human_needed"
                 and r.stage_label_at_dispatch == run.stage_label_at_dispatch)
             warn = "" if nth < 2 else (
@@ -192,34 +193,34 @@ async def _transition(self, run: Run, result: dict, plan_md: str | None) -> None
                      f"{result.get('summary', '(no details reported)')}\n\n"
                      f"When resolved, remove the `DEVCAKE-NEEDS-HUMAN` label and "
                      f"DevCake resumes where it left off.")
-            await self._feed(pmo_id, run.pmo_kind, baton)
+            await mgr._feed(pmo_id, run.pmo_kind, baton)
             if run.pmo_kind == "project":
                 try:
-                    await self.pmo.post_feed(
+                    await mgr.pmo.post_feed(
                         MissionRef(pmo_id, "project"),
                         redact(baton) + "\n\n" + COMMENT_SENTINEL)
                 except Exception:  # noqa: BLE001 — project-update mirror is best-effort; failure logged, the hand-off is already recorded on the feed + audit
                     log.warning("project-update hand-off failed for %s — "
                                 "summary lives in the audit log only",
                                 run.mission_key, exc_info=True)
-            self._audit(pmo_id, "devcake_needs_human",
+            mgr._audit(pmo_id, "devcake_needs_human",
                         f"#{nth}: " + (result.get("summary") or "")[:110])
-        await self._checkpoint(run, "transition:human_needed", _human)
+        await mgr._checkpoint(run, "transition:human_needed", _human)
         run.verdict = f"handed off: needs human on {run.mission_type}"
-        self.needs_human[pmo_id] = (
+        mgr.needs_human[pmo_id] = (
             f"{run.mission_key}: needs human on {run.mission_type}"
             + (f" — {live.url}" if live.url else ""))
     else:
         async def _unknown():
-            await self.pmo.swap_labels(MissionRef(pmo_id, run.pmo_kind),
+            await mgr.pmo.swap_labels(MissionRef(pmo_id, run.pmo_kind),
                                        remove=set(), add={LABEL_SKIP})
-            await self._feed(
+            await mgr._feed(
                 pmo_id, run.pmo_kind,
                 f"ℹ️ DevCake received unknown outcome `{outcome}` — parked with "
                 f"`DEVCAKE-SKIP` for a human to inspect.")
-            self._audit(pmo_id, "label_add",
+            mgr._audit(pmo_id, "label_add",
                         f"{LABEL_SKIP} (unknown outcome {outcome})")
-        await self._checkpoint(run, "transition:unknown_park", _unknown)
+        await mgr._checkpoint(run, "transition:unknown_park", _unknown)
         run.verdict = redact(
             f"rejected: unknown outcome {outcome} — parked with DEVCAKE-SKIP")
 

--- a/app/tests/test_crash_recovery.py
+++ b/app/tests/test_crash_recovery.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from devcake.config import PMOInstance
+from devcake.domain.orchestrator import transitions
 from fakes import FakeForgeRuntime
 
 from devcake.domain.run import Run, utcnow
@@ -499,11 +500,11 @@ def test_human_needed_baton_posted_once(tmp_path):
     )
     store.save(run)
     result = {"outcome": "human_needed", "summary": "stuck on secrets"}
-    run_coro(mgr._transition(run, result, None))
+    run_coro(transitions.transition(mgr, run, result, None))
     assert sum(1 for c in comments if "needs a human" in c.lower()
                or "DevCake needs a human" in c) == 1
     # redelivery: checkpoint skips baton
-    run_coro(mgr._transition(run, result, None))
+    run_coro(transitions.transition(mgr, run, result, None))
     assert sum(1 for c in comments if "needs a human" in c.lower()
                or "DevCake needs a human" in c) == 1
     assert "transition:human_needed" in run.finalized_steps
@@ -564,7 +565,7 @@ def test_redelivery_own_label_swap_is_not_external_transition(tmp_path):
     )
     store.save(run)
     result = {"outcome": "executed", "pr_url": "https://x/pr/1"}
-    run_coro(mgr._transition(run, result, None))
+    run_coro(transitions.transition(mgr, run, result, None))
     assert not any("changed externally" in c for c in comments)
     assert any("awaiting REVIEW" in c for c in comments)  # transition resumed
     assert "transition:executed" in run.finalized_steps
@@ -577,7 +578,7 @@ def test_redelivery_own_label_swap_is_not_external_transition(tmp_path):
         state="finalizing", stage_label_at_dispatch=LABEL_EXECUTE,
     )
     store.save(fresh)
-    run_coro(mgr._transition(fresh, result, None))
+    run_coro(transitions.transition(mgr, fresh, result, None))
     assert any("changed externally" in c for c in comments)
     # non-swap checkpoints (feeds, pr comments) must NOT suppress the check:
     # a human canceling the mission between deliveries still halts the resume
@@ -591,7 +592,7 @@ def test_redelivery_own_label_swap_is_not_external_transition(tmp_path):
         finalized_steps=["transition:executed:feed"],  # feed is not a swap
     )
     store.save(canceled)
-    run_coro(mgr._transition(canceled, result, None))
+    run_coro(transitions.transition(mgr, canceled, result, None))
     assert any("changed externally" in c for c in comments)
     assert "transition:executed" not in canceled.finalized_steps
 

--- a/app/tests/test_decomposition_depth.py
+++ b/app/tests/test_decomposition_depth.py
@@ -6,6 +6,7 @@ unlimited). Depth is read from the mission's own record only: the app-managed
 description is inert."""
 
 from devcake.config import AppConfig
+from devcake.domain.orchestrator import decomposition
 from devcake.domain.orchestrator.markers import (DECOMPOSITION_MARKER_RE,
                                                  at_decomposition_limit,
                                                  decomposition_depth)
@@ -33,7 +34,7 @@ def make_depth_mgr(tmp_path, m, limit=2):
 
 def decompose(mgr, drafts=None):
     drafts = drafts if drafts is not None else [{"title": "a"}, {"title": "b"}]
-    return run_coro(mgr._finalize_decomposition(
+    return run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None),
         {"outcome": "decomposed", "decomposition": drafts}))
 

--- a/app/tests/test_repo_routing.py
+++ b/app/tests/test_repo_routing.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 from devcake.config import PMOInstance
 from devcake.domain.model import Mission
+from devcake.domain.orchestrator import review
 from devcake.domain.repo_routing import (REASON_ZERO_REPO, marker_repo,
                                          resolve_repo)
 from devcake.domain.run import Run
@@ -122,7 +123,7 @@ def test_vanished_repo_contract_in_sweeps_and_review(tmp_path):
 
     run = _run("gone")
     run.mission_pmo_id = "p1"
-    run_coro(mgr._finalize_review(run, {"verdict": "approve"}))   # must not raise
+    run_coro(review.finalize_review(mgr, run, {"verdict": "approve"}))   # must not raise
     assert "no longer configured" in (run.verdict or "")
 
 

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -10,6 +10,7 @@ import pytest
 from devcake.config import AppConfig, DevType
 from devcake.ports.forge import ForgeError, PullRequest
 from devcake.domain.orchestrator import MissionManager
+from devcake.domain.orchestrator import decomposition, review, transitions
 from devcake.domain.model import Activity, ActivityEntry, Mission
 from devcake.adapters.files.run_store import RunStore
 from devcake.domain.run import Run
@@ -180,7 +181,7 @@ def test_external_transition_aborts_inv3(tmp_path):
     run = Run(run_id="T-1-1-ONBOARD-XXXXXX", mission_key="T-1", mission_pmo_id="p1",
               mission_type="ONBOARD", dev_type="senior-dev", seq=1,
               stage_label_at_dispatch=None)   # dispatched when NO stage label
-    run_coro(mgr._transition(run, {"outcome": "plan_needed"}, None))
+    run_coro(transitions.transition(mgr, run, {"outcome": "plan_needed"}, None))
     assert fake.swaps == []                    # nothing applied — human won
     assert any("changed externally" in c for c in fake.comments)
 
@@ -204,7 +205,7 @@ def _run(mission_type="EXECUTE", stage="DEVCAKE-EXECUTE"):
 def test_human_needed_keeps_stage_and_hands_off(tmp_path):
     m = mission("in_progress", {"DEVCAKE", "DEVCAKE-EXECUTE"})
     mgr, fake, store = make_mgr(tmp_path, m)
-    run_coro(mgr._transition(_run(), {"outcome": "human_needed",
+    run_coro(transitions.transition(mgr, _run(), {"outcome": "human_needed",
                                       "summary": "grant repo:write to the token"},
                              None))
     assert "DEVCAKE-NEEDS-HUMAN" in m.labels
@@ -217,7 +218,7 @@ def test_human_needed_keeps_stage_and_hands_off(tmp_path):
 def test_human_needed_from_onboard_restores_backlog(tmp_path):
     m = mission("in_progress", {"DEVCAKE"})       # ONBOARD flipped it in_progress
     mgr, fake, store = make_mgr(tmp_path, m)
-    run_coro(mgr._transition(_run("ONBOARD", None),
+    run_coro(transitions.transition(mgr, _run("ONBOARD", None),
                              {"outcome": "human_needed", "summary": "s"}, None))
     assert "DEVCAKE-NEEDS-HUMAN" in m.labels
     assert fake.statuses == ["backlog"]           # avoids row-9 stranding
@@ -229,7 +230,7 @@ def test_human_needed_allowed_for_projects(tmp_path):
     mgr, fake, store = make_mgr(tmp_path, m)
     run = _run("ONBOARD", None)
     run.pmo_kind = "project"
-    run_coro(mgr._transition(run, {"outcome": "human_needed",
+    run_coro(transitions.transition(mgr, run, {"outcome": "human_needed",
                                    "summary": "grant the scope"}, None))
     assert "DEVCAKE-NEEDS-HUMAN" in m.labels      # not parked with SKIP
     assert "DEVCAKE-SKIP" not in m.labels
@@ -251,7 +252,7 @@ def test_awaiting_merge_redelivery_not_misread_as_external(tmp_path):
     mgr.config.auto_merge = False
     run = _run("REVIEW", "DEVCAKE-REVIEW")
     run.finalized_steps = ["review:awaiting_merge"]            # checkpointed
-    run_coro(mgr._transition(run, {"outcome": "reviewed", "verdict": "approve",
+    run_coro(transitions.transition(mgr, run, {"outcome": "reviewed", "verdict": "approve",
                                    "report_md": "ok"}, None))
     assert not any("changed externally" in c for c in fake.comments)
     assert not (run.verdict or "").startswith("skipped:")
@@ -264,7 +265,7 @@ def test_illegal_outcome_parks_never_acts(tmp_path):
     # would raise AttributeError and fail this test)
     m = mission("in_progress", {"DEVCAKE", "DEVCAKE-EXECUTE"})
     mgr, fake, store = make_mgr(tmp_path, m)
-    run_coro(mgr._transition(_run(), {"outcome": "reviewed",
+    run_coro(transitions.transition(mgr, _run(), {"outcome": "reviewed",
                                       "verdict": "approve"}, None))
     assert "DEVCAKE-SKIP" in m.labels
     assert "DEVCAKE-EXECUTE" in m.labels          # stage untouched, only parked
@@ -272,7 +273,7 @@ def test_illegal_outcome_parks_never_acts(tmp_path):
     # and a PLAN run may only return "planned"
     m2 = mission("in_progress", {"DEVCAKE", "DEVCAKE-PLAN"})
     mgr2, fake2, _ = make_mgr(tmp_path, m2)
-    run_coro(mgr2._transition(_run("PLAN", "DEVCAKE-PLAN"),
+    run_coro(transitions.transition(mgr2, _run("PLAN", "DEVCAKE-PLAN"),
                               {"outcome": "decomposed", "decomposition": [{}]},
                               None))
     assert "DEVCAKE-SKIP" in m2.labels and fake2.created == []
@@ -281,7 +282,7 @@ def test_illegal_outcome_parks_never_acts(tmp_path):
 def test_second_handoff_escalates_warning(tmp_path):
     m = mission("in_progress", {"DEVCAKE", "DEVCAKE-EXECUTE"})
     mgr, fake, store = make_mgr(tmp_path, m)
-    run_coro(mgr._transition(_run(), {"outcome": "human_needed", "summary": "s1"},
+    run_coro(transitions.transition(mgr, _run(), {"outcome": "human_needed", "summary": "s1"},
                              None))
     assert not any("Hand-off #" in c for c in fake.comments)   # first: no warning
     prior = _run()
@@ -290,7 +291,7 @@ def test_second_handoff_escalates_warning(tmp_path):
     prior.result = {"outcome": "human_needed"}
     store.save(prior)
     m.labels.discard("DEVCAKE-NEEDS-HUMAN")       # human resolved + resumed
-    run_coro(mgr._transition(_run(), {"outcome": "human_needed", "summary": "s2"},
+    run_coro(transitions.transition(mgr, _run(), {"outcome": "human_needed", "summary": "s2"},
                              None))
     assert any("Hand-off #2" in c and "DEVCAKE-SKIP" in c for c in fake.comments)
     assert "DEVCAKE-NEEDS-HUMAN" in m.labels      # warned, never parked
@@ -480,7 +481,7 @@ def test_executed_trivially_is_illegal_and_parks(tmp_path):
     outright (preproduction, no deprecation window); a stray one parks."""
     m = mission("in_progress", {"DEVCAKE"})
     mgr, fake, _store = make_mgr(tmp_path, m)
-    run_coro(mgr._transition(_run("ONBOARD", None),
+    run_coro(transitions.transition(mgr, _run("ONBOARD", None),
                              {"outcome": "executed_trivially",
                               "pr_url": "https://forge/mr/1", "summary": "s"},
                              None))
@@ -494,7 +495,7 @@ def test_onboard_opportunistic_plan_skips_plan_stage(tmp_path):
     formed and the mission jumps straight to EXECUTE."""
     m = mission("in_progress", {"DEVCAKE"})
     mgr, fake, _store = make_mgr(tmp_path, m)
-    run_coro(mgr._transition(_run("ONBOARD", None),
+    run_coro(transitions.transition(mgr, _run("ONBOARD", None),
                              {"outcome": "plan_needed", "summary": "s"},
                              "## Plan\nappend the line to README.md"))
     assert any(n == "PLAN_1.md" for n, _ in fake.uploads)
@@ -548,7 +549,7 @@ def test_decomposition_wires_blocked_by_edges(tmp_path):
     drafts = [{"title": "docs", "priority": "high"},
               {"title": "code", "priority": "high", "blocked_by": [1]},
               {"title": "polish", "blocked_by": [1, 2]}]
-    run_coro(mgr._transition(_run("ONBOARD", None),
+    run_coro(transitions.transition(mgr, _run("ONBOARD", None),
                              {"outcome": "decomposed", "decomposition": drafts},
                              None))
     assert [t for t, _ in fake.created] == ["docs", "code", "polish"]
@@ -565,14 +566,14 @@ def test_decomposition_children_inherit_repo_marker(tmp_path):
     m.description = "Do the big thing\n\n`devcake-repo:beta`"
     mgr, fake, _store = make_mgr(tmp_path, m)
     drafts = [{"title": "docs"}, {"title": "code", "blocked_by": [1]}]
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None), {"outcome": "decomposed", "decomposition": drafts}))
     children = fake.all_missions[1:]
     assert len(children) == 2
     assert all("`devcake-repo:beta`" in c.description for c in children)
     # replay with the marker present stays idempotent
     m.status = "in_progress"
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None), {"outcome": "decomposed", "decomposition": drafts}))
     assert len(fake.created) == 2
 
@@ -580,7 +581,7 @@ def test_decomposition_children_inherit_repo_marker(tmp_path):
 def test_decomposition_children_clean_without_marker(tmp_path):
     m = mission("in_progress", {"DEVCAKE"})
     mgr, fake, _store = make_mgr(tmp_path, m)
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None),
         {"outcome": "decomposed", "decomposition": [{"title": "solo"}]}))
     assert "devcake-repo" not in fake.all_missions[1].description
@@ -593,7 +594,7 @@ def test_decomposition_children_inherit_containing_project(tmp_path):
     m = mission("in_progress", {"DEVCAKE"})
     m.parent_ref = "proj-9"
     mgr, fake, _store = make_mgr(tmp_path, m)
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None),
         {"outcome": "decomposed", "decomposition": [{"title": "a"},
                                                     {"title": "b"}]}))
@@ -601,7 +602,7 @@ def test_decomposition_children_inherit_containing_project(tmp_path):
 
     solo = mission("in_progress", {"DEVCAKE"})
     mgr2, fake2, _ = make_mgr(tmp_path / "solo", solo)
-    run_coro(mgr2._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr2, 
         _run("ONBOARD", None),
         {"outcome": "decomposed", "decomposition": [{"title": "c"}]}))
     assert [pr for _, pr in fake2.created] == [None]
@@ -611,7 +612,7 @@ def test_decomposition_children_inherit_containing_project(tmp_path):
     mgr3, fake3, _ = make_mgr(tmp_path / "proj", proj)
     run = _run("ONBOARD", None)
     run.pmo_kind = "project"
-    run_coro(mgr3._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr3, 
         run, {"outcome": "decomposed", "decomposition": [{"title": "d"}]}))
     assert [pr for _, pr in fake3.created] == ["p1"]
 
@@ -652,7 +653,7 @@ def test_decomposition_inherits_dependent_edges_before_cancel(tmp_path):
     fake.all_missions.append(dep_mission("d1", "T-90", blocked_by=["p1"]))
     fake.all_missions.append(dep_mission("d2", "T-91", status="done",
                                          blocked_by=["p1"]))
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None),
         {"outcome": "decomposed", "decomposition": [{"title": "a"},
                                                     {"title": "b"}]}))
@@ -674,7 +675,7 @@ def test_decomposition_inherits_open_blockers_onto_children(tmp_path):
     mgr, fake, _store = make_mgr(tmp_path, m)
     fake.all_missions.append(dep_mission("b-open", "T-80"))
     fake.all_missions.append(dep_mission("b-done", "T-81", status="done"))
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None),
         {"outcome": "decomposed", "decomposition": [{"title": "a"},
                                                     {"title": "b"}]}))
@@ -697,13 +698,13 @@ def test_inherited_edge_failure_keeps_original_open_and_gated(tmp_path):
     run = _run("ONBOARD", None)
     drafts = [{"title": "a"}, {"title": "b"}]
     with pytest.raises(RuntimeError):
-        run_coro(mgr._finalize_decomposition(
+        run_coro(decomposition.finalize_decomposition(mgr, 
             run, {"outcome": "decomposed", "decomposition": drafts}))
     assert m.status != "canceled"                 # original still gates D
     assert ("status", "canceled") not in fake.ops
 
     fake.fail_relations = set()                   # transient error heals
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         run, {"outcome": "decomposed", "decomposition": drafts}))
     assert m.status == "canceled"
     assert ("id-1", "d1") in fake.relations and ("id-2", "d1") in fake.relations
@@ -712,7 +713,7 @@ def test_inherited_edge_failure_keeps_original_open_and_gated(tmp_path):
     mgr2, fake2, _ = make_mgr(tmp_path / "sib", m2)
     fake2.fail_relations = {("id-1", "id-2")}
     with pytest.raises(RuntimeError):
-        run_coro(mgr2._finalize_decomposition(
+        run_coro(decomposition.finalize_decomposition(mgr2, 
             _run("ONBOARD", None),
             {"outcome": "decomposed",
              "decomposition": [{"title": "a"},
@@ -731,12 +732,12 @@ def test_inherited_edge_to_deleted_dependent_converges_on_retry(tmp_path):
     run = _run("ONBOARD", None)
     drafts = [{"title": "a"}, {"title": "b"}]
     with pytest.raises(RuntimeError):
-        run_coro(mgr._finalize_decomposition(
+        run_coro(decomposition.finalize_decomposition(mgr, 
             run, {"outcome": "decomposed", "decomposition": drafts}))
     assert m.status != "canceled"
 
     fake.all_missions.remove(doomed)              # human deleted the issue
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         run, {"outcome": "decomposed", "decomposition": drafts}))
     assert m.status == "canceled"
     assert not any(blocked == "d1" for _, blocked in fake.relations)
@@ -748,7 +749,7 @@ def test_lineage_note_failure_never_blocks_cancel(tmp_path):
     m = mission("in_progress", {"DEVCAKE"})
     mgr, fake, _store = make_mgr(tmp_path, m)
     fake.fail_append = True
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None),
         {"outcome": "decomposed", "decomposition": [{"title": "a"}]}))
     assert m.status == "canceled"
@@ -764,7 +765,7 @@ def test_depth_park_restores_backlog_and_sets_verdict(tmp_path):
     m.description = marker(depth=2)
     mgr, fake, _store = make_mgr(tmp_path, m)
     run = _run("ONBOARD", None)
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         run, {"outcome": "decomposed", "decomposition": [{"title": "a"}]}))
     assert "DEVCAKE-SKIP" in m.labels
     assert m.status == "backlog"
@@ -783,13 +784,13 @@ def test_depth_gate_replay_stable_after_limit_change(tmp_path):
     drafts = [{"title": "a"}, {"title": "b"}]
     fake.fail_relations = {("id-1", "id-2")}       # crash mid-wiring
     with pytest.raises(RuntimeError):
-        run_coro(mgr._finalize_decomposition(
+        run_coro(decomposition.finalize_decomposition(mgr, 
             run, {"outcome": "decomposed",
                   "decomposition": [{"title": "a"},
                                     {"title": "b", "blocked_by": [1]}]}))
     mgr.config.max_decomposition_depth = 1         # operator lowers the limit
     fake.fail_relations = set()
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         run, {"outcome": "decomposed",
               "decomposition": [{"title": "a"},
                                 {"title": "b", "blocked_by": [1]}]}))
@@ -805,15 +806,15 @@ def test_inherited_edges_replay_semantics(tmp_path):
     fake.all_missions.append(dep_mission("d1", "T-90", blocked_by=["p1"]))
     drafts = [{"title": "a"}, {"title": "b"}]
     first = _run("ONBOARD", None)
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         first, {"outcome": "decomposed", "decomposition": drafts}))
     count = len(fake.relations)
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         first, {"outcome": "decomposed", "decomposition": drafts}))
     assert len(fake.relations) == count           # checkpoints all skipped
 
     m.status = "in_progress"
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None),
         {"outcome": "decomposed", "decomposition": drafts}))
     assert len(fake.created) == 2                 # children reused
@@ -827,7 +828,7 @@ def test_canceled_parent_gets_lineage_note(tmp_path):
     m = mission("in_progress", {"DEVCAKE"})
     mgr, fake, _store = make_mgr(tmp_path, m)
     drafts = [{"title": "a"}, {"title": "b"}]
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None), {"outcome": "decomposed",
                                 "decomposition": drafts}))
     assert "_Decomposed by DevCake into T-2, T-3_" in m.description
@@ -836,7 +837,7 @@ def test_canceled_parent_gets_lineage_note(tmp_path):
     assert note_at < fake.ops.index(("status", "canceled"))
 
     m.status = "in_progress"                      # fresh-run replay
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None), {"outcome": "decomposed",
                                 "decomposition": drafts}))
     assert m.description.count("_Decomposed by DevCake into") == 1
@@ -848,7 +849,7 @@ def test_project_decomposition_appends_no_lineage_note(tmp_path):
     mgr, fake, _store = make_mgr(tmp_path, proj)
     run = _run("ONBOARD", None)
     run.pmo_kind = "project"
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         run, {"outcome": "decomposed", "decomposition": [{"title": "a"}]}))
     assert not any(op[0] == "append_description" for op in fake.ops)
 
@@ -860,7 +861,7 @@ def test_project_decomposition_inherits_nothing(tmp_path):
     fake.all_missions.append(dep_mission("d1", "T-90", blocked_by=["p1"]))
     run = _run("ONBOARD", None)
     run.pmo_kind = "project"
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         run, {"outcome": "decomposed", "decomposition": [{"title": "a"}]}))
     assert not any(blocked == "d1" for _, blocked in fake.relations)
 
@@ -870,13 +871,13 @@ def test_decomposition_replay_reuses_marker_parts(tmp_path):
     mgr, fake, _store = make_mgr(tmp_path, m)
     drafts = [{"title": "docs"}, {"title": "code", "blocked_by": [1]}]
     first = _run("ONBOARD", None)
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         first, {"outcome": "decomposed", "decomposition": drafts}))
     assert len(fake.created) == 2
 
     m.status = "in_progress"
     second = _run("ONBOARD", None)
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         second, {"outcome": "decomposed", "decomposition": drafts}))
 
     assert len(fake.created) == 2
@@ -887,14 +888,14 @@ def test_decomposition_replay_reuses_marker_parts(tmp_path):
 def test_decomposition_manifest_conflict_hands_off_without_writes(tmp_path):
     m = mission("in_progress", {"DEVCAKE"})
     mgr, fake, _store = make_mgr(tmp_path, m)
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         _run("ONBOARD", None),
         {"outcome": "decomposed", "decomposition": [{"title": "original"}]}))
     assert len(fake.created) == 1
 
     m.status = "in_progress"
     retry = _run("ONBOARD", None)
-    run_coro(mgr._finalize_decomposition(
+    run_coro(decomposition.finalize_decomposition(mgr, 
         retry,
         {"outcome": "decomposed", "decomposition": [{"title": "changed"}]}))
 
@@ -909,7 +910,7 @@ def test_decomposition_rejects_forward_or_self_blocked_by(tmp_path):
     mgr, fake, store = make_mgr(tmp_path, m)
     for bad in ([1], [2]):                        # self-reference / forward reference
         with pytest.raises(ValueError):
-            run_coro(mgr._finalize_decomposition(
+            run_coro(decomposition.finalize_decomposition(mgr, 
                 _run("ONBOARD", None),
                 {"outcome": "decomposed",
                  "decomposition": [{"title": "a", "blocked_by": bad},
@@ -1100,7 +1101,7 @@ def test_reject_report_attached_feed_short_pr_full(tmp_path):
     forge = FakeForge()
     mgr, fake, store = make_mgr(tmp_path, m, forge=forge)
     report = "finding: " + "R" * 3000
-    run_coro(mgr._finalize_review(_run("REVIEW", "DEVCAKE-REVIEW"),
+    run_coro(review.finalize_review(mgr, _run("REVIEW", "DEVCAKE-REVIEW"),
                                   {"verdict": "reject", "report_md": report}))
     assert any(n == "1_REVIEW_REPORT.md" for n, _ in fake.uploads)
     feed = next(c for c in fake.comments if "REVIEW rejected" in c)
@@ -1123,7 +1124,7 @@ def test_reject_report_upload_redacts_run_password(tmp_path):
     register_runtime_secret(run.run_id, "s3cret-relay-pw")
     try:
         report = "leaked: s3cret-relay-pw\n" + "R" * 3000
-        run_coro(mgr._finalize_review(run, {"verdict": "reject",
+        run_coro(review.finalize_review(mgr, run, {"verdict": "reject",
                                             "report_md": report}))
     finally:
         unregister_runtime_secret(run.run_id)
@@ -1134,7 +1135,7 @@ def test_reject_report_upload_redacts_run_password(tmp_path):
 # ── docs/03 §4.1 merge-failure branches ──────────────────────────────────────
 
 def _approve_review(mgr):
-    return mgr._finalize_review(_run("REVIEW", "DEVCAKE-REVIEW"),
+    return review.finalize_review(mgr, _run("REVIEW", "DEVCAKE-REVIEW"),
                                 {"verdict": "approve", "report_md": "ok"})
 
 
@@ -1343,7 +1344,7 @@ def test_illegal_outcome_sets_verdict(tmp_path):
     m = mission("in_progress", {"DEVCAKE", "DEVCAKE-EXECUTE"})
     mgr, fake, store = make_mgr(tmp_path, m)
     run = _run()
-    run_coro(mgr._transition(run, {"outcome": "reviewed", "verdict": "approve"},
+    run_coro(transitions.transition(mgr, run, {"outcome": "reviewed", "verdict": "approve"},
                              None))
     assert run.verdict and run.verdict.startswith("rejected:")
     assert "illegal for EXECUTE" in run.verdict
@@ -1355,7 +1356,7 @@ def test_external_transition_sets_verdict(tmp_path):
     run = Run(run_id="T-1-1-ONBOARD-XXXXXX", mission_key="T-1",
               mission_pmo_id="p1", mission_type="ONBOARD",
               dev_type="senior-dev", seq=1, stage_label_at_dispatch=None)
-    run_coro(mgr._transition(run, {"outcome": "plan_needed"}, None))
+    run_coro(transitions.transition(mgr, run, {"outcome": "plan_needed"}, None))
     assert run.verdict and run.verdict.startswith("skipped:")
 
 
@@ -1363,7 +1364,7 @@ def test_human_needed_sets_verdict_and_advisory(tmp_path):
     m = mission("in_progress", {"DEVCAKE", "DEVCAKE-EXECUTE"})
     mgr, fake, store = make_mgr(tmp_path, m)
     run = _run()
-    run_coro(mgr._transition(run, {"outcome": "human_needed", "summary": "s"},
+    run_coro(transitions.transition(mgr, run, {"outcome": "human_needed", "summary": "s"},
                              None))
     assert run.verdict == "handed off: needs human on EXECUTE"
     assert "p1" in mgr.needs_human
@@ -1426,7 +1427,7 @@ def test_executed_feed_uses_descriptor_pr_noun(tmp_path):
     forge = FakeForge()
     forge.descriptor = type("D", (), {"pr_noun": "merge request"})()
     mgr, fake, _store = make_mgr(tmp_path, m, forge=forge)
-    run_coro(mgr._transition(_run("EXECUTE", "DEVCAKE-EXECUTE"),
+    run_coro(transitions.transition(mgr, _run("EXECUTE", "DEVCAKE-EXECUTE"),
                              {"outcome": "executed",
                               "pr_url": "https://forge/mr/1", "summary": "s"},
                              None))

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -45,7 +45,7 @@ app/devcake/
     model.py       #   entities, Mission Type derivation, label set (02)
     run.py         #   Run record + state machine
     run_bootstrap.py#  dispatch spine: ACL → digest → durable save → executor.start (04 §3.1)
-    orchestrator/  #   package: MissionManager façade + focused modules (04)
+    orchestrator/  #   package: MissionManager (DI + verbs) + module functions (04, ADR-0015)
                    #     manager, schedule, dispatch, finalize, transitions,
                    #     review, decomposition, sweeps, feed, markers, mapper
     mapper_service.py  # Relations Mapper cadence (ADR-0007; ISSUES #36 first cut)

--- a/docs/04-orchestrator.md
+++ b/docs/04-orchestrator.md
@@ -3,7 +3,7 @@
 > **Audience:** implementers. This is the most correctness-sensitive document in the set.
 > **Depends on:** `00-overview.md` (INV-1…6), `02-domain-model.md` (derivation table, Run, AppConfig).
 
-The orchestrator is the always-on core of the main app. **Implementation** lives under `app/devcake/domain/orchestrator/` as a package (ISSUES #36): `MissionManager` remains the public façade; schedule, dispatch, finalize, transitions, review, decomposition, sweeps, feed policy, and MAPPER mission ops are focused modules. `MapperService` (cadence) stays in `domain/mapper_service.py`. Wiring and the three loops live in `api/main.py`.
+The orchestrator is the always-on core of the main app. **Implementation** lives under `app/devcake/domain/orchestrator/` as a package (ISSUES #36, structure per ADR-0015): `MissionManager` is the DI container + advisory state + public verb surface, holding explicit delegating methods; schedule, dispatch, finalize, transitions, review, decomposition, sweeps, feed policy, and MAPPER mission ops are focused modules whose functions take the manager (`mgr`) as an explicit first parameter. Step-finalization seams are module-public (`transitions.transition`, `review.finalize_review`, `decomposition.finalize_decomposition`) — the sanctioned test seam. `MapperService` (cadence) stays in `domain/mapper_service.py`. Wiring and the three loops live in `api/main.py`.
 
 It runs three cooperating loops on one asyncio event loop:
 


### PR DESCRIPTION
Re-opened #20 (stacked-base retarget not possible via gh CLI). Same content, rebased onto main: transitions.transition / review.finalize_review / decomposition.finalize_decomposition module-public, self→mgr in the three modules, 56 test call sites respelled (zero assertion changes), docs/04+01 updated. Verified: ruff clean, 637 passed / 1 skipped via pytest_app.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)