### PR TITLE
fix: resolve 9 re-audit findings — the #30 poll-lock fix was itself incomplete

### DIFF
--- a/admin/spa/DESIGN.md
+++ b/admin/spa/DESIGN.md
@@ -69,9 +69,9 @@ the route to exactly ONE section component. Every section is a component in
 `src/components/`: `PmoSection`, `DevTypesSection`, `SkillsSection`,
 `AssignmentsSection`, `PromptsSection`, `ProfilesSection`, `LimitsSection`,
 `TrafficSection`. Most sections pull the shared draft themselves via
-`useSharedDraft()` (ConfigDraftContext); the two oldest (`PromptsSection`,
-`ProfilesSection`) still take `cfg`/`setField` as props from the dispatcher —
-either wiring is acceptable, but new sections use `useSharedDraft()`. A section
+`useSharedDraft()` (ConfigDraftContext); `PromptsSection` is the exception —
+it takes `cfg`/`setField`/`devTypeNames` as props from the dispatcher. Either
+wiring is acceptable, but new sections use `useSharedDraft()`. A section
 owns its section-local state and dialogs (its own `ConfirmDialog`, wizards,
 etc. — closed dialogs render null, so this stays invisible in the DOM);
 anything cross-page (the draft itself, Save/DirtyBar/NavGuard in `DraftChrome`)

--- a/admin/spa/src/components/DevTypesSection.jsx
+++ b/admin/spa/src/components/DevTypesSection.jsx
@@ -228,6 +228,7 @@ function DevTypeCard({ name, draftDt, serverDt, harnesses, setField, onDelete, o
           !h.skills_dir && (d.skills || []).length
             ? ` — ${d.skills.length} selected skill(s) will be skipped`
             : ""}.`}
+        optionsUnavailable={catalogErr}
         emptyNote={catalogErr
           ? "skill catalog unavailable (couldn't load /skills) — selected skills shown as-is"
           : "no skills in the catalog yet — see the Skills section"}

--- a/admin/spa/src/components/SelectionChips.jsx
+++ b/admin/spa/src/components/SelectionChips.jsx
@@ -19,6 +19,11 @@ export default function SelectionChips({
   firstBadge = "",         // appended to the FIRST selected chip (e.g. " · default")
   disabled = false,        // whole-control off (note rendered after the chips)
   disabledNote = "",
+  // when true (e.g. the catalog fetch failed), a selected name absent from
+  // options is NOT assumed stale — it renders as a neutral present chip, not a
+  // red click-to-remove one, so a transient outage can't read as "deleted"
+  // and invite accidental removal (re-audit #7)
+  optionsUnavailable = false,
 }) {
   const stale = selected.filter((n) => !options.some((o) => o.name === n));
   return (
@@ -50,11 +55,22 @@ export default function SelectionChips({
           );
         })}
         {stale.map((n) => (
-          <button key={n} type="button" title={staleNote} disabled={disabled}
-            onClick={() => onChange(selected.filter((x) => x !== n))}
-            className="rounded-full border border-red-300 bg-red-50 px-2.5 py-0.5 text-xs font-medium text-red-700 line-through hover:bg-red-100 dark:border-red-900 dark:bg-red-950/60 dark:text-red-300 dark:hover:bg-red-950">
-            {n} ✕
-          </button>
+          optionsUnavailable ? (
+            // catalog couldn't load — show as a normal present chip (neutral,
+            // still toggleable), never as a "deleted" red ✕ (re-audit #7)
+            <button key={n} type="button" title={staleNote} disabled={disabled}
+              onClick={() => onChange(selected.filter((x) => x !== n))}
+              className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition border-accent-400 bg-accent-50 text-accent-800 dark:border-accent-700 dark:bg-accent-950/70 dark:text-accent-200${
+                disabled ? " cursor-not-allowed opacity-60" : ""}`}>
+              {n}
+            </button>
+          ) : (
+            <button key={n} type="button" title={staleNote} disabled={disabled}
+              onClick={() => onChange(selected.filter((x) => x !== n))}
+              className="rounded-full border border-red-300 bg-red-50 px-2.5 py-0.5 text-xs font-medium text-red-700 line-through hover:bg-red-100 dark:border-red-900 dark:bg-red-950/60 dark:text-red-300 dark:hover:bg-red-950">
+              {n} ✕
+            </button>
+          )
         ))}
         {disabled && disabledNote && (
           <span className="text-xs text-neutral-500 dark:text-neutral-400">{disabledNote}</span>

--- a/app/devcake/api/clear.py
+++ b/app/devcake/api/clear.py
@@ -58,9 +58,9 @@ async def stop_and_drain(store: RunStore, executor: DaguExecutor,
         # mission status against the live finalize. Skip anything no longer
         # dispatched/running. (The caller also holds the poll lock, so no
         # NEW run is dispatched during the drain — audit D5 #2/#8.)
-        run = store.get(snap.run_id) or snap
-        if run.state not in ("dispatched", "running"):
-            continue
+        run = store.get(snap.run_id)
+        if run is None or run.state not in ("dispatched", "running"):
+            continue                                    # gone / finalizing / terminal
         try:
             await run_manager.kill(run, "failed", "operator clear-runs")
             stopped.append(run.run_id)

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -462,14 +462,19 @@ async def clear_runs():
     """
     from .clear import clear_all
     with tracer.start_as_current_span("system.clear_runs") as span:
-        # Hold the poll lock across the ENTIRE wipe (audit D5 #2/#8): the poll
-        # loop is the only dispatcher, and it acquires this same lock — so a
-        # cycle cannot dispatch a fresh run mid-drain/mid-wipe. Without this,
-        # a mission whose run we just killed (and whose stage label survives)
-        # is redispatched during the drain, its record then deleted while its
-        # container is live, and clear_redis's ACL sweep races that container's
-        # SIGTERM grace — the exact root cause D3 was meant to close.
-        async with poll_rt.lock:
+        # Serialize the wipe against EVERY dispatch path (audit D5 #2/#8 +
+        # re-audit #0/#6). Two locks, acquired in a fixed order:
+        #   • poll_rt.lock stops the periodic poll cycle (and force-poll) —
+        #     the poll loop takes it at cycle start, so no cycle runs.
+        #   • bootstrap.dispatch_lock is the true chokepoint: EVERY dispatch
+        #     flavor (poll, oauth, mapper "run now", hello) creates its ACL
+        #     user + container inside RunBootstrap.launch under this lock.
+        #     poll_rt.lock alone missed the three non-poll paths, so the
+        #     ACL/SIGTERM race D3 targeted was still reachable — this closes it.
+        # Order poll_rt.lock → dispatch_lock matches the poll loop's own order
+        # (run_cycle holds poll_rt.lock, then launch takes dispatch_lock), so
+        # there is no lock-ordering inversion / deadlock.
+        async with poll_rt.lock, manager.bootstrap.dispatch_lock:
             result = await clear_all(store, executor, messaging, runlog,
                                      internal_forge=internal_forge,
                                      run_manager=manager)

--- a/app/devcake/api/mission_actions.py
+++ b/app/devcake/api/mission_actions.py
@@ -257,7 +257,12 @@ async def stop_all_runs(
     skipped: list[str] = []
     errors: list[dict[str, str]] = []
     for snap in run_store.active():
-        run = run_store.get(snap.run_id) or snap        # re-read current state
+        run = run_store.get(snap.run_id)                # re-read current state
+        if run is None:
+            # the record was deleted under us (a concurrent clear-runs wipe);
+            # killing would store.save it back, resurrecting a phantom failed
+            # run after "start fresh" (re-audit #1). Nothing to stop here.
+            continue
         if getattr(run, "state", None) not in ("dispatched", "running"):
             skipped.append(run.run_id)                  # finalizing/terminal
             continue

--- a/app/devcake/domain/run_bootstrap.py
+++ b/app/devcake/domain/run_bootstrap.py
@@ -7,6 +7,7 @@ oauth) should call launch(); callers own mission-specific fields and spans.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from .run import Run, auth_digest
@@ -27,6 +28,14 @@ class RunBootstrap:
         self.store = store
         self.messaging = messaging
         self.executor = executor
+        # THE serialization point for every dispatch flavor (audit re-audit
+        # #0/#6): clear-runs holds this lock across its whole wipe, so no run
+        # can create a `dev-<run_id>` ACL user or start a container while the
+        # ACL sweep is deleting `dev-*` — the poll-loop lock alone missed the
+        # oauth / mapper-run-now / hello paths, which bypass it. A run
+        # launched just BEFORE the wipe grabs the lock is already in
+        # store.save (below) → the drain's active() snapshot catches it.
+        self.dispatch_lock = asyncio.Lock()
 
     async def launch(self, run: Run, *, image: str) -> Run:
         """Persist durable intent, then trigger the executor.
@@ -35,17 +44,18 @@ class RunBootstrap:
         Callers must fully populate mission/dev fields (and optional
         ``traceparent``) before calling.
         """
-        password = await self.messaging.create_run_user(run.run_id)
-        run.auth_digest = auth_digest(password)
-        self.store.save(run)  # durable intent BEFORE the trigger
-        await self.executor.start(
-            params={
-                "RUN_ID": run.run_id,
-                "IMAGE": image,
-                "TRACEPARENT": run.traceparent or "",
-                "REDIS_USER": f"dev-{run.run_id}",
-                "REDIS_PASSWORD": password,
-            },
-            dag_run_id=run.run_id,
-        )
+        async with self.dispatch_lock:
+            password = await self.messaging.create_run_user(run.run_id)
+            run.auth_digest = auth_digest(password)
+            self.store.save(run)  # durable intent BEFORE the trigger
+            await self.executor.start(
+                params={
+                    "RUN_ID": run.run_id,
+                    "IMAGE": image,
+                    "TRACEPARENT": run.traceparent or "",
+                    "REDIS_USER": f"dev-{run.run_id}",
+                    "REDIS_PASSWORD": password,
+                },
+                dag_run_id=run.run_id,
+            )
         return run

--- a/app/devcake/settings_bundle.py
+++ b/app/devcake/settings_bundle.py
@@ -123,11 +123,19 @@ def serialize_current(config: AppConfig, dev_types: dict[str, DevType], *,
                       include_secrets: bool = True,
                       include_credential_files: bool = False,
                       include_setup_env: bool = False,
+                      include_orphan_secrets: bool = False,
                       skill_payloads: list[dict] | None = None) -> dict:
     """Snapshot the live world into a bundle dict. dismissed_alerts is
     STRIPPED (importing someone else's dismissals could hide active
     advisories); credential files are export-only opt-in (host-migration
-    material, never profile material)."""
+    material, never profile material).
+
+    ``include_orphan_secrets`` (default False): user-facing snapshots
+    (profiles, export) drop connection secrets for instances not in the
+    config — they are not part of the reproducible world (audit D5 #15/#16).
+    The apply/rollback path sets it True so the pre-apply snapshot is
+    BYTE-EXACT — a rollback must restore secrets stored for an instance the
+    incoming bundle was about to add (re-audit #3)."""
     bundle: dict = {
         "kind": BUNDLE_KIND,
         "bundle_schema_version": BUNDLE_SCHEMA_VERSION,
@@ -161,10 +169,16 @@ def serialize_current(config: AppConfig, dev_types: dict[str, DevType], *,
         # profile permanently diverged. A snapshot reproduces the CONFIG's
         # world; an instance-less secret is not part of it. The live orphan
         # itself is untouched (it has its own lifecycle — docs/18).
-        live_keys = ({f"pmo-{p.name}" for p in config.pmos}
-                     | {f"repo-{r.name}" for r in config.repos})
-        conns = {k: v for k, v in secrets_store.list_connection_secrets().items()
-                 if k in live_keys}
+        # EXCEPTION: the rollback path (include_orphan_secrets=True) keeps them
+        # so the pre-apply snapshot is byte-exact and a rollback loses nothing
+        # (re-audit #3).
+        all_conns = secrets_store.list_connection_secrets()
+        if include_orphan_secrets:
+            conns = all_conns
+        else:
+            live_keys = ({f"pmo-{p.name}" for p in config.pmos}
+                         | {f"repo-{r.name}" for r in config.repos})
+            conns = {k: v for k, v in all_conns.items() if k in live_keys}
         sec: dict = {
             "connections": conns,
             "harness": secrets_store.list_harness_secrets(),
@@ -657,7 +671,8 @@ def apply_bundle(bundle: dict, *, config: AppConfig,
     previous = serialize_current(
         config, dev_types,
         include_config=new_cfg is not None,
-        include_secrets=parsed["secrets"] is not None)
+        include_secrets=parsed["secrets"] is not None,
+        include_orphan_secrets=True)   # byte-exact rollback (re-audit #3)
 
     applied: list[str] = []
     try:

--- a/app/tests/test_run_bootstrap.py
+++ b/app/tests/test_run_bootstrap.py
@@ -144,6 +144,27 @@ def test_launch_makes_run_retrievable_and_active():
     assert any(r.run_id == run.run_id for r in store.active())
 
 
+def test_launch_serializes_on_dispatch_lock():
+    """Re-audit #0/#6: clear-runs holds bootstrap.dispatch_lock across its wipe
+    so NO dispatch flavor (poll/oauth/mapper/hello) can create an ACL user or
+    start a container mid-wipe. Prove launch actually blocks on the lock."""
+    async def scenario():
+        store = InMemoryStore()
+        messaging = FakeMessaging()
+        bootstrap = RunBootstrap(store, messaging, FakeExecutor(store))
+        await bootstrap.dispatch_lock.acquire()        # clear-runs holds it
+        task = asyncio.ensure_future(
+            bootstrap.launch(_hello_run(), image="devcake/dev-hello:latest"))
+        await asyncio.sleep(0)                          # let launch try to run
+        # blocked: no ACL user created, no executor start, nothing persisted
+        assert not hasattr(messaging, "last_run_id")
+        assert store.all() == []
+        bootstrap.dispatch_lock.release()              # wipe done
+        await task
+        assert len(store.all()) == 1                    # now it proceeds
+    asyncio.new_event_loop().run_until_complete(scenario())
+
+
 def test_dispatch_hello_uses_bootstrap_spine():
     """Hello path (docs/04 §3.1): fields are hello-specific; spine is shared."""
     from devcake.domain.runs import HELLO_IMAGE, RunManager

--- a/app/tests/test_settings_bundle.py
+++ b/app/tests/test_settings_bundle.py
@@ -86,6 +86,22 @@ def test_serialize_apply_roundtrip_onto_fresh_deployment(monkeypatch, tmp_path):
     assert (dst / "secrets" / "connections" / "pmo-linear.json").stat().st_mode & 0o777 == 0o600
 
 
+def test_rollback_snapshot_keeps_orphan_secrets_byte_exact(monkeypatch, tmp_path):
+    """Re-audit #3: user-facing snapshots drop orphan secrets, but the apply
+    ROLLBACK snapshot must be byte-exact — include_orphan_secrets=True — or a
+    failed apply loses a secret stored for an instance the bundle was adding."""
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, dts = _world(config_mod, secrets, tpl)
+    secrets.write_connection_secret("repo", "incoming", "token", "ghp_incoming_7")
+    # user-facing (default) drops the not-yet-in-config secret
+    facing = sb.serialize_current(cfg, dts, include_secrets=True)
+    assert "repo-incoming" not in facing["secrets"]["connections"]
+    # rollback snapshot keeps it byte-exact
+    rollback = sb.serialize_current(cfg, dts, include_secrets=True,
+                                    include_orphan_secrets=True)
+    assert rollback["secrets"]["connections"]["repo-incoming"] == {"token": "ghp_incoming_7"}
+
+
 def test_serialize_excludes_orphan_connection_secrets(monkeypatch, tmp_path):
     """Audit D5 #15/#16: a stored secret for an instance NOT in the config
     (deleted card, secret lingered) must not ride the snapshot — else it shows

--- a/scripts/backup_gitea.sh
+++ b/scripts/backup_gitea.sh
@@ -30,9 +30,15 @@ if docker ps --format '{{.Names}}' | grep -q gitea; then
   echo "      re-run this script, then docker compose up -d." >&2
 fi
 
-# --user "$(id -u):$(id -g)" so the credential tarball is owned by the invoking
-# operator, not root, and umask 077 so it is not world-readable (audit D5 #19).
-docker run --rm --user "$(id -u):$(id -g)" \
+# tar runs as ROOT (the container default) so it can read gitea's rootless
+# 0700 data dirs (git/, custom/, jwt/private.pem — owned by the in-container
+# uid 1000, unreadable to a host operator whose uid != 1000; re-audit #4).
+# The basename rides an ENV VAR, never interpolated into the shell string, so
+# a filename with quotes/spaces is safe (re-audit #5). umask 077 keeps the
+# tarball non-world-readable, and a trailing chown hands it to the invoking
+# operator instead of leaving it root-owned (audit D5 #19).
+docker run --rm \
+  -e OUT_BASE="$OUT_BASE" -e OWNER="$(id -u):$(id -g)" \
   -v "$VOLUME":/src:ro -v "$OUT_DIR":/out alpine \
-  sh -c "umask 077 && tar czf '/out/$OUT_BASE' -C /src ."
+  sh -c 'umask 077 && tar czf "/out/$OUT_BASE" -C /src . && chown "$OWNER" "/out/$OUT_BASE"'
 echo "wrote $OUT_DIR/$OUT_BASE — contains repo content AND Gitea's credential DB; store like a password export"


### PR DESCRIPTION
You asked me to re-audit PR #30. It found **9 confirmed findings, 3 refuted** — and the headline is that **my #30 fix repeated the D3 mistake one level deeper.**

## The critical one

#30's Clear-Runs poll-lock rested on a code comment: *"the poll loop is the only dispatcher."* That's **false** — `oauth_start`, `run_mapper` ("run now"), and `dispatch_hello` each dispatch a fresh run through `RunBootstrap.launch` **without** `poll_rt.lock`. So a login/mapper/hello run launched mid-wipe still had its `dev-<id>` ACL user deleted by the sweep while its container was live: the **exact D3 root cause, still reachable.**

Fixed at the **true chokepoint** this time — `RunBootstrap.launch`, which *every* dispatch flavor provably funnels through (grep-verified + the module docstring says so). It now holds a `dispatch_lock` around ACL-create + container-start; clear-runs holds that same lock across the whole wipe (with `poll_rt.lock`, fixed acquire order → no deadlock). This is architecturally stronger than the prior two attempts because it guards the one place the race lives, not N call sites.

## The rest

- **#1** — stop-paths no longer resurrect a record a concurrent clear deleted.
- **#3** — the apply rollback snapshot is byte-exact again (the D5 orphan filter had defeated it).
- **#4/#5/#19** — `backup_gitea.sh`: my D5 `--user` hardening **broke backups on any host whose uid ≠ 1000** (couldn't read gitea's 0700 dirs → silent partial tar). Now tar-as-root + chown + env-var basename. Live-verified.
- **#7** — skill chips no longer read as "deleted" on a transient `/skills` failure.
- **#8** — a false DESIGN.md claim.

## Verification

- ruff clean; **653 passed, 1 skipped** (+2 regression tests, incl. one proving `launch` blocks on a held `dispatch_lock`); check:ui **46/46**; backup live-verified (absolute path, operator-owned, 0600, 0700 dirs captured).

Regression test per load-bearing fix. Given this fix touches the same concurrency surface that was wrong twice, I'd recommend one more re-audit of *this* delta before the v0.2 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)