### PR TITLE
fix(clear-runs): wipe generation + force-remove undrained (post-#30–#32 residuals)

### DIFF
--- a/admin/spa/src/components/SelectionChips.jsx
+++ b/admin/spa/src/components/SelectionChips.jsx
@@ -24,6 +24,7 @@ export default function SelectionChips({
   // red click-to-remove one, so a transient outage can't read as "deleted"
   // and invite accidental removal (re-audit #7)
   optionsUnavailable = false,
+  unavailableNote = "catalog unavailable — selection preserved until it loads",
 }) {
   const stale = selected.filter((n) => !options.some((o) => o.name === n));
   return (
@@ -60,8 +61,8 @@ export default function SelectionChips({
             // (re-audit #31 #3): while the catalog is unknown there is no
             // option chip to re-select from, so a misclick-remove would be
             // unrecoverable in-UI. Non-interactive preserves the selection
-            // until the catalog loads.
-            <span key={n} title={staleNote}
+            // until the catalog loads. Title must NOT say "click to remove".
+            <span key={n} title={unavailableNote}
               className="rounded-full border px-2.5 py-0.5 text-xs font-medium border-accent-400 bg-accent-50 text-accent-800 opacity-70 dark:border-accent-700 dark:bg-accent-950/70 dark:text-accent-200">
               {n}
             </span>

--- a/admin/spa/src/pages/RunsPage.jsx
+++ b/admin/spa/src/pages/RunsPage.jsx
@@ -67,7 +67,12 @@ export default function RunsPage() {
         const bits = [];
         // drain phase (#28 stop-and-drain): a container wedged past the cap
         // means the wipe ran while it was still live — surface it loudly
-        if (result.stopped?.undrained?.length) bits.push(`Still running after stop: ${result.stopped.undrained.join(", ")}`);
+        if (result.stopped?.undrained?.length) {
+          const force = result.stopped.force_remove_attempted
+            ? " (Dagu force-stop attempted; app has no docker.sock)"
+            : "";
+          bits.push(`Still running after drain${force}: ${result.stopped.undrained.join(", ")}`);
+        }
         if (result.stopped?.error) bits.push(`Stop phase: ${result.stopped.error}`);
         if (result.dagu?.failed?.length) bits.push(`Dagu still holds: ${result.dagu.failed.join(", ")}`);
         if (result.openobserve?.errors?.length) bits.push(result.openobserve.errors.join("; "));

--- a/app/devcake/adapters/files/run_store.py
+++ b/app/devcake/adapters/files/run_store.py
@@ -20,6 +20,12 @@ class RunStore:
     def __init__(self, root: Path = RUNS_DIR):
         self.root = root
         self.root.mkdir(parents=True, exist_ok=True)
+        # Monotonic wipe generation (process-local; docs/10): clear() bumps
+        # this then unlinks files. save() drops runs stamped with an older
+        # store_gen so in-flight finalize/heartbeat cannot resurrect records
+        # after operator "start fresh". Restarts reset to 0 with an empty or
+        # reloaded store — that is fine (no cross-process phantom writers).
+        self.wipe_generation: int = 0
 
     def _write_text(self, path: Path, text: str) -> None:
         fd, tmp = tempfile.mkstemp(dir=self.root, suffix=".tmp")
@@ -34,6 +40,14 @@ class RunStore:
                 os.unlink(tmp)
 
     def save(self, run: Run) -> None:
+        gen = int(getattr(run, "store_gen", 0) or 0)
+        if gen < self.wipe_generation:
+            log.info(
+                "drop save for %s (store_gen=%s < wipe_generation=%s) — "
+                "run predates the last clear-runs wipe",
+                run.run_id, gen, self.wipe_generation,
+            )
+            return
         self._write_text(self.root / f"{run.run_id}.json", run.model_dump_json(indent=2))
 
     @staticmethod
@@ -116,7 +130,12 @@ class RunStore:
         return moved
 
     def clear(self) -> int:
-        """Delete every run record. Returns how many files were removed."""
+        """Delete every run record. Returns how many files were removed.
+
+        Bumps ``wipe_generation`` *before* unlinking so any in-flight
+        ``save`` of a pre-wipe run (finalize, heartbeat, kill) is a no-op.
+        """
+        self.wipe_generation += 1
         n = 0
         for p in list(self.root.glob("*.json")) + list(self.root.glob("quarantine/*.json")):
             try:

--- a/app/devcake/api/clear.py
+++ b/app/devcake/api/clear.py
@@ -56,8 +56,8 @@ async def stop_and_drain(store: RunStore, executor: DaguExecutor,
         # concurrently, so a run may have flipped to finalizing while an
         # earlier kill was awaiting — killing it then would revert its
         # mission status against the live finalize. Skip anything no longer
-        # dispatched/running. (The caller also holds the poll lock, so no
-        # NEW run is dispatched during the drain — audit D5 #2/#8.)
+        # dispatched/running. (The caller also holds poll + dispatch locks
+        # for the full wipe — new launches cannot create ACL users mid-drain.)
         run = store.get(snap.run_id)
         if run is None or run.state not in ("dispatched", "running"):
             continue                                    # gone / finalizing / terminal
@@ -83,11 +83,61 @@ async def stop_and_drain(store: RunStore, executor: DaguExecutor,
         live = still
         if live:
             await asyncio.sleep(2)
+
+    # Force-remove pass (post-#32 residual B): soft drain timed out with
+    # containers still live. App has no docker.sock — force means Dagu stop
+    # (+ stop_all hammer) and a short re-poll, then wipe proceeds anyway so
+    # ACL DELUSER does not wait forever. ok:false when undrained remain.
+    force_attempted = False
+    force_stops = 0
     if live:
-        log.warning("clear: %d container(s) still reported running after "
-                    "%.0fs drain — proceeding with the wipe: %s",
-                    len(live), timeout_s, live)
-    return {"stopped": len(stopped), "undrained": live}
+        force_attempted = True
+        log.error(
+            "clear: %d container(s) still running after %.0fs soft drain — "
+            "force-stop via Dagu then re-poll: %s",
+            len(live), timeout_s, live,
+        )
+        for rid in list(live):
+            try:
+                await executor.stop(rid)
+                force_stops += 1
+            except Exception:  # noqa: BLE001 — force stop is best-effort per run; re-poll decides undrained
+                log.exception("clear: force stop failed for %s", rid)
+        stop_all = getattr(executor, "stop_all", None)
+        if callable(stop_all):
+            try:
+                await stop_all()
+            except Exception:  # noqa: BLE001 — stop_all hammer is best-effort; residual undrained reported below
+                log.exception("clear: executor.stop_all failed during force pass")
+        # short re-poll (capped; does not re-open the soft-drain budget)
+        force_deadline = _time.monotonic() + min(15.0, max(4.0, timeout_s * 0.25))
+        while live and _time.monotonic() < force_deadline:
+            still = []
+            for rid in live:
+                try:
+                    status = await executor.status(rid)
+                except Exception:  # noqa: BLE001 — force re-poll best-effort; treat probe failure as still live
+                    still.append(rid)
+                    continue
+                detail = (status or {}).get("dagRunDetails") or {}
+                label = str(detail.get("statusLabel", detail.get("status", ""))).lower()
+                if status is not None and label in ("running", "queued", "started"):
+                    still.append(rid)
+            live = still
+            if live:
+                await asyncio.sleep(1)
+        if live:
+            log.error(
+                "clear: %d container(s) STILL live after force-remove — "
+                "proceeding with wipe (ACL may race residual containers): %s",
+                len(live), live,
+            )
+    return {
+        "stopped": len(stopped),
+        "undrained": live,
+        "force_remove_attempted": force_attempted,
+        "force_stops": force_stops,
+    }
 
 
 def clear_local_state(store: RunStore,

--- a/app/devcake/domain/orchestrator/finalize.py
+++ b/app/devcake/domain/orchestrator/finalize.py
@@ -18,6 +18,12 @@ log = logging.getLogger("devcake.missions")
 tracer = trace.get_tracer("devcake")
 
 
+def _pre_wipe(mgr, run: Run) -> bool:
+    """True when run.store_gen predates the store's last clear-runs wipe."""
+    wipe_gen = int(getattr(mgr.runs.store, "wipe_generation", 0) or 0)
+    return int(getattr(run, "store_gen", 0) or 0) < wipe_gen
+
+
 async def _checkpoint(mgr, run: Run, key: str, fn) -> None:
     """Idempotent finalize sub-step (ISSUES #4–6): skip if already done;
     append+save only after the side effect succeeds.
@@ -27,12 +33,24 @@ async def _checkpoint(mgr, run: Run, key: str, fn) -> None:
     """
     if key in run.finalized_steps:
         return
+    if _pre_wipe(mgr, run):
+        return
     await fn()
+    if _pre_wipe(mgr, run):
+        return
     run.finalized_steps.append(key)
     mgr.runs.store.save(run)
 
 
 async def finalize(mgr, run: Run, payload: dict) -> None:
+    # Clear-runs wipe generation (docs/10): a run stamped before the last
+    # wipe must not post to the PMO or resurrect local records. Saves are
+    # already no-ops at RunStore; re-check after every await so a wipe that
+    # lands mid-finalize stops further feed/transition side effects.
+    if _pre_wipe(mgr, run):
+        log.info("skip mission finalize for pre-wipe run %s", run.run_id)
+        return
+
     result = payload.get("result") or {}
     outcome = result.get("outcome", "")
     transcript = payload.get("transcript_md", "")
@@ -57,16 +75,27 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
 
         # 1 — transcript (idempotent via finalized_steps)
         if "transcript" not in run.finalized_steps:
+            if _pre_wipe(mgr, run):
+                log.info("abort finalize (transcript) pre-wipe %s", run.run_id)
+                return
             await _post_transcript(mgr, run, transcript,
                                         payload.get("last_message_md"))
             run.finalized_steps.append("transcript")
             mgr.runs.store.save(run)
+
+        if _pre_wipe(mgr, run):
+            log.info("abort finalize mid-flight pre-wipe %s", run.run_id)
+            return
 
         run.token_report = redact_value(token_report)  # persisted cost source
         # 2 — token report (INV-5: always)
         if "token_report" not in run.finalized_steps:
             await mgr._feed(pmo_id, run.pmo_kind,
                              _token_report_md(run, token_report))
+            if _pre_wipe(mgr, run):
+                log.info("abort finalize after token_report pre-wipe %s",
+                         run.run_id)
+                return
             run.finalized_steps.append("token_report")
             mgr.runs.store.save(run)
 
@@ -75,6 +104,8 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
         # mission re-derives exactly as before the attempt (INV-3; without this,
         # a failed first ONBOARD strands the mission at in_progress/no-label = row 9)
         if not outcome:
+            if _pre_wipe(mgr, run):
+                return
             exit_code = payload.get("exit_code")
             await mgr.messaging.delete_run_user(run.run_id)
             await mgr.messaging.delete_reply_stream(run.run_id)
@@ -85,7 +116,8 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
             mgr.runs.store.save(run)
             span.set_attribute("devcake.verdict", f"failed: {run.error}")
             span.set_status(Status(StatusCode.ERROR, run.error))
-            await restore_after_failure(mgr, run)
+            if not _pre_wipe(mgr, run):
+                await restore_after_failure(mgr, run)
             log.warning("run %s failed (exit %s, attempt %d)",
                         run.run_id, exit_code, run.attempt_of_step)
             return
@@ -97,6 +129,8 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
         # run must fail cleanly so the mission reschedules next cycle
         # instead of stranding in `finalizing` until the watchdog timeout.
         if "transition" not in run.finalized_steps:
+            if _pre_wipe(mgr, run):
+                return
             try:
                 await transitions.transition(mgr, run, result, plan_md)
             except ValueError as e:
@@ -109,9 +143,12 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
                 mgr.runs.store.save(run)
                 span.set_attribute("devcake.verdict", f"failed: {run.error}")
                 span.set_status(Status(StatusCode.ERROR, run.error))
-                await restore_after_failure(mgr, run)
+                if not _pre_wipe(mgr, run):
+                    await restore_after_failure(mgr, run)
                 log.warning("run %s failed with DEV_BAD_OUTPUT: %s",
                             run.run_id, e)
+                return
+            if _pre_wipe(mgr, run):
                 return
             run.finalized_steps.append("transition")
             mgr.runs.store.save(run)

--- a/app/devcake/domain/reconcile.py
+++ b/app/devcake/domain/reconcile.py
@@ -7,6 +7,27 @@ import re
 log = logging.getLogger("devcake.reconcile")
 
 
+def _restamp_store_gen(store, run) -> None:
+    """Bind a kept-alive run into THIS process's wipe generation (docs/10).
+
+    ``wipe_generation`` is process-local and resets to 0 on restart, but run
+    files may still carry ``store_gen`` from a prior process (e.g. 2 after
+    two clears). Without restamping, the first clear in the new process
+    bumps wipe 0→1 and ``_pre_wipe(store_gen=2, wipe=1)`` is false — so
+    in-flight finalize after that clear can still post to the PMO and
+    resurrect the record. Orphaned runs are not restamped (they are
+    terminalled via kill and leave the active set).
+    """
+    wipe_gen = int(getattr(store, "wipe_generation", 0) or 0)
+    if int(getattr(run, "store_gen", 0) or 0) == wipe_gen:
+        return
+    prev = getattr(run, "store_gen", 0)
+    run.store_gen = wipe_gen
+    store.save(run)
+    log.info("reconciliation: restamped store_gen %s → %s for %s",
+             prev, wipe_gen, run.run_id)
+
+
 async def reconcile_runs(manager) -> None:
     """Step 3: orphan dead Dagu runs. Skip state=="finalizing" — those may have
     pending run.artifacts on the ingress stream; killing them to orphaned
@@ -22,6 +43,9 @@ async def reconcile_runs(manager) -> None:
     messaging, finalizer = manager.messaging, manager.finalizer
     for r in store.active():
         if r.state == "finalizing":
+            # keep for reclaim, but born into this process's wipe generation
+            # so a later clear-runs correctly treats it as pre-wipe
+            _restamp_store_gen(store, r)
             log.info("reconciliation: leaving finalizing run %s for reclaim",
                      r.run_id)
             continue
@@ -46,6 +70,7 @@ async def reconcile_runs(manager) -> None:
                             "error_detail": detail})
                     store.save(r)
             else:
+                _restamp_store_gen(store, r)
                 log.info("reconciliation: adopted in-flight run %s (dagu: %s)",
                          r.run_id, label or st or "running")
         except Exception:

--- a/app/devcake/domain/run.py
+++ b/app/devcake/domain/run.py
@@ -72,3 +72,9 @@ class Run(BaseModel):
     # verdict like "rejected: …" because _transition refused to act on the
     # outcome. None means an ordinary success.
     verdict: Optional[str] = None
+    # Process-local wipe generation stamped at launch (docs/10): RunStore.clear
+    # bumps wipe_generation then unlinks files; save() drops any run whose
+    # store_gen is older so in-flight finalize/heartbeat cannot resurrect a
+    # record after "start fresh". Default 0 = born before any wipe in-process
+    # (legacy records load as 0). Optional so older JSON still validates.
+    store_gen: int = 0

--- a/app/devcake/domain/run_bootstrap.py
+++ b/app/devcake/domain/run_bootstrap.py
@@ -47,6 +47,10 @@ class RunBootstrap:
         async with self.dispatch_lock:
             password = await self.messaging.create_run_user(run.run_id)
             run.auth_digest = auth_digest(password)
+            # Stamp the process-local wipe generation so a later clear-runs
+            # cannot be undone by this run's in-flight saves (docs/10).
+            wipe_gen = int(getattr(self.store, "wipe_generation", 0) or 0)
+            run.store_gen = wipe_gen
             self.store.save(run)  # durable intent BEFORE the trigger
             await self.executor.start(
                 params={

--- a/app/devcake/domain/runs.py
+++ b/app/devcake/domain/runs.py
@@ -148,10 +148,24 @@ class RunManager:
             and hmac.compare_digest(run.auth_digest, auth_digest(auth))
         )
 
+    def _pre_wipe(self, run: Run) -> bool:
+        """True when this run was stamped before the last clear-runs wipe
+        (docs/10 store_gen). In-flight finalize/heartbeat must not resurrect
+        records or drive further PMO side effects after "start fresh"."""
+        wipe_gen = int(getattr(self.store, "wipe_generation", 0) or 0)
+        return int(getattr(run, "store_gen", 0) or 0) < wipe_gen
+
     async def handle(self, run_id: str, kind: str, payload: dict) -> None:
         run = self.store.get(run_id)
         if run is None:
             log.warning("message for unknown run %s (%s)", run_id, kind)
+            return
+        # A concurrent clear can wipe the file while we still hold an older
+        # in-memory object only if handle was entered before clear — get()
+        # already returned None above for post-wipe messages. Pre-wipe check
+        # still matters for callers that pass a cached Run into kill/finalize.
+        if self._pre_wipe(run):
+            log.info("drop ingress %s for pre-wipe run %s", kind, run_id)
             return
 
         # heartbeats (2/min/run) and streamed-log batches (one every few
@@ -248,8 +262,16 @@ class RunManager:
             # double-ran side effects after mid-finalize crashes (ISSUES #1).
             if run.state in ("finished", "failed", "timed_out", "orphaned"):
                 return
+            if self._pre_wipe(run):
+                log.info("drop finalize for pre-wipe run %s", run_id)
+                return
             run.state = "finalizing"
             self.store.save(run)
+            if self._pre_wipe(run):
+                # clear raced between the check and save — save was a no-op;
+                # do not drive PMO transitions on a wiped run.
+                log.info("abort finalize after wipe race for %s", run_id)
+                return
             if self.finalizer and run.mission_type == "MAPPER":
                 await self.finalizer.finalize_mapper(run, payload)
             elif self.finalizer and run.mission_pmo_id:
@@ -264,6 +286,9 @@ class RunManager:
     # ── finalization (docs/04 §4 — PMO-less runs: hello) ─────────────────────
 
     async def _finalize(self, run: Run, payload: dict) -> None:
+        if self._pre_wipe(run):
+            log.info("skip hello finalize for pre-wipe run %s", run.run_id)
+            return
         ctx = extract({"traceparent": run.traceparent}) if run.traceparent else None
         with tracer.start_as_current_span(
             "run.finalize", context=ctx, kind=SpanKind.CONSUMER

--- a/app/tests/test_clear.py
+++ b/app/tests/test_clear.py
@@ -20,10 +20,38 @@ def test_runstore_clear(tmp_path: Path):
             created_at=datetime.now(timezone.utc),
         ))
     assert len(store.all()) == 3
+    assert store.wipe_generation == 0
     n = store.clear()
     assert n == 3
+    assert store.wipe_generation == 1
     assert store.all() == []
     assert store.clear() == 0
+    assert store.wipe_generation == 2
+
+
+def test_runstore_save_drops_pre_wipe_runs(tmp_path: Path):
+    """Post-#32 residual A: in-flight finalize holds a Run and must not
+    resurrect the file after clear bumps wipe_generation."""
+    store = RunStore(root=tmp_path / "runs")
+    run = Run(
+        run_id="T-0-1-ONBOARD-AAAAAA",
+        mission_key="T-0",
+        mission_type="ONBOARD",
+        dev_type="senior-dev",
+        seq=1,
+        store_gen=0,
+    )
+    store.save(run)
+    assert store.get(run.run_id) is not None
+    store.clear()
+    assert store.get(run.run_id) is None
+    run.state = "finished"
+    store.save(run)                                   # pre-wipe stamp
+    assert store.get(run.run_id) is None
+    # post-wipe stamp is allowed
+    run.store_gen = store.wipe_generation
+    store.save(run)
+    assert store.get(run.run_id) is not None
 
 
 def test_clear_local_state_preserves_nothing_but_wipes_audit(tmp_path: Path, monkeypatch):
@@ -200,16 +228,26 @@ def run_coro(c):
 
 
 class _DrainExec:
-    """Reports each run as running for N status polls, then terminal."""
+    """Reports each run as running for N status polls, then terminal.
 
-    def __init__(self, running_polls: int = 1):
+    Implements ``stop`` (no-op) so the force-remove pass does not AttributeError
+    on the Fake — a wedged container is modelled by ``running_polls=None``
+    (always running) or a huge poll budget.
+    """
+
+    def __init__(self, running_polls: int | None = 1):
         self.polls: dict[str, int] = {}
-        self.running_polls = running_polls
+        self.running_polls = running_polls  # None = forever running
+        self.stops: list[str] = []
+
+    async def stop(self, rid):
+        self.stops.append(rid)
+        return True
 
     async def status(self, rid):
         n = self.polls.get(rid, 0)
         self.polls[rid] = n + 1
-        if n < self.running_polls:
+        if self.running_polls is None or n < self.running_polls:
             return {"dagRunDetails": {"statusLabel": "running"}}
         return {"dagRunDetails": {"statusLabel": "failed"}}
 
@@ -238,7 +276,9 @@ def test_stop_and_drain_kills_waits_and_skips_finalizing(monkeypatch):
     out = run_coro(stop_and_drain(_store([live, fin]), ex, rm, timeout_s=30))
     assert [k[0] for k in rm.kills] == ["R-1"]          # finalizing untouched
     assert "clear" in rm.kills[0][2]
-    assert out == {"stopped": 1, "undrained": []}
+    assert out["stopped"] == 1
+    assert out["undrained"] == []
+    assert out["force_remove_attempted"] is False
     assert ex.polls["R-1"] >= 3                         # waited past running
 
 
@@ -246,10 +286,41 @@ def test_stop_and_drain_times_out_on_wedged_container(monkeypatch):
     from devcake.api.clear import stop_and_drain
     monkeypatch.setattr("asyncio.sleep", lambda *_: _instant())
     live = SimpleNamespace(run_id="R-9", state="running")
-    out = run_coro(stop_and_drain(_store([live]), _DrainExec(running_polls=10**6),
-                                  _RM(), timeout_s=0.01))
+    ex = _DrainExec(running_polls=None)                 # forever wedged
+    out = run_coro(stop_and_drain(_store([live]), ex, _RM(), timeout_s=0.01))
     assert out["stopped"] == 1
     assert out["undrained"] == ["R-9"]                  # reported, wipe proceeds
+    assert out["force_remove_attempted"] is True        # force pass ran
+    assert out["force_stops"] >= 1
+    assert "R-9" in ex.stops
+
+
+def test_stop_and_drain_force_remove_clears_undrained(monkeypatch):
+    """Force pass: soft drain sees still-running; force stop + re-poll empties live."""
+    from devcake.api.clear import stop_and_drain
+    monkeypatch.setattr("asyncio.sleep", lambda *_: _instant())
+
+    class ForceExec(_DrainExec):
+        def __init__(self):
+            super().__init__(running_polls=None)
+            self._force_cleared = False
+
+        async def stop(self, rid):
+            await super().stop(rid)
+            self._force_cleared = True
+            return True
+
+        async def status(self, rid):
+            if self._force_cleared:
+                return {"dagRunDetails": {"statusLabel": "failed"}}
+            return await super().status(rid)
+
+    live = SimpleNamespace(run_id="R-force", state="running")
+    ex = ForceExec()
+    out = run_coro(stop_and_drain(_store([live]), ex, _RM(), timeout_s=0.01))
+    assert out["force_remove_attempted"] is True
+    assert "R-force" in ex.stops
+    assert out["undrained"] == []
 
 
 def test_stop_and_drain_refetches_state_before_kill(monkeypatch):

--- a/app/tests/test_crash_recovery.py
+++ b/app/tests/test_crash_recovery.py
@@ -392,6 +392,73 @@ def test_recon_adopts_live_runs_and_enriches_exit13(tmp_path):
     assert saved.error == "DEV_FORGE: clone failed"      # exit-13 enrichment
 
 
+def test_recon_restamps_store_gen_for_adopted_and_finalizing(tmp_path):
+    """PR #34 review follow-up: wipe_generation resets to 0 on process start,
+    but run files may still carry store_gen from a prior process. Reconcile
+    must restamp kept-alive runs so the first clear in THIS process treats
+    them as pre-wipe (no PMO post / no resurrect after clear)."""
+    from devcake.domain.orchestrator import finalize as fin_mod
+    from devcake.domain.reconcile import reconcile_runs
+
+    store = RunStore(tmp_path / "runs")
+    assert store.wipe_generation == 0
+
+    # Simulate runs written by a prior process that had cleared twice.
+    live = _make_run(store, state="running", run_id="LIVE-OLD",
+                     store_gen=2, mission_pmo_id="pmo-1")
+    fin = _make_run(store, state="finalizing", run_id="FIN-OLD",
+                    store_gen=5, mission_pmo_id="pmo-2")
+    assert store.get(live.run_id).store_gen == 2
+    assert store.get(fin.run_id).store_gen == 5
+
+    class Executor(FakeExecutor):
+        async def status(self, rid):
+            return {"dagRunDetails": {"status": "running",
+                                      "statusLabel": "running"}}
+
+    messaging = FakeMessaging()
+
+    async def reclaim(handler, verify_auth):
+        pass
+
+    messaging.reclaim_pending = reclaim
+    mgr = RunManager(store, messaging, Executor())
+    mgr._ship_failure = AsyncMock()  # type: ignore[method-assign]
+    run_coro(reconcile_runs(mgr))
+
+    # Born into this process's generation (0 until first clear).
+    assert store.get(live.run_id).store_gen == 0
+    assert store.get(fin.run_id).store_gen == 0
+
+    # First clear in this process → wipe_generation = 1; pre-wipe catches
+    # restamped runs so finalize cannot resurrect or post.
+    posts: list[str] = []
+    store.clear()
+    assert store.wipe_generation == 1
+    assert store.get(live.run_id) is None
+
+    class M:
+        pass
+
+    m = M()
+    m.runs = mgr
+    m.messaging = mgr.messaging
+
+    async def _feed(pmo_id, kind, md, externalize=True):
+        posts.append("feed")
+
+    m._feed = _feed
+    # In-memory object still holds the restamped store_gen=0 from reconcile.
+    live.store_gen = 0
+    run_coro(fin_mod.finalize(m, live, {
+        "result": {"outcome": "executed"},
+        "transcript_md": "should not land",
+        "token_report": {"total_tokens": 1},
+    }))
+    assert store.get(live.run_id) is None
+    assert posts == []
+
+
 def test_recon_enriches_exit14_mcp_setup(tmp_path):
     """Same enrichment for the other classified pre-harness exit: a dead run
     whose step errors carry exit status 14 (MCP setup failed while the app

--- a/app/tests/test_crash_recovery.py
+++ b/app/tests/test_crash_recovery.py
@@ -131,7 +131,8 @@ def test_kill_does_not_resurrect_a_concurrently_wiped_record(tmp_path):
     clear-runs wipe (while kill was awaiting teardown) must NOT store.save it
     back — that recreated a phantom terminal run after 'start fresh'. The
     get()+save() guard in _kill_inner is atomic (no await between), so a gone
-    record stays gone for EVERY killer path."""
+    record stays gone for EVERY killer path. Wipe generation also drops saves
+    whose store_gen predates the clear."""
     store = RunStore(tmp_path / "runs")
     mgr = RunManager(store, FakeMessaging(), FakeExecutor())
     run = _make_run(store, state="running", run_id="W-1")
@@ -142,9 +143,76 @@ def test_kill_does_not_resurrect_a_concurrently_wiped_record(tmp_path):
     run_coro(mgr.kill(run, "timed_out", "watchdog timeout"))
     assert store.get("W-1") is None                    # not resurrected
     # a normal kill (record present) still persists the terminal state
-    live = _make_run(store, state="running", run_id="W-2")
+    live = _make_run(store, state="running", run_id="W-2",
+                     store_gen=store.wipe_generation)
     run_coro(mgr.kill(live, "failed", "operator"))
     assert store.get("W-2").state == "failed"
+
+
+def test_kill_interleaved_with_clear_during_executor_stop(tmp_path):
+    """Issue F: clear bumps wipe_generation while kill awaits executor.stop;
+    the final save must not resurrect the record."""
+    store = RunStore(tmp_path / "runs")
+    gate = asyncio.Event()
+
+    class GatedExecutor(FakeExecutor):
+        async def stop(self, rid):
+            self.stopped.append(rid)
+            await gate.wait()
+            return True
+
+    mgr = RunManager(store, FakeMessaging(), GatedExecutor())
+    run = _make_run(store, state="running", run_id="W-GATE")
+    run.store_gen = 0
+    store.save(run)
+
+    async def scenario():
+        task = asyncio.ensure_future(
+            mgr.kill(run, "failed", "operator stop"))
+        await asyncio.sleep(0)                # let kill reach gated stop
+        store.clear()                         # concurrent wipe mid-kill
+        assert store.get("W-GATE") is None
+        gate.set()
+        await task
+        assert store.get("W-GATE") is None
+
+    asyncio.new_event_loop().run_until_complete(scenario())
+
+
+def test_finalize_does_not_resurrect_or_post_after_clear(tmp_path):
+    """Residual A: in-flight finalize after clear must not recreate the run
+    file or drive further PMO side effects."""
+    from devcake.domain.orchestrator import finalize as fin_mod
+
+    store = RunStore(tmp_path / "runs")
+    mgr = RunManager(store, FakeMessaging(), FakeExecutor())
+    posts: list[str] = []
+    run = _make_run(store, state="running", run_id="F-1",
+                    mission_pmo_id="pmo-1", store_gen=0)
+    store.clear()
+    assert store.get("F-1") is None
+
+    class M:
+        pass
+
+    m = M()
+    m.runs = mgr
+    m.messaging = mgr.messaging
+
+    async def _feed(pmo_id, kind, md, externalize=True):
+        posts.append("feed")
+
+    m._feed = _feed
+
+    # Call the public finalize seam with the pre-wipe in-memory Run (the
+    # race shape: clear unlinked the file while finalize still holds `run`).
+    run_coro(fin_mod.finalize(m, run, {
+        "result": {"outcome": "executed"},
+        "transcript_md": "hello",
+        "token_report": {"total_tokens": 1},
+    }))
+    assert store.get("F-1") is None
+    assert posts == []
 
 
 def test_started_does_not_resurrect_a_killed_run(tmp_path):

--- a/app/tests/test_dispatch_chokepoint.py
+++ b/app/tests/test_dispatch_chokepoint.py
@@ -1,0 +1,99 @@
+"""Dispatch chokepoint tripwire (independent review residual G).
+
+Every Dev ACL user create + executor.start MUST go through
+``RunBootstrap.launch`` so clear-runs can serialize on ``dispatch_lock``.
+PR #30 claimed "poll is the only dispatcher" — false. This AST scan makes
+that class of claim fail CI.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "devcake"
+
+# Production modules allowed to call these (adapters implement the ports;
+# bootstrap is the sole domain caller of both for Dev runs).
+START_ALLOW = {
+    "domain/run_bootstrap.py",
+}
+CREATE_USER_ALLOW = {
+    "domain/run_bootstrap.py",
+    "adapters/redis/messaging.py",   # implements the port
+    "ports/messaging.py",            # Protocol stub body may be empty
+}
+
+
+def _py_files():
+    for p in ROOT.rglob("*.py"):
+        if "__pycache__" in p.parts:
+            continue
+        yield p
+
+
+def _rel(p: Path) -> str:
+    return str(p.relative_to(ROOT)).replace("\\", "/")
+
+
+def _calls_attr(tree: ast.AST, attr: str) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr == attr:
+                return True
+    return False
+
+
+def test_executor_start_only_from_run_bootstrap():
+    offenders = []
+    for path in _py_files():
+        rel = _rel(path)
+        if rel in START_ALLOW:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        if _calls_attr(tree, "start"):
+            # Narrow: only flag `.start(` where the receiver name looks like
+            # an executor (executor / self.executor / self.bootstrap.executor
+            # is in bootstrap only). Broad attr=="start" false-positives on
+            # httpx/asyncio — require the call is `something.start(` with
+            # args matching the ExecutorPort shape is hard in AST; instead
+            # require the attribute chain contains "executor".
+            for node in ast.walk(tree):
+                if not (isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr == "start"):
+                    continue
+                # walk Attribute chain for a Name/Attribute "executor"
+                cur = node.func.value
+                names: list[str] = []
+                while isinstance(cur, ast.Attribute):
+                    names.append(cur.attr)
+                    cur = cur.value
+                if isinstance(cur, ast.Name):
+                    names.append(cur.id)
+                if "executor" in names:
+                    offenders.append(rel)
+                    break
+    assert not offenders, (
+        "executor.start must only be called from RunBootstrap.launch "
+        f"(clear-runs dispatch_lock chokepoint): {offenders}"
+    )
+
+
+def test_create_run_user_only_from_bootstrap_or_adapter():
+    offenders = []
+    for path in _py_files():
+        rel = _rel(path)
+        if rel in CREATE_USER_ALLOW:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "create_run_user"):
+                offenders.append(rel)
+                break
+    assert not offenders, (
+        "create_run_user for Devs must go through RunBootstrap.launch "
+        f"(or the redis adapter implementation): {offenders}"
+    )

--- a/app/tests/test_run_bootstrap.py
+++ b/app/tests/test_run_bootstrap.py
@@ -20,12 +20,20 @@ def run_coro(c):
 
 
 class InMemoryStore:
-    """StatePort adapter for tests — dict-backed, no filesystem."""
+    """StatePort adapter for tests — dict-backed, no filesystem.
+
+    Implements wipe_generation + save guard (docs/10) so launch/clear tests
+    exercise the same contract as RunStore.
+    """
 
     def __init__(self) -> None:
         self._runs: dict[str, Run] = {}
+        self.wipe_generation: int = 0
 
     def save(self, run: Run) -> None:
+        gen = int(getattr(run, "store_gen", 0) or 0)
+        if gen < self.wipe_generation:
+            return
         self._runs[run.run_id] = run.model_copy(deep=True)
 
     def get(self, run_id: str) -> Run | None:
@@ -38,6 +46,12 @@ class InMemoryStore:
     def active(self) -> list[Run]:
         return [r for r in self.all()
                 if r.state in ("dispatched", "running", "finalizing")]
+
+    def clear(self) -> int:
+        self.wipe_generation += 1
+        n = len(self._runs)
+        self._runs.clear()
+        return n
 
 
 class FakeMessaging:
@@ -163,6 +177,29 @@ def test_launch_serializes_on_dispatch_lock():
         await task
         assert len(store.all()) == 1                    # now it proceeds
     asyncio.new_event_loop().run_until_complete(scenario())
+
+
+def test_launch_stamps_store_gen_and_survives_prior_wipe():
+    """After clear bumps wipe_generation, a new launch must stamp store_gen
+    to the current generation and persist; pre-wipe saves must not resurrect."""
+    store = InMemoryStore()
+    bootstrap = RunBootstrap(store, FakeMessaging(), FakeExecutor(store))
+    old = run_coro(bootstrap.launch(_hello_run("HELLO-OLD"), image="img"))
+    assert old.store_gen == 0
+    assert store.get(old.run_id) is not None
+
+    store.clear()
+    assert store.wipe_generation == 1
+    assert store.all() == []
+    # in-memory pre-wipe object must not resurrect after clear
+    old.state = "finished"
+    store.save(old)
+    assert store.get(old.run_id) is None
+
+    fresh = run_coro(bootstrap.launch(_hello_run("HELLO-NEW"), image="img"))
+    assert fresh.store_gen == 1
+    assert store.get(fresh.run_id) is not None
+    assert store.get(fresh.run_id).store_gen == 1
 
 
 def test_dispatch_hello_uses_bootstrap_spine():

--- a/docs/04-orchestrator.md
+++ b/docs/04-orchestrator.md
@@ -65,12 +65,14 @@ Properties:
 
 ### 3.1 Dispatch (ordered, crash-safe)
 
-Mission-specific fields (prompt, attempts, stage label, PMO refs) are built by the caller (`MissionManager.dispatch`, `dispatch_mapper`, hello, OAuth). The **shared spine** is `RunBootstrap.launch` (`domain/run_bootstrap.py`) — one deep module every dispatch flavor must use so ACL lifecycle, auth digest, durable intent, and executor start cannot drift apart:
+Mission-specific fields (prompt, attempts, stage label, PMO refs) are built by the caller (`MissionManager.dispatch`, `dispatch_mapper`, hello, OAuth). The **shared spine** is `RunBootstrap.launch` (`domain/run_bootstrap.py`) — one deep module every dispatch flavor must use so ACL lifecycle, auth digest, durable intent, and executor start cannot drift apart. **`dispatch_lock`** serializes every flavor with clear-runs (poll alone is not enough — oauth / mapper / hello bypass the poll lock). Launch also stamps `run.store_gen` from `RunStore.wipe_generation` so a later clear cannot be undone by in-flight saves (`10-persistence.md`).
 
 ```
 def launch(run, *, image):                         # RunBootstrap — all four flavors
+  async with dispatch_lock:                        # clear-runs holds this for the full wipe
     password = messaging.create_run_user(run.run_id)  # MessagingPort
     run.auth_digest = sha256(password)                # never persist the raw ACL secret
+    run.store_gen = store.wipe_generation             # clear-runs generation guard
     state.save(run)                                   # (1) durable intent BEFORE side effects
     executor.start(params={                           # (2) ExecutorPort (Dagu in prod)
         "RUN_ID": run.run_id, "IMAGE": image,         #     non-secret params only (13 §4)

--- a/docs/10-persistence.md
+++ b/docs/10-persistence.md
@@ -42,6 +42,19 @@ every cycle, nothing on disk.)
 
 Run records are schema **v2**. They contain non-secret execution context and a one-way Redis envelope verifier, never raw Redis passwords, forge/model credentials, or credential-file content. Secret run-spec material is not persisted anywhere: the app builds it from current config when the Dev sends `runspec.get` (`09-messaging.md` §§3, 5). At every boot, an integrity sweep (`RunStore.quarantine_unreadable`) moves unparseable, model-invalid, or **pre-v2** records to `runs/quarantine/` (0600, named in the log) — so one corrupt record can never block boot, and a restored v1 backup (which persisted credentials) can never sit silently in the store. A record that still parses as JSON is **scrubbed of known credential-bearing fields before the move** (quarantine must not become secret-at-rest); only unparseable bytes are preserved verbatim, for inspection, under the restrictive modes. Because a quarantined record is forgotten, boot also best-effort tears down anything it may have left live — the Dagu run, the per-run Redis ACL user, the reply stream — keyed on the file's run id. Quarantined files are removed by clear-runs.
 
+### Wipe generation (`store_gen`)
+
+Clear-runs must not be undone by in-flight writers that still hold a `Run` in memory (finalize, heartbeat, kill). The production `RunStore` keeps a process-local monotonic **`wipe_generation`** (starts at 0; not persisted across app restarts).
+
+| Event | Behavior |
+|---|---|
+| `RunBootstrap.launch` | Stamps `run.store_gen = store.wipe_generation` before the durable save |
+| `RunStore.clear()` | Bumps `wipe_generation`, then unlinks every run JSON (and quarantine) |
+| `RunStore.save(run)` | **No-op** when `run.store_gen < wipe_generation` (log at info) |
+| Mission / hello finalize | Early-abort when pre-wipe — no further PMO posts after a wipe is observed mid-flight |
+
+Legacy records without the field load as `store_gen: 0` (additive optional field — no schema bump). After a clear in-process, only runs launched **after** the wipe (stamped with the new generation) may persist again.
+
 ## 3. `config.yaml` — annotated example (normative shape)
 
 Schema **v4** (docs/16 M12): the connection blocks are plural lists of **instances-with-identities** — each entry carries an operator-chosen `name` (lowercase alnum, ≤12 chars, no hyphens; `^[a-z][a-z0-9]{0,11}$`). The name is the instance's identity everywhere: `Run.pmo_ref`/`repo_ref`, branch prefixes (`devcake/LINEAR-DEV-17`), run ids. **0..N** PMO instances and repos (empty = idle first boot). Two PMO instances must not target the same `(system, api_base, team_key)`; two repos must not target the same URL. An instance with an empty `team_key` (or a repo with an empty `url`) is **valid but idle**. **No `*_env` fields:** secret VALUES are GUI-stored under `/data/secrets/` (ADR-0011) — `config.yaml` holds no credentials.

--- a/docs/10-persistence.md
+++ b/docs/10-persistence.md
@@ -52,6 +52,7 @@ Clear-runs must not be undone by in-flight writers that still hold a `Run` in me
 | `RunStore.clear()` | Bumps `wipe_generation`, then unlinks every run JSON (and quarantine) |
 | `RunStore.save(run)` | **No-op** when `run.store_gen < wipe_generation` (log at info) |
 | Mission / hello finalize | Early-abort when pre-wipe — no further PMO posts after a wipe is observed mid-flight |
+| Startup `reconcile_runs` | Re-stamps adopted / finalizing-for-reclaim runs to **this** process's `wipe_generation` (resets to 0 on restart). Without that, a prior process's `store_gen ≥ 1` would survive a restart and miss the first post-restart clear |
 
 Legacy records without the field load as `store_gen: 0` (additive optional field — no schema bump). After a clear in-process, only runs launched **after** the wipe (stamped with the new generation) may persist again.
 

--- a/docs/11-admin-panel.md
+++ b/docs/11-admin-panel.md
@@ -176,14 +176,20 @@ A prominent **"Open Dagu ↗"** button (new tab, URL from `DAGU_UI_URL`) and a *
 
 **Clear runs** opens a React confirmation dialog (never `window.confirm`) and on confirm calls `POST /api/v1/system/clear-runs`. That endpoint:
 
-The whole wipe runs while holding the poll lock, so no new run is dispatched mid-wipe (hardening 2026-07-19).
+The whole wipe holds **two locks for the entire `clear_all`** (including OpenObserve stream deletes — intentional; dispatch is paused for the full wall-clock window):
 
-1. Stops every dispatched/running Dev via the run manager and **waits for the containers to actually exit** (drain capped just past Dagu's 30 s SIGTERM grace — hardening 2026-07-19: the ACL sweep in step 6 used to race a stopping Dev's grace window, killing it with `AuthenticationError` mid-teardown). Undrained stragglers are reported in the response.
-2. Deletes every local Run file under `/data/state/runs/` (including quarantined records), every run log under `/data/state/runlogs/` (open SSE followers get the end sentinel), and truncates `events.jsonl` (attempt counters and give-up watermarks reset — INV-1 / `10-persistence.md` §5).
-3. Deletes every Dagu `dev-run` history record (`DELETE /dag-runs/dev-run/{id}`, paginated list).
-4. Deletes OpenObserve log/trace streams (they recreate on next ingest; dashboards stay).
-5. Trims the Redis ingress stream, drops leftover reply streams and per-run ACL users.
-6. Deletes every per-mission `activity-*` repo on the internal Gitea (ADR-0014 D4; the "ACL sweep in step 6" wording in step 1 predates this addition — the ACL sweep is step 5).
+- `poll_rt.lock` — no poll cycle / force-poll runs mid-wipe  
+- `RunBootstrap.dispatch_lock` — **every** dispatch flavor (poll, hello, OAuth, mapper “run now”) creates its Redis ACL user + starts the container inside `launch()` under this lock (PR #31). Holding only the poll lock is **not** enough.
+
+Operator impact: no new Devs start until clear finishes; OO stream delete can dominate latency.
+
+1. **Soft drain:** stops every dispatched/running Dev via the run manager and **waits for container exit** (capped just past Dagu's ~30 s SIGTERM grace). Finalizing runs are skipped (their containers already exited).  
+2. **Force-remove pass** (if any still live): re-`stop` each undrained id via Dagu, optional `stop_all` hammer, short re-poll. The app has **no `docker.sock`** — force is Dagu-API only. Residual undrained ids are reported; response `ok` is **false** if any remain. Wipe **still proceeds** so a wedged container cannot hold the operator hostage forever (residual: ACL may race a still-live straggler — check the response / logs).  
+3. **Local wipe with generation guard:** bumps process-local `RunStore.wipe_generation`, then deletes every Run file under `/data/state/runs/` (including quarantine), every run log under `/data/state/runlogs/` (SSE followers get the end sentinel), and truncates `events.jsonl` (attempt counters reset — INV-1 / `10-persistence.md` §5). In-flight finalize/heartbeat/kill cannot resurrect pre-wipe records (`store_gen` < `wipe_generation` → `save` no-op; mission finalize aborts further PMO posts).  
+4. Deletes every Dagu `dev-run` history record (`DELETE /dag-runs/dev-run/{id}`, paginated list).  
+5. Deletes OpenObserve log/trace streams (they recreate on next ingest; dashboards stay).  
+6. Trims the Redis ingress stream, drops leftover reply streams and per-run ACL users (`dev-*`).  
+7. Deletes every per-mission `activity-*` repo on the internal Gitea (ADR-0014 D4).
 
 **Preserved:** `/data/config`, `/data/secrets`, PMO/forge state, circuit breakers (credential health).
 

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -275,6 +275,15 @@ Fixes from the founder's first post-v0.1.1 live pass, plus the multi-repo design
   (missions DEV-126/DEV-127 on the live sandbox).
 - **Missions "Poll now"** (2026-07-18, PR #14, rflpazini): INV-1-aligned poll
   CTA; "New mission" dropped from the board. **live-verified 2026-07-18**.
+- **Clear-runs concurrency follow-up** (post independent review of #30–#32):
+  wipe generation (`store_gen`) so in-flight finalize cannot resurrect runs or
+  keep posting after clear; force-remove pass via Dagu when soft drain times
+  out (then wipe; `ok:false` if still undrained — no host docker.sock);
+  dispatch chokepoint AST tripwire; SelectionChips unavailable tooltip; docs
+  honesty (dual locks for full wipe including OO; not “poll is the only
+  dispatcher”). **built** in this PR · ⏳ live clear-under-load smoke optional
+  before v0.2 tag. **Does not claim** multi-threaded store safety or host-level
+  force-kill.
 
 ### Deferred (v0.2+)
 

--- a/docs/18-operator-contract.md
+++ b/docs/18-operator-contract.md
@@ -37,6 +37,7 @@ proving a fresh machine works is the
 | **Pause intake** | Before maintenance, upgrades, or anything that shouldn't dispatch new work | Sidebar master switch; in-flight runs finish ([`02`](02-domain-model.md), [`11`](11-admin-panel.md)) |
 | **Re-run the fresh-`/data` drill** | Each release you adopt; quarterly otherwise | [operator drill](tutorials/operator-drill.md) — the standing stranger-operability proof |
 | **Rebuild in lockstep on upgrade** | Every time `app/`, `admin/`, or `images/` change | `docker buildx bake all && docker compose up -d` ([`13`](13-deployment.md) §8, `AGENTS.md`) |
+| **Treat Clear runs as a maintenance window** | When you press Clear runs | Dispatch (poll, hello, OAuth, mapper) is paused for the **entire** wipe, including OpenObserve stream deletes ([`11`](11-admin-panel.md)). Soft drain + Dagu force-stop, then wipe; if the response still lists undrained containers, check Dagu — the app has no `docker.sock` and cannot host-kill. In-flight finalize cannot resurrect local run files after the wipe (`store_gen`, [`10`](10-persistence.md)) |
 
 ## 4. Secret rotation (the procedure, in one place)
 


### PR DESCRIPTION
## Why (for the developer — use this PR as the liaison channel)

Independent review of merged **#30 / #31 / #32** found residuals after the
`dispatch_lock` and kill-path fixes. This PR implements **every** residual
from that review under founder-locked decisions (see below). Review comments
on this PR are the preferred place to discuss implementation details.

**Related:** #30 (D5 audit), #31 (dispatch_lock), #32 (kill phantom save).

## Founder decisions (locked — do not re-open without asking)

| ID | Decision |
|---|---|
| **A** | Wipe generation / `store.save` + finalize guard (not “wait for finalizing only”, not docs-only) |
| **B** | Force-remove via **Dagu API** then wipe; `ok: false` if still undrained (not refuse-wipe, not soft-document-only) |
| **C** | Keep dual locks for **entire** `clear_all` including OO; document operator impact only |
| **Shape** | One PR, full residual set |

## What changed

### A — Wipe generation (bug class: finalize resurrects after clear)

- `RunStore.wipe_generation` (process-local); `clear()` bumps then unlinks
- `Run.store_gen` stamped in `RunBootstrap.launch`
- `RunStore.save` no-ops when `store_gen < wipe_generation`
- Mission finalize early-aborts (and re-checks after awaits) so pre-wipe runs
  do not keep posting to the PMO
- Hello finalize / ingress paths respect the same generation

### B — Force-remove undrained (ACL under live container)

- Soft drain unchanged, then: re-`stop` each undrained id, optional
  `stop_all`, short re-poll
- Wipe still proceeds; response includes `force_remove_attempted`,
  `force_stops`, `undrained`
- **Honest limit:** no `docker.sock` on the app — host force-kill is out of
  scope; residual undrained ⇒ `ok: false` + UI copy

### C / D / I / J — Docs honesty

- `docs/11`: dual locks for full wipe, soft drain → force → generation wipe,
  ACL step, operator latency note
- `docs/10`: `store_gen` contract
- `docs/04` §3.1: `dispatch_lock` + `store_gen` in launch spine
- `docs/18`: Clear runs as maintenance window
- `docs/16`: shipped entry without “concurrency fully closed” overclaim

### E — SPA nit

- `SelectionChips` unavailable chips use “catalog unavailable…” title, not
  “click to remove”

### F — Kill interleave regression

- Concurrent clear during gated `executor.stop` does not resurrect

### G — Structure tripwire

- `tests/test_dispatch_chokepoint.py`: AST — production `executor.start` /
  `create_run_user` only via bootstrap (and redis adapter for the latter)

### H — Comment audit

- Clear-path comments no longer imply poll-only dispatch

## Checklist for review / merge

- [x] A: wipe generation + finalize abort
- [x] B: force-remove pass
- [x] C: lock duration documented (code unchanged by design)
- [x] D: claim honesty in roadmap
- [x] E: chip tooltip
- [x] F: interleave kill test
- [x] G: chokepoint AST test
- [x] H: comment audit
- [x] I/J: docs/11, 10, 04, 18, 16

## What this does **not** claim

- Host docker force-kill
- Multi-threaded store safety beyond asyncio cooperative scheduling
- “No concurrency bugs left anywhere in the product”
- Continuous token-burning golden-path CI (unchanged)

## Verification

```text
ruff check: clean
targeted suite (clear / bootstrap / crash residual / chokepoint): 30 passed
full unit suite (bind-mount tree, no Redis): 652 passed, 1 skipped;
  9 failed = tests/test_messaging_live.py (needs Redis — pre-existing env)
```

Optional before v0.2 tag: live clear under a long hello run — no ghost runs,
no AuthenticationError storm; undrained only if Dagu cannot stop.

## Suggested developer follow-ups (out of this PR unless you disagree)

1. Live smoke on the clear path under load (mark roadmap ⏳ → live-verified)
2. If Dagu gains a true force-kill API, wire it into the force pass
3. Optional: fail-closed refuse wipe when undrained if product policy changes