### PR TITLE
docs(14): §0a how to read the security contract

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -145,7 +145,7 @@ Operating duties — once at setup and recurring — live in
 
 | Doc | Governs |
 |---|---|
-| **`14-security.md`** | **Product security contract** — threat model, trust zones, operator checklist |
+| **`14-security.md`** | **Product security contract** — threat model, trust zones, §0a reading aid, operator checklist |
 | `01-architecture.md` | Component topology, interaction matrix, ports & adapters layering |
 | `02-domain-model.md` | Entities, fields, Mission Type derivation, label set, state machine |
 | `03-mission-lifecycle.md` | The four Mission Type playbooks, `result.json`, canonical prompts |

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -145,7 +145,7 @@ Operating duties — once at setup and recurring — live in
 
 | Doc | Governs |
 |---|---|
-| **`14-security.md`** | **Product security contract** — threat model, trust zones, §0a reading aid, operator checklist |
+| **`14-security.md`** | **Product security contract** — threat model, trust zones, risk-bucket reading aid, operator checklist |
 | `01-architecture.md` | Component topology, interaction matrix, ports & adapters layering |
 | `02-domain-model.md` | Entities, fields, Mission Type derivation, label set, state machine |
 | `03-mission-lifecycle.md` | The four Mission Type playbooks, `result.json`, canonical prompts |

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -26,6 +26,71 @@ it does not nanny-gate most of those choices. See §8.
 
 If that contract is wrong for your environment, do not run DevCake there.
 
+### 0a. How to read this contract
+
+The rest of this file mixes **design stance**, **implementation residuals**, and
+**fog at the edges**. A simple reading aid (Rumsfeld’s three buckets):
+
+| Term | Meaning here |
+|---|---|
+| **Known knowns** | Named and accepted. Part of the product deal—not bugs to “fix away.” |
+| **Known unknowns** | The *kind* of failure is known; *whether / when / how hard* it hits is not. |
+| **Unknown unknowns** | Paths not fully inventoried (composition, novel tooling, platform surprises). |
+
+**Rule:** design choices (capable agents, prompt injection as input, open Dev
+egress and credentials in the Dev under the current stack) are **known knowns**.
+Do not reclassify them as unknown simply because they are sharp.
+
+Tables below give the **shape** of risk per trust zone (§2). Detail and controls
+follow in later sections; this subsection does not replace zone C branch
+protection or the operator checklist (§9).
+
+#### Zone A — Host / control plane
+
+| Risk shape | Bucket | Implication |
+|---|---|---|
+| Dedicated host; not multi-tenant SaaS | Known known | One machine’s trust boundary is the product boundary |
+| Dagu holds `docker.sock` | Known known | Dagu ≈ host-root blast radius (§5) |
+| Admin auth + GUI secrets (+ export) | Known known | Admin password ≈ full secret set (§4) |
+| `/data`, profiles, backups, `gitea_data` | Known known | Treat as secret dumps (§1, §4) |
+| Control ports default loopback | Known known | Public bind is operator-chosen total exposure |
+| Operator session theft / misconfig | Known unknown | Surfaces known; timing and compliance are ops |
+| Control-plane CVEs / supply chain | Known unknown | Pins help; next CVE is timing |
+| Unlisted admin/Dagu/API footguns | Unknown unknown | Not fully enumerated |
+
+#### Zone B — Dev (agent execution)
+
+| Risk shape | Bucket | Implication |
+|---|---|---|
+| Ticket + repo content steers the agent | Known known | Prompt injection is design input (§3) |
+| Dev is a powerful coding agent | Known known | Code, git, tools, network by design (§6) |
+| Forge + model credentials in the Dev | Known known | Current delivery model (runspec / env / files) |
+| Open outbound internet | Known known | Forge, packages, model APIs (§6) |
+| Redaction only on app→PMO/forge writes | Known known | Does not cover Dev egress (§7) |
+| Shared host kernel (Docker container) | Known known | Not a multi-tenant jail (§6) |
+| This mission’s injection or tool misuse succeeds | Known unknown | Capability known; per-run outcome is not |
+| Key exfil / phone-home over open egress | Known unknown | Easy in principle; whether it happens is incident weather |
+| Write-token misuse if forge protection is weak | Known unknown | Zone C configuration is the variable (§2 zone C) |
+| Novel harness / MCP / dependency composition | Unknown unknown | Tooling churn and combos not fully listed |
+
+#### Zone C — Supply chain (path to default branch)
+
+| Risk shape | Bucket | Implication |
+|---|---|---|
+| Branch protection is the real merge fence | Known known | App cannot invent forge physics (§2 zone C) |
+| Who can write tickets/repos steers agents | Known known | Membership is a control (§0) |
+| `auto_merge` gates the **app** only | Known known | Does not strip Dev merge capability |
+| LEGAL_OUTCOMES + INV-4 | Known known | Block forged **app** deputy paths, not all forge API use |
+| Protection actually on and non-bypass for the Dev account | Known unknown | `/health` is advisory; forge truth is external |
+| Human merges a bad PR | Known unknown | Process risk outside the app |
+| Forge product or novel social path | Unknown unknown | Outside day-to-day inventory |
+
+**One-line read-across:** Zone A is mostly known knowns (host trust is the deal).
+Zone B’s sharp edges are mostly known knowns of a capable agent runtime; the
+weather is known unknowns. Zone C’s strategy is known known; whether protection
+and humans hold is known unknown. Unknown unknowns are fog at the edges—not an
+excuse to treat keys-in-Dev or open egress as mysteries.
+
 ---
 
 ## 1. Asset inventory

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -28,68 +28,19 @@ If that contract is wrong for your environment, do not run DevCake there.
 
 ### 0a. How to read this contract
 
-The rest of this file mixes **design stance**, **implementation residuals**, and
-**fog at the edges**. A simple reading aid (Rumsfeld’s three buckets):
+This file mixes **design stance**, **implementation residuals**, and **fog at
+the edges**. A reading aid (Rumsfeld’s three buckets), applied row-by-row in
+the §10 residual-risk tables:
 
-| Term | Meaning here |
-|---|---|
-| **Known knowns** | Named and accepted. Part of the product deal—not bugs to “fix away.” |
-| **Known unknowns** | The *kind* of failure is known; *whether / when / how hard* it hits is not. |
-| **Unknown unknowns** | Paths not fully inventoried (composition, novel tooling, platform surprises). |
+| Term | Meaning here | What to do with it |
+|---|---|---|
+| **Known known** | Named and accepted — part of the product deal, not a bug to “fix away” | Don’t file it; read the stance (§§2–8) |
+| **Known unknown** | The *kind* of failure is known; *whether / when / how hard* it hits is not | Two flavors: **weather** — you can only watch; **verifiable state** — retire it today via the §9 checklist |
+| **Unknown unknown** | Paths not inventoried (composition, novel tooling, platform surprises) | A finding that maps to no §10 row and no §§2–8 stance is one — report it |
 
-**Rule:** design choices (capable agents, prompt injection as input, open Dev
-egress and credentials in the Dev under the current stack) are **known knowns**.
+**Rule:** design choices — capable agents, prompt injection as input, open Dev
+egress, credentials in the Dev under the current stack — are **known knowns**.
 Do not reclassify them as unknown simply because they are sharp.
-
-Tables below give the **shape** of risk per trust zone (§2). Detail and controls
-follow in later sections; this subsection does not replace zone C branch
-protection or the operator checklist (§9).
-
-#### Zone A — Host / control plane
-
-| Risk shape | Bucket | Implication |
-|---|---|---|
-| Dedicated host; not multi-tenant SaaS | Known known | One machine’s trust boundary is the product boundary |
-| Dagu holds `docker.sock` | Known known | Dagu ≈ host-root blast radius (§5) |
-| Admin auth + GUI secrets (+ export) | Known known | Admin password ≈ full secret set (§4) |
-| `/data`, profiles, backups, `gitea_data` | Known known | Treat as secret dumps (§1, §4) |
-| Control ports default loopback | Known known | Public bind is operator-chosen total exposure |
-| Operator session theft / misconfig | Known unknown | Surfaces known; timing and compliance are ops |
-| Control-plane CVEs / supply chain | Known unknown | Pins help; next CVE is timing |
-| Unlisted admin/Dagu/API footguns | Unknown unknown | Not fully enumerated |
-
-#### Zone B — Dev (agent execution)
-
-| Risk shape | Bucket | Implication |
-|---|---|---|
-| Ticket + repo content steers the agent | Known known | Prompt injection is design input (§3) |
-| Dev is a powerful coding agent | Known known | Code, git, tools, network by design (§6) |
-| Forge + model credentials in the Dev | Known known | Current delivery model (runspec / env / files) |
-| Open outbound internet | Known known | Forge, packages, model APIs (§6) |
-| Redaction only on app→PMO/forge writes | Known known | Does not cover Dev egress (§7) |
-| Shared host kernel (Docker container) | Known known | Not a multi-tenant jail (§6) |
-| This mission’s injection or tool misuse succeeds | Known unknown | Capability known; per-run outcome is not |
-| Key exfil / phone-home over open egress | Known unknown | Easy in principle; whether it happens is incident weather |
-| Write-token misuse if forge protection is weak | Known unknown | Zone C configuration is the variable (§2 zone C) |
-| Novel harness / MCP / dependency composition | Unknown unknown | Tooling churn and combos not fully listed |
-
-#### Zone C — Supply chain (path to default branch)
-
-| Risk shape | Bucket | Implication |
-|---|---|---|
-| Branch protection is the real merge fence | Known known | App cannot invent forge physics (§2 zone C) |
-| Who can write tickets/repos steers agents | Known known | Membership is a control (§0) |
-| `auto_merge` gates the **app** only | Known known | Does not strip Dev merge capability |
-| LEGAL_OUTCOMES + INV-4 | Known known | Block forged **app** deputy paths, not all forge API use |
-| Protection actually on and non-bypass for the Dev account | Known unknown | `/health` is advisory; forge truth is external |
-| Human merges a bad PR | Known unknown | Process risk outside the app |
-| Forge product or novel social path | Unknown unknown | Outside day-to-day inventory |
-
-**One-line read-across:** Zone A is mostly known knowns (host trust is the deal).
-Zone B’s sharp edges are mostly known knowns of a capable agent runtime; the
-weather is known unknowns. Zone C’s strategy is known known; whether protection
-and humans hold is known unknown. Unknown unknowns are fog at the edges—not an
-excuse to treat keys-in-Dev or open egress as mysteries.
 
 ---
 
@@ -446,32 +397,43 @@ Tutorials: `docs/tutorials/01-first-mission.md`, `13-deployment.md`.
 
 ## 10. Residual risk summary
 
+Bucket per §0a. **Weather** = you can only watch; **verify** =
+operator-verifiable state — retire it via the §9 checklist.
+
 ### Zone A — Host / control plane
 
-| Risk | Blast radius | Owns |
-|---|---|---|
-| Dagu or sock compromise | Host root | Design (dedicated host) |
-| Admin password leak / mis-bound :8080 | All GUI secrets + config mutation + clear-runs | Operator + design |
-| Volume/backup theft | All secrets | Operator (host encryption/backups) |
+| Risk | Blast radius | Owns | Bucket |
+|---|---|---|---|
+| Dagu or sock compromise | Host root | Design (dedicated host) | Known known (radius); weather (occurrence) |
+| Admin password leak / mis-bound :8080 | All GUI secrets + config mutation + clear-runs | Operator + design | Verify the bind (§9); leak is weather |
+| Volume/backup theft | All secrets | Operator (host encryption/backups) | Weather |
+| Control-plane CVEs (Dagu, Redis, OO, Gitea images) | Component-dependent; sock-adjacent (Dagu) = host root | Design (pins) + operator (update cadence) | Weather — the next CVE is timing |
 
 ### Zone B — Agent execution
 
-| Risk | Blast radius | Owns |
-|---|---|---|
-| Prompt injection via ticket/repo | Bad PR content; push; **merge if unprotected**; secret exfil | Design + operator (team/repo ACL + branch protection) |
-| Write token on non-EXECUTE | Push (and potentially merge) from “read” stages | Operator (RO PAT) |
-| Open egress | Exfil of env | Design |
-| No Dev cgroup HostConfig | Host resource exhaustion | Engineering debt (§11) |
-| Unauth OTLP | Forged/flooded telemetry on this host | Design (dedicated host) |
+| Risk | Blast radius | Owns | Bucket |
+|---|---|---|---|
+| Prompt injection via ticket/repo | Bad PR content; push; **merge if unprotected**; secret exfil | Design + operator (team/repo ACL + branch protection) | Known known (capability); weather (per-run outcome) |
+| Write token on non-EXECUTE | Push (and potentially merge) from “read” stages | Operator (RO PAT) | Verify — set the RO PAT (§9) |
+| Open egress | Exfil of env | Design | Known known |
+| No Dev cgroup HostConfig | Host resource exhaustion | Engineering debt (§11) | Known known until §11 lands |
+| Unauth OTLP | Forged/flooded telemetry on this host | Design (dedicated host) | Known known |
 
 ### Zone C — Supply chain
 
-| Risk | Blast radius | Owns |
-|---|---|---|
-| Unprotected default branch | Direct or weak path to main (agent **or** app) | **Operator** |
-| Relying on `auto_merge` off alone | Agent still holds write token + CLI | **Operator** (must also protect branch) |
-| `auto_merge` **on** + weak review / no reviewer token | App merges after REVIEW without formal forge approval | Operator |
-| Shared EXECUTE/REVIEW identity | Weaker second look | Operator |
+| Risk | Blast radius | Owns | Bucket |
+|---|---|---|---|
+| Unprotected default branch | Direct or weak path to main (agent **or** app) | **Operator** | Verify at the forge (§9): protection on **and** Dev account non-bypass — `/health` is advisory |
+| Relying on `auto_merge` off alone | Agent still holds write token + CLI | **Operator** (must also protect branch) | Known known — off gates the app only |
+| `auto_merge` **on** + weak review / no reviewer token | App merges after REVIEW without formal forge approval | Operator | Verify — reviewer token + forge review rules (§9) |
+| Shared EXECUTE/REVIEW identity | Weaker second look | Operator | Known known if chosen — warned (§8), not gated |
+| Human merges a bad PR | Bad code lands via the legitimate merge path | Operator (review process) | Weather — process risk outside the app |
+
+**Read-across:** the sharp edges are mostly known knowns of a capable agent
+runtime on a trusted host; the known unknowns split into weather (watch) and
+verifiable state (retire via §9). Anything that maps to no row here and no
+stance in §§2–8 is an **unknown unknown** — which is also the definition of a
+security finding worth reporting.
 
 ---
 

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -29,18 +29,21 @@ If that contract is wrong for your environment, do not run DevCake there.
 ### 0a. How to read this contract
 
 This file mixes **design stance**, **implementation residuals**, and **fog at
-the edges**. A reading aid (Rumsfeld’s three buckets), applied row-by-row in
-the §10 residual-risk tables:
+the edges**. A reading aid (Rumsfeld’s three buckets) and the plain labels the
+§10 residual-risk tables use for them:
 
-| Term | Meaning here | What to do with it |
+| Term | Meaning here | §10 label · what to do |
 |---|---|---|
-| **Known known** | Named and accepted — part of the product deal, not a bug to “fix away” | Don’t file it; read the stance (§§2–8) |
-| **Known unknown** | The *kind* of failure is known; *whether / when / how hard* it hits is not | Two flavors: **weather** — you can only watch; **verifiable state** — retire it today via the §9 checklist |
-| **Unknown unknown** | Paths not inventoried (composition, novel tooling, platform surprises) | A finding that maps to no §10 row and no §§2–8 stance is one — report it |
+| **Known known** | Named and accepted — by design (the deal) or as tracked debt (§11) | **Accepted** · don’t file it; read the stance (§§2–8) |
+| **Known unknown** | The *kind* of failure is known; *whether / when / how hard* it hits is not | **Weather** · you can only watch — or **Verify** · operator-checkable state, retire it via §9 |
+| **Unknown unknown** | Paths not inventoried (composition, novel tooling, platform surprises) | No label — a finding that maps to no §10 row and no §§2–8 stance is one; report it |
 
 **Rule:** design choices — capable agents, prompt injection as input, open Dev
 egress, credentials in the Dev under the current stack — are **known knowns**.
-Do not reclassify them as unknown simply because they are sharp.
+Do not reclassify them as unknown simply because they are sharp. The inverse
+also holds: naming a control here never immunizes it — an implemented claim
+that fails to hold (anything §8 marks **hard** or **gate**; INV-4; §7
+redaction at its choke points) is a bug to report, not weather.
 
 ---
 
@@ -82,7 +85,7 @@ Compromise of Dagu auth, the admin password, or the host is total for that machi
 | Mission text + repo content in prompts | **Trusted by design** (adult-operator / OpenClaw-class). Prompt injection is not a product defect (§3). |
 | Forge + model credentials in the Dev | Required for clone/push and harnesses. Open **egress** by design (forge, package registries, model APIs). |
 | MCP setup commands / `extra_cli_args` | **Admin-equivalent code execution** inside the disposable container (`11-admin-panel.md`). |
-| Skill-store skills (`DevType.skills` / `skills_required`) | **Operator-controlled agent instructions** (same trust class as the MCP command area; **ADR-0016**). Available skills are installed for optional consult; Required adds a soft-force prompt line only (not kernel-enforced). The store repo is writable by anyone with Gitea access. The entrypoint refuses absolute/`..` paths and confines writes to the registry-declared skills dir under `$HOME` (the runspec `skills_dir` is itself validated home-relative — absolute/`..` values fall back to the default) — that guards file placement, not content. |
+| Skill-store skills (`DevType.skills` / `skills_required`) | **Operator-controlled agent instructions** (same trust class as the MCP command area; **ADR-0016**). Available skills are installed for optional consult; Required adds a soft-force prompt line only (not kernel-enforced). The store repo is writable by human Gitea accounts; mission Dev tokens are never collaborators on it (no machine user, no tokens — the app reads it with the admin credential), so an injected Dev cannot poison skills for future runs. The entrypoint refuses absolute/`..` paths and confines writes to the registry-declared skills dir under `$HOME` (the runspec `skills_dir` is itself validated home-relative — absolute/`..` values fall back to the default) — that guards file placement, not content. |
 | Harness flags (`--dangerously-skip-permissions`, etc.) | Autonomous coding requires them; Devs are not a secure sandbox product (§6). |
 | Unauthenticated OTLP to `otel-collector` | Residual on the dedicated host (self-noise / volume fill). Ops signal, not a tenancy boundary (§10). |
 | Internal Gitea mission tokens | **User-scoped, not repo-scoped** (live-verified). Isolation is one machine user + collaborator grant per mission (`adr/0010`), not forge-side repo ACLs. Admin password never enters Devs. **Extra in-container RO clones** expand the same class: **blocker RO mounts** (ADR-0017 — a dependent mission’s Dev may receive a **done** blocker’s `token_read` as an `extra_repos` credential) and **reference repos** (PMO `reference_repos` — RO clone of configured cards into every stage). Still one credential per listed repo, never the Gitea admin password. |
@@ -397,15 +400,18 @@ Tutorials: `docs/tutorials/01-first-mission.md`, `13-deployment.md`.
 
 ## 10. Residual risk summary
 
-Bucket per §0a. **Weather** = you can only watch; **verify** =
-operator-verifiable state — retire it via the §9 checklist.
+Bucket labels per §0a: **Accepted** = the deal (or tracked debt — §11);
+**Weather** = you can only watch; **Verify** = operator-checkable state —
+retire it via the §9 checklist. The label names the decision-relevant aspect;
+nearly every row also pairs an accepted blast radius with an uncertain
+occurrence.
 
 ### Zone A — Host / control plane
 
 | Risk | Blast radius | Owns | Bucket |
 |---|---|---|---|
-| Dagu or sock compromise | Host root | Design (dedicated host) | Known known (radius); weather (occurrence) |
-| Admin password leak / mis-bound :8080 | All GUI secrets + config mutation + clear-runs | Operator + design | Verify the bind (§9); leak is weather |
+| Dagu or sock compromise | Host root | Design (dedicated host) | Accepted — the radius is the deal |
+| Admin password leak / mis-bound :8080 | All GUI secrets + config mutation + clear-runs | Operator + design | Verify the bind (§9); the leak itself is weather |
 | Volume/backup theft | All secrets | Operator (host encryption/backups) | Weather |
 | Control-plane CVEs (Dagu, Redis, OO, Gitea images) | Component-dependent; sock-adjacent (Dagu) = host root | Design (pins) + operator (update cadence) | Weather — the next CVE is timing |
 
@@ -413,27 +419,29 @@ operator-verifiable state — retire it via the §9 checklist.
 
 | Risk | Blast radius | Owns | Bucket |
 |---|---|---|---|
-| Prompt injection via ticket/repo | Bad PR content; push; **merge if unprotected**; secret exfil | Design + operator (team/repo ACL + branch protection) | Known known (capability); weather (per-run outcome) |
+| Prompt injection via ticket/repo | Bad PR content; push; **merge if unprotected**; secret exfil | Design + operator (team/repo ACL + branch protection) | Accepted — the capability is design; per-run outcome is weather |
 | Write token on non-EXECUTE | Push (and potentially merge) from “read” stages | Operator (RO PAT) | Verify — set the RO PAT (§9) |
-| Open egress | Exfil of env | Design | Known known |
-| No Dev cgroup HostConfig | Host resource exhaustion | Engineering debt (§11) | Known known until §11 lands |
-| Unauth OTLP | Forged/flooded telemetry on this host | Design (dedicated host) | Known known |
+| Open egress | Exfil of env | Design | Accepted |
+| No Dev cgroup HostConfig | Host resource exhaustion | Engineering debt (§11) | Accepted — tracked debt (§11) |
+| Unauth OTLP | Forged/flooded telemetry on this host | Design (dedicated host) | Accepted |
+| `activity-*` repos: past transcripts greppable by every future Dev until Clear | Cross-mission exposure of anything choke-point redaction missed (§1, ADR-0014) | Design (single-operator) + operator (Clear cadence) | Accepted |
 
 ### Zone C — Supply chain
 
 | Risk | Blast radius | Owns | Bucket |
 |---|---|---|---|
 | Unprotected default branch | Direct or weak path to main (agent **or** app) | **Operator** | Verify at the forge (§9): protection on **and** Dev account non-bypass — `/health` is advisory |
-| Relying on `auto_merge` off alone | Agent still holds write token + CLI | **Operator** (must also protect branch) | Known known — off gates the app only |
+| Relying on `auto_merge` off alone | Agent still holds write token + CLI | **Operator** (must also protect branch) | Accepted — off gates the app only |
 | `auto_merge` **on** + weak review / no reviewer token | App merges after REVIEW without formal forge approval | Operator | Verify — reviewer token + forge review rules (§9) |
-| Shared EXECUTE/REVIEW identity | Weaker second look | Operator | Known known if chosen — warned (§8), not gated |
+| Shared EXECUTE/REVIEW identity | Weaker second look | Operator | Verify — independent identity (§9); dismissing the §8 warning = accepting |
 | Human merges a bad PR | Bad code lands via the legitimate merge path | Operator (review process) | Weather — process risk outside the app |
 
-**Read-across:** the sharp edges are mostly known knowns of a capable agent
-runtime on a trusted host; the known unknowns split into weather (watch) and
-verifiable state (retire via §9). Anything that maps to no row here and no
-stance in §§2–8 is an **unknown unknown** — which is also the definition of a
-security finding worth reporting.
+**Read-across:** the sharp edges are mostly **accepted** properties of a
+capable agent runtime on a trusted host; the rest splits into weather (watch)
+and verifiable state (retire via §9). Anything that maps to no row here and no
+stance in §§2–8 is an **unknown unknown** — report it. So is any implemented
+claim that fails to hold (§0a Rule): mapping to a stance never immunizes
+breaking it.
 
 ---
 


### PR DESCRIPTION
## Summary
- **§0a How to read this contract** (~18 lines): Rumsfeld three-bucket vocabulary mapped once to the three plain labels §10 uses (**Accepted / Weather / Verify**), plus the design-choice rule and its inverse — an implemented claim failing to hold (§8 hard/gate, INV-4, §7 redaction choke points) is always a reportable finding.
- **§10 Residual risk summary** gains a **Bucket** column using only those three labels — buckets are *applied* only here, so there is one risk summary, not two. Verifiable-state rows say what to retire and where (§9).
- New §10 rows: control-plane CVEs (zone A); `activity-*` transcript exposure across missions (zone B, ADR-0014); human merges a bad PR (zone C).
- Read-across defines reportable findings both ways: unknown unknowns (no row, no stance) **and** broken implemented claims.
- §2B clarification: the skill store is writable by human Gitea accounts only — mission Dev tokens are never collaborators on it (verified against `adapters/gitea/provision.py`), so an injected Dev cannot poison skills for future runs.
- `00-overview.md` blurb: "risk-bucket reading aid".

## Test plan
- [x] Docs-only — §0 → §0a → §1 and §9 → §10 → §11 flows re-read; every Verify pointer lands on a real §9 item; §10 uses only the three §0a-defined labels; skill-store claim checked against provisioning code
