### PR TITLE
fix(admin): missions board fits at 1280 — column floor 9rem→8rem

### DIFF
--- a/admin/spa/src/pages/MissionsPage.jsx
+++ b/admin/spa/src/pages/MissionsPage.jsx
@@ -231,14 +231,16 @@ export default function MissionsPage() {
           create one there and DevCake will pick it up on the next cycle.
         </p>
       )}
-      {/* Fluid columns; overflow-x-auto is the mobile fallback below 9rem/col. */}
+      {/* Fluid columns (max 18rem); 8rem/col floor keeps all 7 columns fitting
+          without horizontal scroll down to 1280 (7×8rem + gaps < the content
+          area) — overflow-x-auto is the mobile fallback below that. */}
       <div data-testid="board-scroller" className="overflow-x-auto pb-4">
         <div className="flex gap-2">
           {COLUMNS.map((col) => (
             <section
               key={col.id}
               aria-label={col.label}
-              className="flex flex-1 basis-0 min-w-[9rem] max-w-[18rem] flex-col rounded-card border border-neutral-200 bg-stone-50 p-2 dark:border-neutral-800 dark:bg-neutral-950/40"
+              className="flex flex-1 basis-0 min-w-[8rem] max-w-[18rem] flex-col rounded-card border border-neutral-200 bg-stone-50 p-2 dark:border-neutral-800 dark:bg-neutral-950/40"
             >
               <header className="mb-2 flex items-center justify-between px-1 pb-1">
                 <span className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">


### PR DESCRIPTION
Fixes the pre-existing `check:ui` failure surfaced in #36: the Missions board's 7 columns at `min-w-[9rem]` (1056px total) overflowed the ~992px content area at a 1280 viewport, failing the suite's own `empty board fits at 1280×900` assertion.

Lowering the column floor to `min-w-[8rem]` (128px) lets the flex-distributed ~135px width win at 1280, so all 7 columns fit without horizontal scroll — matching the board test's intent — while columns stay fluid up to `max-w-[18rem]` at wider viewports. Cards `truncate`, so the narrower floor doesn't overflow them.

**check:ui now fully green:** settings 16, hierarchy 18, redesign 9 (+1 skip), **missions 8 (was 7+1 fail)**, profiles 7 — 58 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)