### PR TITLE
docs: defer iron-proxy-class Dev egress on the roadmap

### DIFF
--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -420,9 +420,11 @@ contract:
 - Protocol hardens: credential-upload filename allowlist + size cap; PMO
   `download_asset` host allowlist / redirect policy (all adapters that fetch
   feed assets); stronger bootstrap password policy than a short deny-list.
-- Optional: gVisor/Kata for Devs; egress proxy allowlists; OIDC if you must
-  expose the admin UI beyond loopback; OTLP bearer auth on the collector
-  (low priority on a dedicated single-tenant host).
+- Optional: gVisor/Kata for Devs; egress allowlists / credential-injection
+  proxy (e.g. [iron-proxy](https://github.com/ironsh/iron-proxy) class —
+  deferred radar in `16-roadmap.md`); OIDC if you must expose the admin UI
+  beyond loopback; OTLP bearer auth on the collector (low priority on a
+  dedicated single-tenant host).
 
 **Not backlog (explicit non-goals):** multi-tenant SaaS hardening; treating
 prompt injection as a ship-blocking defect; hard-gating dispatch on every

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -590,8 +590,22 @@ long-lived incomplete dialect API.
   approval, merge ordering); still capped at 0-or-1 work repo per mission.
 - **Per-run scoped forge tokens** and the rest of `14` §7 — companion to
   internal per-mission tokens; revisit when threat model demands it.
-- **Network egress allowlists / reduced sandbox-bypass** for non-EXECUTE
-  stages (ISSUES #16).
+- **Network egress allowlists / Dev egress proxy** (ISSUES #16 + radar) —
+  optional Zone B defense-in-depth: default-deny outbound and/or
+  **credential-injection MITM** so Devs hold proxy tokens rather than real
+  model/forge keys. Candidate implementation class:
+  [iron-proxy](https://github.com/ironsh/iron-proxy) (Apache-2.0; Hermes Agent
+  already integrates a host-daemon form). **Not** a sandbox product rewrite and
+  **not** a substitute for zone C branch protection (`14` §0–§3, §6, §11).
+  Promote only after a time-boxed spike proves: (1) enforcement beyond DNS
+  alone (nftables/TPROXY or measured non-bypass for our harness set), (2)
+  coexistence with `devcake_runtime` (Redis, otel-collector, internal Gitea)
+  without naive private-CIDR denials, (3) inventory of what still must be
+  real secrets in-container (OAuth files, uncovered auth schemes, MCP
+  `secret_env`), (4) no silent fallback to real keys when “enforced,” (5)
+  operator docs that do not overclaim isolation. Default-off / ops overlay
+  until then; opportunity cost is high (CA lifecycle, allowlists, Dagu spawn
+  path, every TLS client in the Dev image).
 - **Additional log-connector backends** (Loki; others on demand) in the
   standalone plugin repo <https://github.com/fidecastro/devcake-logs-mcp>
   (`LogBackend` seam; core MCP ports already shipped).


### PR DESCRIPTION
## Summary
- Expand deferred **Network egress allowlists** into optional Zone B defense-in-depth covering allowlists and credential-injection proxies ([iron-proxy](https://github.com/ironsh/iron-proxy) class; Hermes as reference integration).
- Document spike gates (enforce beyond DNS, runtime-network coexistence, secret inventory, no silent real-key fallback, no overclaim) and default-off posture.
- Cross-link from `docs/14-security.md` §11 engineering backlog.

## Test plan
- [x] Docs-only — re-read deferred item against `14` Zone B residuals