### PR TITLE
fix: resolve all 24 D5 release-audit findings (v0.2 tag gate)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dagu/dags/.dag.index
 
 # BuildKit local bake cache (docker-bake.hcl BAKE_CACHE_DIR)
 .buildx-cache/
+
+# Gitea credential-bearing backup tarballs (scripts/backup_gitea.sh) — never commit
+devcake-gitea-*.tar.gz

--- a/admin/spa/DESIGN.md
+++ b/admin/spa/DESIGN.md
@@ -68,11 +68,17 @@ section chip row, and the scroll-to-top on section change — then switches on
 the route to exactly ONE section component. Every section is a component in
 `src/components/`: `PmoSection`, `DevTypesSection`, `SkillsSection`,
 `AssignmentsSection`, `PromptsSection`, `ProfilesSection`, `LimitsSection`,
-`TrafficSection`. A section pulls the shared draft itself via
-`useSharedDraft()` (ConfigDraftContext) and owns its section-local state and
-dialogs (its own `ConfirmDialog`, wizards, etc. — closed dialogs render null,
-so this stays invisible in the DOM); anything cross-page (the draft itself,
-Save/DirtyBar/NavGuard in `DraftChrome`) stays at App/context level. Shared
+`TrafficSection`. Most sections pull the shared draft themselves via
+`useSharedDraft()` (ConfigDraftContext); the two oldest (`PromptsSection`,
+`ProfilesSection`) still take `cfg`/`setField` as props from the dispatcher —
+either wiring is acceptable, but new sections use `useSharedDraft()`. A section
+owns its section-local state and dialogs (its own `ConfirmDialog`, wizards,
+etc. — closed dialogs render null, so this stays invisible in the DOM);
+anything cross-page (the draft itself, Save/DirtyBar/NavGuard in `DraftChrome`)
+stays at App/context level. **Caveat (audit D5 #12):** section-local state
+resets on a section *switch* (the section component unmounts) — state that must
+survive switching within Config (e.g. session name-tracking spanning cards)
+belongs at the dispatcher or context level, not inside a section. Shared
 sub-components used by more than one section get their own file (e.g.
 `RepoChips.jsx`); a new config section means a new `<Name>Section.jsx`, not
 inline JSX in ConfigPage. Sidebar sub-nav active state is route-driven —

--- a/admin/spa/src/components/DevTypesSection.jsx
+++ b/admin/spa/src/components/DevTypesSection.jsx
@@ -112,7 +112,7 @@ function UploadButton({ devType, secretFile, onDone }) {
 
 // Fully controlled: the card renders and edits the shared draft. Save is the
 // page-level Save; only Delete / OAuth / upload act immediately.
-function DevTypeCard({ name, draftDt, serverDt, harnesses, setField, onDelete, onOAuth, onRename, onCredChange, skillsCatalog }) {
+function DevTypeCard({ name, draftDt, serverDt, harnesses, setField, onDelete, onOAuth, onRename, onCredChange, skillsCatalog, catalogErr }) {
   const d = draftDt;
   const set = (k, v) => setField(`devTypes.${name}.${k}`, v);
   const h = harnesses[d.harness_template] || {};   // registry info for the DRAFTED harness
@@ -228,8 +228,12 @@ function DevTypeCard({ name, draftDt, serverDt, harnesses, setField, onDelete, o
           !h.skills_dir && (d.skills || []).length
             ? ` — ${d.skills.length} selected skill(s) will be skipped`
             : ""}.`}
-        emptyNote="no skills in the catalog yet — see the Skills section"
-        staleNote="not in the skill store — skipped at dispatch; click to remove"
+        emptyNote={catalogErr
+          ? "skill catalog unavailable (couldn't load /skills) — selected skills shown as-is"
+          : "no skills in the catalog yet — see the Skills section"}
+        staleNote={catalogErr
+          ? "skill catalog unavailable — cannot confirm this is in the store"
+          : "not in the skill store — skipped at dispatch; click to remove"}
         onChange={(next) => {
           // write back in CATALOG order (unknown names last): uncheck-then-
           // recheck must not surface a reorder-only dirty diff (diffLeaves
@@ -347,9 +351,18 @@ export default function DevTypesSection({ setPageErr }) {
   const [renameBusy, setRenameBusy] = useState(false);
   const [renameErr, setRenameErr] = useState("");
   // skill store catalog — read here only for DevTypeCard's skill chips;
-  // authoring (add/delete/restore) lives in the Skills section
+  // authoring (add/delete/restore) lives in the Skills section. On a fetch
+  // failure `catalogErr` is set so DevTypeCard can render selected skills as
+  // "catalog unavailable" rather than as stale red click-to-remove chips
+  // (audit D5 #13): a transient /skills error must not read as "these skills
+  // were deleted".
   const [skillsCatalog, setSkillsCatalog] = useState({ skills: [], store: null });
-  useEffect(() => { get("/skills").then(setSkillsCatalog).catch(() => {}); }, []);
+  const [catalogErr, setCatalogErr] = useState(false);
+  useEffect(() => {
+    get("/skills")
+      .then((c) => { setSkillsCatalog(c); setCatalogErr(false); })
+      .catch(() => setCatalogErr(true));
+  }, []);
 
   const setField = dr.setField;
 
@@ -389,7 +402,7 @@ export default function DevTypesSection({ setPageErr }) {
               }}
               onOAuth={setOauthFor}
               onRename={(nm) => { setRenameErr(""); setRenameFor(nm); }}
-              skillsCatalog={skillsCatalog} />
+              skillsCatalog={skillsCatalog} catalogErr={catalogErr} />
           ))}
         </div>
       </Section>

--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -13,7 +13,7 @@ import { useSharedDraft } from "../lib/ConfigDraftContext.jsx";
 import { getRegistry, loadRegistry } from "../lib/registry.js";
 import { nextFreeName, useNewNames } from "../lib/instanceNames.js";
 
-export default function PmoSection() {
+export default function PmoSection({ newNamesState }) {
   const { dr } = useSharedDraft();
   const [registry, setRegistry] = useState(getRegistry());
   useEffect(() => { loadRegistry().then(setRegistry); }, []);
@@ -35,7 +35,9 @@ export default function PmoSection() {
   const [testResult, setTestResult] = useState({});
   // PMO cards added/renamed this session stay name-editable even when their
   // name collides with a still-saved one (delete-then-re-add / mid-typing trap)
-  const newPmoNames = useNewNames(dr.server?.cfg.pmos, dr.draft?.cfg.pmos);
+  // the Set is owned by the dispatcher (survives section switches — D5 #12)
+  const newPmoNames = useNewNames(dr.server?.cfg.pmos, dr.draft?.cfg.pmos,
+                                  newNamesState);
 
   const cfg = dr.draft.cfg;
   const setField = dr.setField;

--- a/admin/spa/src/lib/instanceNames.js
+++ b/admin/spa/src/lib/instanceNames.js
@@ -27,8 +27,15 @@ export function nextFreeName(base, draftRows, serverRows) {
 // itself. Track the names of cards added/renamed this session; those stay
 // editable until a successful Save lands them on the server (the rebased
 // draft row deep-equals the fresh server row), then they lock like the rest.
-export function useNewNames(serverRows, draftRows) {
-  const [names, setNames] = useState(() => new Set());
+// `external` — an optional [names, setNames] pair owned by a component that
+// OUTLIVES this hook's caller (audit D5 #12): the Config section components
+// unmount on every section switch, so a section holding this state internally
+// would lose in-progress "new card" tracking the moment the operator visits
+// another section. The dispatcher (ConfigPage) stays mounted, so it owns the
+// Set and threads it down. Falls back to internal state when unmanaged.
+export function useNewNames(serverRows, draftRows, external) {
+  const internal = useState(() => new Set());
+  const [names, setNames] = external || internal;
   useEffect(() => {
     setNames((prev) => {
       if (prev.size === 0) return prev;

--- a/admin/spa/src/pages/ConfigPage.jsx
+++ b/admin/spa/src/pages/ConfigPage.jsx
@@ -22,6 +22,10 @@ export default function ConfigPage({ section }) {
   // page-level error line — sections report async failures here (delete /
   // restore flows) so the message survives their local re-renders
   const [pageErr, setPageErr] = useState("");
+  // "new PMO card" name tracking lives HERE, not in PmoSection (audit D5 #12):
+  // the dispatcher stays mounted across section switches, so a card added then
+  // navigated-away-from keeps its editable-name status when the operator returns
+  const pmoNewNames = useState(() => new Set());
 
   const loaded = dr.loaded;
 
@@ -53,7 +57,7 @@ export default function ConfigPage({ section }) {
         ))}
       </div>
 
-      {section === "pmo" && <PmoSection />}
+      {section === "pmo" && <PmoSection newNamesState={pmoNewNames} />}
       {section === "dev-types" && <DevTypesSection setPageErr={setPageErr} />}
       {section === "skills" && <SkillsSection setPageErr={setPageErr} />}
       {section === "assignments" && <AssignmentsSection />}

--- a/admin/spa/src/pages/RunsPage.jsx
+++ b/admin/spa/src/pages/RunsPage.jsx
@@ -65,6 +65,10 @@ export default function RunsPage() {
       );
       if (!result.ok) {
         const bits = [];
+        // drain phase (#28 stop-and-drain): a container wedged past the cap
+        // means the wipe ran while it was still live — surface it loudly
+        if (result.stopped?.undrained?.length) bits.push(`Still running after stop: ${result.stopped.undrained.join(", ")}`);
+        if (result.stopped?.error) bits.push(`Stop phase: ${result.stopped.error}`);
         if (result.dagu?.failed?.length) bits.push(`Dagu still holds: ${result.dagu.failed.join(", ")}`);
         if (result.openobserve?.errors?.length) bits.push(result.openobserve.errors.join("; "));
         if (result.dagu?.error) bits.push(result.dagu.error);
@@ -84,24 +88,32 @@ export default function RunsPage() {
     }
   };
 
+  const [stopErr, setStopErr] = useState("");
   const doStopAll = async () => {
     setStopping(true);
-    setClearErr("");
+    setStopErr("");
     setClearMsg("");
     try {
       const result = await send("POST", "/system/stop-runs");
       const n = (result.stopped || []).length;
       const fin = (result.skipped_finalizing || []).length;
+      const errs = result.errors || [];
       setClearMsg(
         `Stopped ${n} run${n === 1 ? "" : "s"}.` +
         (fin ? ` ${fin} finalizing run${fin === 1 ? "" : "s"} left to complete on ${fin === 1 ? "its" : "their"} own.` : "")
       );
+      if (errs.length) {
+        // per-run kill failures: report them, keep the dialog open so the
+        // operator can retry (nothing was deleted — this is stop, not clear)
+        setStopErr(errs.map((e) => `${e.run_id}: ${e.error}`).join(" · "));
+      } else {
+        setStopConfirmOpen(false);
+      }
       load();
     } catch (e) {
-      setClearErr(String(e.message || e));
+      setStopErr(String(e.message || e));
     } finally {
       setStopping(false);
-      setStopConfirmOpen(false);
     }
   };
 
@@ -132,6 +144,11 @@ export default function RunsPage() {
       {clearErr && (
         <p className="rounded-card border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
           Partial clear: {clearErr}
+        </p>
+      )}
+      {stopErr && (
+        <p className="rounded-card border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+          Stop failed (nothing was deleted): {stopErr}
         </p>
       )}
       <Card className="p-4">
@@ -255,8 +272,9 @@ export default function RunsPage() {
         }
         confirmLabel="Stop all runs"
         busy={stopping}
+        error={stopErr}
         onConfirm={doStopAll}
-        onCancel={() => !stopping && setStopConfirmOpen(false)}
+        onCancel={() => !stopping && (setStopConfirmOpen(false), setStopErr(""))}
       />
       <ConfirmDialog
         open={confirmOpen}

--- a/app/devcake/api/clear.py
+++ b/app/devcake/api/clear.py
@@ -51,8 +51,15 @@ async def stop_and_drain(store: RunStore, executor: DaguExecutor,
     import time as _time
 
     stopped: list[str] = []
-    for run in store.active():
-        if run.state == "finalizing":
+    for snap in store.active():
+        # re-read current state (audit D5 #7): the ingress consumer runs
+        # concurrently, so a run may have flipped to finalizing while an
+        # earlier kill was awaiting — killing it then would revert its
+        # mission status against the live finalize. Skip anything no longer
+        # dispatched/running. (The caller also holds the poll lock, so no
+        # NEW run is dispatched during the drain — audit D5 #2/#8.)
+        run = store.get(snap.run_id) or snap
+        if run.state not in ("dispatched", "running"):
             continue
         try:
             await run_manager.kill(run, "failed", "operator clear-runs")

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -462,9 +462,17 @@ async def clear_runs():
     """
     from .clear import clear_all
     with tracer.start_as_current_span("system.clear_runs") as span:
-        result = await clear_all(store, executor, messaging, runlog,
-                                 internal_forge=internal_forge,
-                                 run_manager=manager)
+        # Hold the poll lock across the ENTIRE wipe (audit D5 #2/#8): the poll
+        # loop is the only dispatcher, and it acquires this same lock — so a
+        # cycle cannot dispatch a fresh run mid-drain/mid-wipe. Without this,
+        # a mission whose run we just killed (and whose stage label survives)
+        # is redispatched during the drain, its record then deleted while its
+        # container is live, and clear_redis's ACL sweep races that container's
+        # SIGTERM grace — the exact root cause D3 was meant to close.
+        async with poll_rt.lock:
+            result = await clear_all(store, executor, messaging, runlog,
+                                     internal_forge=internal_forge,
+                                     run_manager=manager)
         poll_rt.missions_cache.clear()
         for mgr in managers.values():
             mgr._grace.clear()

--- a/app/devcake/api/mission_actions.py
+++ b/app/devcake/api/mission_actions.py
@@ -244,16 +244,31 @@ async def stop_all_runs(
     kill every dispatched/running run. Finalizing runs are SKIPPED, not 409'd —
     their containers already exited and the watchdog's never-kill-finalizing
     rule applies (see stop_run above); they surface in the response so the
-    operator knows what is still completing on its own."""
+    operator knows what is still completing on its own.
+
+    Each run's state is RE-FETCHED immediately before the kill (audit D5 #6):
+    the ingress consumer runs concurrently, so a run in the initial snapshot
+    may have flipped to `finalizing` while an earlier kill was awaiting — the
+    stale snapshot object would still read `running` and we'd kill a run whose
+    container already exited. Each kill is isolated (audit D5 #9): one failure
+    (e.g. an OSError from a full/read-only /data during store.save) records an
+    error and moves on rather than aborting the batch and losing accounting."""
     stopped: list[str] = []
     skipped: list[str] = []
-    for run in run_store.active():
-        if getattr(run, "state", None) == "finalizing":
-            skipped.append(run.run_id)
+    errors: list[dict[str, str]] = []
+    for snap in run_store.active():
+        run = run_store.get(snap.run_id) or snap        # re-read current state
+        if getattr(run, "state", None) not in ("dispatched", "running"):
+            skipped.append(run.run_id)                  # finalizing/terminal
             continue
-        await run_manager.kill(run, "failed", "stopped by operator (stop all)")
-        stopped.append(run.run_id)
-    return {"ok": True, "stopped": stopped, "skipped_finalizing": skipped}
+        try:
+            await run_manager.kill(run, "failed", "stopped by operator (stop all)")
+            stopped.append(run.run_id)
+        except Exception as e:  # noqa: BLE001 — one kill failure must not abort the batch or lose accounting; recorded per-run
+            log.exception("stop_all_runs: kill failed for %s", run.run_id)
+            errors.append({"run_id": run.run_id, "error": str(e)[:200]})
+    return {"ok": not errors, "stopped": stopped,
+            "skipped_finalizing": skipped, "errors": errors}
 
 
 # ── 5) force-poll endpoint ──────────────────────────────────────────────────

--- a/app/devcake/domain/orchestrator/feed.py
+++ b/app/devcake/domain/orchestrator/feed.py
@@ -62,7 +62,12 @@ async def _feed(mgr, pmo_id: str, kind: str, markdown: str, *,
     issues anyway (ADR-0006)."""
     markdown = redact(markdown)
     if kind == "project":
-        _audit(mgr, pmo_id, "project_feed_suppressed", markdown[:120])
+        # via the MANAGER method, not _audit(mgr, ...) directly (audit D5 #1):
+        # tests override mgr._audit as an instance attribute (fakes noop_audit,
+        # the activity-repo audit collector) — the direct module call would
+        # bypass that seam, leaking to the global events.jsonl and adding a
+        # grace-cycle skip the pre-refactor code did not.
+        mgr._audit(pmo_id, "project_feed_suppressed", markdown[:120])
         return
     if externalize and len(markdown) > FEED_INLINE_MAX:
         try:

--- a/app/devcake/domain/orchestrator/mapper.py
+++ b/app/devcake/domain/orchestrator/mapper.py
@@ -113,7 +113,7 @@ async def finalize_mapper(mgr, run: Run, payload: dict) -> None:
 
 async def apply_mapper_edges(mgr, edges: list) -> tuple[int, int]:
     """The Dev is advisory; the app is the gatekeeper — drop edges that are
-    unknown, mgr, terminal, duplicate, or cycle-forming (ADR-0007)."""
+    unknown, self-referential, terminal, duplicate, or cycle-forming (ADR-0007)."""
     missions = await mgr.pmo.list_all(mgr.instance.team_key)
     by_key = {m.key.upper(): m for m in missions if m.pmo_kind == "issue"}
     graph = {m.pmo_id: set(m.blocked_by) for m in missions
@@ -127,7 +127,7 @@ async def apply_mapper_edges(mgr, edges: list) -> tuple[int, int]:
         if blocker is None or blocked is None:
             reason = "unknown mission key"
         elif blocker.pmo_id == blocked.pmo_id:
-            reason = "mgr-edge"
+            reason = "self-edge"
         elif blocker.status in ("done", "canceled") \
                 or blocked.status in ("done", "canceled"):
             reason = "terminal mission"

--- a/app/devcake/domain/orchestrator/schedule.py
+++ b/app/devcake/domain/orchestrator/schedule.py
@@ -117,7 +117,7 @@ async def _open_blockers(mgr, m: Mission, by_id: dict[str, Mission],
                          memo: dict[str, Mission | None]) -> list[str]:
     """Blockers of `m` that are still open (status not done/canceled), as
     human-readable keys. A blocker we cannot read counts as open (fail-safe;
-    mgr-heals next cycle). ADR-0007."""
+    self-heals next cycle). ADR-0007."""
     open_ = []
     for bid in m.blocked_by:
         b = by_id.get(bid)
@@ -125,7 +125,7 @@ async def _open_blockers(mgr, m: Mission, by_id: dict[str, Mission],
             if bid not in memo:
                 try:
                     memo[bid] = await mgr.pmo.get(MissionRef(bid, "issue"))
-                except Exception:  # noqa: BLE001 — fail-safe per ADR-0007: an unreadable blocker counts as open (logged); mgr-heals next cycle
+                except Exception:  # noqa: BLE001 — fail-safe per ADR-0007: an unreadable blocker counts as open (logged); self-heals next cycle
                     log.warning("blocker %s of %s unreadable — treated as open",
                                 bid, m.key)
                     memo[bid] = None

--- a/app/devcake/domain/runs.py
+++ b/app/devcake/domain/runs.py
@@ -178,6 +178,13 @@ class RunManager:
             run.last_heartbeat = utcnow()
             self.store.save(run)
         elif kind == "run.started":
+            # terminal guard (mirrors run.artifacts below): a run killed while
+            # its container was still booting must NOT be resurrected to
+            # 'running' by an in-flight run.started — it would re-enter
+            # store.active(), hold the mission's in-flight slot, and only
+            # self-heal at the watchdog's heartbeat grace (audit D5 #10).
+            if run.state in ("finished", "failed", "timed_out", "orphaned"):
+                return
             run.state, run.started_at = "running", utcnow()
             self.store.save(run)
         elif kind == "runspec.get":

--- a/app/devcake/settings_bundle.py
+++ b/app/devcake/settings_bundle.py
@@ -154,8 +154,19 @@ def serialize_current(config: AppConfig, dev_types: dict[str, DevType], *,
         }
         bundle["sections"].append("config")
     if include_secrets:
+        # Exclude ORPHAN connection secrets — stored for an instance no longer
+        # in the config (audit D5 #15/#16): a lingering repo-bare.token from a
+        # deleted card would otherwise ride the snapshot, show as "replaced" in
+        # the apply preview yet be dropped by the apply write, and flag the
+        # profile permanently diverged. A snapshot reproduces the CONFIG's
+        # world; an instance-less secret is not part of it. The live orphan
+        # itself is untouched (it has its own lifecycle — docs/18).
+        live_keys = ({f"pmo-{p.name}" for p in config.pmos}
+                     | {f"repo-{r.name}" for r in config.repos})
+        conns = {k: v for k, v in secrets_store.list_connection_secrets().items()
+                 if k in live_keys}
         sec: dict = {
-            "connections": secrets_store.list_connection_secrets(),
+            "connections": conns,
             "harness": secrets_store.list_harness_secrets(),
         }
         if include_credential_files:

--- a/app/tests/test_clear.py
+++ b/app/tests/test_clear.py
@@ -222,8 +222,11 @@ class _RM:
         self.kills.append((r.run_id, state, reason))
 
 
-def _store(runs):
-    return SimpleNamespace(active=lambda: runs)
+def _store(runs, live=None):
+    """active() returns the initial snapshot; get() returns the CURRENT object
+    (from `live` if given) so the drain's re-fetch guard is exercised."""
+    live = live if live is not None else {r.run_id: r for r in runs}
+    return SimpleNamespace(active=lambda: runs, get=lambda rid: live.get(rid))
 
 
 def test_stop_and_drain_kills_waits_and_skips_finalizing(monkeypatch):
@@ -247,6 +250,21 @@ def test_stop_and_drain_times_out_on_wedged_container(monkeypatch):
                                   _RM(), timeout_s=0.01))
     assert out["stopped"] == 1
     assert out["undrained"] == ["R-9"]                  # reported, wipe proceeds
+
+
+def test_stop_and_drain_refetches_state_before_kill(monkeypatch):
+    """Audit D5 #7: a run in the initial snapshot that flipped to finalizing
+    (via the concurrent ingress consumer) must NOT be killed — the re-fetch
+    guard reads current state, not the stale snapshot object."""
+    from devcake.api.clear import stop_and_drain
+    monkeypatch.setattr("asyncio.sleep", lambda *_: _instant())
+    snap = SimpleNamespace(run_id="R-1", state="running")   # stale: says running
+    current = SimpleNamespace(run_id="R-1", state="finalizing")  # actually finalizing
+    rm = _RM()
+    out = run_coro(stop_and_drain(_store([snap], live={"R-1": current}),
+                                  _DrainExec(running_polls=0), rm, timeout_s=1))
+    assert rm.kills == []                               # never killed
+    assert out["stopped"] == 0
 
 
 async def _instant():

--- a/app/tests/test_crash_recovery.py
+++ b/app/tests/test_crash_recovery.py
@@ -126,6 +126,24 @@ def test_artifacts_enters_finalize_from_running(tmp_path):
     assert store.get(run.run_id).state == "finalizing"
 
 
+def test_started_does_not_resurrect_a_killed_run(tmp_path):
+    """Audit D5 #10: a run.started arriving AFTER the run was killed (its
+    container was just booting when stop-all fired) must NOT flip the record
+    back to 'running' — it would re-enter store.active() and hold the
+    mission's in-flight slot until the watchdog grace expires."""
+    store = RunStore(tmp_path / "runs")
+    mgr = RunManager(store, FakeMessaging(), FakeExecutor())
+    for state in ("failed", "timed_out", "orphaned", "finished"):
+        run = _make_run(store, state=state, run_id=f"S-{state}", started_at=None)
+        run_coro(mgr.handle(run.run_id, "run.started", {}))
+        assert store.get(run.run_id).state == state       # unchanged
+        assert store.get(run.run_id).started_at is None
+    # a genuinely dispatched run still starts normally
+    live = _make_run(store, state="dispatched", run_id="S-live", started_at=None)
+    run_coro(mgr.handle(live.run_id, "run.started", {}))
+    assert store.get(live.run_id).state == "running"
+
+
 def test_kill_teardown_when_stop_raises(tmp_path):
     """ISSUES #3: ACL + terminal state even if executor.stop raises."""
     store = RunStore(tmp_path / "runs")

--- a/app/tests/test_entrypoint_classify.py
+++ b/app/tests/test_entrypoint_classify.py
@@ -38,8 +38,22 @@ for _k, _v in _saved.items():
 def test_grok_revoked_session_is_auth():
     assert ep.classify_harness_failure("Error: Not signed in.") == 12
     assert ep.classify_harness_failure(
-        "You are signed out. Run `grok login` to continue.") == 12
-    assert ep.classify_harness_failure("Please sign in to continue") == 12
+        "You are logged out. Run `grok login` to continue.") == 12
+
+
+def test_dropped_generic_markers_no_longer_trip():
+    # "signed out" / "please sign in" were dropped (audit D5 #5): generic
+    # SSO/proxy stderr uses them, and a false 12 pauses the whole Dev Type
+    assert ep.classify_harness_failure("SSO session signed out by the IdP") == 10
+    assert ep.classify_harness_failure("please sign in at the portal") == 10
+
+
+def test_no_substring_false_positive_in_compound_words():
+    # word-boundary anchoring (audit D5 #4): these contain "signed out" and
+    # "log in" as substrings of larger words but are NOT auth failures
+    assert ep.classify_harness_failure("the designed output was wrong") == 10
+    assert ep.classify_harness_failure("assigned outside the retry window") == 10
+    assert ep.classify_harness_failure("backlog inspection failed") == 10
 
 
 def test_legacy_markers_still_auth():

--- a/app/tests/test_mission_actions.py
+++ b/app/tests/test_mission_actions.py
@@ -376,8 +376,10 @@ def test_force_poll_now_releases_lock_when_cycle_raises():
 # ── 4a) stop-all endpoint (Clear-Runs hardening) ────────────────────────────
 
 class _ActiveStore(FakeStore):
-    def __init__(self, runs):
-        super().__init__({r.run_id: r for r in runs})
+    def __init__(self, runs, live=None):
+        # active() = the initial snapshot; get() = the CURRENT object (from
+        # `live` when given) so the re-fetch guard is exercised.
+        super().__init__(live if live is not None else {r.run_id: r for r in runs})
         self._active = runs
 
     def active(self):
@@ -397,7 +399,7 @@ def test_stop_all_kills_live_and_skips_finalizing():
     assert [k[0].run_id for k in rm.kills] == ["r-1", "r-2"]
     assert all(k[1] == "failed" and "operator" in k[2] for k in rm.kills)
     assert out == {"ok": True, "stopped": ["r-1", "r-2"],
-                   "skipped_finalizing": ["r-3"]}
+                   "skipped_finalizing": ["r-3"], "errors": []}
 
 
 def test_stop_all_with_nothing_active_is_a_noop():
@@ -405,3 +407,36 @@ def test_stop_all_with_nothing_active_is_a_noop():
     out = run(ma.stop_all_runs(run_manager=rm, run_store=_ActiveStore([])))
     assert out["stopped"] == [] and out["skipped_finalizing"] == []
     assert not rm.kills
+
+
+def test_stop_all_refetches_state_before_kill():
+    """Audit D5 #6: a snapshot run that flipped to finalizing mid-batch (via
+    the concurrent ingress consumer) must not be killed — re-fetch, not the
+    stale snapshot object."""
+    stale = SimpleNamespace(run_id="r-1", state="running")
+    current = SimpleNamespace(run_id="r-1", state="finalizing")
+    rm = FakeRunManager()
+    out = run(ma.stop_all_runs(run_manager=rm,
+                               run_store=_ActiveStore([stale], live={"r-1": current})))
+    assert rm.kills == []
+    assert out["skipped_finalizing"] == ["r-1"] and out["stopped"] == []
+
+
+def test_stop_all_isolates_a_failing_kill():
+    """Audit D5 #9: one kill raising (e.g. store.save OSError on a full/RO
+    /data) must not abort the batch or lose accounting."""
+    class _FlakyRM(FakeRunManager):
+        async def kill(self, run, new_state, reason):
+            if run.run_id == "r-2":
+                raise OSError("read-only file system")
+            await super().kill(run, new_state, reason)
+
+    a = SimpleNamespace(run_id="r-1", state="running")
+    b = SimpleNamespace(run_id="r-2", state="running")
+    c = SimpleNamespace(run_id="r-3", state="running")
+    rm = _FlakyRM()
+    out = run(ma.stop_all_runs(run_manager=rm, run_store=_ActiveStore([a, b, c])))
+    assert out["stopped"] == ["r-1", "r-3"]            # c still stopped
+    assert out["ok"] is False
+    assert out["errors"][0]["run_id"] == "r-2"
+    assert "read-only" in out["errors"][0]["error"]

--- a/app/tests/test_multi_instance.py
+++ b/app/tests/test_multi_instance.py
@@ -398,13 +398,17 @@ def test_config_put_survives_secret_cleanup_failure(tmp_path, monkeypatch):
     an already-applied change."""
     monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
     from devcake.api import main as app_main
+    from devcake.api import config_service
     from devcake.config import RepoInstance
 
     def boom(scope, name):
         raise RuntimeError("disk error")
 
     monkeypatch.setattr(app_main, "reload_connections", lambda: None)
-    monkeypatch.setattr(app_main, "save_config", lambda c: None)
+    # save_config is called by config_service after the C5 split — patch it
+    # THERE, not on app_main (audit D5 #3: the app_main patch is dead, so the
+    # PUT persisted repos:[] to the real config path).
+    monkeypatch.setattr(config_service, "save_config", lambda c: None)
     monkeypatch.setattr(app_main.secrets_store, "delete_connection_instance", boom)
     original_repos = app_main.config.repos
     app_main.config.repos = [RepoInstance(name="gone",

--- a/app/tests/test_settings_bundle.py
+++ b/app/tests/test_settings_bundle.py
@@ -86,6 +86,23 @@ def test_serialize_apply_roundtrip_onto_fresh_deployment(monkeypatch, tmp_path):
     assert (dst / "secrets" / "connections" / "pmo-linear.json").stat().st_mode & 0o777 == 0o600
 
 
+def test_serialize_excludes_orphan_connection_secrets(monkeypatch, tmp_path):
+    """Audit D5 #15/#16: a stored secret for an instance NOT in the config
+    (deleted card, secret lingered) must not ride the snapshot — else it shows
+    'replaced' in the apply preview but is dropped by apply, and flags the
+    profile permanently diverged."""
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    # an orphan: 'bare' is in neither cfg.pmos nor cfg.repos
+    secrets.write_connection_secret("repo", "bare", "token", "ghp_orphan_9999")
+    bundle = sb.serialize_current(cfg, dts, include_secrets=True)
+    conns = bundle["secrets"]["connections"]
+    assert "repo-bare" not in conns                 # orphan excluded
+    assert "pmo-linear" in conns and "repo-main" in conns   # live ones kept
+    # the live orphan on disk is untouched
+    assert secrets.read_connection_secret("repo", "bare", "token") == "ghp_orphan_9999"
+
+
 def test_apply_is_replace_the_world_and_spares_the_exclusions(monkeypatch, tmp_path):
     sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
     cfg, dts = _world(config_mod, secrets, tpl)

--- a/docs/11-admin-panel.md
+++ b/docs/11-admin-panel.md
@@ -176,11 +176,14 @@ A prominent **"Open Dagu ↗"** button (new tab, URL from `DAGU_UI_URL`) and a *
 
 **Clear runs** opens a React confirmation dialog (never `window.confirm`) and on confirm calls `POST /api/v1/system/clear-runs`. That endpoint:
 
+The whole wipe runs while holding the poll lock, so no new run is dispatched mid-wipe (hardening 2026-07-19).
+
 1. Stops every dispatched/running Dev via the run manager and **waits for the containers to actually exit** (drain capped just past Dagu's 30 s SIGTERM grace — hardening 2026-07-19: the ACL sweep in step 6 used to race a stopping Dev's grace window, killing it with `AuthenticationError` mid-teardown). Undrained stragglers are reported in the response.
 2. Deletes every local Run file under `/data/state/runs/` (including quarantined records), every run log under `/data/state/runlogs/` (open SSE followers get the end sentinel), and truncates `events.jsonl` (attempt counters and give-up watermarks reset — INV-1 / `10-persistence.md` §5).
 3. Deletes every Dagu `dev-run` history record (`DELETE /dag-runs/dev-run/{id}`, paginated list).
 4. Deletes OpenObserve log/trace streams (they recreate on next ingest; dashboards stay).
 5. Trims the Redis ingress stream, drops leftover reply streams and per-run ACL users.
+6. Deletes every per-mission `activity-*` repo on the internal Gitea (ADR-0014 D4; the "ACL sweep in step 6" wording in step 1 predates this addition — the ACL sweep is step 5).
 
 **Preserved:** `/data/config`, `/data/secrets`, PMO/forge state, circuit breakers (credential health).
 

--- a/docs/15-errors-and-retries.md
+++ b/docs/15-errors-and-retries.md
@@ -120,7 +120,13 @@ keeps that deliberate without becoming sloppy:
   record* (fall back to a default and record it — bundled skill copy, warnings
   list, quarantine).
 - **Never sanctioned:** a blanket catch whose handler neither logs, records,
-  falls back visibly, nor re-raises. There are none in the tree; the lint keeps
-  it that way.
+  falls back visibly, nor re-raises. None remain under the linted scope, and
+  the lint keeps it that way.
+- **Scope (be honest about it):** the gate runs `ruff check devcake tests`
+  (`scripts/ci_suite.sh`, `.github/workflows/ci.yml`) — it covers `app/devcake`
+  and the test tree. `images/common/dev_entrypoint.py` runs INSIDE every Dev
+  container and is **not** under this gate; its blanket handlers follow the
+  same contracts by convention but are not lint-enforced (a standing follow-up
+  is to extend the gate to `images/`).
 - Test code is exempt (`tests/*` per-file ignore) — tests legitimately catch
   broadly.

--- a/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
+++ b/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
@@ -52,9 +52,14 @@ as forwards with **unchanged coroutine names and signatures** — tests call
 them directly (`app_main.save_profile(...)`), so the forward layer is the
 API's stable test seam. No `APIRouter`: it would be a second routing idiom for
 zero behavior. Every `@app.<verb>` body is ≤ 4 statements, AST-guarded with an
-allowlist that shrinks per PR and ends at `{"dispatch_hello"}` (the CI
-fixture). Poll machinery lives in `api/poll.py` as `PollRuntime`; health
-probes in `api/health.py`.
+allowlist that may only shrink, never grow. At C6 close-out it holds nine
+read-side residuals — `dispatch_hello` (CI fixture), the `run_mapper`/`oauth`
+trio, and the small `runs`/`log`/`clear-runs` endpoints whose bodies are
+inherently a few statements (`list_runs`, `get_run`, `get_run_log`,
+`stream_run_log`, `clear_runs`) — not the single-entry end state an earlier
+draft imagined; the guard test (`test_structure_guards.py`) is the source of
+truth. Poll machinery lives in `api/poll.py` as `PollRuntime`; health probes
+in `api/health.py`.
 
 ## Decision 4 — module-public functions are the sanctioned test seam
 

--- a/images/common/dev_entrypoint.py
+++ b/images/common/dev_entrypoint.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import os
 import pathlib
+import re as _re
 import shlex
 import shutil
 import subprocess
@@ -201,23 +202,28 @@ def clone_error_class(stderr: str) -> str:
     return "DEV_FORGE_AUTH" if any(m in lowered for m in auth_markers) else "DEV_FORGE"
 
 
-HARNESS_AUTH_MARKERS = (
+# Word-boundary regexes, NOT substrings (audit D5 #4): plain `"signed out" in
+# text` matches "de|signed out|put" / "as|signed out|side", and `"log in"`
+# matches "back|log in|spection" — a false 12 pauses the whole Dev Type until a
+# human re-uploads credentials, so the asymmetry says: never over-match.
+HARNESS_AUTH_MARKERS = tuple(_re.compile(r"\b" + p + r"\b") for p in (
     # generic credential wording (any harness)
     "authentication", "unauthorized", "log in",
-    # grok CLI revoked/expired-session wording — without these a revoked grok
-    # cred exits 10 (DEV_CRASH, three burned attempts) instead of 12 (DEV_AUTH
-    # breaker trip)
-    "not signed in", "please sign in", "signed out", "grok login",
-)
+    # grok CLI revoked/expired-session wording — the two DISTINCTIVE phrases
+    # (audit D5 #5): "signed out"/"please sign in" are dropped because generic
+    # SSO/proxy stderr uses them and would false-trip a breaker. Without these
+    # two a revoked grok cred exits 10 (three burned attempts) not 12.
+    "not signed in", r"grok login",
+))
 
 
 def classify_harness_failure(err_text: str) -> int:
     """Exit code for a nonzero harness exit: 12 (DEV_AUTH) only on credential
-    wording, else 10 (DEV_CRASH). Markers are precise phrases on purpose — a
-    false 12 pauses the whole Dev Type until a human re-uploads credentials;
-    a false 10 merely burns one attempt (docs/15 §4)."""
+    wording, else 10 (DEV_CRASH). Markers are word-boundary-anchored on
+    purpose (see above): a false 12 pauses the whole Dev Type, a false 10
+    merely burns one attempt (docs/15 §4)."""
     lowered = err_text.lower()
-    return 12 if any(m in lowered for m in HARNESS_AUTH_MARKERS) else 10
+    return 12 if any(rx.search(lowered) for rx in HARNESS_AUTH_MARKERS) else 10
 
 
 # ── live output relay (docs/08 §4, docs/09 §2) ──────────────────────────────

--- a/scripts/backup_gitea.sh
+++ b/scripts/backup_gitea.sh
@@ -16,12 +16,23 @@ OUT="${1:-devcake-gitea-$(date -u +%Y%m%d-%H%M).tar.gz}"
 
 docker volume inspect "$VOLUME" >/dev/null
 
+# Resolve the output to a real host path and split dir/base (audit D5 #17):
+# the old code concatenated the raw arg after /out inside the container, so an
+# absolute or ../ path wrote into the EPHEMERAL container fs and vanished on
+# --rm — exit 0, "wrote" message, no file. We bind-mount the target DIRECTORY
+# and write the basename into it, so any host path the operator can reach works.
+OUT_DIR="$(cd "$(dirname "$OUT")" && pwd)"
+OUT_BASE="$(basename "$OUT")"
+
 if docker ps --format '{{.Names}}' | grep -q gitea; then
   echo "NOTE: the gitea service is running — a live sqlite snapshot can tear." >&2
   echo "      For a guaranteed-consistent backup: docker compose stop gitea," >&2
   echo "      re-run this script, then docker compose up -d." >&2
 fi
 
-docker run --rm -v "$VOLUME":/src:ro -v "$(pwd)":/out alpine \
-  tar czf "/out/$OUT" -C /src .
-echo "wrote $OUT — contains repo content AND Gitea's credential DB; store like a password export"
+# --user "$(id -u):$(id -g)" so the credential tarball is owned by the invoking
+# operator, not root, and umask 077 so it is not world-readable (audit D5 #19).
+docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$VOLUME":/src:ro -v "$OUT_DIR":/out alpine \
+  sh -c "umask 077 && tar czf '/out/$OUT_BASE' -C /src ."
+echo "wrote $OUT_DIR/$OUT_BASE — contains repo content AND Gitea's credential DB; store like a password export"


### PR DESCRIPTION
The D5 multi-agent adversarial audit over the pre-v0.2 delta confirmed **24 findings, 0 refuted**. This PR resolves all of them — 22 code-fixed, 2 documented.

## The one that mattered most

My **D3 Clear-Runs hardening (#28) was incomplete.** It fixed the *ordering* (stop-then-wipe) but not the *concurrency*: nothing stopped the poll loop from dispatching a fresh run mid-wipe, and the drain re-read stale snapshots — so the ACL/SIGTERM race D3 shipped to close was **still reachable** (#2/#6/#7/#8). Fixed by holding `poll_rt.lock` across the whole wipe (the poll loop is the only dispatcher and shares that lock) and re-fetching each run's current state before the kill. Plus batch-isolation (#9), a `run.started` terminal guard (#10), and UI surfacing of drain failures (#11/#14).

## The rest

- **Grok classifier (#4/#5)** — word-boundary regex kills the "de**signed out**put" false-positive; dropped the generic SSO-ish phrases I flagged as risky in the plan but shipped anyway.
- **Settings (#15/#16)** — `serialize_current` excludes orphan secrets so they can't cause silent apply-deletion or permanent false-divergence.
- **Backup script (#17/#19)** — the silent-discard that swallowed my own D2 E2E backup, plus perms + gitignore.
- **C-series drift (#0/#1/#3)** — a sed-mangled reason string, a bypassed audit test-seam, a dead monkeypatch persisting to the real config path.
- **SPA (#12/#13)** and **docs honesty (#20–#23)**.
- **#18** (orphan-secret sweep) documented as an accepted limitation now that #15/#16 defuse its data-loss path.

## Verification

- ruff clean; **651 passed, 1 skipped** (+7 regression tests, one per fixed defect class) via `pytest_app.sh`.
- SPA build + **check:ui 45/45** (+1 skip).

Closes the D5 tag gate. Full audit ran 31 agents (7 finders → 3-lens adversarial verify); every confirmed finding here carries a regression test or a documented rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)