### PR TITLE
docs(thesis): adopt docs/19 "Why DevCake" thesis + suite wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@ Product voice and pitch variants: [`docs/17-positioning.md`](docs/17-positioning
 
 ---
 
+## Why DevCake?
+
+The deepest AI-assisted work today happens in CLI harnesses — Claude Code,
+Grok Build, Codex — with an expert invisibly orchestrating each session:
+curating context, sizing the task, sequencing the work, verifying the output.
+DevCake mechanizes that orchestration for board-shaped work. It is not a new
+coding agent; it is a session made repeatable, without the expert chained to
+the keyboard.
+
+The method is context hygiene, engineered: one clear goal per session, tasks
+decomposed until they fit, fresh containers, curated read-only mounts of
+exactly the relevant prior work, feedback at step boundaries — never
+interruption inside one. We call it putting AI to work in a state of flow,
+and we treat the conditions for it as a design target, not a hope.
+
+We believe this works; we have not yet proven it. The mechanisms are built
+and tested; the results so far are our own use. The full argument — its
+evidence status stated claim by claim, and what would change our mind — is
+[`docs/19-thesis.md`](docs/19-thesis.md).
+
+---
+
 ## Who this is for
 
 - Teams already running work on a **PMO board** (Linear and Gitea Issues in-tree)
@@ -236,6 +258,7 @@ must not exceed [`docs/14-security.md`](docs/14-security.md).
 | Admin API & UI contract | [`docs/11-admin-panel.md`](docs/11-admin-panel.md) |
 | History and backlog | [`docs/16-roadmap.md`](docs/16-roadmap.md) |
 | How we talk about it | [`docs/17-positioning.md`](docs/17-positioning.md) |
+| Why this exists — the thesis | [`docs/19-thesis.md`](docs/19-thesis.md) |
 
 Full map and architecture: [`docs/00`](docs/00-overview.md) §7 · [`docs/01`](docs/01-architecture.md).
 

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -163,5 +163,6 @@ Operating duties — once at setup and recurring — live in
 | `16-roadmap.md` | Milestone era + closed releases + living log after v0.2 |
 | `17-positioning.md` | Outward voice — must not outclaim `14` |
 | `18-operator-contract.md` | What the operator owns — setup pointer + recurring duties + rotation |
+| `19-thesis.md` | Why DevCake — the thesis: four claims with evidence status, scope doctrine (ordering vs originating), falsifiers |
 | `adr/` | Records of significant architectural decisions |
 | `tutorials/` | Operator path (includes supply-chain checklist) |

--- a/docs/17-positioning.md
+++ b/docs/17-positioning.md
@@ -1,7 +1,8 @@
 # 17 — Positioning: What This Is, and How We Say It
 
 > **Audience:** anyone writing outward-facing words about this project — README,
-> website, pitch, launch post. The README is the applied version of this doc.
+> website, pitch, launch post. The README is the applied version of this doc;
+> the full argument it compresses is [`19-thesis.md`](19-thesis.md).
 > **Status:** adopted at v0 close; motto and fit criteria revised 2026-07-18
 > (pre-v0.2) — §1, §1b. **Aligned with the product security contract**
 > in [`14-security.md`](14-security.md). Outward copy must not claim a stronger
@@ -169,6 +170,9 @@ What we don't claim: that it replaces engineers (it drafts and reviews; you
 decide); that it's magic (receipts exist so you can see when it isn't); or that
 it is a multi-tenant secure sandbox (it is a powerful agent on **your** host —
 `14`).
+
+The long-form version of this argument — evidence status stated per claim,
+falsifiers included — is [`19-thesis.md`](19-thesis.md).
 
 ## 6. The name (open decision)
 

--- a/docs/19-thesis.md
+++ b/docs/19-thesis.md
@@ -1,0 +1,227 @@
+# 19 — Why DevCake: The Thesis
+
+> **Audience:** anyone deciding whether this project deserves their attention —
+> a skeptical practitioner, a potential contributor, a researcher.
+> [`17-positioning.md`](17-positioning.md) is the compressed voice of this
+> document; the README is the applied version of `17`.
+> **Status:** adopted 2026-07-28 (first version) — expected to evolve with
+> evidence (§2, §7).
+> **Security:** aligned with [`14-security.md`](14-security.md) — nothing here
+> claims a stronger posture, and every autonomy claim inherits the trust
+> clauses of `17` §1a.
+
+## 0. How to read this
+
+This document makes four claims and refuses to let them borrow each other's
+confidence. Every section carries one of four labels:
+
+- **held** — true by construction; the codebase enforces it (an ADR or
+  invariant is cited).
+- **observed** — our experience running it: honest, but anecdotal and
+  unmeasured.
+- **argued** — reasoned against the field as of July 2026; this label decays
+  as the field moves.
+- **bet** — forward-looking and falsifiable; §7 states what would change our
+  mind.
+
+We believe this thesis. We have not proven it. The difference is stated per
+claim, in plain sight, because a thesis that hedges honestly ages better than
+one that persuades.
+
+## 1. The question
+
+Why does this project exist, when you could open a Claude Code session, buy an
+IDE copilot, or run an always-on assistant? Those are the real alternatives,
+so the thesis starts with them.
+
+**A bare CLI harness session (Claude Code, Grok Build, Codex).** This is the
+strongest alternative, because it is not our competitor — it is our worker.
+The deepest AI-assisted work we know of happens in exactly these tools. But
+look at what makes a great session great: an expert human sits at the top of
+it, invisibly doing the orchestration — curating what enters the context,
+sizing the task to what one session can do well, sequencing this task after
+that one, verifying the output, and carrying memory to the next session.
+The depth comes from the harness, the model, *and that expert attention*.
+DevCake's founding observation is that for board-shaped work, the expert's
+orchestration can be mechanized: the ticket is the goal, decomposition is the
+sizing, `blocked_by` is the sequencing, curated mounts and the activity mirror
+are the memory, and REVIEW plus your merge is the verification. DevCake is not
+"better than a session." It is a session made repeatable, without the expert
+chained to the keyboard — for the subset of work a board can specify.
+
+**An IDE copilot.** Pairing is companionship: superb for exploration, taste,
+and problems you cannot yet write down. It also spends the scarcest resource —
+expert attention — linearly with the work produced. DevCake is delegation, not
+companionship (`17` §1b): if you cannot write the ticket, DevCake is the wrong
+tool, and the copilot is the right one.
+
+**An always-on assistant.** One long-lived mind, many concerns, interruptions
+welcome, conversation-shaped input and output. That shape is genuinely good at
+breadth and low latency — and it is the *opposite* of the conditions deep work
+needs, because everything the assistant touches enters one accumulating
+context. We think that class of tool belongs *above* the board, deciding and
+communicating, not below it doing the deep work (§6). DevCake does not compete
+with it; DevCake is what it should delegate to.
+
+## 2. The mechanism: work in a state of flow *(held mechanisms, observed results)*
+
+The claim: model-plus-harness pairs do their deepest work under conditions you
+can name, and those conditions can be engineered rather than hoped for. The
+name we use is borrowed deliberately: Csikszentmihalyi described flow as what
+attention becomes when the information entering a mind is ordered toward a
+clear goal, matched to skill, and fed back immediately. Substitute "context
+window" for "mind" and the conditions translate one for one — not as
+psychology, but as an engineering checklist:
+
+| Condition for deep work | DevCake mechanism (held) | Where |
+|---|---|---|
+| A clear goal | The Mission spec and its PLAN artifact — one goal per session | `03-mission-lifecycle.md` |
+| A task sized to ability | Bounded decomposition: work is cut until a unit fits one session | ADR-0012 |
+| Ordered, uncontaminated information | Fresh container per step; a curated activity mirror; quoting quarantine; read-only mounts of exactly the relevant upstream trees | ADR-0014, ADR-0017, INV-6 |
+| Immediate feedback | The workspace's own compilers and tests; a skeptical REVIEW step | `03`, `17` §1 |
+| No interruption mid-task | Intervention lands only at step boundaries — a human edit always beats an in-flight agent *between* steps, never by breaking into one | INV-3 |
+
+Two disciplines keep the conditions true at the seams:
+
+**Impedance matching.** Every boundary a piece of work crosses must conserve
+it. Decomposition conserves scope — children may neither invent work their
+parent never asked for nor drop work it did. Summaries match the outbound
+signal to what the next session can absorb — a raw context dump into the next
+step is a mismatch, and we removed exactly that (ADR-0014). Read-only mounts
+are one-way valves — downstream work can never push mutations into upstream
+truth. Mismatches at these seams do not fail loudly at the boundary; they
+*reflect*, surfacing later as retries, review rejections, and rework. That
+reflection is measurable, and §4 says how.
+
+**Feedback is not interruption.** Flow dies from interruption but is
+constituted by feedback. DevCake's granularity encodes the difference: gates
+before a step, review after a step, never a poke inside one.
+
+**Status, honestly.** The mechanisms above are held — they are how the system
+is built, and a large test suite pins them. The *conclusion* — that this
+envelope produces better deep work than the alternatives — is observed: daily
+internal use on this project's own development, and early trials on
+non-software deep work that went qualitatively better than we expected. None
+of it is blind-judged or baselined. A controlled comparison — same task, same
+model, envelope on versus off — is the planned instrument, and until it
+exists, this section is a belief we act on, not a result we report.
+
+## 3. What is actually new *(argued)*
+
+None of the parts are new. CLI harnesses exist and are excellent; task boards
+are decades old; agent frameworks are abundant. The combination is what we
+have not seen elsewhere, and it has four load-bearing members:
+
+1. **The board is derived from, never duplicated.** The PMO system is the
+   single source of truth (ADR-0003, INV-1); DevCake keeps no second queue, no
+   private dependency database, no interface you must adopt. Add a label to
+   start; remove it to stop.
+2. **Envelope, not agent.** We do not build a coding agent and ask you to bet
+   on it. We orchestrate the harnesses that already win — deliberately
+   model-plural, so judgment roles and volume roles can run different vendors
+   on subscriptions you already own. Every harness release upgrades DevCake's
+   workforce without a line of our code changing.
+3. **A trust regime that refuses to overclaim.** Receipts on every step
+   (INV-5), an adult-operator security contract (`14`), a positioning doc that
+   bans its own marketing from exceeding it (`17` §1a), and an operator
+   contract that says what you own (`18`). We believe the honesty is a
+   feature, not a disclaimer.
+4. **Flow discipline as a design target.** Context hygiene is not an
+   accident of the container model; it is the point. The mechanisms of §2
+   exist because ordering information is the product.
+
+Each member exists somewhere in the field. We have not found the four
+together, and we think the combination — not any component — is the identity
+of the project. This is an argument against the field as of July 2026; it is
+dated, and it decays.
+
+## 4. As an instrument *(conjecture, stated testably)*
+
+DevCake might matter to people who study these systems, for one structural
+reason: it makes context hygiene a *controllable variable* instead of an
+anecdote. The same model and harness can run the same task inside or outside
+the envelope; every step already emits transcripts, token bills, timings,
+retry counts, and review verdicts, because receipts are doctrine (INV-5) —
+the environment is instrumented by default, not by special arrangement.
+
+Questions it can operationalize:
+
+- Does curated context beat accumulated context for fixed task and model —
+  and by how much, on what task shapes?
+- **Reflection coefficients:** rework and rejection rates per boundary type
+  (decomposition, summary, mount) as a measure of impedance mismatch — which
+  seams leak, and which matching parameters (unit size, summary length) tune
+  them.
+- A taxonomy of *unattended* harness failure, which differs from interactive
+  failure: what actually happens when nobody is watching, classified by exit
+  behavior and breaker events (`15-errors-and-retries.md`).
+
+We run DevCake as a production tool, not a laboratory, and we make no claim
+that research value has been demonstrated — only that the instrument exists,
+already collects the data, and states its questions in falsifiable form.
+
+## 5. Why open source is the trust model *(held today, bet forward)*
+
+The security contract is blunt: this is a self-hosted system on a dedicated
+machine where control plane ≅ host root, and the agents it runs hold your
+forge and model credentials (`14`). An operator who grants that much trust
+must be able to read the thing they are trusting. Source access is therefore
+not a distribution strategy — it is a precondition of the security posture.
+"Read it before you run it" is the only honest install instruction for a
+system shaped like this.
+
+The same architecture forfeits, by design, every classic lock-in: there is no
+hosted tenant to hold your data, no second queue to migrate off, no
+proprietary format — the board and the forge were always yours, and removing
+DevCake means removing a label. A project that deliberately cannot trap its
+users has one viability path: be genuinely worth running, in public, where
+the trust story can be audited. That is the bet — that a tool whose honesty
+regime and trust envelope are inspectable will earn adoption that marketing
+could not, and that a community can form around the doctrine as much as the
+code. It is a bet, not a plan; §7 says what would falsify it.
+
+## 6. The scope doctrine *(normative)*
+
+DevCake sits below a membrane, and the membrane is the board. Above it live
+deciding, coordinating, and communicating — humans today, possibly other
+software tomorrow. Below it lives ordered deep work. Every DevCake feature
+must pass one test:
+
+> **In-scope work orders information crossing a flow boundary. Out-of-scope
+> work originates intent or converses with the world.**
+
+The pockets of non-flow work DevCake contains are all ordering steps, inbound
+or outbound: mapping orders repo-space, decomposition orders task-space,
+blocker gating orders time, mounts order what enters a session, transcripts
+and summaries order what leaves one. And each observes a hard limit: the
+mapper never invents a Mission; decomposition never exceeds its parent's
+scope; DevCake honors `blocked_by` edges but never draws one of its own
+volition (ADR-0007 — an external agent, human or otherwise, owns the edges);
+summaries never address an external audience.
+
+The moment a proposed feature originates intent or holds a conversation, it
+belongs above the membrane, and the answer is no — however useful it would
+be. This section exists to be cited in that argument.
+
+## 7. What would change our mind *(the falsifiers)*
+
+- **The measurement fails.** If the controlled comparison of §2 shows the
+  envelope adds nothing over bare sessions for board-shaped work, the flow
+  claim dies, and DevCake is a scheduler with good manners. We would say so.
+- **Models make hygiene irrelevant.** Some of this system depreciates with
+  every model release by design — context packing, prompt craft, harness
+  workarounds. The thesis survives that; it is supposed to. But if effective
+  context becomes so robust that *ordering itself* stops mattering — sizing,
+  sequencing, conservation at seams — then §2 reduces to nostalgia, and only
+  the trust envelope and board derivation would remain worth keeping.
+- **Board discipline is rarer than we believe.** The whole design amplifies
+  an existing discipline (`17` §1b). If almost no team can sustain tickets
+  that are written to be picked up, the addressable work shrinks toward zero
+  and the thesis is true but irrelevant.
+- **The envelope gets absorbed.** Harness vendors are climbing toward
+  orchestration. If a single vendor's stack does all of §2 well, our remaining
+  claim is what a vendor will not build: cross-vendor plurality, board-native
+  derivation, and a self-hosted trust envelope. If those stop mattering too,
+  the project completes its arc as a good internal tool and an honest set of
+  documents — which is not nothing, and we would rather end there than
+  overclaim our way past it.


### PR DESCRIPTION
## What

Adopts `docs/19-thesis.md` — the full "Why DevCake?" argument — as the first version of the project thesis, and wires it into the suite.

**The doc** is organized around the skeptic's question (*why not a bare Claude Code session, an IDE copilot, an always-on assistant?*) rather than around its own claims. The four claims — (a) it works, (b) it's novel, (c) it's research-relevant, (d) FOSS is the trust model — each carry an explicit epistemic status label (**held / observed / argued / bet**) so no claim borrows another's confidence. §6 makes the scope doctrine normative and citable ("in-scope work orders information crossing a flow boundary; out-of-scope work originates intent or converses with the world"). §7 states the falsifiers, including the uncomfortable ones.

**Wiring (zero-drift):**
- `README.md` — new "Why DevCake?" distillation after the intro + a Documentation-table row
- `docs/00-overview.md` — §7 document-map row for 19
- `docs/17-positioning.md` — header + §5 now name 19 as the argument they compress

## Compliance

- Inherits 17 §1a trust clauses; claims no security posture beyond `14` (declared in the doc header).
- Tone guide (17 §4): no banned words; no unverified numbers.
- Docs-only change — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)