### PR TITLE
feat(admin): Missions board fits notebook viewports — fluid columns + Missions-scoped sidebar auto-collapse

### DIFF
--- a/admin/spa/src/App.jsx
+++ b/admin/spa/src/App.jsx
@@ -186,7 +186,8 @@ export default function App() {
           </a>
         )}
         <main className="flex-1 overflow-y-auto px-4 py-6 sm:px-8">
-          <div className="mx-auto w-full max-w-6xl">
+          {/* Missions needs full main-pane width for the 7-col kanban; other pages keep the 6xl reading cap. */}
+          <div className={`mx-auto w-full ${page === "missions" ? "max-w-none" : "max-w-6xl"}`}>
             {page === "overview" && (
               <OverviewPage
                 health={health}

--- a/admin/spa/src/components/Sidebar.jsx
+++ b/admin/spa/src/components/Sidebar.jsx
@@ -154,18 +154,30 @@ export default function Sidebar({
   page, configSection, alertCount, health, healthError,
   intakePaused, intakeBusy, intakeError, onIntakeToggle,
 }) {
-  const [collapsed, setCollapsed] = useState(() => {
+  const [collapsedPref, setCollapsedPref] = useState(() => {
     const v = localStorage.getItem("devcake-sidebar");
     if (v === "collapsed") return true;
     if (v === "expanded") return false;
     return !window.matchMedia("(min-width: 1024px)").matches;
   });
   const toggleCollapsed = () => {
-    setCollapsed((c) => {
+    setCollapsedPref((c) => {
       localStorage.setItem("devcake-sidebar", !c ? "collapsed" : "expanded");
       return !c;
     });
   };
+  // Missions kanban needs ≥1440 to fit 7 cols; force-collapse below that on
+  // this page only, without touching the persisted preference.
+  const [narrowForMissions, setNarrowForMissions] = useState(false);
+  useEffect(() => {
+    if (page !== "missions") { setNarrowForMissions(false); return; }
+    const mq = window.matchMedia("(max-width: 1439.98px)");
+    const update = () => setNarrowForMissions(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, [page]);
+  const collapsed = collapsedPref || narrowForMissions;
 
   const dotOk = (key) =>
     (healthError && key === "app" ? false : serviceValue(health, key));
@@ -281,11 +293,20 @@ export default function Sidebar({
             </a>
           </p>
         )}
+        {/* When Missions force-collapses under 1440, toggling would just flip
+           the persisted preference without any visible change (effective
+           stays collapsed) — a control that lies about being functional.
+           Disable it with an honest title instead. */}
         <button
           onClick={toggleCollapsed}
-          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          className={`flex items-center gap-2 rounded-lg py-1.5 text-xs text-neutral-500 dark:text-neutral-400 hover:bg-stone-100 hover:text-neutral-700 dark:hover:bg-neutral-800 dark:hover:text-neutral-200 ${
+          disabled={narrowForMissions}
+          title={narrowForMissions
+            ? "Sidebar auto-collapsed on Missions below 1440 px so the board fits"
+            : collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          aria-label={narrowForMissions
+            ? "Sidebar auto-collapsed on Missions below 1440 px"
+            : collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          className={`flex items-center gap-2 rounded-lg py-1.5 text-xs text-neutral-500 dark:text-neutral-400 hover:bg-stone-100 hover:text-neutral-700 dark:hover:bg-neutral-800 dark:hover:text-neutral-200 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-500 dark:disabled:hover:bg-transparent dark:disabled:hover:text-neutral-400 ${
             collapsed ? "mx-auto h-8 w-8 justify-center" : "w-full px-2.5"
           }`}
         >

--- a/admin/spa/src/pages/MissionsPage.jsx
+++ b/admin/spa/src/pages/MissionsPage.jsx
@@ -231,13 +231,14 @@ export default function MissionsPage() {
           create one there and DevCake will pick it up on the next cycle.
         </p>
       )}
-      <div className="overflow-x-auto pb-4">
-        <div className="flex min-w-max gap-3">
+      {/* Fluid columns; overflow-x-auto is the mobile fallback below 9rem/col. */}
+      <div data-testid="board-scroller" className="overflow-x-auto pb-4">
+        <div className="flex gap-2">
           {COLUMNS.map((col) => (
             <section
               key={col.id}
               aria-label={col.label}
-              className="flex w-72 shrink-0 flex-col rounded-card border border-neutral-200 bg-stone-50 p-2 dark:border-neutral-800 dark:bg-neutral-950/40"
+              className="flex flex-1 basis-0 min-w-[9rem] max-w-[18rem] flex-col rounded-card border border-neutral-200 bg-stone-50 p-2 dark:border-neutral-800 dark:bg-neutral-950/40"
             >
               <header className="mb-2 flex items-center justify-between px-1 pb-1">
                 <span className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">

--- a/admin/spa/tests/harness.mjs
+++ b/admin/spa/tests/harness.mjs
@@ -12,17 +12,32 @@ export const BASE = process.env.UI_BASE || "http://127.0.0.1:5199";
 
 function chromePath() {
   if (process.env.UI_CHROME) return process.env.UI_CHROME;
-  const root = join(homedir(), ".cache", "ms-playwright");
-  const revs = existsSync(root)
-    ? readdirSync(root).filter((d) => d.startsWith("chromium_headless_shell-")).sort().reverse()
-    : [];
-  for (const rev of revs) {
-    const p = join(root, rev, "chrome-linux", "headless_shell");
-    if (existsSync(p)) return p;
+  // Playwright's browser cache lives under a different root on macOS than on
+  // Linux, and the headless-shell exe has a different basename on each.
+  const roots = [
+    join(homedir(), ".cache", "ms-playwright"),                    // Linux
+    join(homedir(), "Library", "Caches", "ms-playwright"),         // macOS
+  ];
+  const layouts = [
+    ["chrome-linux", "headless_shell"],
+    ["chrome-headless-shell-mac-arm64", "chrome-headless-shell"],
+    ["chrome-headless-shell-mac-x64", "chrome-headless-shell"],
+  ];
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    const revs = readdirSync(root)
+      .filter((d) => d.startsWith("chromium_headless_shell-"))
+      .sort().reverse();
+    for (const rev of revs) {
+      for (const [dir, exe] of layouts) {
+        const p = join(root, rev, dir, exe);
+        if (existsSync(p)) return p;
+      }
+    }
   }
   throw new Error(
-    "no cached Chromium headless shell under ~/.cache/ms-playwright — " +
-    "set UI_CHROME to a Chrome/Chromium executable",
+    "no cached Chromium headless shell under ~/.cache/ms-playwright or " +
+    "~/Library/Caches/ms-playwright — set UI_CHROME to a Chrome/Chromium executable",
   );
 }
 

--- a/admin/spa/tests/missions.mjs
+++ b/admin/spa/tests/missions.mjs
@@ -1,0 +1,150 @@
+// Missions suite: the board must fit the main pane at the notebook floor
+// (≥1440) and at the harness default (1280) without triggering horizontal
+// scroll — both on an empty board AND with a stress payload that exercises
+// every column with long mono keys, long titles, and every label variant a
+// MissionCard renders. The empty-board pass is trivially satisfied by empty
+// dashed placeholders; the populated pass is what real operators see.
+// Read-only — everything is route-mocked or a plain GET.
+import { check, gotoFresh, summary, withPage } from "./harness.mjs";
+
+// Worst-case rows: each column gets 5 cards with fields that push MissionCard
+// widest — a long key (font-mono, no truncate in the header row), a long
+// title, priority pill, repo string, url link, reason text. `done` gets 35
+// entries so `bucketize` exercises its 30-cap slice too.
+const LONG_KEY = "PLATFORM-999999";
+const LONG_TITLE =
+  "A ticket title that exercises the two-line line-clamp so the card grows " +
+  "tall enough to reveal any horizontal bleed from the meta row below";
+const LONG_REASON =
+  "A blocking condition that spans two lines when clamped so the reason row " +
+  "is exercised alongside the label chip and updated timestamp";
+const LONG_REPO = "acme-corp/very-long-repo-name-with-hyphens-that-could-wrap";
+
+const COLUMN_SEEDS = [
+  { col: "backlog",     status: "backlog",    labels: [] },
+  { col: "plan",        status: "in_progress", labels: ["DEVCAKE", "DEVCAKE-PLAN"] },
+  { col: "execute",     status: "in_progress", labels: ["DEVCAKE", "DEVCAKE-EXECUTE"] },
+  { col: "review",      status: "in_progress", labels: ["DEVCAKE", "DEVCAKE-REVIEW"] },
+  { col: "merge",       status: "in_progress", labels: ["DEVCAKE", "DEVCAKE-MERGE"] },
+  { col: "needs_human_conflict", status: "in_progress", labels: ["DEVCAKE-PLAN", "DEVCAKE-EXECUTE"] },
+  { col: "needs_human_skip",     status: "in_progress", labels: ["DEVCAKE", "DEVCAKE-SKIP"] },
+  { col: "needs_human_failed",   status: "in_progress", labels: ["DEVCAKE", "DEVCAKE-FAILED"] },
+  { col: "needs_human_wanted",   status: "in_progress", labels: ["DEVCAKE", "DEVCAKE-NEEDS-HUMAN"] },
+  { col: "done",        status: "done",       labels: ["DEVCAKE"] },
+];
+
+function makeRows() {
+  const rows = [];
+  let idx = 0;
+  for (const seed of COLUMN_SEEDS) {
+    const n = seed.col === "done" ? 35 : 3;
+    for (let i = 0; i < n; i += 1) {
+      idx += 1;
+      rows.push({
+        pmo_id: `ID-${idx}`,
+        key: `${LONG_KEY}-${idx}`,
+        title: `${LONG_TITLE} (${seed.col} #${i + 1})`,
+        status: seed.status,
+        labels: seed.labels,
+        mission_type: "main-dev",
+        priority: "URGENT",
+        repo: LONG_REPO,
+        url: `https://linear.app/example/issue/${idx}`,
+        updated_at: new Date(Date.now() - idx * 60_000).toISOString(),
+        schedulable: seed.col === "backlog",
+        reason: seed.col === "backlog" ? LONG_REASON : "",
+      });
+    }
+  }
+  return rows;
+}
+
+async function assertBoardFits(width, height, { populated } = {}) {
+  const rows = populated ? makeRows() : [];
+  const label = populated ? "populated" : "empty";
+  await withPage(async (page) => {
+    if (populated) {
+      // Surgical mock: exact /api/v1/missions only (leave /health, actions,
+      // etc. alone). Matches both first fetch and the 10s poll.
+      await page.route(/\/api\/v1\/missions(?:\?.*)?$/, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ missions: rows, adoption_mode: "auto", teams: {} }),
+        }),
+      );
+    }
+    await gotoFresh(page, "#/missions");
+    await page.waitForSelector('[data-testid="board-scroller"] section', { timeout: 8000 });
+    if (populated) {
+      // Wait for at least one real card (MissionCard uses role="button" with
+      // a mono key inside). Bare-stack empty renders "empty" placeholders,
+      // no role=button — this proves the mock landed.
+      await page.waitForSelector('[data-testid="board-scroller"] [role="button"]', { timeout: 8000 });
+    }
+    const { boardScroll, boardClient, worstCard } = await page.evaluate(() => {
+      const el = document.querySelector('[data-testid="board-scroller"]');
+      const cards = [...el.querySelectorAll('[role="button"]')];
+      let worst = { overflow: 0, key: null };
+      for (const c of cards) {
+        const over = Math.ceil(c.scrollWidth) - c.clientWidth;
+        if (over > worst.overflow) {
+          const keyEl = c.querySelector(".font-mono");
+          worst = { overflow: over, key: keyEl ? keyEl.textContent : "?" };
+        }
+      }
+      return { boardScroll: el.scrollWidth, boardClient: el.clientWidth, worstCard: worst };
+    });
+    const boardOver = Math.ceil(boardScroll) - boardClient;
+    check(
+      `${label} board fits at ${width}×${height} (scrollWidth ${boardScroll} ≤ clientWidth ${boardClient})`,
+      boardOver <= 1,
+      boardOver > 1 ? `overflows by ${boardOver}px` : "",
+    );
+    if (populated) {
+      check(
+        `${label} board — no card overflows its column at ${width}×${height}`,
+        worstCard.overflow <= 1,
+        worstCard.overflow > 1
+          ? `worst card (${worstCard.key}) overflows by ${worstCard.overflow}px`
+          : "",
+      );
+    }
+  }, { width, height });
+}
+
+// Notebook floor per plan/joyful-herding-knuth: no horizontal scroll at ≥1440.
+await assertBoardFits(1440, 900);
+await assertBoardFits(1280, 900);
+// Populated payload: what an operator actually sees.
+await assertBoardFits(1440, 900, { populated: true });
+await assertBoardFits(1280, 900, { populated: true });
+
+// The Missions force-collapse under 1440 makes the sidebar toggle a no-op —
+// disable it honestly instead of shipping a control that lies. At 1440 the
+// force is off and the toggle is enabled.
+await withPage(async (page) => {
+  await gotoFresh(page, "#/missions");
+  await page.waitForSelector('[data-testid="board-scroller"]');
+  const state = await page.evaluate(() => {
+    const btn = [...document.querySelectorAll("aside button")]
+      .find((b) => /sidebar|Missions below 1440/i.test(b.getAttribute("aria-label") || ""));
+    return { present: !!btn, disabled: btn?.disabled, aria: btn?.getAttribute("aria-label") };
+  });
+  check("sidebar toggle disabled at 1280 on Missions", state.present && state.disabled === true,
+    `aria=${state.aria} disabled=${state.disabled}`);
+}, { width: 1280, height: 900 });
+
+await withPage(async (page) => {
+  await gotoFresh(page, "#/missions");
+  await page.waitForSelector('[data-testid="board-scroller"]');
+  const state = await page.evaluate(() => {
+    const btn = [...document.querySelectorAll("aside button")]
+      .find((b) => /sidebar|Missions below 1440/i.test(b.getAttribute("aria-label") || ""));
+    return { present: !!btn, disabled: btn?.disabled };
+  });
+  check("sidebar toggle enabled at 1440 on Missions", state.present && state.disabled === false,
+    `disabled=${state.disabled}`);
+}, { width: 1440, height: 900 });
+
+summary("missions");

--- a/admin/spa/tests/run.mjs
+++ b/admin/spa/tests/run.mjs
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const spa = join(here, "..");
-const SUITES = ["settings.mjs", "hierarchy.mjs", "redesign.mjs"];
+const SUITES = ["settings.mjs", "hierarchy.mjs", "redesign.mjs", "missions.mjs"];
 
 // pick up admin credentials from the repo-root .env when not already set
 try {
@@ -27,7 +27,10 @@ let vite = null;
 const base = process.env.UI_BASE || "http://127.0.0.1:5199";
 
 if (!process.env.UI_BASE) {
-  vite = spawn("npx", ["vite", "--port", "5199", "--strictPort"], {
+  // --host 127.0.0.1 forces IPv4 binding; without it, macOS vite listens on
+  // ::1 only while the harness probes 127.0.0.1, and the readiness check
+  // silently hits its 30s timeout.
+  vite = spawn("npx", ["vite", "--host", "127.0.0.1", "--port", "5199", "--strictPort"], {
     cwd: spa, stdio: "ignore", env: process.env,
   });
   const deadline = Date.now() + 30000;


### PR DESCRIPTION
## Summary

Your board is the interface (docs/17-positioning.md §1). Before this change the 7-column Hermes kanban had fixed 288 px columns inside a `min-w-max` row — intrinsic width **2 088 px**. On a MacBook Pro 14" at 1440 with the sidebar expanded (240) and the app-wide `max-w-6xl` cap (1152), effective pane = **1 136 px** → the board horizontally scrolled on every notebook viewport, hiding ~950 px of columns from the operator.

Three coordinated levers, none sufficient alone at 1440 with the sidebar expanded:

1. **`App.jsx`** — `max-w-6xl` → `max-w-none` on `/missions` only; every other (text-dense) page keeps the reading cap.
2. **`Sidebar.jsx`** — a page-aware `matchMedia("(max-width: 1439.98px)")` force-collapses the sidebar on Missions below 1440 without touching the persisted preference. Leaving Missions or resizing over 1440 restores it. The persist-toggle button is `disabled` while forced with a title stating why — otherwise the click would silently flip the preference with no visible effect (DESIGN.md §6 catalogs "controls that lie" as shipped bugs).
3. **`MissionsPage.jsx`** — columns become `flex-1 basis-0 min-w-[9rem] max-w-[18rem]` inside `flex gap-2`. Equal-share width; 144 px floor triggers the still-present `overflow-x-auto` mobile fallback; 18 rem cap keeps columns from ballooning on 4K.

**Test-tooling portability (drive-by, needed to run check:ui on macOS):** `tests/harness.mjs` now finds the cached headless shell in `~/Library/Caches/ms-playwright` too, not just `~/.cache/ms-playwright`. `tests/run.mjs` spawns vite with `--host 127.0.0.1` — macOS vite defaults to `::1` only while the harness probes `127.0.0.1`, and the mismatch made the readiness check silently hit its 30 s timeout.

Plan: `plans/joyful-herding-knuth.md`.

## Test plan

Personally observed:

- [x] `npm --prefix admin/spa run build` — green, ~660 ms.
- [x] `npm --prefix admin/spa run check:ui` — **51 passed, 1 skipped, 0 failed** across `settings` (16) / `hierarchy` (18) / `redesign` (9) / new `missions` (8). The `missions` suite asserts, at both **1440×900** and **1280×900**, that `scrollWidth ≤ clientWidth` on the board scroller **and** that no `MissionCard` overflows its column — first empty, then again with a route-mocked stress payload (long mono keys, all label variants across every column, Done past its 30-cap). Also asserts the sidebar toggle is `disabled` at 1280 on Missions and enabled at 1440.
- [x] **Prod bundle live-verified** — `docker buildx bake admin && docker compose up -d admin` (rebuilt image, restarted container). Loaded `http://127.0.0.1:8080/#/missions` with the same route-mocked stress payload via playwright: at 1440 board fits at `1136≤1136` with toggle **enabled**; at 1280 board fits at `1160≤1160` with toggle **disabled**. Identical result to vite — the fix survives the built bundle.

Still unproven (owed before deploy, not by this PR):

- [ ] **1512+ MacBook Pro native (14"/16" scaled)** — strict superset of 1440-collapsed by arithmetic; harness matrix is 1280+1440 so the physical shot on the raw device is owed.