### PR TITLE
fix(dagu): robust DOCKER_GID startup via ./up.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,8 +51,10 @@ ADMIN_PASSWORD=
 DAGU_UI_URL=http://localhost:8525
 OO_UI_URL=http://localhost:5080
 
-# ── Host docker group gid, for Dagu's sock access (stat -c %g /var/run/docker.sock)
-DOCKER_GID=989
+# ── Host docker group gid, for Dagu's sock access
+# Host-specific. Prefer: ./up.sh (discovers from /var/run/docker.sock and
+# upserts this line). Manual: stat -c %g /var/run/docker.sock
+DOCKER_GID=
 
 # (Team key, repository URL, and all credentials are configured through the
 #  admin Config page — no env seeds since schema v4. First boot is empty.)

--- a/README.md
+++ b/README.md
@@ -159,18 +159,21 @@ real EXECUTE: §9.
 ```bash
 git clone https://github.com/fidecastro/devcake && cd devcake
 cp .env.example .env
-# Bootstrap only: strong ADMIN / REDIS / DAGU / OO / GITEA passwords,
-# DOCKER_GID (stat -c %g /var/run/docker.sock). Empty or change-me* values
-# refuse boot unless DEVCAKE_ALLOW_INSECURE=1 (local sandbox only).
-# PMO / forge / model secrets → admin Config after up (not long-lived in .env).
+# Edit .env: strong ADMIN / REDIS / DAGU / OO / GITEA passwords only.
+# Leave DOCKER_GID blank. Empty/change-me* passwords refuse boot unless
+# DEVCAKE_ALLOW_INSECURE=1 (local sandbox only). Operator secrets
+# (PMO / forge / model) go in the admin Config UI after up — not in .env.
 
-docker buildx bake all    # builds all DevCake images (compose never does)
-docker compose up -d      # control ports bind 127.0.0.1
-# App boot auto-creates the OpenObserve ingest user from OO_INGEST_*.
-# Optional dashboard + alerts: python3 scripts/provision_oo.py
+./up.sh --bake            # discovers DOCKER_GID, bakes all images, compose up -d
+# Later restarts (images already baked):  ./up.sh
 
 open http://localhost:8080   # basic auth → Config → secrets + connection tests
+# Optional OO dashboard/alerts: python3 scripts/provision_oo.py
 ```
+
+`./up.sh` is the supported start path: it reads the docker socket’s group id
+into `.env`, optionally bakes, then runs compose. Control ports bind
+`127.0.0.1`. Images are **Bake-only** — compose never builds them.
 
 **Before the first real mission:**
 
@@ -187,14 +190,13 @@ open http://localhost:8080   # basic auth → Config → secrets + connection te
 3. [Tutorial 3 — MCP plugins](docs/tutorials/03-mcp-plugins.md)
 4. Fresh empty volume drill: [operator-drill](docs/tutorials/operator-drill.md)
 
-Rebuild after upgrades or changes under `app/`, `admin/`, or `images/`:
+After upgrades or changes under `app/`, `admin/`, or `images/`:
 
 ```bash
-docker buildx bake all && docker compose up -d
+./up.sh --bake
 ```
 
-Images are **Bake-only**. Compose only runs them. See [`AGENTS.md`](AGENTS.md)
-and [`docs/13-deployment.md`](docs/13-deployment.md).
+More detail: [`AGENTS.md`](AGENTS.md) · [`docs/13-deployment.md`](docs/13-deployment.md).
 
 ---
 

--- a/dagu/init/10-docker-group.sh
+++ b/dagu/init/10-docker-group.sh
@@ -4,6 +4,10 @@
 # created and `sudo -g "#$DOCKER_GID"` fails. Ubuntu has shadow-utils, so we
 # create the group here (custom-init.d runs before the privilege drop).
 # Keeps the daemon at uid 1000 — least privilege for docker.sock access.
+#
+# Invoked by compose's dagu entrypoint wrapper via `sh` (not exec) so a missing
+# host +x bit cannot skip this hook — stock /entrypoint.sh only runs -x files
+# and the bind is :ro. Idempotent if both paths fire.
 set -eu
 if [ "${DOCKER_GID:--1}" != "-1" ]; then
   getent group docker >/dev/null 2>&1 || groupadd -o -g "$DOCKER_GID" docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 # DevCake runtime stack.
 #
 # Images are built ONLY via Bake (docker-bake.hcl) — compose never builds:
-#   docker buildx bake all          # first install / full upgrade
+#   ./up.sh --bake                  # discover DOCKER_GID + bake all + up
+#   ./up.sh                         # day-to-day restart (re-discovers DOCKER_GID)
+#   docker buildx bake all          # first install / full upgrade (manual)
 #   docker buildx bake              # app + admin only
 #   docker buildx bake images       # Dev harnesses + hello
-#   docker compose up -d
+#   docker compose up -d            # needs DOCKER_GID already in .env / env
 #
 # Image tags must match bake output (default TAG/DEVCAKE_TAG=latest).
 name: devcake
@@ -57,6 +59,27 @@ services:
       # entrypoint runs dagu as uid 1000 with group $DOCKER_GID → docker.sock access
       # (least privilege; find yours with: stat -c %g /var/run/docker.sock)
       - DOCKER_GID=${DOCKER_GID:?set DOCKER_GID in .env}
+    # Stock /entrypoint.sh only runs /etc/custom-init.d/* when the file is +x.
+    # The bind is :ro, so a non-executable host file is a silent skip → alpine
+    # `addgroup` fails on this ubuntu image → `sudo: unknown group #$DOCKER_GID`
+    # crash-loop. Always invoke hooks via `sh` (bit-independent), then hand off.
+    entrypoint:
+      - /usr/local/bin/tini
+      - -g
+      - --
+      - /bin/sh
+      - -ec
+      - |
+        if [ -d /etc/custom-init.d ]; then
+          for f in /etc/custom-init.d/*; do
+            [ -f "$$f" ] || continue
+            echo "Running $$f"
+            sh "$$f"
+          done
+        fi
+        exec /entrypoint.sh "$$@"
+      - dagu-init
+    command: ["dagu", "start-all"]
     volumes:
       - dagu_data:/var/lib/dagu
       - ./dagu/dags:/var/lib/dagu/dags:ro  # trusted launch code — RO (docs/14 §5)

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -61,6 +61,8 @@ services:
       - ./dagu/dags:/var/lib/dagu/dags:ro
       - ./dagu/init:/etc/custom-init.d:ro
       - /var/run/docker.sock:/var/run/docker.sock  # ⚠ host root-equivalent — 14 §5
+    # Compose overrides entrypoint: runs custom-init.d via `sh` (bit-independent)
+    # then execs stock /entrypoint.sh — see live docker-compose.yml.
     networks: [control]
 
   redis:
@@ -122,7 +124,7 @@ REDIS_PASSWORD=
 ADMIN_USER=admin
 ADMIN_PASSWORD=
 
-# Host docker group: stat -c %g /var/run/docker.sock
+# Host docker group (auto by ./up.sh; or: stat -c %g /var/run/docker.sock)
 DOCKER_GID=
 
 # Optional local sandbox only — never in production
@@ -139,7 +141,7 @@ Empty or `change-me*` bootstrap passwords refuse app boot unless
 
 - **Version pinned** (`2.10.5` at spec time — everything in this section was **verified live against v2.10.5**, source + running server, and exercised end-to-end at M1). The project rebranded to `dagucloud/dagu` and releases fast; on upgrade, re-check this section against the new version.
 - **Auth (verified at M1):** v2.10.5 locks the API by default (401). We run `DAGU_AUTH_MODE=basic` with `DAGU_AUTH_BASIC_USERNAME/PASSWORD` (env names confirmed from the source's config loader); the app sends HTTP Basic on every call; `/api/v1/health` stays open for the compose healthcheck.
-- **docker.sock access (verified at M1):** the image's entrypoint always drops to uid 1000 via sudo, and its `DOCKER_GID` group setup is broken on the ubuntu base (alpine-only `addgroup`). Our `dagu/init/10-docker-group.sh` (mounted at `/etc/custom-init.d/`, the image's own hook) creates the docker group with `groupadd`, so the daemon runs as `dagu:docker` — least privilege, no root daemon.
+- **docker.sock access (verified at M1):** the image's entrypoint always drops to uid 1000 via sudo, and its `DOCKER_GID` group setup is broken on the ubuntu base (alpine-only `addgroup`). Our `dagu/init/10-docker-group.sh` (mounted at `/etc/custom-init.d/`) creates the docker group with `groupadd`, so the daemon runs as `dagu:docker` — least privilege, no root daemon. Stock `/entrypoint.sh` only runs custom-init scripts that are `+x`, and the bind is `:ro`, so a non-executable host file is a silent skip → `sudo: unknown group #$DOCKER_GID` crash-loop. Compose therefore wraps the entrypoint and always invokes hooks via `sh` before handing off (does not depend on the host execute bit; git still tracks the script as `100755`).
 - **Step ids are `^[a-zA-Z][a-zA-Z0-9_]*$`** (verified) — underscores, not dashes: the DAG's step is `run_dev`.
 - **Auto-retry disabled (verified):** the DAG sets `retry_policy: {limit: 0}` — Dagu would otherwise auto-retry failed runs 3×, fighting DevCake's own attempt counting (`15-errors-and-retries.md` §2).
 - **UI:** served at root on host port 8525; the admin panel links to it with a button (no iframe, no base-path/proxy configuration — confirmed decision).
@@ -189,7 +191,7 @@ steps:
         REDIS_PASSWORD: ${params.REDIS_PASSWORD}
 ```
 
-> Notes from the live verification: no `volumes:` are needed (credentials arrive via `runspec.get`, not bind mounts — and bind-mount sources would resolve on the *daemon host*, not inside the Dagu container). The stock `ghcr.io/dagucloud/dagu` image ships **no docker CLI**, so a shell `docker run` fallback is not viable — irrelevant, since the native executor (Moby SDK over the mounted socket) is fully verified. The image's stock `DOCKER_GID` entrypoint is broken on the 2.10.5 ubuntu image — our `dagu/init/10-docker-group.sh` custom-init fix creates the docker group so the daemon runs as `dagu:docker` (not root / not `user: "0:0"`). In the `container:` env map, host-process env does **not** resolve implicitly; anything beyond params would need DAG-level `secrets:`/`env:` — we deliberately need neither.
+> Notes from the live verification: no `volumes:` are needed (credentials arrive via `runspec.get`, not bind mounts — and bind-mount sources would resolve on the *daemon host*, not inside the Dagu container). The stock `ghcr.io/dagucloud/dagu` image ships **no docker CLI**, so a shell `docker run` fallback is not viable — irrelevant, since the native executor (Moby SDK over the mounted socket) is fully verified. The image's stock `DOCKER_GID` entrypoint is broken on the 2.10.5 ubuntu image — our `dagu/init/10-docker-group.sh` custom-init fix (always invoked via `sh` by the compose entrypoint wrapper, so host `+x` is not required) creates the docker group so the daemon runs as `dagu:docker` (not root / not `user: "0:0"`). In the `container:` env map, host-process env does **not** resolve implicitly; anything beyond params would need DAG-level `secrets:`/`env:` — we deliberately need neither.
 
 ## 5. Two-level containers and networking
 
@@ -262,7 +264,7 @@ Compose services that opt into the **fluentd logging driver** (`dagu`, `redis`, 
 
 ## 8. Runbook
 
-- **First run:** `cp .env.example .env` → strong bootstrap passwords + `DOCKER_GID` → `docker buildx bake all` → `docker compose up -d` → open `http://localhost:8080` → **Configuration** (PMO + model/harness secrets, Dev Types) and **Repositories** (`#/repos`: forge tokens + merge posture) → connection tests → done. Labels bootstrap on startup; **OpenObserve ingest user** is auto-created at app boot from `OO_INGEST_*` (dashboard/alerts still optional via `scripts/provision_oo.py`). Then `14` §9 checklist before first EXECUTE.
+- **First run:** `cp .env.example .env` → strong bootstrap passwords → `./up.sh --bake` (discovers `DOCKER_GID` from the docker socket, bakes all images, `compose up -d`) → open `http://localhost:8080` → **Configuration** (PMO + model/harness secrets, Dev Types) and **Repositories** (`#/repos`: forge tokens + merge posture) → connection tests → done. Day-to-day restarts: `./up.sh`. Labels bootstrap on startup; **OpenObserve ingest user** is auto-created at app boot from `OO_INGEST_*` (dashboard/alerts still optional via `scripts/provision_oo.py`). Then `14` §9 checklist before first EXECUTE.
 - **Upgrading from a pre-Bake install (app ran as root):** the baked app image runs as non-root uid 1000, so `/data` files written by the old root-running app (config.yaml, run records, secrets) crash-loop boot with `PermissionError`. One-time fix before `up`:
   `docker run --rm -v devcake_devcake_data:/data alpine chown -R 1000:1000 /data`
 

--- a/docs/tutorials/01-first-mission.md
+++ b/docs/tutorials/01-first-mission.md
@@ -35,7 +35,8 @@ Fill in **bootstrap only** (schema v4 — see `.env.example`):
 - Strong passwords: `ADMIN_*`, `REDIS_PASSWORD`, `DAGU_PASSWORD`, `OO_*`,
   `GITEA_ADMIN_PASSWORD` (empty/`change-me*` refuse boot unless
   `DEVCAKE_ALLOW_INSECURE=1`).
-- `DOCKER_GID` — `stat -c %g /var/run/docker.sock`.
+- Leave `DOCKER_GID` blank — `./up.sh` discovers it from
+  `/var/run/docker.sock` (or set manually with `stat -c %g /var/run/docker.sock`).
 
 **Do not** put Linear/forge/model tokens in `.env` for normal ops — Config page
 stores them under `/data/secrets/` (ADR-0011).
@@ -43,8 +44,8 @@ stores them under `/data/secrets/` (ADR-0011).
 > ⚠️ Don't put inline comments after values in `.env`.
 
 ```bash
-docker buildx bake all    # FIRST: app, admin, all Dev images
-docker compose up -d      # compose does not build DevCake images
+./up.sh --bake            # DOCKER_GID + bake all + compose up -d
+# Day-to-day (images already baked):  ./up.sh
 ```
 
 Open **http://localhost:8080** (loopback; admin user/password from `.env`).

--- a/docs/tutorials/operator-drill.md
+++ b/docs/tutorials/operator-drill.md
@@ -22,7 +22,7 @@ GUI is up:
 - `REDIS_PASSWORD`, `DAGU_PASSWORD`, `ADMIN_USER`/`ADMIN_PASSWORD` (strong; boot refuses empty/default)
 - `OO_ROOT_PASSWORD`, `OO_INGEST_EMAIL`/`OO_INGEST_PASSWORD` (the OO service account; needs a special char)
 - `GITEA_ADMIN_PASSWORD` (the internal fallback forge's admin)
-- `DOCKER_GID` (`stat -c %g /var/run/docker.sock`)
+- Leave `DOCKER_GID` blank — filled by `./up.sh`
 
 There are **no** `LINEAR_API_KEY`, `GITHUB_TOKEN`, `DEVCAKE_TEAM_KEY`, … lines
 anymore — those are v3 and were removed at v4.
@@ -31,8 +31,7 @@ anymore — those are v3 and were removed at v4.
 
 ```bash
 docker volume rm devcake_devcake_data          # DESTRUCTIVE — the operator drill
-docker buildx bake all
-docker compose up -d
+./up.sh --bake                                 # discovers DOCKER_GID, bakes, ups
 # App boot creates the OO ingest user from OO_INGEST_* (fail-loud).
 # Optional: dashboard + alerts (docs/12 §5):
 #   python3 scripts/provision_oo.py

--- a/up.sh
+++ b/up.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Bring up the DevCake stack with host-discovered DOCKER_GID.
+#
+#   ./up.sh                 # upsert DOCKER_GID → docker compose up -d
+#   ./up.sh --bake          # bake all first, then up
+#   ./up.sh --bake app admin
+#   ./up.sh -- dagu app     # pass service names to compose up
+#   ./up.sh --dry-run       # print discovered GID + planned actions
+#
+# DOCKER_GID is host-specific (the group of /var/run/docker.sock). Compose
+# requires it for Dagu's sock access; this script always re-discovers and
+# writes it into .env so plain `docker compose up -d` works afterwards too.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+SOCK="${DOCKER_SOCK:-/var/run/docker.sock}"
+DRY_RUN=0
+DO_BAKE=0
+BAKE_TARGETS=()
+COMPOSE_ARGS=()
+
+usage() {
+  sed -n '2,12p' "$0" | sed 's/^# \?//'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage 0 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --bake)
+      DO_BAKE=1
+      shift
+      # Collect bake targets until -- or end (default: all).
+      while [[ $# -gt 0 && "$1" != --* && "$1" != "--" ]]; do
+        BAKE_TARGETS+=("$1")
+        shift
+      done
+      ;;
+    --)
+      shift
+      COMPOSE_ARGS+=("$@")
+      break
+      ;;
+    -*)
+      echo "unknown option: $1 (try --help)" >&2
+      usage 2
+      ;;
+    *)
+      # Bare args after options → compose service names (same as after --).
+      COMPOSE_ARGS+=("$@")
+      break
+      ;;
+  esac
+done
+
+discover_docker_gid() {
+  if [[ ! -e "$SOCK" ]]; then
+    echo "error: $SOCK not found — is the Docker daemon running?" >&2
+    exit 1
+  fi
+  local gid=""
+  if gid=$(stat -c '%g' "$SOCK" 2>/dev/null); then
+    :
+  elif gid=$(stat -f '%g' "$SOCK" 2>/dev/null); then
+    : # BSD/macOS
+  else
+    echo "error: cannot read group id of $SOCK" >&2
+    exit 1
+  fi
+  if [[ ! "$gid" =~ ^[0-9]+$ ]]; then
+    echo "error: unexpected DOCKER_GID from $SOCK: ${gid@Q}" >&2
+    exit 1
+  fi
+  printf '%s\n' "$gid"
+}
+
+upsert_env_var() {
+  local key="$1" val="$2" file="$3"
+  local tmp
+  tmp=$(mktemp)
+  if [[ -f "$file" ]]; then
+    awk -v k="$key" -v v="$val" '
+      BEGIN { done = 0 }
+      $0 ~ ("^" k "=") {
+        print k "=" v
+        done = 1
+        next
+      }
+      { print }
+      END {
+        if (!done) {
+          if (NR > 0) print ""
+          print k "=" v
+        }
+      }
+    ' "$file" >"$tmp"
+  else
+    printf '%s=%s\n' "$key" "$val" >"$tmp"
+  fi
+  # Preserve mode when replacing an existing .env (often 600).
+  if [[ -f "$file" ]]; then
+    chmod --reference="$file" "$tmp" 2>/dev/null || chmod "$(stat -c '%a' "$file" 2>/dev/null || echo 600)" "$tmp"
+  else
+    chmod 600 "$tmp"
+  fi
+  mv "$tmp" "$file"
+}
+
+GID="$(discover_docker_gid)"
+echo "── DOCKER_GID=${GID}  (from ${SOCK})"
+
+if [[ ! -f .env ]]; then
+  if [[ -f .env.example ]]; then
+    echo "── creating .env from .env.example"
+    if [[ "$DRY_RUN" -eq 0 ]]; then
+      cp .env.example .env
+      chmod 600 .env
+    fi
+  else
+    echo "error: no .env and no .env.example — create .env with bootstrap passwords first" >&2
+    exit 1
+  fi
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "── would upsert DOCKER_GID=${GID} in .env"
+  if [[ "$DO_BAKE" -eq 1 ]]; then
+    if [[ ${#BAKE_TARGETS[@]} -eq 0 ]]; then
+      echo "── would: docker buildx bake all"
+    else
+      echo "── would: docker buildx bake ${BAKE_TARGETS[*]}"
+    fi
+  fi
+  echo "── would: docker compose up -d ${COMPOSE_ARGS[*]:-}"
+  exit 0
+fi
+
+upsert_env_var DOCKER_GID "$GID" .env
+# Export so this shell's compose invocation sees it even if env_file order is odd.
+export DOCKER_GID="$GID"
+
+if [[ "$DO_BAKE" -eq 1 ]]; then
+  if [[ ${#BAKE_TARGETS[@]} -eq 0 ]]; then
+    echo "── docker buildx bake all"
+    docker buildx bake all
+  else
+    echo "── docker buildx bake ${BAKE_TARGETS[*]}"
+    docker buildx bake "${BAKE_TARGETS[@]}"
+  fi
+fi
+
+if [[ ${#COMPOSE_ARGS[@]} -gt 0 ]]; then
+  echo "── docker compose up -d ${COMPOSE_ARGS[*]}"
+  docker compose up -d "${COMPOSE_ARGS[@]}"
+else
+  echo "── docker compose up -d"
+  docker compose up -d
+fi
+
+echo "── stack starting (admin: http://localhost:8080)"
+echo "   bootstrap passwords still come from .env; operator secrets via Config."


### PR DESCRIPTION
## Summary

- **Dagu never-up when init script loses `+x`:** stock entrypoint only runs `/etc/custom-init.d/*` if executable; the bind is `:ro`, so a non-executable host file is a silent skip → alpine `addgroup` fails → `sudo: unknown group #$DOCKER_GID` crash-loop. Compose now wraps the entrypoint and always invokes hooks via `sh`.
- **Root `./up.sh`:** discovers `DOCKER_GID` from `/var/run/docker.sock`, upserts `.env`, optionally bakes, then `compose up -d`.
- **Docs/quickstart** point at `./up.sh --bake` / `./up.sh` as the supported start path.

## Test plan

- [x] `chmod -x dagu/init/10-docker-group.sh` + recreate dagu → healthy with entrypoint wrapper
- [x] Restored `+x` path still healthy; daemon runs as `dagu:docker`
- [x] `./up.sh --dry-run` reports discovered GID
- [x] Blanked `DOCKER_GID=` in `.env` → `./up.sh -- dagu` rewrote `DOCKER_GID=989` and left dagu healthy