### PR TITLE
fix: Clear internal forge repo drops health and breakers

### DIFF
--- a/app/devcake/api/internal_repos_service.py
+++ b/app/devcake/api/internal_repos_service.py
@@ -135,7 +135,5 @@ async def delete_internal_repo(name: str, *, internal_forge, store,
         await internal_forge.delete_repo(name)
     except Exception as e:  # noqa: BLE001 — upstream-error contract: any forge failure surfaces as 502 with detail, never a raw 500
         raise HTTPException(502, f"delete failed: {str(e)[:200]}")
-    forge_runtime.forges.pop(name, None)
-    forge_runtime.instances.pop(name, None)
-    forge_runtime.internal.discard(name)
+    forge_runtime.unregister(name)
     return {"deleted": name}

--- a/app/devcake/domain/forge_runtime.py
+++ b/app/devcake/domain/forge_runtime.py
@@ -49,7 +49,8 @@ class ForgeRuntime:
         PUT/DELETE lands here, and wiping them failed in-flight zero-repo
         runspecs (Dev exit 20, burned attempt) and REVIEW finalizes for up
         to a poll cycle. Internal entries leave ONLY via the admin delete
-        endpoint, which pops all three maps plus the `internal` name set."""
+        endpoint (`unregister`), which pops forges/instances/internal plus
+        health and breakers so Clear does not leave a latched ghost."""
         live: dict[str, "ForgePort"] = {}
         insts: dict[str, "RepoInstance"] = {}
         for inst in repos:
@@ -80,6 +81,19 @@ class ForgeRuntime:
         self.instances[name] = inst
         self.forges[name] = forge
         self.internal.add(name)
+
+    def unregister(self, name: str) -> None:
+        """Drop a repo from every runtime map (admin Clear of an internal
+        forge repo). Idempotent — missing names are ignored. Must pop
+        health and breakers too: rebuild only drops those for names not in
+        `live`, and internals are carried across rebuilds, so a Clear that
+        only popped forges/instances/internal left latched breakers and
+        stale health until process restart."""
+        self.forges.pop(name, None)
+        self.instances.pop(name, None)
+        self.internal.discard(name)
+        self.health.pop(name, None)
+        self.breakers.pop(name, None)
 
     def get(self, name: str) -> "ForgePort | None":
         """None = the repo is not (or no longer) configured — the caller's

--- a/app/tests/test_forge_runtime.py
+++ b/app/tests/test_forge_runtime.py
@@ -60,18 +60,79 @@ def test_rebuild_still_drops_removed_external_repos():
 
 
 def test_deleted_internal_repo_stays_deleted_across_rebuild():
-    """The admin Clear endpoint pops forges/instances/internal — a later
-    rebuild must not resurrect the entry from a stale carry-over."""
+    """Admin Clear (unregister) drops all five maps; a later rebuild must not
+    resurrect the entry from a stale carry-over (audit A3 carry-over only
+    applies to names still in `internal`)."""
+    name = "linear-t-1"
     rt = ForgeRuntime()
-    rt.register_internal("linear-t-1", _internal_inst("linear-t-1"), object())
+    rt.register_internal(name, _internal_inst(name), object())
+    # latched state as after a 404 probe on a ghost Gitea repo
+    rt.health[name] = {
+        "ok": False, "transient": False,
+        "detail": "repository access failed (HTTP 404)",
+    }
+    rt.latch(name, "repository access failed (HTTP 404)")
+    assert name in rt.breakers and name in rt.health
+
     # what DELETE /api/v1/internal-repos/{name} does:
-    rt.forges.pop("linear-t-1", None)
-    rt.instances.pop("linear-t-1", None)
-    rt.internal.discard("linear-t-1")
+    rt.unregister(name)
+
+    assert rt.get(name) is None
+    assert rt.instance(name) is None
+    assert name not in rt.internal
+    assert name not in rt.health
+    assert name not in rt.breakers
 
     rt.rebuild([_ext()], lambda inst: object())
-    assert rt.get("linear-t-1") is None
-    assert "linear-t-1" not in rt.internal
+    assert rt.get(name) is None
+    assert name not in rt.internal
+    assert name not in rt.health
+    assert name not in rt.breakers
+
+
+def test_delete_internal_repo_service_clears_health_and_breakers():
+    """Service seam: DELETE Clear must go through unregister so health and
+    breakers do not stick after Gitea/secret cleanup. A regression that only
+    pops forges/instances/internal leaves the SPA circuit_breakers alert
+    until process restart — this test fails that incomplete Clear."""
+    from types import SimpleNamespace
+
+    from devcake.api.internal_repos_service import delete_internal_repo
+
+    name = "linear2-dev-137"
+    rt = ForgeRuntime()
+    rt.register_internal(name, _internal_inst(name), object())
+    rt.health[name] = {
+        "ok": False, "transient": False,
+        "detail": "repository access failed (HTTP 404); the token needs "
+                  "write:repository scope and repo access",
+    }
+    rt.latch(name, rt.health[name]["detail"])
+
+    deleted: list[str] = []
+
+    class _Forge:
+        async def delete_repo(self, repo_name: str) -> None:
+            deleted.append(repo_name)
+
+    store = SimpleNamespace(active=lambda: [])
+    out = run_coro(delete_internal_repo(
+        name, internal_forge=_Forge(), store=store, forge_runtime=rt))
+
+    assert out == {"deleted": name}
+    assert deleted == [name]
+    assert rt.get(name) is None
+    assert rt.instance(name) is None
+    assert name not in rt.internal
+    assert name not in rt.health
+    assert name not in rt.breakers
+
+    # config/secret rebuild must not resurrect (internals only carry names
+    # still in `internal`)
+    rt.rebuild([_ext()], lambda inst: object())
+    assert name not in rt.forges
+    assert name not in rt.health
+    assert name not in rt.breakers
 
 
 # ── reference-only repos (founder decision 2026-07-15, round 2) ──────────────


### PR DESCRIPTION
## Summary

- Admin Clear (`DELETE /api/v1/internal-repos/{name}`) only popped `forges` / `instances` / `internal`, leaving latched `health` and `breakers` so the SPA "Circuit breaker tripped" alert survived until process restart.
- Add `ForgeRuntime.unregister(name)` that drops all five maps; call it from `delete_internal_repo`.
- Tests: runtime Clear + rebuild does not resurrect; service seam test fails if Clear only does the incomplete three-pop.

## Test plan

- [x] `./scripts/pytest_app.sh tests/test_forge_runtime.py` (9 passed after rebake)
- [x] Confirmed incomplete three-pop leaves health/breakers so the service test would fail that regression
- [ ] CI green on PR