### PR TITLE
fix(security): hygiene hardening for secrets, probes, and asset downloads

### DIFF
--- a/app/devcake/adapters/gitea_issues/adapter.py
+++ b/app/devcake/adapters/gitea_issues/adapter.py
@@ -8,9 +8,11 @@ origin reachable from the app (internal: http://gitea:3000).
 from __future__ import annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from typing import Any, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
@@ -37,11 +39,14 @@ _NAMED_ASSET_RE = re.compile(
     r"\[([^\]]+\.\w{1,8})\]\((https?://[^\s)]+/attachments/[^\s)]+)\)")
 _BARE_ASSET_RE = re.compile(r"(https?://[^\s)]+/attachments/[A-Za-z0-9-]+)")
 
-# Bundled Gitea ROOT_URL is browser-facing (localhost:3300); the app reaches
-# the container as api_base (gitea:3000). Only these presentation hosts may
-# be rewritten onto the origin — never arbitrary foreign hosts (that made
-# the download allowlist vacuous). See docs/14 §11.
-_REWRITEABLE_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+# Browser-facing loopback names for bundled ROOT_URL (localhost:3300). The
+# app reaches the container as api_base (gitea:3000). Presentation hosts also
+# include GITEA_UI_URL (same signal as internal forge) and the api_base host.
+# Foreign hosts are never rewritten onto the origin (docs/14 §11).
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# Credentialed download_asset path pin — Gitea attachment bytes, not the API.
+_ATTACHMENT_PATH_PREFIX = "/attachments/"
 
 
 class GiteaIssuesAdapter:
@@ -82,28 +87,43 @@ class GiteaIssuesAdapter:
         # in browser_download_url) so the app container can fetch via api_base.
         self._origin = self._api.removesuffix("/api/v1") if self._api else ""
 
+    def _presentation_hosts(self) -> set[str]:
+        """Hosts that may appear on ticket / browser_download_url.
+
+        Fetch origin (api_base) + operator UI (GITEA_UI_URL, default
+        localhost:3300) + loopback. Humans still use Gitea out of band;
+        this only teaches the app which faces belong to *this* Gitea.
+        """
+        hosts = set(_LOOPBACK_HOSTS)
+        ui = (os.environ.get("GITEA_UI_URL") or "http://localhost:3300").strip()
+        for base in (self._origin, self._api, ui):
+            if not base:
+                continue
+            h = urlsplit(base).hostname
+            if h:
+                hosts.add(h.lower())
+        return hosts
+
     def _app_reachable_url(self, url: str) -> str:
-        """Rewrite browser ROOT_URL hosts to the configured api_base origin.
+        """Rewrite presentation hosts to the configured api_base origin.
 
-        Self-hosted Gitea returns attachment URLs with ROOT_URL
-        (http://localhost:3300/...) which is unreachable from the app
-        container; the docker-network origin (http://gitea:3000) is.
+        Self-hosted Gitea returns attachment URLs with ROOT_URL /
+        GITEA_UI_URL which may be unreachable from the app container; the
+        docker-network origin (http://gitea:3000) is.
 
-        Only ``_REWRITEABLE_HOSTS`` (localhost / loopback) are rewritten —
-        foreign hosts are left unchanged so the download allowlist can
-        refuse them (docs/14 §11).
+        Only presentation hosts are rewritten — foreign hosts are left
+        unchanged so the download allowlist can refuse them (docs/14 §11).
         """
         if not url or not self._origin:
             return url
-        from urllib.parse import urlsplit, urlunsplit
         parts = urlsplit(url)
         origin_parts = urlsplit(self._origin)
         if not parts.scheme or not parts.netloc:
             return url
         host = (parts.hostname or "").lower()
-        if host not in _REWRITEABLE_HOSTS:
+        if host not in self._presentation_hosts():
             return url
-        if parts.netloc == origin_parts.netloc:
+        if parts.netloc.lower() == origin_parts.netloc.lower():
             return url
         return urlunsplit((
             origin_parts.scheme, origin_parts.netloc,
@@ -111,16 +131,18 @@ class GiteaIssuesAdapter:
         ))
 
     def _asset_allowed_hosts(self) -> set[str]:
-        """Hosts permitted on download_asset URLs (origin + rewriteable UI)."""
-        from urllib.parse import urlsplit
-        allowed = set(_REWRITEABLE_HOSTS)
-        for base in (self._origin, self._api):
-            if not base:
-                continue
-            h = urlsplit(base).hostname
-            if h:
-                allowed.add(h.lower())
-        return allowed
+        """Hosts permitted on download_asset URLs (presentation set)."""
+        return self._presentation_hosts()
+
+    def _finalize_fetch_url(self, url: str) -> str:
+        """Rewrite presentation → origin, then pin netloc + attachment path."""
+        from ...domain.asset_fetch import (
+            assert_fetch_netloc, assert_path_prefix,
+        )
+        current = self._app_reachable_url(url)
+        assert_fetch_netloc(current, self._origin)
+        assert_path_prefix(current, _ATTACHMENT_PATH_PREFIX)
+        return current
 
     # ── HTTP ────────────────────────────────────────────────────────────────
 
@@ -573,22 +595,27 @@ class GiteaIssuesAdapter:
             meta.get("browser_download_url") or meta.get("uuid") or "")
 
     async def download_asset(self, url: str) -> bytes:
-        """Fetch an attachment; host allowlist before rewrite, no off-host
-        redirects with auth (docs/14 §11)."""
+        """Fetch an attachment; presentation allowlist, rewrite onto api_base,
+        path/netloc pin, size cap, no off-allowlist redirects with auth
+        (docs/14 §11)."""
         from ...domain.asset_fetch import (
             AssetUrlError, assert_downloadable_asset_url,
-            resolve_redirect_location,
+            enforce_download_byte_cap, resolve_redirect_location,
         )
+        if not self._origin:
+            raise RuntimeError(
+                "gitea_issues download refused: api_base is empty")
         allowed = self._asset_allowed_hosts()
-        # 1) refuse evil hosts on the ORIGINAL URL (before rewrite)
         try:
+            # 1) refuse evil hosts on the ORIGINAL URL (before rewrite)
             url = assert_downloadable_asset_url(
                 url, allowed_hosts=allowed, allow_http=True)
+            # 2) presentation → origin; pin netloc + /attachments/ path
+            current = self._finalize_fetch_url(url)
         except AssetUrlError as e:
             raise RuntimeError(f"gitea_issues download refused: {e}") from e
-        # 2) rewrite only localhost/loopback → docker-network origin
-        current = self._app_reachable_url(url)
         headers = self._headers()
+        cap = self.capabilities().attachment_max_bytes
         try:
             async with httpx.AsyncClient(
                     timeout=60, transport=self._transport,
@@ -599,14 +626,13 @@ class GiteaIssuesAdapter:
                         loc = resp.headers.get("location") or ""
                         try:
                             nxt = resolve_redirect_location(current, loc)
-                            # validate pre-rewrite host, then rewrite loopback
                             nxt = assert_downloadable_asset_url(
                                 nxt, allowed_hosts=allowed, allow_http=True)
+                            current = self._finalize_fetch_url(nxt)
                         except AssetUrlError as e:
                             raise RuntimeError(
                                 f"gitea_issues download redirect refused: {e}"
                             ) from e
-                        current = self._app_reachable_url(nxt)
                         continue
                     break
                 else:
@@ -619,7 +645,14 @@ class GiteaIssuesAdapter:
         if resp.status_code >= 400:
             raise RuntimeError(
                 f"gitea_issues download → {resp.status_code}: {resp.text[:200]}")
-        return resp.content
+        try:
+            return enforce_download_byte_cap(
+                resp.content,
+                content_length=resp.headers.get("content-length"),
+                max_bytes=cap,
+            )
+        except AssetUrlError as e:
+            raise RuntimeError(f"gitea_issues download refused: {e}") from e
 
     # ── meta ────────────────────────────────────────────────────────────────
 

--- a/app/devcake/adapters/gitea_issues/adapter.py
+++ b/app/devcake/adapters/gitea_issues/adapter.py
@@ -37,6 +37,12 @@ _NAMED_ASSET_RE = re.compile(
     r"\[([^\]]+\.\w{1,8})\]\((https?://[^\s)]+/attachments/[^\s)]+)\)")
 _BARE_ASSET_RE = re.compile(r"(https?://[^\s)]+/attachments/[A-Za-z0-9-]+)")
 
+# Bundled Gitea ROOT_URL is browser-facing (localhost:3300); the app reaches
+# the container as api_base (gitea:3000). Only these presentation hosts may
+# be rewritten onto the origin — never arbitrary foreign hosts (that made
+# the download allowlist vacuous). See docs/14 §11.
+_REWRITEABLE_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
 
 class GiteaIssuesAdapter:
     """PMOPort over Gitea Issues REST API (/api/v1). Issue-only missions."""
@@ -77,11 +83,15 @@ class GiteaIssuesAdapter:
         self._origin = self._api.removesuffix("/api/v1") if self._api else ""
 
     def _app_reachable_url(self, url: str) -> str:
-        """Rewrite Gitea ROOT_URL hosts to the configured api_base origin.
+        """Rewrite browser ROOT_URL hosts to the configured api_base origin.
 
         Self-hosted Gitea returns attachment URLs with ROOT_URL
         (http://localhost:3300/...) which is unreachable from the app
         container; the docker-network origin (http://gitea:3000) is.
+
+        Only ``_REWRITEABLE_HOSTS`` (localhost / loopback) are rewritten —
+        foreign hosts are left unchanged so the download allowlist can
+        refuse them (docs/14 §11).
         """
         if not url or not self._origin:
             return url
@@ -90,13 +100,27 @@ class GiteaIssuesAdapter:
         origin_parts = urlsplit(self._origin)
         if not parts.scheme or not parts.netloc:
             return url
-        # only rewrite same-path attachments/API links that disagree on host
+        host = (parts.hostname or "").lower()
+        if host not in _REWRITEABLE_HOSTS:
+            return url
         if parts.netloc == origin_parts.netloc:
             return url
         return urlunsplit((
             origin_parts.scheme, origin_parts.netloc,
             parts.path, parts.query, parts.fragment,
         ))
+
+    def _asset_allowed_hosts(self) -> set[str]:
+        """Hosts permitted on download_asset URLs (origin + rewriteable UI)."""
+        from urllib.parse import urlsplit
+        allowed = set(_REWRITEABLE_HOSTS)
+        for base in (self._origin, self._api):
+            if not base:
+                continue
+            h = urlsplit(base).hostname
+            if h:
+                allowed.add(h.lower())
+        return allowed
 
     # ── HTTP ────────────────────────────────────────────────────────────────
 
@@ -549,12 +573,44 @@ class GiteaIssuesAdapter:
             meta.get("browser_download_url") or meta.get("uuid") or "")
 
     async def download_asset(self, url: str) -> bytes:
-        url = self._app_reachable_url(url)
+        """Fetch an attachment; host allowlist before rewrite, no off-host
+        redirects with auth (docs/14 §11)."""
+        from ...domain.asset_fetch import (
+            AssetUrlError, assert_downloadable_asset_url,
+            resolve_redirect_location,
+        )
+        allowed = self._asset_allowed_hosts()
+        # 1) refuse evil hosts on the ORIGINAL URL (before rewrite)
+        try:
+            url = assert_downloadable_asset_url(
+                url, allowed_hosts=allowed, allow_http=True)
+        except AssetUrlError as e:
+            raise RuntimeError(f"gitea_issues download refused: {e}") from e
+        # 2) rewrite only localhost/loopback → docker-network origin
+        current = self._app_reachable_url(url)
+        headers = self._headers()
         try:
             async with httpx.AsyncClient(
                     timeout=60, transport=self._transport,
-                    follow_redirects=True) as client:
-                resp = await client.get(url, headers=self._headers())
+                    follow_redirects=False) as client:
+                for _ in range(5):
+                    resp = await client.get(current, headers=headers)
+                    if resp.status_code in (301, 302, 303, 307, 308):
+                        loc = resp.headers.get("location") or ""
+                        try:
+                            nxt = resolve_redirect_location(current, loc)
+                            # validate pre-rewrite host, then rewrite loopback
+                            nxt = assert_downloadable_asset_url(
+                                nxt, allowed_hosts=allowed, allow_http=True)
+                        except AssetUrlError as e:
+                            raise RuntimeError(
+                                f"gitea_issues download redirect refused: {e}"
+                            ) from e
+                        current = self._app_reachable_url(nxt)
+                        continue
+                    break
+                else:
+                    raise RuntimeError("gitea_issues download: too many redirects")
         except httpx.HTTPError as e:
             raise PMOTransient(f"gitea_issues download network: {e}") from e
         if resp.status_code in (429, 500, 502, 503, 504):

--- a/app/devcake/adapters/linear/adapter.py
+++ b/app/devcake/adapters/linear/adapter.py
@@ -706,10 +706,10 @@ class LinearAdapter:
     async def download_asset(self, url: str) -> bytes:
         """assetUrl downloads require Linear auth (docs/05 §4).
 
-        Host allowlist + no off-host redirects (docs/14 §11)."""
+        Host allowlist + no off-host redirects + size cap (docs/14 §11)."""
         from ...domain.asset_fetch import (
             AssetUrlError, assert_downloadable_asset_url,
-            resolve_redirect_location,
+            enforce_download_byte_cap, resolve_redirect_location,
         )
         allowed = {"uploads.linear.app"}
         try:
@@ -719,6 +719,7 @@ class LinearAdapter:
         # Manual redirects only when the next hop stays on the allowlist —
         # never follow an open redirect with the Linear Authorization header.
         headers = {"Authorization": self._headers["Authorization"]}
+        cap = self.capabilities().attachment_max_bytes
         async with httpx.AsyncClient(
                 timeout=60, transport=self._transport,
                 follow_redirects=False) as client:
@@ -736,7 +737,15 @@ class LinearAdapter:
                             f"linear download redirect refused: {e}") from e
                     continue
                 resp.raise_for_status()
-                return resp.content
+                try:
+                    return enforce_download_byte_cap(
+                        resp.content,
+                        content_length=resp.headers.get("content-length"),
+                        max_bytes=cap,
+                    )
+                except AssetUrlError as e:
+                    raise RuntimeError(
+                        f"linear download refused: {e}") from e
             raise RuntimeError("linear download: too many redirects")
 
     def capabilities(self) -> PMOCapabilities:

--- a/app/devcake/adapters/linear/adapter.py
+++ b/app/devcake/adapters/linear/adapter.py
@@ -704,11 +704,40 @@ class LinearAdapter:
         return uf["assetUrl"]
 
     async def download_asset(self, url: str) -> bytes:
-        """assetUrl downloads require Linear auth (docs/05 §4)."""
-        async with httpx.AsyncClient(timeout=60, follow_redirects=True) as client:
-            resp = await client.get(url, headers={"Authorization": self._headers["Authorization"]})
-            resp.raise_for_status()
-            return resp.content
+        """assetUrl downloads require Linear auth (docs/05 §4).
+
+        Host allowlist + no off-host redirects (docs/14 §11)."""
+        from ...domain.asset_fetch import (
+            AssetUrlError, assert_downloadable_asset_url,
+            resolve_redirect_location,
+        )
+        allowed = {"uploads.linear.app"}
+        try:
+            url = assert_downloadable_asset_url(url, allowed_hosts=allowed)
+        except AssetUrlError as e:
+            raise RuntimeError(f"linear download refused: {e}") from e
+        # Manual redirects only when the next hop stays on the allowlist —
+        # never follow an open redirect with the Linear Authorization header.
+        headers = {"Authorization": self._headers["Authorization"]}
+        async with httpx.AsyncClient(
+                timeout=60, transport=self._transport,
+                follow_redirects=False) as client:
+            current = url
+            for _ in range(5):
+                resp = await client.get(current, headers=headers)
+                if resp.status_code in (301, 302, 303, 307, 308):
+                    loc = resp.headers.get("location") or ""
+                    try:
+                        nxt = resolve_redirect_location(current, loc)
+                        current = assert_downloadable_asset_url(
+                            nxt, allowed_hosts=allowed)
+                    except AssetUrlError as e:
+                        raise RuntimeError(
+                            f"linear download redirect refused: {e}") from e
+                    continue
+                resp.raise_for_status()
+                return resp.content
+            raise RuntimeError("linear download: too many redirects")
 
     def capabilities(self) -> PMOCapabilities:
         return PMOCapabilities(projects_supported=True, project_labels_supported=True,

--- a/app/devcake/api/connections_service.py
+++ b/app/devcake/api/connections_service.py
@@ -6,6 +6,7 @@ thin forwards that pass the composition root's singletons at call time
 
 from __future__ import annotations
 
+import logging
 import re
 
 from fastapi import HTTPException
@@ -14,8 +15,12 @@ from .. import secrets as secrets_store
 from ..config import HARNESS_VAR_PATTERN, _INSTANCE_NAME_RE
 from ..domain.model import ALL_LABELS
 from ..harness import HARNESSES
-from ..ports.forge import mission_branch
+from ..ports.forge import ForgeError, mission_branch
+from ..ports.pmo import PMOTransient
+from ..security import redact
 from .health import reset_protection_cache
+
+log = logging.getLogger("devcake.connections")
 
 # ── GUI-stored secrets (M12, F5): write-only VALUES, never echoed back ───────
 
@@ -277,6 +282,18 @@ async def connections_registry():
     }
 
 
+def _probe_client_error(e: Exception) -> str:
+    """Client-facing probe error: never echo raw vendor bodies (tokens/URLs).
+
+    Domain exceptions keep a short redacted message so operators still get a
+    signal; everything else is a stable generic string. Full detail stays in
+    app logs only."""
+    log.warning("connection probe failed: %s", redact(repr(e))[:500])
+    if isinstance(e, (PMOTransient, ForgeError)):
+        return redact(str(e))[:200]
+    return "connection probe failed — see app logs for details"
+
+
 async def test_pmo(name: str, *, config, managers):
     inst = next((i for i in config.pmos if i.name == name), None)
     if inst is None:
@@ -301,7 +318,7 @@ async def test_pmo(name: str, *, config, managers):
                 "labels_expected": h.managed_labels_expected,
                 "missions_visible": len(missions)}
     except Exception as e:  # noqa: BLE001 — connection-test contract: any probe failure → ok:False + error in the response, never a 500
-        return {"ok": False, "error": str(e)[:300]}
+        return {"ok": False, "error": _probe_client_error(e)}
 
 
 async def test_forge(name: str, *, config, forge_runtime):
@@ -346,4 +363,4 @@ async def test_forge(name: str, *, config, forge_runtime):
                 "reviewer_token_configured": reviewer, "probe_pr": pr is None,
                 "branch_protection": protection.model_dump() if protection else None}
     except Exception as e:  # noqa: BLE001 — connection-test contract: any probe failure → ok:False + error in the response, never a 500
-        return {"ok": False, "error": str(e)[:300]}
+        return {"ok": False, "error": _probe_client_error(e)}

--- a/app/devcake/api/devtypes_service.py
+++ b/app/devcake/api/devtypes_service.py
@@ -188,16 +188,20 @@ async def remove_dev_type(name: str, *, config, dev_types):
 
 async def upload_credentials(name: str, body: dict, *, dev_types,
                              shared_breakers):
-    """{"filename": "...", "content": "..."} → /data/secrets/{name}/ (0600)."""
+    """{"filename": "...", "content": "..."} → /data/secrets/{name}/ (0600).
+
+    Path components validated via secrets.require_credential_ref; size capped
+    at secrets.MAX_CREDENTIAL_FILE_BYTES; write is atomic (docs/14 §11)."""
     if name not in dev_types:
         raise HTTPException(404)
-    from pathlib import Path
-    target = Path(os.environ.get("DEVCAKE_DATA_DIR", "/data")) / "secrets" / name
-    target.mkdir(parents=True, exist_ok=True)
-    fname = os.path.basename(body.get("filename") or "creds.json")
-    p = target / fname
-    p.write_text(body.get("content") or "")
-    p.chmod(0o600)
+    from .. import secrets as secrets_store
+    fname = body.get("filename") or "creds.json"
+    content = body.get("content") or ""
+    try:
+        secrets_store.require_credential_ref(name, fname)
+        secrets_store.write_credential_file(name, fname, content)
+    except ValueError as e:
+        raise HTTPException(422, str(e))
     shared_breakers.pop(name, None)   # fresh credential clears the breaker
     return {"stored": f"{name}/{fname}"}
 

--- a/app/devcake/domain/asset_fetch.py
+++ b/app/devcake/domain/asset_fetch.py
@@ -59,3 +59,59 @@ def resolve_redirect_location(current_url: str, location: str) -> str:
     if not location or not str(location).strip():
         raise AssetUrlError("empty redirect Location")
     return urljoin(current_url, str(location).strip())
+
+
+def assert_fetch_netloc(url: str, origin: str) -> str:
+    """Require *url* netloc to match *origin* netloc (host + port).
+
+    Used after presentation-host rewrite so credentialed GETs only hit the
+    configured api_base origin, not another port on the same hostname.
+    """
+    if not origin or not str(origin).strip():
+        raise AssetUrlError("empty fetch origin")
+    u = urlsplit(url.strip())
+    o = urlsplit(origin.strip())
+    if not u.netloc or not o.netloc:
+        raise AssetUrlError("asset URL or origin missing netloc")
+    if u.netloc.lower() != o.netloc.lower():
+        raise AssetUrlError(
+            f"asset netloc {u.netloc!r} != origin netloc {o.netloc!r}")
+    return url.strip()
+
+
+def assert_path_prefix(url: str, prefix: str) -> str:
+    """Require URL path to start with *prefix* (e.g. Gitea ``/attachments/``)."""
+    if not prefix:
+        raise AssetUrlError("empty path prefix")
+    path = urlsplit(url.strip()).path or ""
+    if not path.startswith(prefix):
+        raise AssetUrlError(
+            f"asset path {path!r} must start with {prefix!r}")
+    return url.strip()
+
+
+def enforce_download_byte_cap(
+    content: bytes,
+    *,
+    content_length: str | None,
+    max_bytes: int,
+) -> bytes:
+    """Refuse oversized attachment bodies (capabilities().attachment_max_bytes).
+
+    Checks Content-Length when present, then the actual body length.
+    """
+    if max_bytes <= 0:
+        raise AssetUrlError("invalid attachment size cap")
+    if content_length is not None and str(content_length).strip():
+        try:
+            declared = int(str(content_length).strip())
+        except ValueError as e:
+            raise AssetUrlError(
+                f"invalid Content-Length {content_length!r}") from e
+        if declared > max_bytes:
+            raise AssetUrlError(
+                f"asset Content-Length {declared} exceeds cap {max_bytes}")
+    if len(content) > max_bytes:
+        raise AssetUrlError(
+            f"asset body {len(content)} bytes exceeds cap {max_bytes}")
+    return content

--- a/app/devcake/domain/asset_fetch.py
+++ b/app/devcake/domain/asset_fetch.py
@@ -1,0 +1,61 @@
+"""PMO attachment download URL policy (docs/14 §11).
+
+Ticket content can point `download_asset` at arbitrary URLs. The app must not
+credential-fetch or SSRF-follow off an allowlist of known vendor asset hosts.
+This module is pure policy — adapters supply their allowed hosts and perform
+the HTTP GET.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urljoin, urlsplit
+
+
+class AssetUrlError(ValueError):
+    """URL refused by the download allowlist / scheme policy."""
+
+
+def assert_downloadable_asset_url(
+    url: str,
+    *,
+    allowed_hosts: set[str],
+    allow_http: bool = False,
+) -> str:
+    """Validate *url* for an authenticated asset download.
+
+    Returns the normalized URL string on success.
+    Raises AssetUrlError when the URL is empty, uses a forbidden scheme,
+    carries userinfo, or its host is outside *allowed_hosts*.
+
+    *allow_http*: internal Gitea origins on the docker network are http;
+    public vendors (Linear) must be https.
+    """
+    if not url or not isinstance(url, str) or not url.strip():
+        raise AssetUrlError("empty asset URL")
+    parts = urlsplit(url.strip())
+    scheme = (parts.scheme or "").lower()
+    if allow_http:
+        if scheme not in ("http", "https"):
+            raise AssetUrlError(f"unsupported asset URL scheme {scheme!r}")
+    elif scheme != "https":
+        raise AssetUrlError(f"asset URL must be https, got {scheme!r}")
+    if parts.username is not None or parts.password is not None:
+        raise AssetUrlError("asset URL must not include userinfo")
+    host = (parts.hostname or "").lower()
+    if not host:
+        raise AssetUrlError("asset URL missing host")
+    allowed = {h.lower() for h in allowed_hosts}
+    if host not in allowed:
+        raise AssetUrlError(f"asset host {host!r} not in allowlist")
+    return url.strip()
+
+
+def resolve_redirect_location(current_url: str, location: str) -> str:
+    """Resolve a redirect *Location* against *current_url* (RFC 3986 join).
+
+    Always joins rather than special-casing ``http`` prefixes so uppercase
+    schemes and relative paths behave consistently.
+    """
+    if not location or not str(location).strip():
+        raise AssetUrlError("empty redirect Location")
+    return urljoin(current_url, str(location).strip())

--- a/app/devcake/domain/oauth.py
+++ b/app/devcake/domain/oauth.py
@@ -10,9 +10,7 @@ this module owns session snapshot + credential landing.
 """
 
 import logging
-import os
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, MutableMapping, Optional
 
 from ..harness import HARNESSES
@@ -20,8 +18,6 @@ from .ids import make_run_id
 from .run import Run
 
 log = logging.getLogger("devcake.oauth")
-
-SECRETS_DIR = Path(os.environ.get("DEVCAKE_DATA_DIR", "/data")) / "secrets"
 
 
 class OAuthManager:
@@ -92,11 +88,10 @@ class OAuthManager:
         run = self.runs.store.get(run_id)
         if not s or not run:
             return
-        target = SECRETS_DIR / s["dev_type"]      # snapshot from start(), never
-        target.mkdir(parents=True, exist_ok=True)  # re-looked-up (see _start_inner)
-        p = target / s["secret_file"]
-        p.write_text(payload["content"])
-        p.chmod(0o600)
+        # snapshot from start(), never re-looked-up (see _start_inner)
+        from .. import secrets as secrets_store
+        secrets_store.write_credential_file(
+            s["dev_type"], s["secret_file"], payload["content"])
         s["state"] = "completed"
         run.state = "finished"
         self.runs.store.save(run)

--- a/app/devcake/domain/orchestrator/feed.py
+++ b/app/devcake/domain/orchestrator/feed.py
@@ -20,6 +20,10 @@ tracer = trace.get_tracer("devcake")
 
 
 def _audit(mgr, pmo_id: str, action: str, detail: str = "") -> None:
+    # Belt-and-braces: detail should be names/counts only, but exception
+    # fragments (e.g. activity_repo_push_failed) can embed secret shapes —
+    # match settings_bundle.audit_event so on-disk JSONL is scrubbed too.
+    detail = redact(detail)
     markers.AUDIT_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(markers.AUDIT_PATH, "a") as f:
         f.write(json.dumps({"ts": datetime.now(timezone.utc).isoformat(),
@@ -33,7 +37,7 @@ def _audit(mgr, pmo_id: str, action: str, detail: str = "") -> None:
     with tracer.start_as_current_span("audit.event") as span:
         span.set_attribute("devcake.audit.action", action)
         span.set_attribute("devcake.pmo.id", pmo_id)
-        span.set_attribute("devcake.audit.detail", redact(detail)[:500])
+        span.set_attribute("devcake.audit.detail", detail[:500])
 
 
 def _trip_breaker(mgr, name: str, reason: str) -> None:

--- a/app/devcake/domain/runs.py
+++ b/app/devcake/domain/runs.py
@@ -258,7 +258,19 @@ class RunManager:
                 self.runlog.append(
                     run_id, [redact(str(l))[:4000] for l in payload["lines"]])
             else:
-                log.info("[%s] %s", run_id, payload.get("message", "") or payload)
+                # OAuth device-code ceremony: never log url/code values
+                # (short-lived auth material; status API still holds them).
+                if payload.get("oauth_url") is not None or payload.get("oauth_error") is not None:
+                    log.info(
+                        "[%s] oauth progress url=%s has_code=%s error=%s",
+                        run_id,
+                        "present" if payload.get("oauth_url") else "absent",
+                        bool(payload.get("code")),
+                        "present" if payload.get("oauth_error") else "absent",
+                    )
+                else:
+                    msg = payload.get("message", "")
+                    log.info("[%s] %s", run_id, msg if msg else "(non-lines run.log)")
                 if self.oauth_mgr:
                     self.oauth_mgr.on_log(run_id, payload)
         elif kind == "oauth.result":

--- a/app/devcake/secrets.py
+++ b/app/devcake/secrets.py
@@ -16,6 +16,7 @@ cached in memory beyond the redaction registry.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -50,21 +51,26 @@ def _harness_path(var: str) -> Path:
     return _root() / "harness" / f"{var}.json"
 
 
-def _atomic_write(path: Path, data: dict) -> None:
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """tmp + fsync + chmod 0600 + replace + dir fsync (POSIX atomic durable)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")  # 0600 by default
     try:
-        with os.fdopen(fd, "w") as f:
-            json.dump(data, f)
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
             f.flush()
             os.fsync(f.fileno())
         os.chmod(tmp, 0o600)
         os.replace(tmp, path)
         _fsync_dir(path.parent)          # make the rename itself durable
-    except Exception:
-        with __import__("contextlib").suppress(FileNotFoundError):
+    except Exception:  # noqa: BLE001 — temp cleanup then re-raise (atomic write contract)
+        with contextlib.suppress(FileNotFoundError):
             os.unlink(tmp)
         raise
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    _atomic_write_bytes(path, json.dumps(data).encode())
 
 
 def _fsync_dir(directory: Path) -> None:
@@ -134,9 +140,11 @@ def delete_connection_field(scope: str, instance: str, field: str) -> None:
 
 
 def delete_connection_instance(scope: str, instance: str) -> None:
+    """Unlink the connection secrets file. Redaction registrations are
+    deliberately kept until process restart — same safe direction as
+    delete_connection_field / delete_harness_secret (a just-revoked value
+    must still scrub late PMO/forge writes)."""
     path = _conn_path(scope, instance)
-    for field in _read(path):
-        security.unregister_runtime_secret(f"conn:{scope}:{instance}:{field}")
     path.unlink(missing_ok=True)
 
 
@@ -180,9 +188,29 @@ def require_credential_ref(dev_type: str, filename: str) -> None:
         raise ValueError(f"invalid credential filename {filename!r}")
 
 
+# Operator-uploaded / OAuth credential files (raw text, not JSON dicts).
+MAX_CREDENTIAL_FILE_BYTES = 1 * 1024 * 1024
+
+
+def write_credential_file(dev_type: str, filename: str, content: str) -> Path:
+    """Atomically write a raw credential file under /data/secrets/{dev_type}/.
+    0600; registers content for redaction when long enough (≥8)."""
+    require_credential_ref(dev_type, filename)
+    raw = content if isinstance(content, str) else str(content or "")
+    data = raw.encode()
+    if len(data) > MAX_CREDENTIAL_FILE_BYTES:
+        raise ValueError(
+            f"credential file too large ({len(data)} > {MAX_CREDENTIAL_FILE_BYTES})")
+    path = _root() / dev_type / filename
+    _atomic_write_bytes(path, data)
+    if len(raw) >= 8:
+        security.register_runtime_secret(
+            f"cred:{dev_type}:{filename}", raw)
+    return path
+
+
 def delete_credential_file(dev_type: str, filename: str) -> None:
     """Unlink one OAuth/uploaded credential file. Missing = no-op."""
-    import contextlib
     require_credential_ref(dev_type, filename)
     path = _root() / dev_type / filename
     path.unlink(missing_ok=True)
@@ -308,7 +336,13 @@ def register_all() -> None:
     glob scan already covers them, but explicit registration means immediate
     coverage for exact-match replacement even below the 16-char scan floor).
     Keys MUST match write_/delete_'s scheme or unregister leaves the
-    boot-registered copy behind."""
+    boot-registered copy behind.
+
+    Credential files (OAuth/upload) are raw text — the JSON-only disk scan
+    misses non-JSON blobs and values under the 16-char floor, so they are
+    registered here under the same ``cred:{dev}:{file}`` keys as
+    write_credential_file.
+    """
     for key, fields in list_connection_secrets().items():
         # {scope}-{instance}; instance names can't contain hyphens
         scope, _, instance = key.partition("-")
@@ -317,6 +351,19 @@ def register_all() -> None:
                 f"conn:{scope}:{instance}:{field}", value)
     for var, value in list_harness_secrets().items():
         security.register_runtime_secret(f"harness:{var}", value)
+    for cf in inventory().get("credential_files") or []:
+        dev, fname = cf.get("dev_type"), cf.get("filename")
+        if not dev or not fname:
+            continue
+        try:
+            require_credential_ref(dev, fname)
+            raw = (_root() / dev / fname).read_text()
+        except (ValueError, OSError) as e:
+            log.error("boot redaction: unreadable credential %s/%s: %s",
+                      dev, fname, e)
+            continue
+        if len(raw) >= 8:
+            security.register_runtime_secret(f"cred:{dev}:{fname}", raw)
 
 
 # ── profile secret snapshots (ADR-0013) ─────────────────────────────────────

--- a/app/devcake/security.py
+++ b/app/devcake/security.py
@@ -72,11 +72,24 @@ _SECRETS_DIR = Path(os.environ.get("DEVCAKE_DATA_DIR", "/data")) / "secrets"
 # them through this registry. Registered at ACL-user creation, dropped at
 # teardown; stale entries are harmless (over-redacting a dead random token).
 _runtime_secrets: dict[str, str] = {}
+# Values displaced by register overwrite (credential rotation). Kept until
+# process restart so a just-rotated secret still scrubs late PMO/forge writes
+# — same safe direction as delete_connection_* keeping redaction on delete.
+# Bounded so pathological rotate loops cannot grow forever.
+_RUNTIME_SECRET_PRIOR_CAP = 64
+_runtime_secret_priors: list[str] = []
 
 
 def register_runtime_secret(key: str, value: str) -> None:
-    if value:
-        _runtime_secrets[key] = value
+    if not value:
+        return
+    prev = _runtime_secrets.get(key)
+    if prev and prev != value and len(prev) >= 8:
+        if prev not in _runtime_secret_priors:
+            _runtime_secret_priors.append(prev)
+            while len(_runtime_secret_priors) > _RUNTIME_SECRET_PRIOR_CAP:
+                _runtime_secret_priors.pop(0)
+    _runtime_secrets[key] = value
 
 
 def unregister_runtime_secret(key: str) -> None:
@@ -122,8 +135,19 @@ def _report_unreadable(path: Path, exc: Exception) -> None:
 _scan_cache: dict[str, tuple[int, int, list[str]]] = {}
 
 
+# Structured secret dirs expect JSON; raw OAuth/upload blobs live under
+# Dev-type dirs and are covered by register_all / write_credential_file.
+_STRUCTURED_SECRET_DIRS = frozenset({
+    "connections", "harness", "profiles", "internal_forge",
+})
+
+
 def _file_values(p) -> list[str]:
-    """Long-ish string values of one stored-secret JSON, mtime/size-cached."""
+    """Long-ish string values of one stored-secret JSON, mtime/size-cached.
+
+    Returns None when *p* is a non-JSON credential file under a Dev-type
+    directory (not a redaction gap — runtime registration owns those).
+    """
     st = p.stat()
     key = str(p)
     hit = _scan_cache.get(key)
@@ -141,7 +165,15 @@ def _file_values(p) -> list[str]:
         elif isinstance(o, str) and len(o) >= 16:
             found.append(o)
 
-    walk(json.loads(p.read_text()))
+    try:
+        walk(json.loads(p.read_text()))
+    except json.JSONDecodeError:
+        # Raw credential files under /data/secrets/{dev_type}/ are intentional
+        # non-JSON; boot register_all covers them. Do not alarm redaction_gap.
+        if p.parent.name not in _STRUCTURED_SECRET_DIRS:
+            _scan_cache[key] = (st.st_mtime_ns, st.st_size, [])
+            return []
+        raise
     _scan_cache[key] = (st.st_mtime_ns, st.st_size, found)
     return found
 
@@ -166,7 +198,9 @@ def redact(text: str, extra_values: list[str] | None = None) -> str:
     """Scrub known secret values + token patterns from PMO-bound content."""
     if not text:
         return text
-    runtime = sorted(_runtime_secrets.values(), key=len, reverse=True)
+    runtime = sorted(
+        list(_runtime_secrets.values()) + list(_runtime_secret_priors),
+        key=len, reverse=True)
     for value in _known_values() + runtime + [v for v in (extra_values or []) if v]:
         if len(value) >= 8:
             text = text.replace(value, MASK)

--- a/app/devcake/settings_crypto.py
+++ b/app/devcake/settings_crypto.py
@@ -54,10 +54,15 @@ def decrypt_blob(passphrase: str, envelope: dict) -> bytes:
         if envelope.get("v") != 1 or envelope.get("cipher") != "aesgcm" \
                 or envelope.get("kdf") != "scrypt":
             raise DecryptError("unsupported envelope")
+        # Pin KDF cost to encrypt-time constants. Never trust envelope n/r/p
+        # for scrypt work — a hostile p/n stalls the FastAPI event loop.
+        for k, expected in _KDF.items():
+            if k in envelope and envelope[k] != expected:
+                raise DecryptError("unsupported envelope")
         salt = base64.b64decode(envelope["salt_b64"])
         nonce = base64.b64decode(envelope["nonce_b64"])
         ct = base64.b64decode(envelope["ct_b64"])
-        key = _derive(passphrase, salt, envelope)
+        key = _derive(passphrase, salt, _KDF)
         return AESGCM(key).decrypt(nonce, ct, None)
     except DecryptError:
         raise

--- a/app/tests/test_asset_fetch.py
+++ b/app/tests/test_asset_fetch.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from devcake.domain.asset_fetch import AssetUrlError, assert_downloadable_asset_url
+from devcake.domain.asset_fetch import (
+    AssetUrlError,
+    assert_downloadable_asset_url,
+    assert_fetch_netloc,
+    assert_path_prefix,
+    enforce_download_byte_cap,
+)
 
 
 def test_linear_uploads_host_allowed():
@@ -18,15 +24,33 @@ def test_evil_host_rejected():
             allowed_hosts={"uploads.linear.app"})
 
 
-def test_metadata_and_file_schemes_rejected():
-    with pytest.raises(AssetUrlError):
-        assert_downloadable_asset_url(
-            "http://169.254.169.254/latest/meta-data/",
-            allowed_hosts={"169.254.169.254"})
+def test_file_and_unknown_schemes_rejected():
     with pytest.raises(AssetUrlError):
         assert_downloadable_asset_url(
             "file:///etc/passwd",
             allowed_hosts={"uploads.linear.app"})
+    with pytest.raises(AssetUrlError, match="https"):
+        assert_downloadable_asset_url(
+            "ftp://uploads.linear.app/x",
+            allowed_hosts={"uploads.linear.app"})
+
+
+def test_metadata_ip_refused_when_not_allowlisted():
+    """Host policy (not scheme alone): link-local IP outside allowlist fails."""
+    with pytest.raises(AssetUrlError, match="not in allowlist"):
+        assert_downloadable_asset_url(
+            "http://169.254.169.254/latest/meta-data/",
+            allowed_hosts={"uploads.linear.app"},
+            allow_http=True,
+        )
+
+
+def test_allowlisted_http_host_accepted_when_flagged():
+    """No special link-local denylist — allowlist is the control (docs/14)."""
+    url = "http://169.254.169.254/latest/meta-data/"
+    assert assert_downloadable_asset_url(
+        url, allowed_hosts={"169.254.169.254"}, allow_http=True,
+    ) == url
 
 
 def test_userinfo_rejected():
@@ -73,3 +97,25 @@ def test_host_case_normalized():
     url = "https://Uploads.Linear.App/file"
     assert assert_downloadable_asset_url(
         url, allowed_hosts={"uploads.linear.app"}) == url
+
+
+def test_assert_fetch_netloc_and_path_prefix():
+    origin = "http://gitea:3000"
+    ok = "http://gitea:3000/attachments/abc"
+    assert assert_fetch_netloc(ok, origin) == ok
+    assert assert_path_prefix(ok, "/attachments/") == ok
+    with pytest.raises(AssetUrlError, match="netloc"):
+        assert_fetch_netloc("http://gitea:9/attachments/x", origin)
+    with pytest.raises(AssetUrlError, match="path"):
+        assert_path_prefix("http://gitea:3000/api/v1/user", "/attachments/")
+
+
+def test_enforce_download_byte_cap():
+    assert enforce_download_byte_cap(
+        b"hi", content_length="2", max_bytes=10) == b"hi"
+    with pytest.raises(AssetUrlError, match="Content-Length"):
+        enforce_download_byte_cap(
+            b"x", content_length="100", max_bytes=10)
+    with pytest.raises(AssetUrlError, match="body"):
+        enforce_download_byte_cap(
+            b"x" * 20, content_length=None, max_bytes=10)

--- a/app/tests/test_asset_fetch.py
+++ b/app/tests/test_asset_fetch.py
@@ -1,0 +1,75 @@
+"""PMO asset download URL allowlist (docs/14 §11)."""
+
+import pytest
+
+from devcake.domain.asset_fetch import AssetUrlError, assert_downloadable_asset_url
+
+
+def test_linear_uploads_host_allowed():
+    url = "https://uploads.linear.app/abc/file.png"
+    assert assert_downloadable_asset_url(
+        url, allowed_hosts={"uploads.linear.app"}) == url
+
+
+def test_evil_host_rejected():
+    with pytest.raises(AssetUrlError, match="not in allowlist"):
+        assert_downloadable_asset_url(
+            "https://evil.example/steal",
+            allowed_hosts={"uploads.linear.app"})
+
+
+def test_metadata_and_file_schemes_rejected():
+    with pytest.raises(AssetUrlError):
+        assert_downloadable_asset_url(
+            "http://169.254.169.254/latest/meta-data/",
+            allowed_hosts={"169.254.169.254"})
+    with pytest.raises(AssetUrlError):
+        assert_downloadable_asset_url(
+            "file:///etc/passwd",
+            allowed_hosts={"uploads.linear.app"})
+
+
+def test_userinfo_rejected():
+    with pytest.raises(AssetUrlError, match="userinfo"):
+        assert_downloadable_asset_url(
+            "https://user:pass@uploads.linear.app/x",
+            allowed_hosts={"uploads.linear.app"})
+
+
+def test_http_allowed_only_when_flagged():
+    with pytest.raises(AssetUrlError, match="https"):
+        assert_downloadable_asset_url(
+            "http://gitea:3000/a/b",
+            allowed_hosts={"gitea"})
+    assert assert_downloadable_asset_url(
+        "http://gitea:3000/a/b",
+        allowed_hosts={"gitea"},
+        allow_http=True,
+    ).startswith("http://gitea")
+
+
+def test_empty_url_rejected():
+    with pytest.raises(AssetUrlError, match="empty"):
+        assert_downloadable_asset_url("", allowed_hosts={"x"})
+
+
+def test_resolve_redirect_location_joins_relative_and_absolute():
+    from devcake.domain.asset_fetch import resolve_redirect_location
+    assert resolve_redirect_location(
+        "https://uploads.linear.app/a/start", "/a/final"
+    ) == "https://uploads.linear.app/a/final"
+    assert resolve_redirect_location(
+        "https://uploads.linear.app/a/start",
+        "https://uploads.linear.app/a/other",
+    ) == "https://uploads.linear.app/a/other"
+    # uppercase scheme still treated as absolute via urljoin
+    assert resolve_redirect_location(
+        "https://uploads.linear.app/a/start",
+        "HTTPS://uploads.linear.app/a/U",
+    ).lower().startswith("https://uploads.linear.app/")
+
+
+def test_host_case_normalized():
+    url = "https://Uploads.Linear.App/file"
+    assert assert_downloadable_asset_url(
+        url, allowed_hosts={"uploads.linear.app"}) == url

--- a/app/tests/test_gitea_issues_contract.py
+++ b/app/tests/test_gitea_issues_contract.py
@@ -315,3 +315,49 @@ def test_app_reachable_url_rewrites_root_url_host():
     assert pmo._app_reachable_url(
         "http://gitea:3000/attachments/abc") == (
         "http://gitea:3000/attachments/abc")
+    # Foreign hosts must NOT collapse onto the origin (allowlist would be vacuous)
+    assert pmo._app_reachable_url(
+        "https://evil.example/steal") == "https://evil.example/steal"
+
+
+def test_download_asset_refuses_evil_host():
+    """Allowlist runs before rewrite — ticket SSRF hosts are refused."""
+    pmo = GiteaIssuesAdapter("http://gitea:3000", "tok", "o/r",
+                             transport=httpx.MockTransport(lambda r: httpx.Response(500)))
+    with pytest.raises(RuntimeError, match="refused"):
+        run(pmo.download_asset("https://evil.example/secret"))
+
+
+def test_download_asset_refuses_evil_redirect():
+    """Off-allowlist Location must not be followed with the Gitea token."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        if request.url.path.endswith("/good"):
+            return httpx.Response(
+                302, headers={"Location": "https://evil.example/exfil"})
+        return httpx.Response(200, content=b"should-not-reach")
+
+    pmo = GiteaIssuesAdapter(
+        "http://gitea:3000", "tok", "o/r",
+        transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError, match="redirect refused"):
+        run(pmo.download_asset("http://localhost:3300/attachments/good"))
+    assert len(seen) == 1
+    assert "evil.example" not in seen[0]
+    assert "gitea:3000" in seen[0]
+
+
+def test_download_asset_allows_same_host_redirect():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/start"):
+            return httpx.Response(
+                302, headers={"Location": "/attachments/final"})
+        return httpx.Response(200, content=b"payload-bytes")
+
+    pmo = GiteaIssuesAdapter(
+        "http://gitea:3000", "tok", "o/r",
+        transport=httpx.MockTransport(handler))
+    body = run(pmo.download_asset("http://gitea:3000/attachments/start"))
+    assert body == b"payload-bytes"

--- a/app/tests/test_gitea_issues_contract.py
+++ b/app/tests/test_gitea_issues_contract.py
@@ -320,12 +320,112 @@ def test_app_reachable_url_rewrites_root_url_host():
         "https://evil.example/steal") == "https://evil.example/steal"
 
 
+def test_app_reachable_url_rewrites_gitea_ui_url_host(monkeypatch):
+    """GITEA_UI_URL presentation host (same signal as internal forge) rewrites."""
+    monkeypatch.setenv("GITEA_UI_URL", "https://gitea.example.com")
+    pmo = GiteaIssuesAdapter("http://gitea:3000", "tok", "o/r")
+    assert pmo._app_reachable_url(
+        "https://gitea.example.com/attachments/abc") == (
+        "http://gitea:3000/attachments/abc")
+
+
 def test_download_asset_refuses_evil_host():
     """Allowlist runs before rewrite — ticket SSRF hosts are refused."""
     pmo = GiteaIssuesAdapter("http://gitea:3000", "tok", "o/r",
                              transport=httpx.MockTransport(lambda r: httpx.Response(500)))
     with pytest.raises(RuntimeError, match="refused"):
         run(pmo.download_asset("https://evil.example/secret"))
+
+
+def test_download_asset_refuses_empty_api_base():
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, content=b"nope")
+
+    pmo = GiteaIssuesAdapter(
+        "", "tok", "o/r", transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError, match="api_base is empty"):
+        run(pmo.download_asset("http://localhost:3300/attachments/x"))
+    assert seen == []
+
+
+def test_download_asset_ui_host_downloads_via_origin(monkeypatch):
+    monkeypatch.setenv("GITEA_UI_URL", "https://gitea.example.com")
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, content=b"via-origin")
+
+    pmo = GiteaIssuesAdapter(
+        "http://gitea:3000", "tok", "o/r",
+        transport=httpx.MockTransport(handler))
+    body = run(pmo.download_asset(
+        "https://gitea.example.com/attachments/uuid-1"))
+    assert body == b"via-origin"
+    assert seen == ["http://gitea:3000/attachments/uuid-1"]
+
+
+def test_download_asset_wrong_port_rewrites_onto_origin_netloc():
+    """Presentation hostname on another port must not be GETted; rewrite first."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, content=b"pinned")
+
+    pmo = GiteaIssuesAdapter(
+        "http://gitea:3000", "tok", "o/r",
+        transport=httpx.MockTransport(handler))
+    body = run(pmo.download_asset("http://gitea:9/attachments/x"))
+    assert body == b"pinned"
+    assert seen == ["http://gitea:3000/attachments/x"]
+
+
+def test_download_asset_refuses_api_path():
+    """Same-origin API paths are not attachment downloads."""
+    pmo = GiteaIssuesAdapter(
+        "http://gitea:3000", "tok", "o/r",
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, content=b"x")))
+    with pytest.raises(RuntimeError, match="refused"):
+        run(pmo.download_asset("http://gitea:3000/api/v1/user"))
+
+
+def test_download_asset_refuses_redirect_to_api_path():
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        if request.url.path.endswith("/start"):
+            return httpx.Response(
+                302, headers={"Location": "/api/v1/user"})
+        return httpx.Response(200, content=b"nope")
+
+    pmo = GiteaIssuesAdapter(
+        "http://gitea:3000", "tok", "o/r",
+        transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError, match="redirect refused"):
+        run(pmo.download_asset("http://gitea:3000/attachments/start"))
+    assert len(seen) == 1
+
+
+def test_download_asset_refuses_oversized_body():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=b"x" * 100,
+            headers={"Content-Length": "100"})
+
+    pmo = GiteaIssuesAdapter(
+        "http://gitea:3000", "tok", "o/r",
+        transport=httpx.MockTransport(handler))
+    # Monkeypatch capability cap via a tiny wrapper: call enforce with low cap
+    # by patching capabilities on the instance.
+    pmo.capabilities = lambda: type(  # type: ignore[method-assign]
+        "C", (), {"attachment_max_bytes": 50})()
+    with pytest.raises(RuntimeError, match="refused"):
+        run(pmo.download_asset("http://gitea:3000/attachments/big"))
 
 
 def test_download_asset_refuses_evil_redirect():

--- a/app/tests/test_hygiene_audit_oauth_probe.py
+++ b/app/tests/test_hygiene_audit_oauth_probe.py
@@ -1,0 +1,159 @@
+"""Hygiene slices: mission audit redact, OAuth log scrub, probe client errors,
+credential upload caps, atomic credential write."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from devcake.security import MASK, register_runtime_secret, unregister_runtime_secret
+
+
+def run_coro(c):
+    return asyncio.new_event_loop().run_until_complete(c)
+
+
+def test_mission_audit_detail_redacted_on_disk(tmp_path, monkeypatch):
+    import devcake.domain.orchestrator.markers as markers
+    from devcake.domain.orchestrator import feed
+
+    audit = tmp_path / "events.jsonl"
+    monkeypatch.setattr(markers, "AUDIT_PATH", audit)
+    secret = "hygiene-audit-secret-token-xyz"
+    register_runtime_secret("test:hygiene-audit", secret)
+    try:
+        mgr = SimpleNamespace(instance_name="lin", _grace_next=set())
+        feed._audit(mgr, "ISSUE-1", "activity_repo_push_failed",
+                    f"push failed: {secret} mid")
+        line = json.loads(audit.read_text().strip().splitlines()[-1])
+        assert secret not in line["detail"]
+        assert MASK in line["detail"] or "REDACTED" in line["detail"]
+        assert "ISSUE-1" == line["pmo_id"]
+        assert "ISSUE-1" in mgr._grace_next
+    finally:
+        unregister_runtime_secret("test:hygiene-audit")
+
+
+def test_oauth_run_log_does_not_log_url_or_code(tmp_path, caplog):
+    from devcake.adapters.files.run_store import RunStore
+    from devcake.domain.run import Run
+    from devcake.domain.runs import RunManager
+
+    rid = "r-oauth-1"
+    store = RunStore(root=tmp_path / "runs")
+    mgr = RunManager(store, messaging=None, executor=None)
+    store.save(Run(run_id=rid, mission_key="OAUTH", mission_type="OAUTH",
+                   dev_type="main-dev", seq=1))
+    seen = []
+    mgr.oauth_mgr = type("Stub", (), {
+        "on_log": lambda self, r, p: seen.append((r, p)),
+        "sessions": {}})()
+    url = "https://accounts.x.ai/device?user_code=ABCD-EFGH"
+    code = "ABCD-EFGH"
+    with caplog.at_level(logging.INFO, logger="devcake.runs"):
+        run_coro(mgr.handle(rid, "run.log", {"oauth_url": url, "code": code}))
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert url not in joined
+    assert code not in joined
+    assert "oauth progress" in joined
+    assert seen == [(rid, {"oauth_url": url, "code": code})]
+
+
+def test_probe_client_error_hides_token_shaped_unknown():
+    from devcake.api.connections_service import _probe_client_error
+    from devcake.ports.pmo import PMOTransient
+
+    secretish = "Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz012345"
+    msg = _probe_client_error(RuntimeError(secretish))
+    assert "ghp_" not in msg
+    assert "Bearer" not in msg
+    assert "see app logs" in msg
+
+    transient = _probe_client_error(PMOTransient("rate limited by vendor"))
+    assert "rate limited" in transient
+
+
+def test_write_credential_file_atomic_and_capped(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import secrets as s
+
+    p = s.write_credential_file("coder", "auth.json", '{"tok":"x"}')
+    assert p.read_text() == '{"tok":"x"}'
+    assert (p.stat().st_mode & 0o777) == 0o600
+
+    with pytest.raises(ValueError, match="too large"):
+        s.write_credential_file(
+            "coder", "big.json", "x" * (s.MAX_CREDENTIAL_FILE_BYTES + 1))
+    with pytest.raises(ValueError, match="invalid credential"):
+        s.write_credential_file("coder", "../etc/passwd", "nope")
+    with pytest.raises(ValueError, match="invalid credential"):
+        s.write_credential_file("harness", "x.json", "nope")
+
+
+def test_upload_credentials_rejects_oversize_and_traversal(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake.api import devtypes_service as dts
+    from devcake.config import DevType
+    from fastapi import HTTPException
+
+    dts_types = {"coder": DevType(name="coder", harness_template="grok-build")}
+    breakers = {"coder": "DEV_AUTH"}
+
+    with pytest.raises(HTTPException) as e:
+        run_coro(dts.upload_credentials(
+            "coder",
+            {"filename": "../secrets/x", "content": "x"},
+            dev_types=dts_types, shared_breakers=breakers))
+    assert e.value.status_code == 422
+
+    from devcake import secrets as s
+    with pytest.raises(HTTPException) as e2:
+        run_coro(dts.upload_credentials(
+            "coder",
+            {"filename": "ok.json",
+             "content": "y" * (s.MAX_CREDENTIAL_FILE_BYTES + 1)},
+            dev_types=dts_types, shared_breakers=breakers))
+    assert e2.value.status_code == 422
+
+    out = run_coro(dts.upload_credentials(
+        "coder",
+        {"filename": "ok.json", "content": "credential-body"},
+        dev_types=dts_types, shared_breakers=breakers))
+    assert out["stored"] == "coder/ok.json"
+    assert "coder" not in breakers
+    path = tmp_path / "secrets" / "coder" / "ok.json"
+    assert path.read_text() == "credential-body"
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_delete_connection_instance_keeps_redaction(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import secrets as s
+    from devcake.security import redact
+
+    s.write_connection_secret("pmo", "lin", "api_key", "revoked-token-value1")
+    s.delete_connection_instance("pmo", "lin")
+    assert not (tmp_path / "secrets" / "connections" / "pmo-lin.json").exists()
+    assert "revoked-token-value1" not in redact("leak revoked-token-value1 end")
+
+
+def test_register_all_reloads_credential_files(tmp_path, monkeypatch):
+    """Boot register_all must re-register raw credential files (not JSON-only)."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import secrets as s
+    from devcake.security import redact, unregister_runtime_secret
+
+    secret = "raw-oauth-blob-not-json!!"
+    s.write_credential_file("coder", "auth.txt", secret)
+    # Simulate process restart: drop the runtime registration only
+    unregister_runtime_secret("cred:coder:auth.txt")
+    assert secret in redact(f"leak {secret} end")  # not registered
+    s.register_all()
+    try:
+        assert secret not in redact(f"leak {secret} end")
+    finally:
+        unregister_runtime_secret("cred:coder:auth.txt")

--- a/app/tests/test_linear_download_asset.py
+++ b/app/tests/test_linear_download_asset.py
@@ -61,3 +61,18 @@ def test_download_asset_follows_same_host_redirect():
         transport=httpx.MockTransport(handler))
     body = run(a.download_asset("https://uploads.linear.app/team/start"))
     assert body == b"linear-bytes"
+
+
+def test_download_asset_refuses_oversized_body():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=b"y" * 80,
+            headers={"Content-Length": "80"})
+
+    a = LinearAdapter(
+        api_key="lin_api_test_key_xxxxxxxxxxxx",
+        transport=httpx.MockTransport(handler))
+    a.capabilities = lambda: type(  # type: ignore[method-assign]
+        "C", (), {"attachment_max_bytes": 40})()
+    with pytest.raises(RuntimeError, match="refused"):
+        run(a.download_asset("https://uploads.linear.app/team/big.bin"))

--- a/app/tests/test_linear_download_asset.py
+++ b/app/tests/test_linear_download_asset.py
@@ -1,0 +1,63 @@
+"""Linear download_asset host allowlist + redirect policy (docs/14 §11)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from devcake.adapters.linear.adapter import LinearAdapter
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_download_asset_refuses_evil_host():
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(500)
+
+    a = LinearAdapter(
+        api_key="lin_api_test_key_xxxxxxxxxxxx",
+        transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError, match="refused"):
+        run(a.download_asset("https://evil.example/steal"))
+    assert seen == []  # never issued HTTP
+
+
+def test_download_asset_refuses_evil_redirect():
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        if "good" in str(request.url):
+            return httpx.Response(
+                302, headers={"Location": "https://evil.example/exfil"})
+        return httpx.Response(200, content=b"nope")
+
+    a = LinearAdapter(
+        api_key="lin_api_test_key_xxxxxxxxxxxx",
+        transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError, match="redirect refused"):
+        run(a.download_asset("https://uploads.linear.app/team/good"))
+    assert len(seen) == 1
+    assert "uploads.linear.app" in seen[0]
+    assert "evil.example" not in "".join(seen)
+
+
+def test_download_asset_follows_same_host_redirect():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/start"):
+            return httpx.Response(
+                302, headers={"Location": "/team/final.bin"})
+        return httpx.Response(200, content=b"linear-bytes")
+
+    a = LinearAdapter(
+        api_key="lin_api_test_key_xxxxxxxxxxxx",
+        transport=httpx.MockTransport(handler))
+    body = run(a.download_asset("https://uploads.linear.app/team/start"))
+    assert body == b"linear-bytes"

--- a/app/tests/test_oauth.py
+++ b/app/tests/test_oauth.py
@@ -6,7 +6,6 @@ import asyncio
 
 import pytest
 
-import devcake.domain.oauth as oauth_mod
 from devcake.config import DevType
 from devcake.harness import HARNESSES
 from devcake.domain.oauth import OAuthManager
@@ -34,7 +33,7 @@ class NullMessaging:
 def make_mgr(tmp_path, monkeypatch):
     from devcake.domain.runs import RunManager
 
-    monkeypatch.setattr(oauth_mod, "SECRETS_DIR", tmp_path / "secrets")
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
     store = RunStore(tmp_path / "runs")
     executor = FakeExecutor()
     messaging = NullMessaging()

--- a/app/tests/test_run_bootstrap.py
+++ b/app/tests/test_run_bootstrap.py
@@ -260,13 +260,12 @@ def test_dispatch_mapper_uses_bootstrap_spine(tmp_path, monkeypatch):
 
 def test_oauth_start_uses_bootstrap_spine(tmp_path, monkeypatch):
     """OAuth path: session snapshot stays in OAuthManager; spine is RunBootstrap."""
-    import devcake.domain.oauth as oauth_mod
     from devcake.config import DevType
     from devcake.domain.oauth import OAuthManager
     from devcake.domain.runs import RunManager
     from devcake.harness import HARNESSES
 
-    monkeypatch.setattr(oauth_mod, "SECRETS_DIR", tmp_path / "secrets")
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
     store = InMemoryStore()
     executor = FakeExecutor(store)
     runs = RunManager(store, FakeMessaging(), executor)

--- a/app/tests/test_security.py
+++ b/app/tests/test_security.py
@@ -208,11 +208,16 @@ def test_register_all_boot_coverage_and_key_scheme(tmp_path, monkeypatch):
     try:
         out = redact("boot leak short-key-1 and tiny-value9 end")
         assert "short-key-1" not in out and "tiny-value9" not in out
-    finally:
-        # unregister must remove the boot-registered copies — this is the
-        # key-scheme contract (conn:{scope}:{instance}:{field} / harness:{var})
+        # Instance delete unlinks the file but KEEPS redaction registrations
+        # until restart (safe direction — same as field/harness delete).
         secrets_store.delete_connection_instance("pmo", "linear")
+        assert not (conn_dir / "pmo-linear.json").exists()
+        still = redact("after-delete short-key-1 end")
+        assert "short-key-1" not in still
+    finally:
+        # key-scheme contract: explicit unregister drops boot-registered keys
         from devcake.security import unregister_runtime_secret
+        unregister_runtime_secret("conn:pmo:linear:api_key")
         unregister_runtime_secret("harness:XAI_API_KEY")
     out = redact("short-key-1 tiny-value9")
     assert "short-key-1" in out and "tiny-value9" in out

--- a/app/tests/test_security.py
+++ b/app/tests/test_security.py
@@ -111,6 +111,53 @@ def test_runtime_secret_registry():
     assert redact("nothing to mask") == "nothing to mask"
 
 
+def test_runtime_secret_overwrite_keeps_prior_redacted():
+    """Credential rotation must not unmask the previous value until restart."""
+    from devcake import security as sec
+    from devcake.security import register_runtime_secret, unregister_runtime_secret
+
+    old = "rotated-away-secret-value-aaaa"
+    new = "rotated-in-secret-value-bbbb"
+    register_runtime_secret("cred:coder:auth.txt", old)
+    try:
+        register_runtime_secret("cred:coder:auth.txt", new)
+        assert old not in redact(f"leak {old} end")
+        assert new not in redact(f"leak {new} end")
+        assert MASK in redact(f"leak {old} and {new}")
+    finally:
+        unregister_runtime_secret("cred:coder:auth.txt")
+        # priors are process-local until restart; drop test values if present
+        if old in sec._runtime_secret_priors:
+            sec._runtime_secret_priors.remove(old)
+        if new in sec._runtime_secret_priors:
+            sec._runtime_secret_priors.remove(new)
+
+
+def test_raw_credential_file_does_not_alarm_redaction_gap(
+        tmp_path, monkeypatch, caplog):
+    """Non-JSON Dev-type credential files are not a redaction_gap (runtime
+    register_all owns them); corrupt connection JSON still alarms."""
+    import logging
+
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    # Point security scan at the same tree
+    import devcake.security as sec
+    monkeypatch.setattr(sec, "_SECRETS_DIR", tmp_path / "secrets")
+    monkeypatch.setattr(sec, "_reported_unreadable", set())
+    monkeypatch.setattr(sec, "_scan_cache", {})
+
+    raw_dir = tmp_path / "secrets" / "coder"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "auth.txt").write_text("not-json-raw-oauth-blob!!")
+
+    with caplog.at_level(logging.ERROR, logger="devcake.security"):
+        # force disk scan
+        sec.redact("hello")
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "unreadable secrets file" not in joined
+    assert "auth.txt" not in joined or "redaction" not in joined.lower()
+
+
 def test_oo_ingest_and_ro_forge_tokens_redacted(monkeypatch):
     """ISSUES #13/#15 follow-up: the opt-in credentials (ingest OO user, RO
     forge PATs) must be masked like every other platform secret — they are

--- a/app/tests/test_settings_crypto.py
+++ b/app/tests/test_settings_crypto.py
@@ -48,3 +48,26 @@ def test_unsupported_envelope_refused():
                                        "kdf": "scrypt"})
     with pytest.raises(DecryptError):
         decrypt_blob("correct horse", {})
+
+
+def test_hostile_scrypt_params_rejected_fast():
+    """Untrusted n/r/p must not drive scrypt cost (event-loop DoS)."""
+    import time
+    from devcake.settings_crypto import _KDF
+
+    env = encrypt_blob("correct horse", b"payload-bytes")
+    hostile = {**env, "p": 1024}
+    t0 = time.perf_counter()
+    with pytest.raises(DecryptError) as exc:
+        decrypt_blob("correct horse", hostile)
+    elapsed = time.perf_counter() - t0
+    assert str(exc.value) == "unsupported envelope"
+    assert elapsed < 0.2, f"hostile KDF took {elapsed:.3f}s — params not pinned"
+
+    for key, bad in (("n", 2**20), ("r", 64), ("p", 64)):
+        with pytest.raises(DecryptError) as e:
+            decrypt_blob("correct horse", {**env, key: bad})
+        assert str(e.value) == "unsupported envelope"
+
+    # matching params (the ones encrypt wrote) still decrypt
+    assert decrypt_blob("correct horse", {**env, **_KDF}) == b"payload-bytes"

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -260,7 +260,7 @@ Internal vs external is **only** `api_base` + token + board path — one system,
 - **Relations:** `POST/GET/DELETE …/issues/{index}/dependencies` with `IssueMeta{owner,repo,index}`. `create_relation(blocker, blocked)` makes `blocked` depend on `blocker`. Duplicate create returns 500 “does already exist” → treated as success. `ensure_labels` enables `internal_tracker.enable_issue_dependencies` on the board (off by default on new repos).
 - **Labels:** repo labels; `PUT …/issues/{index}/labels` replaces the full set (`native_label_swap_atomic=True`). Managed set ensured uppercase.
 - **Feed:** issue comments; markdown markers round-trip byte-for-byte (live-verified).
-- **Attachments:** multipart `POST …/issues/{index}/assets`. Gitea returns `browser_download_url` with **ROOT_URL** (`localhost:3300`); the adapter rewrites the host to `api_base` so the app container can download.
+- **Attachments:** multipart `POST …/issues/{index}/assets`. Gitea returns `browser_download_url` with **ROOT_URL** / `GITEA_UI_URL` (bundled: `localhost:3300`); the adapter rewrites **presentation hosts** (`api_base` host, `GITEA_UI_URL` host, loopback) onto `api_base` so the app container can download, pins path to `/attachments/` and origin netloc, and refuses off-allowlist redirects with the PMO token (docs/14 §11). Operator use of the Gitea UI and direct git remains unrestricted.
 
 ### 9.4 Operator setup (bundled Gitea)
 

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -455,9 +455,13 @@ contract:
 - Protocol hardens: ~~credential-upload filename allowlist + size cap~~
   (`secrets.require_credential_ref` + `MAX_CREDENTIAL_FILE_BYTES` + atomic
   `write_credential_file`); ~~PMO `download_asset` host allowlist / redirect
-  policy~~ (`domain/asset_fetch.py` — Linear `uploads.linear.app`, Gitea Issues
-  configured origin only; no off-allowlist redirects with auth headers);
-  stronger bootstrap password policy than a short deny-list.
+  policy~~ (`domain/asset_fetch.py` — Linear `uploads.linear.app`; Gitea Issues
+  presentation hosts = `api_base` + `GITEA_UI_URL` + loopback, rewritten onto
+  `api_base` origin, path pin `/attachments/`, netloc pin, body size cap;
+  no off-allowlist redirects with auth headers). Operator use of the Gitea UI
+  / direct git (migrate, clone, push) remains out of band and unrestricted by
+  this app-side policy. Stronger bootstrap password policy than a short
+  deny-list remains open.
 - Optional: gVisor/Kata for Devs; egress allowlists / credential-injection
   proxy (e.g. [iron-proxy](https://github.com/ironsh/iron-proxy) class —
   deferred radar in `16-roadmap.md`); OIDC if you must expose the admin UI

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -452,9 +452,12 @@ contract:
 
 - Docker HostConfig CPU/memory/PID limits on Dev containers (when Dagu supports
   them, or via another spawn path).
-- Protocol hardens: credential-upload filename allowlist + size cap; PMO
-  `download_asset` host allowlist / redirect policy (all adapters that fetch
-  feed assets); stronger bootstrap password policy than a short deny-list.
+- Protocol hardens: ~~credential-upload filename allowlist + size cap~~
+  (`secrets.require_credential_ref` + `MAX_CREDENTIAL_FILE_BYTES` + atomic
+  `write_credential_file`); ~~PMO `download_asset` host allowlist / redirect
+  policy~~ (`domain/asset_fetch.py` — Linear `uploads.linear.app`, Gitea Issues
+  configured origin only; no off-allowlist redirects with auth headers);
+  stronger bootstrap password policy than a short deny-list.
 - Optional: gVisor/Kata for Devs; egress allowlists / credential-injection
   proxy (e.g. [iron-proxy](https://github.com/ironsh/iron-proxy) class —
   deferred radar in `16-roadmap.md`); OIDC if you must expose the admin UI


### PR DESCRIPTION
## Summary

- Pin scrypt KDF params on settings decrypt so hostile envelopes cannot stall the event loop
- Redact mission audit JSONL details (match settings audit); scrub OAuth device URL/code from app logs
- Atomic credential file writes (0600), boot `register_all` for credential files, keep redaction after instance secret delete
- Sanitize connection-test client errors; credential upload path validation + 1 MiB cap
- PMO `download_asset` host allowlist + safe redirects (Linear + Gitea Issues; rewrite only localhost/loopback)

## Test plan

- [x] `ruff check` on touched modules
- [x] `docker buildx bake app-test` + pytest (1055 passed, live Redis suite ignored offline)
- [x] Targeted: settings_crypto hostile KDF, asset_fetch policy, Linear/Gitea download mock redirects, hygiene audit/oauth/probe/upload, secrets register_all
- [x] CI green on this PR