### PR TITLE
feat: turn-discipline epilogue + exit-11 terminal evidence (ADR-0022 PR-1)

### DIFF
--- a/app/devcake/prompts/__init__.py
+++ b/app/devcake/prompts/__init__.py
@@ -141,6 +141,20 @@ where they conflict with the mission description or with older comments, the
 most recent human comment wins.
 """
 
+# Appended to every playbook that must WRITE result.json (all but PLAN, whose
+# result.json the entrypoint synthesizes from the final message). Weaker models
+# end a turn to narrate an intention ("Let me continue with…"); a turn without
+# a tool call is the harness's end-of-run signal, so the run dies mid-mission
+# as exit 11 with the file never written (docs/15 §2b; measured live: a clean
+# `EndTurn` after hours of work with only the endgame remaining).
+TURN_DISCIPLINE = """
+### Ending your turn ends the run
+Never end your turn to narrate next steps or think out loud — if work remains,
+call a tool. A message without a tool call is treated as your FINAL answer: the
+run terminates immediately and any unfinished work is lost. Before you end your
+turn, verify that /workspace/out/result.json exists and is complete.
+"""
+
 
 # {decomposition_rule} wordings (ADR-0012): dispatch picks by the mission's
 # PMO-recorded depth vs the configured limit (dispatch._decomposition_rule).
@@ -191,7 +205,8 @@ def onboard_prompt(identifying_prompt: str, mission: Mission,
          "reference_repos": reference_repos,
          "blocker_repos": blocker_repos,
          "decomposition_rule": decomposition_rule})
-    return identifying_prompt + "\n" + text + HUMAN_HANDOFF + HUMAN_COMMENTS_NOTE
+    return (identifying_prompt + "\n" + text
+            + HUMAN_HANDOFF + HUMAN_COMMENTS_NOTE + TURN_DISCIPLINE)
 
 
 PLAN_PLAYBOOK = """
@@ -291,7 +306,8 @@ def execute_prompt(identifying_prompt: str, mission: Mission, repo_name: str,
          "description": mission.description or "(no description)",
          "reference_repos": reference_repos,
          "blocker_repos": blocker_repos})
-    return identifying_prompt + "\n" + text + HUMAN_HANDOFF + HUMAN_COMMENTS_NOTE
+    return (identifying_prompt + "\n" + text
+            + HUMAN_HANDOFF + HUMAN_COMMENTS_NOTE + TURN_DISCIPLINE)
 
 
 REVIEW_PLAYBOOK = """
@@ -339,7 +355,8 @@ def review_prompt(identifying_prompt: str, mission: Mission,
          "description": mission.description or "(no description)",
          "reference_repos": reference_repos,
          "blocker_repos": blocker_repos})
-    return identifying_prompt + "\n" + text + HUMAN_HANDOFF + HUMAN_COMMENTS_NOTE
+    return (identifying_prompt + "\n" + text
+            + HUMAN_HANDOFF + HUMAN_COMMENTS_NOTE + TURN_DISCIPLINE)
 
 
 MAPPER_PLAYBOOK = """
@@ -388,4 +405,7 @@ def mapper_prompt(identifying_prompt: str, missions: list[Mission]) -> str:
         rows.append(f"- **{m.key}** · {m.status} · blocked by: {blockers}\n"
                     f"  {m.title} — {head or '(no description)'}")
     table = "\n".join(rows) or "(no open missions)"
-    return identifying_prompt + "\n" + MAPPER_PLAYBOOK.format(mission_table=table)
+    # MAPPER stays un-templated (founder decision 2026-07-14) — TURN_DISCIPLINE
+    # is a code-owned epilogue like the others, not a template
+    return (identifying_prompt + "\n"
+            + MAPPER_PLAYBOOK.format(mission_table=table) + TURN_DISCIPLINE)

--- a/app/tests/test_entrypoint_fault.py
+++ b/app/tests/test_entrypoint_fault.py
@@ -325,6 +325,54 @@ def test_forensics_payload_stays_small_under_pathological_input(tmp_path):
     assert any("more" in e for e in info["out_listing"])
 
 
+# ── terminal evidence (ADR-0022 PR-1) ────────────────────────────────────────
+# What the exit-11 artifact names about HOW the stream ended: "ended cleanly
+# but early" (EndTurn) vs "just stopped" (null). Driven by the committed
+# captures wherever one carries the shape.
+
+def test_grok_terminal_evidence_names_the_narrate_and_stop_shape():
+    """grok_loop_nocap is the measured exit-11 shape: exit 0, clean end event,
+    stopReason EndTurn — the evidence must surface exactly that."""
+    for name in ("grok_loop_nocap.jsonl", "grok_loop_cap30.jsonl"):
+        ev = ep.terminal_evidence("grok-build", fx(name))
+        assert ev["event"] == "end" and ev["stop_reason"] == "EndTurn"
+        assert ev["num_turns"] == 16
+    healthy = ep.terminal_evidence("grok-build", fx("grok_healthy.jsonl"))
+    assert healthy["event"] == "end" and healthy["session_id"]
+
+
+def test_grok_terminal_evidence_error_and_truncated_streams():
+    err = ep.terminal_evidence("grok-build", fx("grok_empty.jsonl"))
+    assert err["event"] == "error" and "empty response" in err["message"]
+    # a stream that just stopped (text deltas, no terminal event) → None,
+    # which serializes as `"terminal": null` — that absence IS the evidence
+    assert ep.terminal_evidence(
+        "grok-build", J({"type": "text", "data": "working…"})) is None
+    assert ep.terminal_evidence("grok-build", "") is None
+
+
+def test_claude_terminal_evidence_reads_the_result_event():
+    ev = ep.terminal_evidence("claude-code", fx("claude_empty_completion.jsonl"))
+    assert ev["event"] == "result" and ev["subtype"] == "success"
+    assert ep.terminal_evidence("claude-code", J({"type": "assistant"})) is None
+
+
+def test_codex_terminal_evidence_reads_turn_completed():
+    ev = ep.terminal_evidence("codex", fx("codex_healthy.jsonl"))
+    assert ev["event"] == "turn.completed"
+    assert ep.terminal_evidence("codex", J({"type": "turn.started"})) is None
+
+
+def test_terminal_evidence_never_raises_on_hostile_shapes():
+    hostile = "\n".join([
+        J({"type": "end", "stopReason": ["not", "a", "string"], "num_turns": {}}),
+        J({"type": "turn.completed", "usage": "none"}),
+        J({"type": "result", "subtype": 7, "usage": []}),
+        "not json at all", J([1, 2, 3])])
+    for harness in ("grok-build", "codex", "claude-code", "unknown"):
+        ep.terminal_evidence(harness, hostile)  # must not raise
+
+
 # ── misplaced result.json ────────────────────────────────────────────────────
 
 def _ws(tmp_path):

--- a/app/tests/test_prompts.py
+++ b/app/tests/test_prompts.py
@@ -108,6 +108,22 @@ def test_human_comments_note_everywhere():
         assert "🧑 HUMAN" in p
 
 
+def test_turn_discipline_in_result_writing_playbooks():
+    """ADR-0022 PR-1: weaker models end a turn to narrate an intention; a
+    turn without a tool call is the harness's end-of-run signal, so the run
+    dies as exit 11 mid-mission (docs/15 §2b). The epilogue rides every
+    playbook that must WRITE result.json — code-owned, so it survives
+    operator template overrides. PLAN is excluded: read-only, its final
+    message IS the deliverable, ending the turn is correct there."""
+    writing = (onboard_prompt("ID", M), execute_prompt("ID", M, "repo", GH_PR),
+               review_prompt("ID", M), mapper_prompt("ID", [M]))
+    for p in writing:
+        assert "Never end your turn" in p
+        assert "call a tool" in p
+        assert "verify that /workspace/out/result.json exists" in p
+    assert "Never end your turn" not in plan_prompt("ID", M)
+
+
 def test_mapper_prompt_embeds_missions():
     a = Mission(instance="linear", pmo_id="ida", pmo_kind="issue", key="T-1", title="write docs",
                 description="x" * 500, status="backlog",

--- a/docs/07-dev-runtime.md
+++ b/docs/07-dev-runtime.md
@@ -109,7 +109,12 @@ Real secrets (harness and forge credentials) never appear in Dagu params, DAG YA
 exit 0 with an empty or failed in-band terminal event, and stderr often carries
 no failure information — the entrypoint inspects the stream before deciding.
 Exits 10, 11, 15 and 16 carry `error_class`, `error_detail` and bounded
-workspace forensics. Scenario captures: `app/tests/fixtures/harness_streams/`.
+workspace forensics. On exit 11 the forensics additionally name the stream's
+terminal event under `terminal` (`continuation.terminal_evidence`): a clean
+early stop (grok `end`/`stopReason EndTurn` with `num_turns`, claude `result`,
+codex `turn.completed`) versus `null` for a stream that just stopped — the
+narrate-and-stop diagnosis at fleet scale. Scenario captures:
+`app/tests/fixtures/harness_streams/`.
 
 **Which harnesses can reach exit 16.** `claude-code` (`max_turns` /
 `error_max_turns`) and `grok-build` (`max_turns_reached` event) — see

--- a/images/common/dev_entrypoint.py
+++ b/images/common/dev_entrypoint.py
@@ -65,6 +65,7 @@ from devcake_dev.domain.fault import (  # noqa: E402
     _one_line,
 )
 from devcake_dev.harness.argv import harness_argv  # noqa: E402
+from devcake_dev.harness.continuation import terminal_evidence  # noqa: E402
 from devcake_dev.harness.render import (  # noqa: E402
     BATCH_LINES,
     FLUSH_SECS,
@@ -437,6 +438,11 @@ def main() -> None:
     api_status = harness_api_error_status(harness, out)
     forensics = workspace_forensics(WORKSPACE / "out", harness_exit, out_bytes,
                                     out_lines_n, err_text[-FORENSIC_STDERR_TAIL:])
+    # ADR-0022 PR-1: names the terminal event on the exit-11 paths, where the
+    # exit status cannot distinguish "ended cleanly but early" (stopReason
+    # EndTurn — the narrate-and-stop shape) from a stream that just stopped.
+    # Computed here because `out` is released on the next statement.
+    terminal_ev = terminal_evidence(harness, out)
     # `out` is not read again below; releasing the joined copy here keeps the
     # peak off the artifact path, where the payload is serialized repeatedly.
     out = ""
@@ -552,11 +558,13 @@ def main() -> None:
                 recovered_path, recovery_note = str(stray), note
                 print(f"[devcake] recovered result.json from {stray}", file=sys.stderr)
             except Exception as e2:                # the stray is no better
+                forensics["terminal"] = terminal_ev
                 fail(11, "DEV_BAD_OUTPUT", f"{note} | recovered file invalid: {e2}",
                      f"result.json missing/invalid: {e}\n\n{note}\n\n"
                      f"recovered file also invalid: {e2}\n\n---\n\n{result_text}",
                      bad_output_reason=bad_output_reason(e2))
         else:                                      # row 9
+            forensics["terminal"] = terminal_ev
             fail(11, "DEV_BAD_OUTPUT", f"{e}{' | ' + note if note else ''}",
                  f"result.json missing/invalid: {e}"
                  + (f"\n\n{note}" if note else "")

--- a/images/common/devcake_dev/harness/continuation.py
+++ b/images/common/devcake_dev/harness/continuation.py
@@ -1,0 +1,77 @@
+"""Continuation domain (ADR-0022) — pure stream → evidence helpers.
+
+Dev-side domain like fault.py: no Redis, no subprocess, no filesystem. A
+separate module because its helpers need BOTH tokens.py (grok_end_event) and
+fault.py (claude_result_event) — landing them in either would cycle the
+import between those two (tokens already imports from fault).
+"""
+from __future__ import annotations
+
+import json
+
+from devcake_dev.domain.fault import _dict, _one_line, claude_result_event
+from devcake_dev.harness.tokens import grok_end_event
+
+
+def _grok_error_event(out: str):
+    """Last {"type":"error"} event, or None. An error event outranks nothing:
+    on the exit-11 paths it cannot occur (an error event is a fault, exit 15),
+    but this helper must stay honest for any stream it is handed."""
+    found = None
+    for line in out.splitlines():
+        try:
+            ev = json.loads(line)
+        except Exception:  # noqa: BLE001 — one unparseable line never costs the evidence
+            continue
+        if isinstance(ev, dict) and ev.get("type") == "error":
+            found = ev
+    return found
+
+
+def terminal_evidence(harness: str, out: str):
+    """Small terminal-event summary for the exit-11 forensics dict, or None
+    when the stream carries no terminal event at all — None IS evidence then
+    (it serializes as null under the `terminal` key: the stream just stopped).
+
+    The exit status and stderr cannot distinguish "the model ended its turn
+    cleanly but early" (grok stopReason EndTurn, the narrate-and-stop shape)
+    from a truncated stream; this names which one happened. Guarded like
+    every stream parser — model-adjacent bytes must never abort the artifact
+    path. An unknown harness falls through to the claude arm, mirroring
+    main()'s renderer dispatch and harness_fault."""
+    try:
+        if harness == "grok-build":
+            ev = grok_end_event(out)
+            if ev is not None:
+                return {"event": "end",
+                        "stop_reason": str(ev.get("stopReason") or ""),
+                        "num_turns": ev.get("num_turns"),
+                        "session_id": str(ev.get("sessionId") or "")}
+            err = _grok_error_event(out)
+            if err is not None:
+                return {"event": "error",
+                        "message": _one_line(str(err.get("message") or ""), 120)}
+            return None
+        if harness == "codex":
+            completed = None
+            for line in out.splitlines():
+                try:
+                    ev = json.loads(line)
+                except Exception:  # noqa: BLE001 — as above
+                    continue
+                if isinstance(ev, dict) and ev.get("type") == "turn.completed":
+                    completed = ev
+            if completed is None:
+                return None
+            return {"event": "turn.completed",
+                    "output_tokens": _dict(completed.get("usage")).get("output_tokens")}
+        ev = claude_result_event(out)
+        if ev is None:
+            return None
+        return {"event": "result",
+                "subtype": str(ev.get("subtype") or ""),
+                "terminal_reason": str(ev.get("terminal_reason") or ""),
+                "num_turns": ev.get("num_turns"),
+                "is_error": bool(ev.get("is_error"))}
+    except Exception:  # noqa: BLE001 — evidence is advisory; the fail() path outranks it
+        return None


### PR DESCRIPTION
## What

First slice of the in-container continuation work (ADR-0022, designed with the founder 2026-08-02). Two independent, harness-neutral mitigations for the dominant stress-test failure — ~50% of long grok-build runs dying as exit 11 with a **clean** `end` event (`stopReason: EndTurn`) mid-mission (narrate-and-stop: a turn without a tool call is the harness's end-of-run signal).

### 1a. `TURN_DISCIPLINE` prompt epilogue
- New code-owned epilogue in `app/devcake/prompts/__init__.py`, appended to every playbook that must WRITE `result.json` (ONBOARD/EXECUTE/REVIEW/MAPPER). PLAN excluded: read-only, its final message IS the deliverable.
- Code-owned like `HUMAN_HANDOFF`, so it survives operator template overrides — no `template_warnings()` machinery needed.
- MAPPER stays un-templated (founder decision 2026-07-14); an epilogue is not a template.

### 1b. Exit-11 terminal evidence
- New pure module `images/common/devcake_dev/harness/continuation.py` (seeds the ADR-0022 module; placed there because it needs both `tokens.grok_end_event` and `fault.claude_result_event` — either existing home would cycle the import).
- `terminal_evidence(harness, out)` names HOW the stream ended on the two exit-11 `fail()` paths, under `evidence.terminal` (also rendered into `transcript_md`): grok `end`/`stopReason`/`num_turns`/`session_id` (or `error`), claude `result` event fields, codex `turn.completed` — `null` = the stream just stopped.
- Computed before `out` is released (ordering is load-bearing); `workspace_forensics()` itself untouched, exits 10/12/15/16 untouched.

## Why now

This makes the narrate-and-stop mechanism measurable at fleet scale (stopReason + num_turns on every exit-11 artifact) *before* the continuation loop lands, and the epilogue attacks incidence immediately.

## Tests

- `test_prompts.py`: epilogue present on all four writing playbooks, absent on PLAN.
- `test_entrypoint_fault.py`: new terminal-evidence section, fixture-driven — `grok_loop_nocap`/`grok_loop_cap30` are the exact measured exit-11 shape (exit 0, EndTurn, 16 turns); error/truncated/hostile-shape arms included.
- Full suite via `./scripts/pytest_app.sh`: **1172 passed, 1 skipped**.

Docs: one paragraph in `docs/07` §4 naming the `terminal` evidence key (zero-drift). The full docs/ADR sweep rides PR-2 with the loop itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)