### PR TITLE
refactor(api): C4 — PollRuntime + health module extracted from main.py (ADR-0015)

### DIFF
--- a/app/devcake/api/health.py
+++ b/app/devcake/api/health.py
@@ -1,0 +1,180 @@
+"""Health probes + the /api/v1/health payload builder (docs/11, docs/12).
+
+Application-service module per ADR-0015 Decision 3: explicit parameters,
+never imports main.py. Probe contract (docs/15 §7): any probe failure maps to
+False/None/ok:False — /health must never 500.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+import httpx
+import redis.asyncio as aioredis
+
+from .. import security
+from ..adapters.dagu import DAGU_URL
+from ..prompts import templates as prompt_templates
+from ..telemetry import OO_URL
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD", "")
+
+
+async def _check_redis() -> bool:
+    try:
+        r = aioredis.from_url(REDIS_URL, password=REDIS_PASSWORD or None, socket_timeout=3)
+        try:
+            return bool(await r.ping())
+        finally:
+            await r.aclose()
+    except Exception:  # noqa: BLE001 — probe contract: any failure → False; /health must never 500
+        return False
+
+
+# branch-protection probe (A2, docs/14): cached — /health is polled every 10 s
+# by the SPA, the forge API needs at most one look every few minutes
+_protection_cache: dict = {"ts": 0.0, "value": {}}
+
+
+def reset_protection_cache() -> None:
+    """Config reload hook: repos may have changed — reprobe on next /health."""
+    _protection_cache["ts"] = 0.0
+
+
+async def _branch_protection(forge_runtime) -> dict:
+    """{repo_name: BranchProtection|None} across every configured repo."""
+    if time.monotonic() - _protection_cache["ts"] > 300 or _protection_cache["ts"] == 0:
+        _protection_cache["ts"] = time.monotonic()
+        out: dict = {}
+        for name, f in forge_runtime.forges.items():
+            inst = forge_runtime.instance(name)
+            # reference-only repos: DevCake never pushes or merges there, so
+            # the unprotected-default-branch advisory would be pure noise
+            if inst is not None and inst.reference_only:
+                continue
+            try:
+                prot = await f.default_branch_protection(
+                    inst.default_branch if inst else "main")
+                out[name] = prot.model_dump() if prot else None
+            except Exception:  # noqa: BLE001 — probe contract: failure → None (advisory omitted); /health must never 500
+                out[name] = None
+        _protection_cache["value"] = out
+    return _protection_cache["value"]
+
+
+async def _check_http(url: str) -> bool:
+    try:
+        async with httpx.AsyncClient(timeout=3) as client:
+            return (await client.get(url)).status_code < 500
+    except Exception:  # noqa: BLE001 — probe contract: any failure → False; /health must never 500
+        return False
+
+
+# 60s-cached probe: does the OO service account actually authenticate?
+# Catches "compose up before provision_oo.py" / rotated-password drift —
+# without it, telemetry 401s silently forever (ISSUES #13 review finding).
+_oo_ingest_cache: dict = {"ts": 0.0, "result": None}
+
+
+async def _oo_ingest_check() -> dict:
+    now = time.monotonic()
+    if _oo_ingest_cache["result"] is not None and now - _oo_ingest_cache["ts"] < 60:
+        return _oo_ingest_cache["result"]
+    from ..telemetry import OO_ORG, _basic_auth
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            r = await client.get(f"{OO_URL}/api/{OO_ORG}/streams",
+                                 params={"type": "logs"},
+                                 headers={"Authorization": f"Basic {_basic_auth()}"})
+        result = {"ok": r.status_code == 200,
+                  "detail": "" if r.status_code == 200 else
+                  f"HTTP {r.status_code} — the OO service account cannot "
+                  f"authenticate; run scripts/provision_oo.py (ISSUES #13)"}
+    except Exception as e:  # noqa: BLE001 — probe contract: any failure → ok:False + detail; /health must never 500
+        result = {"ok": False, "detail": f"probe failed: {str(e)[:150]}"}
+    _oo_ingest_cache.update(ts=now, result=result)
+    return result
+
+
+async def build_health_payload(*, config, dev_types, managers, mappers,
+                               forge_runtime, shared_breakers, store,
+                               internal_forge, poll_rt) -> dict:
+    """The /api/v1/health body (docs/11 §0). All deps explicit — unit-testable
+    with fakes; the route in main.py is a one-line forward."""
+    redis_ok, dagu_ok, oo_ok = await asyncio.gather(
+        _check_redis(),
+        _check_http(f"{DAGU_URL}/api/v1/health"),
+        _check_http(f"{OO_URL}/healthz"),
+    )
+    # per-instance PMO health (schema v3): unconfigured instances show grey
+    # (ok: None), never red; the scalar `pmo` aggregate keeps the SPA's
+    # health dot working (true = every configured instance probes ok)
+    pmo_instances: dict[str, dict] = {}
+    for inst in config.pmos:
+        if not inst.configured:
+            pmo_instances[inst.name] = {"ok": None, "configured": False,
+                                        "team": ""}
+            continue
+        mgr = managers.get(inst.name)
+        try:
+            ok = bool(mgr) and (await mgr.pmo.health_probe(inst.team_key)).ok
+        except Exception:  # noqa: BLE001 — probe contract: any failure → ok:False for this instance; /health must never 500
+            ok = False
+        pmo_instances[inst.name] = {"ok": ok, "configured": True,
+                                    "team": inst.team_key}
+    configured_ok = [v["ok"] for v in pmo_instances.values() if v["configured"]]
+    prefixed = len(managers) > 1   # advisory text carries the instance when N>1
+
+    def _merged(attr: str) -> dict:
+        out: dict = {}
+        for name, mgr in managers.items():
+            for k, v in getattr(mgr, attr).items():
+                out[k] = f"[{name}] {v}" if prefixed and isinstance(v, str) else v
+        return out
+
+    return {
+        "app": True,
+        "redis": redis_ok,
+        "dagu": dagu_ok,
+        "openobserve": oo_ok,
+        "oo_ingest": await _oo_ingest_check(),
+        "pmo": bool(configured_ok) and all(configured_ok),
+        "pmo_instances": pmo_instances,
+        "forge": forge_runtime.health,
+        # dev-type breakers + per-repo forge breakers, one map for the SPA
+        "circuit_breakers": {**shared_breakers,
+                             **{f"repo:{k}": v
+                                for k, v in forge_runtime.breakers.items()}},
+        "intake_paused": config.intake_paused,
+        # poll cadence surface for the Missions "Last polled Ns ago · next in
+        # ~Ns" indicator — INV-1 made visible, not hidden behind a spinner
+        "last_poll_at": (poll_rt.last_poll_at.isoformat()
+                         if poll_rt.last_poll_at else None),
+        "poll_interval_seconds": config.poll_interval_seconds,
+        "active_runs": len(store.active()),
+        "forge_protection": await _branch_protection(forge_runtime),
+        "anomalies": _merged("anomalies"),
+        "merge_handoffs": _merged("merge_handoffs"),
+        "needs_human": _merged("needs_human"),
+        "dependency_cycles": [
+            ([f"{name}:{k}" for k in cyc] if prefixed else cyc)
+            for name, mgr in managers.items() for cyc in mgr.cycles],
+        "blocked_reasons": _merged("blocked_reasons"),
+        # instances whose poll segment failed with a PERMANENT error (audit
+        # A1) — the other instances keep polling; this names the sick one
+        "poll_degraded": dict(poll_rt.poll_degraded),
+        "internal_forge": (await internal_forge.health()
+                           if internal_forge is not None else None),
+        "mapper_degraded": " · ".join(
+            f"[{name}] {msg}" if prefixed else str(msg)
+            for name, mp in mappers.items() if (msg := mp.degraded())) or None,
+        # active templates that no longer resolve (fallback-to-default in
+        # effect) — the SPA derives a dismissable alert per entry (v0.1.1)
+        "prompt_template_warnings": (
+            prompt_templates.template_warnings(config)
+            + prompt_templates.devtype_prompt_warnings(config, dev_types)),
+        "security_warnings": security.security_warnings(config),
+    }

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -55,6 +55,8 @@ from ..prompts import templates as prompt_templates
 from ..ports.pmo import PMOTransient
 from ..telemetry import OO_URL, setup_telemetry
 from .auth import credentials_configured, enforce_control_plane_auth
+from .health import build_health_payload, reset_protection_cache
+from .poll import PollRuntime
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
 log = logging.getLogger("devcake")
@@ -141,7 +143,7 @@ def reload_connections() -> None:
     unlabeled until restart."""
     forge_runtime.rebuild(config.repos, make_forge)
     build_managers()
-    _protection_cache["ts"] = 0.0          # repos may have changed — reprobe
+    reset_protection_cache()               # repos may have changed — reprobe
 
     async def _ensure():
         for mgr in list(managers.values()):
@@ -160,231 +162,14 @@ manager.oauth_mgr = oauth_mgr
 runlog = RunLogStore()
 manager.runlog = runlog
 
-# poll-cycle snapshot served by /api/v1/missions (advisory cache — INV-1)
-missions_cache: list[dict] = []
-
-
-# PERSISTENT cross-instance ownership (v0.1 plan H1 + review finding):
-# pmo_id → owning instance name. Persistence is load-bearing — a per-cycle
-# rebuild would flip ownership of a shared mission the moment its owner has
-# one PMOTransient cycle, double-dispatching it. Released only when the
-# OWNER successfully polls and no longer sees the mission, or leaves config
-# (and never while a run for the mission is still active — audit A15).
-# Durable across restarts via OwnerStore (audit A15: in-memory-only
-# ownership reopened the duplicate-dispatch window on every restart).
-from ..adapters.files.owner_store import OwnerStore  # noqa: E402
-
-_owner_store = OwnerStore()
-_mission_owner: dict[str, str] = _owner_store.load()
-
-# instance → last poll-segment error (audit A1): a PERMANENT PMO failure
-# (revoked key, deleted team) skips only that instance's segment; this map
-# surfaces it in /health as `poll_degraded`. Cleared on a green segment.
-_poll_degraded: dict[str, str] = {}
-
-# Wall-clock UTC of the last poll cycle that finished (periodic OR manual).
-# Surfaced in /health as `last_poll_at` so the SPA can render "Last polled Ns
-# ago" honestly — a stale timestamp is a signal, not something to hide.
-_last_poll_at: datetime | None = None
-
-# Shared lock + cycle counter for both the periodic poll_loop and the manual
-# POST /api/v1/poll/run trigger. Semantics: at most one poll cycle in flight
-# at a time (concurrent list_all + missions_cache mutation would race).
-# asyncio.Lock() at module scope defers loop binding to first await (Py3.10+).
-_poll_lock: asyncio.Lock = asyncio.Lock()
-_poll_cycle_counter: int = 0
-
-
-def _next_poll_cycle_id() -> int:
-    """Advance the shared cycle counter and return the new id."""
-    global _poll_cycle_counter
-    _poll_cycle_counter += 1
-    return _poll_cycle_counter
-
-
-def _claim_missions(mgr: MissionManager, fetched: list,
-                    owner: dict[str, str]) -> list:
-    """Cross-instance dedupe on the RAW pmo_id: a Linear project can be
-    accessible to two teams, so two instances in one workspace would both
-    adopt it — duplicate decomposition, label fights. The first instance to
-    see it claims it (durably — see _mission_owner); others surface an
-    anomaly and skip. Pure function (hermetically tested)."""
-    missions = []
-    for m in fetched:
-        prior = owner.get(m.pmo_id)
-        if prior is not None and prior != mgr.instance_name:
-            mgr.anomalies[m.pmo_id] = (
-                f"{m.key} is also visible to instance '{prior}' — handled "
-                f"there (shared project?); skipped here")
-            continue
-        owner[m.pmo_id] = mgr.instance_name
-        missions.append(m)
-    return missions
-
-
-def _release_stale_ownership(polled_ok: dict[str, set]) -> None:
-    """Drop ownership entries whose owner left config, or whose owner
-    successfully polled this cycle and no longer sees the mission (done +
-    aged out of list_all, or deleted). A FAILED poll releases nothing, and
-    neither does an ACTIVE run for the mission (audit A15: releasing while
-    the ex-owner's run still executes lets another instance re-dispatch the
-    same work — the in-flight guard only sees its own pmo_ref)."""
-    in_flight = {r.mission_pmo_id for r in store.active() if r.mission_pmo_id}
-    for pmo_id, name in list(_mission_owner.items()):
-        if pmo_id in in_flight:
-            continue
-        if name not in managers:
-            del _mission_owner[pmo_id]
-        elif name in polled_ok and pmo_id not in polled_ok[name]:
-            del _mission_owner[pmo_id]
-
-
-async def _poll_instance(mgr: MissionManager,
-                         cache_rows: list[dict]) -> tuple[int, int, int, set]:
-    """One instance's poll segment: fetch + cross-instance dedupe + derive +
-    gate + sweeps + schedule + cache rows. Returns (seen, candidates,
-    dispatched, fetched_ids). Raises PMOTransient for the caller's
-    per-instance skip."""
-    fetched = await mgr.pmo.list_all(mgr.instance.team_key)
-    fetched_ids = {m.pmo_id for m in fetched}
-    missions = _claim_missions(mgr, fetched, _mission_owner)
-    run_snapshot = mgr.runs.store.all()   # one read per segment, not per mission
-    for m in missions:
-        # per-mission repo resolution (M10/M11): a transient poll artifact —
-        # dispatch re-resolves live (sticky) before anything irreversible.
-        # resolve_repo_live un-gates zero-repo missions onto the internal
-        # fallback forge (provisions a per-mission repo at intake). A Gitea
-        # outage must GATE the mission, never abort the whole poll cycle for
-        # every instance (review finding #2) — the boot promise that an
-        # outage "degrades only zero-repo missions" depends on this.
-        try:
-            m.repo, m.repo_reason = await mgr.resolve_repo_live(
-                m, all_runs=run_snapshot)
-        except Exception as e:  # noqa: BLE001 — poll guard: a forge outage gates THIS mission only (reason recorded + logged); it must never abort the whole cycle
-            m.repo, m.repo_reason = None, (
-                f"internal forge unreachable — mission gated: {str(e)[:150]}")
-            log.warning("repo resolution failed for %s: %s", m.key, e)
-    derived = [(m, derive(m, config.adoption_mode)) for m in missions]
-    # the gate is a poll artifact, computed EVERY cycle — pause freezes
-    # dispatch, never information (docs/04 §2)
-    gate = await mgr.gate_map(missions)
-    await mgr.sweeps(missions)   # merge + tracking sweeps (docs/04 §1)
-    # intake pause (docs/11): no NEW dispatches — in-flight runs still
-    # finalize (ingress consumer) and sweeps above keep running
-    if config.intake_paused:
-        dispatched = 0
-    else:
-        dispatched = await mgr.schedule(missions, gate)
-        # .get: build_managers may drop the instance mid-cycle (hot reload) —
-        # a KeyError here would abort the WHOLE poll cycle (review finding)
-        mp = mappers.get(mgr.instance_name)
-        if mp is not None:
-            await mp.maybe_dispatch(missions)
-    mgr.rotate_grace()
-    # anomalies are advisory and per-mission: prune on the FETCHED set (not
-    # just claimed missions — a dedupe anomaly references a mission this
-    # instance never claims) once terminal or no longer visible at all
-    terminal = {m.pmo_id for m in fetched if m.status in ("done", "canceled")}
-    for k in list(mgr.anomalies):
-        if k in terminal or k not in fetched_ids:
-            del mgr.anomalies[k]
-    id_to_key = {m.pmo_id: m.key for m in missions}
-    cache_rows.extend({
-        "instance": mgr.instance_name,
-        "team": mgr.instance.team_key,
-        "key": m.key, "kind": m.pmo_kind, "title": m.title,
-        "status": m.status, "priority": m.priority,
-        "labels": sorted(m.labels), "mission_type": d.mission_type,
-        "schedulable": d.schedulable,
-        # the blocked-by gate is a scheduler concern, not a derivation row —
-        # surfaced so the admin panel shows why (ADR-0007)
-        "repo": m.repo,
-        "reason": gate.get(m.pmo_id, m.repo_reason or d.reason),
-        "blocked_by": [id_to_key.get(b, b) for b in m.blocked_by],
-        "pmo_id": m.pmo_id,
-        # surfaced for the Missions board card (Linear link + Done-column sort)
-        "url": m.url,
-        "updated_at": m.updated_at,
-    } for m, d in derived)
-    return (len(missions), sum(1 for _, d in derived if d.schedulable),
-            dispatched, fetched_ids)
-
-
-async def run_poll_cycle(cycle: int) -> None:
-    """One poll cycle (docs/04 §1): per configured instance — fetch + dedupe
-    + derive + gate + dispatch + sweeps — then the merged cache. A failing
-    instance (PMOTransient or a PERMANENT error like a revoked key — audit
-    A1) skips only ITS segment, never the whole cycle; permanent failures
-    surface in /health `poll_degraded` until a green segment clears them."""
-    with tracer.start_as_current_span("poll.cycle") as span:
-        span.set_attribute("devcake.poll.cycle", cycle)
-        try:
-            # a latched repo re-probes every cycle so a transient failure
-            # (or a rotated-back token) self-heals without an operator
-            if forge_runtime.breakers:
-                await refresh_forge_health()
-            cache_rows: list[dict] = []
-            seen, cand, disp = 0, 0, 0
-            polled_ok: dict[str, set] = {}       # instance → fetched pmo_ids
-            owner_before = dict(_mission_owner)  # persisted iff changed below
-            for mgr in _managers_in_config_order():
-                with tracer.start_as_current_span("poll.instance") as ispan:
-                    ispan.set_attribute("devcake.instance", mgr.instance_name)
-                    try:
-                        s, c, d, ids = await _poll_instance(mgr, cache_rows)
-                        polled_ok[mgr.instance_name] = ids
-                        seen, cand, disp = seen + s, cand + c, disp + d
-                        _poll_degraded.pop(mgr.instance_name, None)
-                    except PMOTransient as e:
-                        # transient PMO trouble skips only THIS instance's
-                        # segment — the others still poll this cycle. Not
-                        # marked degraded: transient is expected weather.
-                        ispan.set_attribute("devcake.outcome", "PMO_TRANSIENT")
-                        log.warning("poll.cycle %d: instance %s skipped: %s",
-                                    cycle, mgr.instance_name, e)
-                    except Exception as e:
-                        # a PERMANENT per-instance failure (revoked key,
-                        # deleted team → RuntimeError) must not starve the
-                        # remaining instances (audit A1)
-                        ispan.set_attribute("devcake.outcome", "INSTANCE_ERROR")
-                        _poll_degraded[mgr.instance_name] = (
-                            f"{type(e).__name__}: {str(e)[:200]}")
-                        log.exception("poll.cycle %d: instance %s FAILED — "
-                                      "segment skipped", cycle, mgr.instance_name)
-            _release_stale_ownership(polled_ok)
-            if _mission_owner != owner_before:   # durable claim (audit A15)
-                _owner_store.save(_mission_owner)
-            # a skipped instance keeps its LAST snapshot in the cache
-            # (v0 behavior: PMO trouble never blanks the view)
-            cache_rows.extend(
-                row for row in missions_cache
-                if row["instance"] in managers
-                and row["instance"] not in polled_ok)
-            missions_cache[:] = cache_rows
-            span.set_attribute("devcake.missions.seen", seen)
-            span.set_attribute("devcake.missions.candidates", cand)
-            span.set_attribute("devcake.missions.dispatched", disp)
-            log.info("poll.cycle %d: %d missions, %d candidates, %d dispatched "
-                     "(%d instances)", cycle, seen, cand, disp, len(managers))
-        except Exception:
-            # a poll cycle must NEVER kill the loop — log and try again next tick
-            span.set_attribute("devcake.outcome", "cycle_error")
-            log.exception("poll.cycle %d failed", cycle)
-        finally:
-            # stamped even on cycle_error — a partial cycle IS a poll attempt;
-            # /health surfaces this as `last_poll_at` for the SPA's Missions
-            # "Last polled Ns ago" honesty (docs/11 §0)
-            global _last_poll_at
-            _last_poll_at = datetime.now(timezone.utc)
-
-
-async def poll_loop() -> None:
-    """Periodic poll driver. Shares `_poll_lock` and `_poll_cycle_counter`
-    with `POST /api/v1/poll/run` — at most one cycle in flight."""
-    while True:
-        async with _poll_lock:
-            await run_poll_cycle(_next_poll_cycle_id())
-        await asyncio.sleep(config.poll_interval_seconds)
+# The poll machinery (ownership claims, cycle driver, missions cache, loop)
+# lives in api/poll.py — constructed ONCE with live references and never
+# rebuilt on config reload (ADR-0015 Decision 2). `poll_rt.missions_cache`
+# keeps one stable list identity; /api/v1/missions serves it by reference.
+poll_rt = PollRuntime(
+    config=config, managers=managers, mappers=mappers, store=store,
+    forge_runtime=forge_runtime, refresh_forge_health=refresh_forge_health,
+    managers_in_config_order=_managers_in_config_order)
 
 
 def _refuse_insecure_passwords() -> None:
@@ -476,7 +261,7 @@ async def lifespan(app: FastAPI):
     await refresh_forge_health()
     await reconcile_runs(manager)
     tasks = [
-        asyncio.create_task(poll_loop(), name="poll_loop"),
+        asyncio.create_task(poll_rt.loop(), name="poll_loop"),
         asyncio.create_task(messaging.consume_forever(manager.handle, manager.verify_auth),
                             name="ingress_consumer"),
         asyncio.create_task(watchdog_loop(manager), name="watchdog"),
@@ -502,152 +287,13 @@ app.middleware("http")(enforce_control_plane_auth)
 FastAPIInstrumentor.instrument_app(app)
 
 
-async def _check_redis() -> bool:
-    try:
-        r = aioredis.from_url(REDIS_URL, password=REDIS_PASSWORD or None, socket_timeout=3)
-        try:
-            return bool(await r.ping())
-        finally:
-            await r.aclose()
-    except Exception:  # noqa: BLE001 — probe contract: any failure → False; /health must never 500
-        return False
-
-
-# branch-protection probe (A2, docs/14): cached — /health is polled every 10 s
-# by the SPA, the forge API needs at most one look every few minutes
-_protection_cache: dict = {"ts": 0.0, "value": {}}
-
-
-async def _branch_protection() -> dict:
-    """{repo_name: BranchProtection|None} across every configured repo."""
-    if time.monotonic() - _protection_cache["ts"] > 300 or _protection_cache["ts"] == 0:
-        _protection_cache["ts"] = time.monotonic()
-        out: dict = {}
-        for name, f in forge_runtime.forges.items():
-            inst = forge_runtime.instance(name)
-            # reference-only repos: DevCake never pushes or merges there, so
-            # the unprotected-default-branch advisory would be pure noise
-            if inst is not None and inst.reference_only:
-                continue
-            try:
-                prot = await f.default_branch_protection(
-                    inst.default_branch if inst else "main")
-                out[name] = prot.model_dump() if prot else None
-            except Exception:  # noqa: BLE001 — probe contract: failure → None (advisory omitted); /health must never 500
-                out[name] = None
-        _protection_cache["value"] = out
-    return _protection_cache["value"]
-
-
-async def _check_http(url: str) -> bool:
-    try:
-        async with httpx.AsyncClient(timeout=3) as client:
-            return (await client.get(url)).status_code < 500
-    except Exception:  # noqa: BLE001 — probe contract: any failure → False; /health must never 500
-        return False
-
-
-# 60s-cached probe: does the OO service account actually authenticate?
-# Catches "compose up before provision_oo.py" / rotated-password drift —
-# without it, telemetry 401s silently forever (ISSUES #13 review finding).
-_oo_ingest_cache: dict = {"ts": 0.0, "result": None}
-
-
-async def _oo_ingest_check() -> dict:
-    now = time.monotonic()
-    if _oo_ingest_cache["result"] is not None and now - _oo_ingest_cache["ts"] < 60:
-        return _oo_ingest_cache["result"]
-    from ..telemetry import OO_ORG, _basic_auth
-    try:
-        async with httpx.AsyncClient(timeout=5) as client:
-            r = await client.get(f"{OO_URL}/api/{OO_ORG}/streams",
-                                 params={"type": "logs"},
-                                 headers={"Authorization": f"Basic {_basic_auth()}"})
-        result = {"ok": r.status_code == 200,
-                  "detail": "" if r.status_code == 200 else
-                  f"HTTP {r.status_code} — the OO service account cannot "
-                  f"authenticate; run scripts/provision_oo.py (ISSUES #13)"}
-    except Exception as e:  # noqa: BLE001 — probe contract: any failure → ok:False + detail; /health must never 500
-        result = {"ok": False, "detail": f"probe failed: {str(e)[:150]}"}
-    _oo_ingest_cache.update(ts=now, result=result)
-    return result
-
-
 @app.get("/api/v1/health")
 async def health():
-    redis_ok, dagu_ok, oo_ok = await asyncio.gather(
-        _check_redis(),
-        _check_http(f"{DAGU_URL}/api/v1/health"),
-        _check_http(f"{OO_URL}/healthz"),
-    )
-    # per-instance PMO health (schema v3): unconfigured instances show grey
-    # (ok: None), never red; the scalar `pmo` aggregate keeps the SPA's
-    # health dot working (true = every configured instance probes ok)
-    pmo_instances: dict[str, dict] = {}
-    for inst in config.pmos:
-        if not inst.configured:
-            pmo_instances[inst.name] = {"ok": None, "configured": False,
-                                        "team": ""}
-            continue
-        mgr = managers.get(inst.name)
-        try:
-            ok = bool(mgr) and (await mgr.pmo.health_probe(inst.team_key)).ok
-        except Exception:  # noqa: BLE001 — probe contract: any failure → ok:False for this instance; /health must never 500
-            ok = False
-        pmo_instances[inst.name] = {"ok": ok, "configured": True,
-                                    "team": inst.team_key}
-    configured_ok = [v["ok"] for v in pmo_instances.values() if v["configured"]]
-    prefixed = len(managers) > 1   # advisory text carries the instance when N>1
-
-    def _merged(attr: str) -> dict:
-        out: dict = {}
-        for name, mgr in managers.items():
-            for k, v in getattr(mgr, attr).items():
-                out[k] = f"[{name}] {v}" if prefixed and isinstance(v, str) else v
-        return out
-
-    return {
-        "app": True,
-        "redis": redis_ok,
-        "dagu": dagu_ok,
-        "openobserve": oo_ok,
-        "oo_ingest": await _oo_ingest_check(),
-        "pmo": bool(configured_ok) and all(configured_ok),
-        "pmo_instances": pmo_instances,
-        "forge": forge_runtime.health,
-        # dev-type breakers + per-repo forge breakers, one map for the SPA
-        "circuit_breakers": {**shared_breakers,
-                             **{f"repo:{k}": v
-                                for k, v in forge_runtime.breakers.items()}},
-        "intake_paused": config.intake_paused,
-        # poll cadence surface for the Missions "Last polled Ns ago · next in
-        # ~Ns" indicator — INV-1 made visible, not hidden behind a spinner
-        "last_poll_at": (_last_poll_at.isoformat() if _last_poll_at else None),
-        "poll_interval_seconds": config.poll_interval_seconds,
-        "active_runs": len(store.active()),
-        "forge_protection": await _branch_protection(),
-        "anomalies": _merged("anomalies"),
-        "merge_handoffs": _merged("merge_handoffs"),
-        "needs_human": _merged("needs_human"),
-        "dependency_cycles": [
-            ([f"{name}:{k}" for k in cyc] if prefixed else cyc)
-            for name, mgr in managers.items() for cyc in mgr.cycles],
-        "blocked_reasons": _merged("blocked_reasons"),
-        # instances whose poll segment failed with a PERMANENT error (audit
-        # A1) — the other instances keep polling; this names the sick one
-        "poll_degraded": dict(_poll_degraded),
-        "internal_forge": (await internal_forge.health()
-                           if internal_forge is not None else None),
-        "mapper_degraded": " · ".join(
-            f"[{name}] {msg}" if prefixed else str(msg)
-            for name, mp in mappers.items() if (msg := mp.degraded())) or None,
-        # active templates that no longer resolve (fallback-to-default in
-        # effect) — the SPA derives a dismissable alert per entry (v0.1.1)
-        "prompt_template_warnings": (
-            prompt_templates.template_warnings(config)
-            + prompt_templates.devtype_prompt_warnings(config, dev_types)),
-        "security_warnings": _security_warnings(),
-    }
+    return await build_health_payload(
+        config=config, dev_types=dev_types, managers=managers,
+        mappers=mappers, forge_runtime=forge_runtime,
+        shared_breakers=shared_breakers, store=store,
+        internal_forge=internal_forge, poll_rt=poll_rt)
 
 
 @app.get("/api/v1/health/live")
@@ -662,7 +308,7 @@ async def list_missions():
     # `teams` maps every configured instance for group-by consumers
     return {"teams": {i.name: i.team_key for i in config.pmos if i.configured},
             "adoption_mode": config.adoption_mode,
-            "missions": missions_cache}
+            "missions": poll_rt.missions_cache}
 
 
 def _pr_url_of(run) -> str | None:
@@ -731,7 +377,7 @@ async def mission_action(pmo_id: str, body: _MissionActionBody):
     """Retry / park / unpark / resume via label swap. Returns projected labels."""
     from .mission_actions import label_action
     return await label_action(pmo_id, body.action,
-                              missions_cache=missions_cache, managers=managers)
+                              missions_cache=poll_rt.missions_cache, managers=managers)
 
 
 @app.post("/api/v1/missions/{pmo_id}/comment")
@@ -740,7 +386,7 @@ async def mission_comment(pmo_id: str, body: _SteeringBody):
     the next poll classifies it as HUMAN and resets the attempt counter."""
     from .mission_actions import post_steering
     return await post_steering(pmo_id, body.body,
-                               missions_cache=missions_cache, managers=managers)
+                               missions_cache=poll_rt.missions_cache, managers=managers)
 
 
 @app.post("/api/v1/poll/run")
@@ -757,9 +403,9 @@ async def force_poll_route():
     """
     from .mission_actions import force_poll_now
     return await force_poll_now(
-        lock=_poll_lock,
-        next_cycle_id=_next_poll_cycle_id,
-        run_cycle=run_poll_cycle)
+        lock=poll_rt.lock,
+        next_cycle_id=poll_rt.next_cycle_id,
+        run_cycle=poll_rt.run_cycle)
 
 
 @app.post("/api/v1/runs/{run_id}/stop")
@@ -807,7 +453,7 @@ async def clear_runs():
     with tracer.start_as_current_span("system.clear_runs") as span:
         result = await clear_all(store, executor, messaging, runlog,
                                  internal_forge=internal_forge)
-        missions_cache.clear()
+        poll_rt.missions_cache.clear()
         for mgr in managers.values():
             mgr._grace.clear()
             mgr._grace_next.clear()
@@ -1503,7 +1149,7 @@ async def put_secret(scope: str, instance: str, field: str, body: dict):
     secrets_store.write_connection_secret(scope, instance, field, value)
     if scope == "repo":
         forge_runtime.breakers.pop(instance, None)
-        _protection_cache["ts"] = 0.0
+        reset_protection_cache()
     # adapters capture credentials by VALUE at construction — a rotated
     # secret takes effect only through a rebuild, same as a config PUT
     reload_connections()
@@ -1516,7 +1162,7 @@ async def delete_secret(scope: str, instance: str, field: str):
     secrets_store.delete_connection_field(scope, instance, field)
     if scope == "repo":
         forge_runtime.breakers.pop(instance, None)
-        _protection_cache["ts"] = 0.0
+        reset_protection_cache()
     reload_connections()
     return {"present": False}
 

--- a/app/devcake/api/poll.py
+++ b/app/devcake/api/poll.py
@@ -1,0 +1,248 @@
+"""Poll machinery (docs/04 §1): PollRuntime owns the cross-instance poll
+cycle — durable ownership claims, per-instance segments, the missions cache,
+and the periodic loop.
+
+Constructed ONCE in the composition root with LIVE references (the managers
+dict, config object, forge runtime) and never rebuilt on config reload —
+hot-swapped instances appear because `build_managers()` mutates the shared
+dict in place (ADR-0015 Decision 2). `missions_cache` keeps one stable list
+identity for the same reason (`/api/v1/missions` serves it by reference).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from opentelemetry import trace
+
+from ..adapters.files.owner_store import OwnerStore
+from ..domain.model import derive
+from ..domain.orchestrator import MissionManager
+from ..ports.pmo import PMOTransient
+
+log = logging.getLogger("devcake")
+tracer = trace.get_tracer("devcake")
+
+
+def _claim_missions(mgr: MissionManager, fetched: list,
+                    owner: dict[str, str]) -> list:
+    """Cross-instance dedupe on the RAW pmo_id: a Linear project can be
+    accessible to two teams, so two instances in one workspace would both
+    adopt it — duplicate decomposition, label fights. The first instance to
+    see it claims it (durably — see PollRuntime.mission_owner); others surface
+    an anomaly and skip. Pure function (hermetically tested)."""
+    missions = []
+    for m in fetched:
+        prior = owner.get(m.pmo_id)
+        if prior is not None and prior != mgr.instance_name:
+            mgr.anomalies[m.pmo_id] = (
+                f"{m.key} is also visible to instance '{prior}' — handled "
+                f"there (shared project?); skipped here")
+            continue
+        owner[m.pmo_id] = mgr.instance_name
+        missions.append(m)
+    return missions
+
+
+class PollRuntime:
+    """The poll loop's state and drivers, extracted from the composition root.
+
+    PERSISTENT cross-instance ownership (v0.1 plan H1 + review finding):
+    pmo_id → owning instance name. Persistence is load-bearing — a per-cycle
+    rebuild would flip ownership of a shared mission the moment its owner has
+    one PMOTransient cycle, double-dispatching it. Released only when the
+    OWNER successfully polls and no longer sees the mission, or leaves config
+    (and never while a run for the mission is still active — audit A15).
+    Durable across restarts via OwnerStore."""
+
+    def __init__(self, *, config, managers: dict[str, MissionManager],
+                 mappers: dict, store, forge_runtime, refresh_forge_health,
+                 managers_in_config_order, owner_store: OwnerStore | None = None):
+        self.config = config
+        self.managers = managers                    # live reference
+        self.mappers = mappers                      # live reference
+        self.store = store
+        self.forge_runtime = forge_runtime
+        self.refresh_forge_health = refresh_forge_health
+        self.managers_in_config_order = managers_in_config_order
+        self.owner_store = owner_store if owner_store is not None else OwnerStore()
+        self.mission_owner: dict[str, str] = self.owner_store.load()
+        # instance → last poll-segment error (audit A1): a PERMANENT PMO
+        # failure (revoked key, deleted team) skips only that instance's
+        # segment; surfaced in /health as `poll_degraded`. Cleared on green.
+        self.poll_degraded: dict[str, str] = {}
+        # Wall-clock UTC of the last poll cycle that finished (periodic OR
+        # manual) — /health `last_poll_at`; a stale timestamp is a signal.
+        self.last_poll_at: datetime | None = None
+        # Shared lock + cycle counter for the periodic loop and the manual
+        # POST /api/v1/poll/run trigger: at most one cycle in flight
+        # (concurrent list_all + missions_cache mutation would race).
+        self.lock: asyncio.Lock = asyncio.Lock()
+        self.cycle_counter: int = 0
+        # poll-cycle snapshot served by /api/v1/missions (advisory — INV-1)
+        self.missions_cache: list[dict] = []
+
+    def next_cycle_id(self) -> int:
+        """Advance the shared cycle counter and return the new id."""
+        self.cycle_counter += 1
+        return self.cycle_counter
+
+    def release_stale_ownership(self, polled_ok: dict[str, set]) -> None:
+        """Drop ownership entries whose owner left config, or whose owner
+        successfully polled this cycle and no longer sees the mission (done +
+        aged out of list_all, or deleted). A FAILED poll releases nothing, and
+        neither does an ACTIVE run for the mission (audit A15: releasing while
+        the ex-owner's run still executes lets another instance re-dispatch the
+        same work — the in-flight guard only sees its own pmo_ref)."""
+        in_flight = {r.mission_pmo_id for r in self.store.active()
+                     if r.mission_pmo_id}
+        for pmo_id, name in list(self.mission_owner.items()):
+            if pmo_id in in_flight:
+                continue
+            if name not in self.managers:
+                del self.mission_owner[pmo_id]
+            elif name in polled_ok and pmo_id not in polled_ok[name]:
+                del self.mission_owner[pmo_id]
+
+    async def poll_instance(self, mgr: MissionManager,
+                            cache_rows: list[dict]) -> tuple[int, int, int, set]:
+        """One instance's poll segment: fetch + cross-instance dedupe + derive +
+        gate + sweeps + schedule + cache rows. Returns (seen, candidates,
+        dispatched, fetched_ids). Raises PMOTransient for the caller's
+        per-instance skip."""
+        fetched = await mgr.pmo.list_all(mgr.instance.team_key)
+        fetched_ids = {m.pmo_id for m in fetched}
+        missions = _claim_missions(mgr, fetched, self.mission_owner)
+        run_snapshot = mgr.runs.store.all()   # one read per segment, not per mission
+        for m in missions:
+            # per-mission repo resolution (M10/M11): a transient poll artifact —
+            # dispatch re-resolves live (sticky) before anything irreversible.
+            # resolve_repo_live un-gates zero-repo missions onto the internal
+            # fallback forge (provisions a per-mission repo at intake). A Gitea
+            # outage must GATE the mission, never abort the whole poll cycle for
+            # every instance (review finding #2) — the boot promise that an
+            # outage "degrades only zero-repo missions" depends on this.
+            try:
+                m.repo, m.repo_reason = await mgr.resolve_repo_live(
+                    m, all_runs=run_snapshot)
+            except Exception as e:  # noqa: BLE001 — poll guard: a forge outage gates THIS mission only (reason recorded + logged); it must never abort the whole cycle
+                m.repo, m.repo_reason = None, (
+                    f"internal forge unreachable — mission gated: {str(e)[:150]}")
+                log.warning("repo resolution failed for %s: %s", m.key, e)
+        derived = [(m, derive(m, self.config.adoption_mode)) for m in missions]
+        # the gate is a poll artifact, computed EVERY cycle — pause freezes
+        # dispatch, never information (docs/04 §2)
+        gate = await mgr.gate_map(missions)
+        await mgr.sweeps(missions)   # merge + tracking sweeps (docs/04 §1)
+        # intake pause (docs/11): no NEW dispatches — in-flight runs still
+        # finalize (ingress consumer) and sweeps above keep running
+        if self.config.intake_paused:
+            dispatched = 0
+        else:
+            dispatched = await mgr.schedule(missions, gate)
+            # .get: build_managers may drop the instance mid-cycle (hot reload) —
+            # a KeyError here would abort the WHOLE poll cycle (review finding)
+            mp = self.mappers.get(mgr.instance_name)
+            if mp is not None:
+                await mp.maybe_dispatch(missions)
+        mgr.rotate_grace()
+        # anomalies are advisory and per-mission: prune on the FETCHED set (not
+        # just claimed missions — a dedupe anomaly references a mission this
+        # instance never claims) once terminal or no longer visible at all
+        terminal = {m.pmo_id for m in fetched if m.status in ("done", "canceled")}
+        for k in list(mgr.anomalies):
+            if k in terminal or k not in fetched_ids:
+                del mgr.anomalies[k]
+        id_to_key = {m.pmo_id: m.key for m in missions}
+        cache_rows.extend({
+            "instance": mgr.instance_name,
+            "team": mgr.instance.team_key,
+            "key": m.key, "kind": m.pmo_kind, "title": m.title,
+            "status": m.status, "priority": m.priority,
+            "labels": sorted(m.labels), "mission_type": d.mission_type,
+            "schedulable": d.schedulable,
+            # the blocked-by gate is a scheduler concern, not a derivation row —
+            # surfaced so the admin panel shows why (ADR-0007)
+            "repo": m.repo,
+            "reason": gate.get(m.pmo_id, m.repo_reason or d.reason),
+            "blocked_by": [id_to_key.get(b, b) for b in m.blocked_by],
+            "pmo_id": m.pmo_id,
+            # surfaced for the Missions board card (Linear link + Done-column sort)
+            "url": m.url,
+            "updated_at": m.updated_at,
+        } for m, d in derived)
+        return (len(missions), sum(1 for _, d in derived if d.schedulable),
+                dispatched, fetched_ids)
+
+    async def run_cycle(self, cycle: int) -> None:
+        """One poll cycle (docs/04 §1): per configured instance — fetch + dedupe
+        + derive + gate + dispatch + sweeps — then the merged cache. A failing
+        instance (PMOTransient or a PERMANENT error like a revoked key — audit
+        A1) skips only ITS segment, never the whole cycle; permanent failures
+        surface in /health `poll_degraded` until a green segment clears them."""
+        with tracer.start_as_current_span("poll.cycle") as span:
+            span.set_attribute("devcake.poll.cycle", cycle)
+            try:
+                # a latched repo re-probes every cycle so a transient failure
+                # (or a rotated-back token) self-heals without an operator
+                if self.forge_runtime.breakers:
+                    await self.refresh_forge_health()
+                cache_rows: list[dict] = []
+                seen, cand, disp = 0, 0, 0
+                polled_ok: dict[str, set] = {}       # instance → fetched pmo_ids
+                owner_before = dict(self.mission_owner)  # persisted iff changed
+                for mgr in self.managers_in_config_order():
+                    with tracer.start_as_current_span("poll.instance") as ispan:
+                        ispan.set_attribute("devcake.instance", mgr.instance_name)
+                        try:
+                            s, c, d, ids = await self.poll_instance(mgr, cache_rows)
+                            polled_ok[mgr.instance_name] = ids
+                            seen, cand, disp = seen + s, cand + c, disp + d
+                            self.poll_degraded.pop(mgr.instance_name, None)
+                        except PMOTransient as e:
+                            # transient PMO trouble skips only THIS instance's
+                            # segment — the others still poll this cycle. Not
+                            # marked degraded: transient is expected weather.
+                            ispan.set_attribute("devcake.outcome", "PMO_TRANSIENT")
+                            log.warning("poll.cycle %d: instance %s skipped: %s",
+                                        cycle, mgr.instance_name, e)
+                        except Exception as e:  # noqa: BLE001 — poll loop guard: a permanent per-instance failure must not starve the remaining instances (audit A1); surfaced via poll_degraded
+                            ispan.set_attribute("devcake.outcome", "INSTANCE_ERROR")
+                            self.poll_degraded[mgr.instance_name] = (
+                                f"{type(e).__name__}: {str(e)[:200]}")
+                            log.exception("poll.cycle %d: instance %s FAILED — "
+                                          "segment skipped", cycle,
+                                          mgr.instance_name)
+                self.release_stale_ownership(polled_ok)
+                if self.mission_owner != owner_before:   # durable claim (A15)
+                    self.owner_store.save(self.mission_owner)
+                # a skipped instance keeps its LAST snapshot in the cache
+                # (v0 behavior: PMO trouble never blanks the view)
+                cache_rows.extend(
+                    row for row in self.missions_cache
+                    if row["instance"] in self.managers
+                    and row["instance"] not in polled_ok)
+                self.missions_cache[:] = cache_rows
+                span.set_attribute("devcake.missions.seen", seen)
+                span.set_attribute("devcake.missions.candidates", cand)
+                span.set_attribute("devcake.missions.dispatched", disp)
+                log.info("poll.cycle %d: %d missions, %d candidates, "
+                         "%d dispatched (%d instances)", cycle, seen, cand,
+                         disp, len(self.managers))
+            except Exception:  # noqa: BLE001 — cycle guard: a poll cycle must NEVER kill the loop; logged, next tick retries
+                span.set_attribute("devcake.outcome", "cycle_error")
+                log.exception("poll.cycle %d failed", cycle)
+            finally:
+                # stamped even on cycle_error — a partial cycle IS a poll
+                # attempt; /health surfaces it as `last_poll_at` (docs/11 §0)
+                self.last_poll_at = datetime.now(timezone.utc)
+
+    async def loop(self) -> None:
+        """Periodic poll driver. Shares `lock` and the cycle counter with
+        `POST /api/v1/poll/run` — at most one cycle in flight."""
+        while True:
+            async with self.lock:
+                await self.run_cycle(self.next_cycle_id())
+            await asyncio.sleep(self.config.poll_interval_seconds)

--- a/app/tests/test_multi_instance.py
+++ b/app/tests/test_multi_instance.py
@@ -113,7 +113,7 @@ def test_shared_mission_claimed_once_with_anomaly(tmp_path, monkeypatch):
     # api.main has import-time singletons (config load, adapters) — point its
     # data dir at tmp so the first import in this process is hermetic
     monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
-    from devcake.api.main import _claim_missions
+    from devcake.api.poll import _claim_missions
     a, b = _mgr("linteama"), _mgr("linteamb")
     shared = _mission("proj-uuid-1", "PRJ-shared", "linteama")
     only_b = _mission("issue-uuid-2", "DEV-9", "linteamb")
@@ -163,12 +163,33 @@ def test_dispatch_stamps_the_dispatching_instances_pmo_ref():
     assert "pmo_ref=mgr.instance_name" in src
 
 
-def test_ownership_survives_a_transient_cycle(tmp_path, monkeypatch):
+def _rt(tmp_path, managers=None, store=None, order=None):
+    """A PollRuntime over fakes (ADR-0015 C4: the poll machinery's test seam
+    is the runtime object itself, not monkeypatched module globals)."""
+    from types import SimpleNamespace
+
+    from devcake.adapters.files.owner_store import OwnerStore
+    from devcake.api.poll import PollRuntime
+    from devcake.config import AppConfig
+
+    managers = managers if managers is not None else {}
+
+    async def _noop():
+        return {}
+
+    return PollRuntime(
+        config=AppConfig(), managers=managers, mappers={},
+        store=store if store is not None else SimpleNamespace(active=lambda: []),
+        forge_runtime=SimpleNamespace(breakers={}),
+        refresh_forge_health=_noop,
+        managers_in_config_order=(order or (lambda: list(managers.values()))),
+        owner_store=OwnerStore(tmp_path / "state" / "mission_owner.json"))
+
+
+def test_ownership_survives_a_transient_cycle(tmp_path):
     """Review finding: ownership of a shared mission must NOT flip to the
     second instance just because the owner had one PMOTransient cycle."""
-    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
-    from devcake.api.main import _claim_missions, _release_stale_ownership
-    from devcake.api import main as app_main
+    from devcake.api.poll import _claim_missions
     a, b = _mgr("linteama"), _mgr("linteamb")
     owner: dict[str, str] = {"proj-1": "linteama"}   # A claimed earlier
     # A's cycle fails (PMOTransient) → A contributes nothing to polled_ok;
@@ -176,11 +197,11 @@ def test_ownership_survives_a_transient_cycle(tmp_path, monkeypatch):
     got_b = _claim_missions(b, [_mission("proj-1", "PRJ-s", "linteamb")], owner)
     assert got_b == [] and owner["proj-1"] == "linteama"
     # release only when the OWNER successfully polls without the mission
-    monkeypatch.setattr(app_main, "managers", {"linteama": a, "linteamb": b})
-    monkeypatch.setattr(app_main, "_mission_owner", owner)
-    app_main._release_stale_ownership({"linteamb": {"proj-1"}})   # B ok, A failed
-    assert owner.get("proj-1") == "linteama"                      # kept
-    app_main._release_stale_ownership({"linteama": set()})        # A ok, gone
+    rt = _rt(tmp_path, managers={"linteama": a, "linteamb": b})
+    rt.mission_owner = owner
+    rt.release_stale_ownership({"linteamb": {"proj-1"}})   # B ok, A failed
+    assert owner.get("proj-1") == "linteama"               # kept
+    rt.release_stale_ownership({"linteama": set()})        # A ok, gone
     assert "proj-1" not in owner
 
 
@@ -198,25 +219,21 @@ def test_owner_store_roundtrip_and_corrupt_file(tmp_path):
     assert OwnerStore(path).load() == {}                       # never wedges boot
 
 
-def test_poll_cycle_persists_ownership_changes(tmp_path, monkeypatch):
+def test_poll_cycle_persists_ownership_changes(tmp_path):
     from devcake.adapters.files.owner_store import OwnerStore
-    from devcake.api import main as app_main
+    from devcake.api.poll import _claim_missions
     a = _mgr("linteama")
-    store_path = tmp_path / "state" / "mission_owner.json"
-    monkeypatch.setattr(app_main, "_owner_store", OwnerStore(store_path))
-    monkeypatch.setattr(app_main, "_mission_owner", {})
-    monkeypatch.setattr(app_main, "managers", {"linteama": a})
-    monkeypatch.setattr(app_main, "_managers_in_config_order", lambda: [a])
-    monkeypatch.setattr(app_main, "missions_cache", [])
+    rt = _rt(tmp_path, managers={"linteama": a})
 
     async def claiming_poll(mgr, cache_rows):
-        got = app_main._claim_missions(
+        got = _claim_missions(
             mgr, [_mission("proj-9", "PRJ-9", mgr.instance_name)],
-            app_main._mission_owner)
+            rt.mission_owner)
         return (len(got), 0, 0, {"proj-9"})
 
-    monkeypatch.setattr(app_main, "_poll_instance", claiming_poll)
-    run_coro(app_main.run_poll_cycle(1))
+    rt.poll_instance = claiming_poll   # instance-attr override, like fakes._audit
+    run_coro(rt.run_cycle(1))
+    store_path = tmp_path / "state" / "mission_owner.json"
     assert OwnerStore(store_path).load() == {"proj-9": "linteama"}
 
 
@@ -224,8 +241,6 @@ def test_release_deferred_while_ex_owner_run_still_active(tmp_path, monkeypatch)
     """Audit A15: releasing a shared mission the moment its owner no longer
     sees it (or left config) lets the surviving instance re-dispatch while
     the ex-owner's run is still executing — duplicate work."""
-    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
-    from devcake.api import main as app_main
     a, b = _mgr("linteama"), _mgr("linteamb")
 
     class FakeStore:
@@ -240,15 +255,15 @@ def test_release_deferred_while_ex_owner_run_still_active(tmp_path, monkeypatch)
                pmo_ref="linteama", state="running")
     live.mission_pmo_id = "proj-1"
     owner = {"proj-1": "linteama"}
-    monkeypatch.setattr(app_main, "managers", {"linteama": a, "linteamb": b})
-    monkeypatch.setattr(app_main, "_mission_owner", owner)
-    monkeypatch.setattr(app_main, "store", FakeStore([live]))
+    rt = _rt(tmp_path, managers={"linteama": a, "linteamb": b},
+             store=FakeStore([live]))
+    rt.mission_owner = owner
     # owner polled green and no longer sees the mission — but its run lives
-    app_main._release_stale_ownership({"linteama": set()})
+    rt.release_stale_ownership({"linteama": set()})
     assert owner == {"proj-1": "linteama"}
     # run finished → release proceeds
-    monkeypatch.setattr(app_main, "store", FakeStore([]))
-    app_main._release_stale_ownership({"linteama": set()})
+    rt.store = FakeStore([])
+    rt.release_stale_ownership({"linteama": set()})
     assert owner == {}
 
 
@@ -257,14 +272,11 @@ def test_permanent_pmo_error_starves_no_other_instance(tmp_path, monkeypatch):
     PMOTransient) on instance A must skip only A's segment — B still polls,
     A's cache rows are retained, and /health surfaces the degradation. A
     green segment clears the degraded flag."""
-    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
-    from devcake.api import main as app_main
     a, b = _mgr("linteama"), _mgr("linteamb")
-    monkeypatch.setattr(app_main, "managers", {"linteama": a, "linteamb": b})
-    monkeypatch.setattr(app_main, "_managers_in_config_order", lambda: [a, b])
+    rt = _rt(tmp_path, managers={"linteama": a, "linteamb": b},
+             order=lambda: [a, b])
     stale_row = {"instance": "linteama", "key": "T-9"}
-    monkeypatch.setattr(app_main, "missions_cache", [stale_row])
-    app_main._poll_degraded.clear()
+    rt.missions_cache[:] = [stale_row]
 
     polled: list[str] = []
 
@@ -275,20 +287,20 @@ def test_permanent_pmo_error_starves_no_other_instance(tmp_path, monkeypatch):
         cache_rows.append({"instance": mgr.instance_name, "key": "T-1"})
         return (1, 0, 0, set())
 
-    monkeypatch.setattr(app_main, "_poll_instance", broken_poll)
-    run_coro(app_main.run_poll_cycle(1))
+    rt.poll_instance = broken_poll
+    run_coro(rt.run_cycle(1))
     assert polled == ["linteamb"]                     # B was never starved
-    assert "RuntimeError" in app_main._poll_degraded["linteama"]
+    assert "RuntimeError" in rt.poll_degraded["linteama"]
     # A keeps its last snapshot (v0 behavior extended to permanent errors)
-    assert stale_row in app_main.missions_cache
+    assert stale_row in rt.missions_cache
 
     async def ok_poll(mgr, cache_rows):
         polled.append(mgr.instance_name)
         return (0, 0, 0, set())
 
-    monkeypatch.setattr(app_main, "_poll_instance", ok_poll)
-    run_coro(app_main.run_poll_cycle(2))
-    assert app_main._poll_degraded == {}              # green cycle clears it
+    rt.poll_instance = ok_poll
+    run_coro(rt.run_cycle(2))
+    assert rt.poll_degraded == {}                     # green cycle clears it
 
 
 def test_dispatch_gates_on_pmo_read_failure(tmp_path):


### PR DESCRIPTION
## What

**C4** — first PR of the main.py split. The poll machinery and health probes move to `api/` modules; main.py keeps composition + forwards.

- **`api/poll.py` (new)**: `PollRuntime` — ownership claims, per-instance segments, `poll_degraded`/`last_poll_at`, lock + cycle counter, and the missions cache as **one stable list identity**. Built once with live references; never rebuilt on config reload. Bodies moved verbatim.
- **`api/health.py` (new)**: probes + caches + `build_health_payload(...)` with explicit deps; `reset_protection_cache()` replaces the three inline `_protection_cache["ts"] = 0` pokes (reload + both secret routes — the ruff F821 sweep caught the two I'd missed).
- **main.py**: ~380 lines out; `/health` is a one-line forward; `/poll/run` reuses `force_poll_now`'s existing injection seam unchanged.
- **Tests**: `test_multi_instance`'s four poll tests construct a `PollRuntime` over fakes instead of monkeypatching `app_main` globals — strictly better isolation, and the only test file touched.

## Verification

- `ruff check devcake tests` clean; full suite via `pytest_app.sh`: **637 passed, 1 skipped** (same count — tests moved seams, none added/removed).
- Live `/health` shape spot-check rides the post-C6 deploy checkpoint (C5/C6 follow immediately; one redeploy for the three).

## Series

A #16 ✅ B #18 ✅ C1 #21 ✅ C2 #22 ✅ C3 #23 ✅ (deployed, smoke green) → **C4 (this)** → C5 (config/profiles/settings services) → C6 (catalog services + ratchet close) → C7 → D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)