### PR TITLE
fix: close the 3 residual re-audit findings — phantom-record race + chip removability

### DIFF
--- a/admin/spa/src/components/SelectionChips.jsx
+++ b/admin/spa/src/components/SelectionChips.jsx
@@ -56,14 +56,15 @@ export default function SelectionChips({
         })}
         {stale.map((n) => (
           optionsUnavailable ? (
-            // catalog couldn't load — show as a normal present chip (neutral,
-            // still toggleable), never as a "deleted" red ✕ (re-audit #7)
-            <button key={n} type="button" title={staleNote} disabled={disabled}
-              onClick={() => onChange(selected.filter((x) => x !== n))}
-              className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition border-accent-400 bg-accent-50 text-accent-800 dark:border-accent-700 dark:bg-accent-950/70 dark:text-accent-200${
-                disabled ? " cursor-not-allowed opacity-60" : ""}`}>
+            // catalog couldn't load — show as a present chip, and DISABLE it
+            // (re-audit #31 #3): while the catalog is unknown there is no
+            // option chip to re-select from, so a misclick-remove would be
+            // unrecoverable in-UI. Non-interactive preserves the selection
+            // until the catalog loads.
+            <span key={n} title={staleNote}
+              className="rounded-full border px-2.5 py-0.5 text-xs font-medium border-accent-400 bg-accent-50 text-accent-800 opacity-70 dark:border-accent-700 dark:bg-accent-950/70 dark:text-accent-200">
               {n}
-            </button>
+            </span>
           ) : (
             <button key={n} type="button" title={staleNote} disabled={disabled}
               onClick={() => onChange(selected.filter((x) => x !== n))}

--- a/app/devcake/domain/runs.py
+++ b/app/devcake/domain/runs.py
@@ -346,7 +346,15 @@ class RunManager:
             run.ended_at = utcnow()
             from ..security import redact
             run.error = redact(reason)
-            self.store.save(run)
+            # Do not RESURRECT a record a concurrent clear-runs wipe just
+            # deleted (re-audit #31 #1/#2): get()+save() with no await between
+            # is atomic under asyncio's cooperative scheduling, so this fully
+            # closes the phantom-record race for EVERY killer — watchdog,
+            # stop-run, stop-all, and clear's own drain all funnel through
+            # here. A record clear already unlinked reads None → we skip; it is
+            # already out of store.active() so nothing re-kills it.
+            if self.store.get(run.run_id) is not None:
+                self.store.save(run)
         if self.finalizer and run.mission_pmo_id:
             try:
                 await self.finalizer.restore_after_failure(run)

--- a/app/tests/test_crash_recovery.py
+++ b/app/tests/test_crash_recovery.py
@@ -126,6 +126,27 @@ def test_artifacts_enters_finalize_from_running(tmp_path):
     assert store.get(run.run_id).state == "finalizing"
 
 
+def test_kill_does_not_resurrect_a_concurrently_wiped_record(tmp_path):
+    """Re-audit #31 #1/#2: a kill whose record was deleted by a concurrent
+    clear-runs wipe (while kill was awaiting teardown) must NOT store.save it
+    back — that recreated a phantom terminal run after 'start fresh'. The
+    get()+save() guard in _kill_inner is atomic (no await between), so a gone
+    record stays gone for EVERY killer path."""
+    store = RunStore(tmp_path / "runs")
+    mgr = RunManager(store, FakeMessaging(), FakeExecutor())
+    run = _make_run(store, state="running", run_id="W-1")
+    # simulate the concurrent wipe: the record is gone by the time kill's
+    # teardown reaches its final save
+    store.clear()
+    assert store.get("W-1") is None
+    run_coro(mgr.kill(run, "timed_out", "watchdog timeout"))
+    assert store.get("W-1") is None                    # not resurrected
+    # a normal kill (record present) still persists the terminal state
+    live = _make_run(store, state="running", run_id="W-2")
+    run_coro(mgr.kill(live, "failed", "operator"))
+    assert store.get("W-2").state == "failed"
+
+
 def test_started_does_not_resurrect_a_killed_run(tmp_path):
     """Audit D5 #10: a run.started arriving AFTER the run was killed (its
     container was just booting when stop-all fired) must NOT flip the record


### PR DESCRIPTION
Re-audit of PR #31 (the third pass on the Clear-Runs concurrency surface) confirmed **3 findings, 0 refuted** — and the headline is the good one:

## The dispatch-lock fix is verified clean ✅

The reviewer explicitly confirmed the `dispatch_lock` change has **no deadlock, no lock-order inversion, no re-entrancy** — the dangerous ACL/SIGTERM race (the one that killed live containers with `AuthenticationError`) is **closed**. Three attempts, finally at the right architectural layer.

## The 3 residuals — a different, benign class, now closed

All three are advisory-only (INV-1: no mission-state corruption) and self-healing:

- **#1/#2** — a lock-free killer (watchdog, stop-run, stop-all) could `store.save` a run's terminal state *after* a concurrent clear wiped it, leaving a phantom record. The re-audit-#1 None-guard only covered the already-gone-at-check window. **Fixed at the shared chokepoint**: `_kill_inner`'s final save is now `if store.get(id) is not None: store.save(run)` — and because `get()`+`save()` have no `await` between them, the check-then-act is **atomic** under asyncio's cooperative scheduling, closing it for *every* killer at once. (Same lesson as dispatch_lock: guard the chokepoint, not the call sites.)
- **#3** — the catalog-unavailable skill chip was still one-click removable, and during a `/skills` outage there's no option chip to re-select, so a misclick was unrecoverable. Now a non-interactive `<span>`.

## Verification

- ruff clean; **654 passed, 1 skipped** (+1 regression: kill does not resurrect a concurrently-wiped record); check:ui **46/46**.

This is the fourth pass on this surface; the concurrency core is now confirmed clean and the residuals are closed at their chokepoint. I'd call the audit gate met — recommend one final full-suite + live smoke, then the v0.2 tag is a founder call on soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)