### PR TITLE
fix: dev-owned pw-browsers + tini PID 1 (ADR-0023 review round)

### DIFF
--- a/docs/07-dev-runtime.md
+++ b/docs/07-dev-runtime.md
@@ -223,7 +223,7 @@ DevCake is **not** a multi-tenant sandbox product (`14-security.md` §6). Isolat
 
 - **Network:** full **outbound** internet (forge, packages, model APIs) plus membership in `devcake_runtime` for Redis, **otel-collector**, and optional internal Gitea. **OpenObserve is not on runtime.** The app/admin/Dagu control plane is not attached. Attachment mechanism in `13-deployment.md` §5.
 - **No `docker.sock`:** Dev containers never receive the Docker socket (`14-security.md` §5).
-- **User:** the entire entrypoint runs as a non-root user (uid 1000) — verified hard requirement at M3: Claude Code refuses `--dangerously-skip-permissions` under root.
+- **User:** the entire entrypoint runs as a non-root user (uid 1000) — verified hard requirement at M3: Claude Code refuses `--dangerously-skip-permissions` under root. PID 1 is `tini` (ADR-0023 fix round): the entrypoint reaps no orphans, and browser process trees would otherwise accumulate zombies over multi-hour runs; Dagu cannot pass `--init` (see **Resources** below).
 - **MCP / extra CLI args:** admin-configured free-text commands run with `shell=True` / harness flags before/with the agent — **admin-equivalent ACE** inside the disposable container (`11-admin-panel.md`).
 - **Resources:** Dagu 2.10.5 step `container:` does **not** support Docker HostConfig CPU/memory/PID fields (schema `additionalProperties: false`). The DAG sets best-effort process-level `resources.limits` (`cpu: "2"`, `memory: "4g"`) where the host enforces cgroups on the DAG run process — this is **not** a guaranteed limit on the sibling Dev container (**engineering debt**, `14` §11). Primary throttle is app concurrency (`concurrency.global_max` + per-Dev-Type caps).
 
@@ -236,10 +236,13 @@ open-ended and runtime `apt` rightly does not exist (no root):
 - **Class A (root-only — baked or impossible):** `build-essential` (native
   pip/npm builds), and the browser stack: playwright's pinned headless
   Chromium shell + every system library it loads, at
-  `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` (world-readable), with the
-  `playwright` CLI on PATH at the same pin (`playwright --version` tells a
-  Dev which version finds the baked browser; a mismatched install falls back
-  to downloading its own — degraded, never broken).
+  `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` — **dev-owned**, because the
+  env var points every install there and a read-only dir would brick any
+  browser the base did not bake (measured; ADR-0023 fix round). Writable is
+  safe: the container is disposable. The `playwright` CLI is on PATH at the
+  same pin (`playwright --version` tells a Dev which version finds the baked
+  browser; a mismatched install downloads its own build alongside —
+  degraded, never broken).
 - **Class B (self-provisioning enablers):** Node/npm/npx (shared base — every
   harness, so a JS repo's dev server always starts), pip/venv, `uv`, and a
   PATH that honors user installs: `~/.local/bin` and `~/.npm-global/bin`

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -455,7 +455,11 @@ Items that improve safety or hygiene **without** changing the adult-operator
 contract:
 
 - Docker HostConfig CPU/memory/PID limits on Dev containers (when Dagu supports
-  them, or via another spawn path).
+  them, or via another spawn path). The ADR-0023 browser floor raises the
+  ceiling a run CAN reach — RAM is spent only when a Dev actually launches
+  the browser (headless shell idle ≈150 MB, active pages 300–800 MB), so
+  budget `concurrency × browser working set` for browser-using fleets until
+  hard limits exist.
 - Protocol hardens: ~~credential-upload filename allowlist + size cap~~
   (`secrets.require_credential_ref` + `MAX_CREDENTIAL_FILE_BYTES` + atomic
   `write_credential_file`); ~~PMO `download_asset` host allowlist / redirect
@@ -468,7 +472,10 @@ contract:
   deny-list remains open.
 - Optional: gVisor/Kata for Devs; egress allowlists / credential-injection
   proxy (e.g. [iron-proxy](https://github.com/ironsh/iron-proxy) class —
-  deferred radar in `16-roadmap.md`); OIDC if you must expose the admin UI
+  deferred radar in `16-roadmap.md`; note the ADR-0023 baked browser widens
+  the injection intake beyond curl — a Dev live-testing pages renders
+  arbitrary third-party content straight into its context, same open-egress
+  accept, bigger funnel); OIDC if you must expose the admin UI
   beyond loopback; OTLP bearer auth on the collector (low priority on a
   dedicated single-tenant host).
 

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -410,7 +410,13 @@ vocabulary at the top of this file).
   poppler/pandas/openpyxl document-and-spreadsheet floor (class C, founder
   decision). Build-time smoke proves the floor AS uid 1000 (headless shell
   must launch). Out by doctrine: sudo, docker, DBs, vendor CLIs,
-  LibreOffice. Base ~1.4 GB, shared layers. **built**.
+  LibreOffice. Base ~1.4 GB, shared layers. **built**. Skeptical-review fix
+  round same day: `/opt/pw-browsers` dev-owned (as shipped, the env var +
+  read-only dir bricked every non-baked browser — measured EACCES after
+  the download; disposable container ⇒ writable is safe) + `tini` as PID 1
+  (browser process trees vs a non-reaping entrypoint) + docs/ADR truth
+  sweep incl. `14` §11 browser-injection radar + memory-budget notes.
+  **built**.
 - **In-container run continuation** (ADR-0022, 2026-08-02): the
   narrate-and-stop landing (exit 0, `stopReason EndTurn`, no `result.json` —
   ~50% of long weak-model runs, hours lost late) is nudged instead of failed:

--- a/docs/adr/0023-dev-toolchain-floor.md
+++ b/docs/adr/0023-dev-toolchain-floor.md
@@ -51,14 +51,23 @@ chosen by *who is able to provide the capability*:
 `playwright@1.61.1` (pinned to the same family as the repo's own admin UI
 suite — one browser stack for the whole codebase) with
 `install --with-deps chromium-headless-shell` at build time, browsers in
-the world-readable `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`, and the
-`playwright` CLI on PATH at the same pin. Rationale over the
-alternatives: deps-only (per-run 170 MB browser downloads — the turn tax
-again) and Debian `chromium` (executablePath plumbing friction, no
-savings) both lose. The shared-base placement means the ~0.6 GB stack
-exists ONCE on disk across all three harness images. A Dev that installs
-a mismatched playwright version falls back to downloading its own build —
-degraded, never broken; the baked pin is discoverable via
+`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`, and the `playwright` CLI on
+PATH at the same pin. Rationale over the alternatives: deps-only (per-run
+170 MB browser downloads — the turn tax again) and Debian `chromium`
+(executablePath plumbing friction, no savings) both lose. The shared-base
+placement means the ~0.6 GB stack exists ONCE on disk across all three
+harness images.
+
+**`/opt/pw-browsers` is dev-owned — corrected by the fix round.** The env
+var points EVERY playwright install at that path, so as first shipped
+(root-owned, `a+rX`) any browser the base did not bake — another
+playwright version's revision, full Chromium, Firefox, WebKit — was
+uninstallable: measured `EACCES` on `__dirlock`, and only *after* the
+download completed. Ownership by `dev` restores self-healing (a
+mismatched pin downloads its own build beside the baked one — degraded,
+never broken); it is safe because the container is disposable, so a run
+that corrupts the shared stack corrupts only itself. The build smoke
+asserts writability. The baked pin stays discoverable via
 `playwright --version`.
 
 ### 3 — Build-time proof, not hope
@@ -86,10 +95,34 @@ image bake therefore asserts the floor on every PR that touches images.
 
 ## Consequences
 
-- Image weight: base grows to roughly 1.4 GB (browser stack ~0.6 GB,
-  build-essential ~0.25 GB, Node ~0.15 GB, the rest small); harness
-  images share the base layers, local bake only, no registry push. First
-  bake is slow; layer cache absorbs the rest.
+- Image weight: harness images land at ~1.9–2.1 GB, base layers shared,
+  local bake only, no registry push — DISK, not RAM (founder note
+  2026-08-02); stale per-SHA tags are the only growth, so periodic
+  `docker image prune` matters more than before. First bake is slow;
+  layer cache absorbs the rest.
+- Memory is a CAPABILITY cost, not a standing one: the browser consumes
+  RAM only when a run launches it (headless shell idle ≈150 MB, active
+  page loads 300–800 MB). The `14` §11 no-hard-container-limits debt is
+  unchanged; its reachable ceiling grew — budget
+  `concurrency × browser working set` for browser-using fleets.
+- `tini` is PID 1 (fix round): the entrypoint reaps nothing, and browser
+  process trees orphan children on unclean exits — without a reaper,
+  multi-hour runs (longer under ADR-0022 continuations) accumulate
+  zombies and stray headless-shells. Dagu cannot pass `--init`.
+- PATH precedence (`~/.npm-global/bin` before `/usr/local/bin`) lets a
+  run shadow binaries the entrypoint itself later invokes (`grok export`,
+  continuation relaunches). No privilege or capability is gained — a Dev
+  already authors its own result.json, and `14` treats Dev output as
+  untrusted; the vector pre-existed on grok (`~/.grok/bin` is dev-owned).
+  Accepted; absolute-path resolution in the entrypoint is the hardening
+  candidate if transcript-evidence integrity ever tightens.
+- A live browser is a wider prompt-injection intake than curl: rendered
+  third-party pages enter the model's context wholesale. Same class as
+  the existing open-egress accepts (`14` §5a); named on the `14` §11
+  egress-allowlist radar.
+- Screenshots of CJK/emoji-heavy pages render tofu (`--with-deps` ships
+  Latin fonts only); `fonts-noto-cjk` (~60 MB) is the add if a fleet
+  needs it.
 - grok Devs gain Node — the silent "cannot even start the dev server"
   failure class disappears.
 - The `08` §7 PATH warning inverts into a guarantee; plugin registration

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         procps \
         ripgrep \
         sqlite3 \
+        tini \
         unzip \
         zip \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -98,14 +99,13 @@ RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 
 # Browser floor (ADR-0023, class A — user-space can download a browser but
 # can NEVER apt-install its shared libraries): playwright's pinned headless
-# shell + its system deps, in a world-readable shared path so every user and
-# every matching-version playwright finds it without re-downloading. The
-# `playwright` CLI itself goes on PATH globally at the same pin.
+# shell + its system deps, in a shared path so every matching-version
+# playwright finds it without re-downloading. The `playwright` CLI itself
+# goes on PATH globally at the same pin.
 ARG PLAYWRIGHT_VERSION
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
 RUN npm install -g "playwright@${PLAYWRIGHT_VERSION}" \
     && playwright install --with-deps chromium-headless-shell \
-    && chmod -R a+rX /opt/pw-browsers \
     && npm cache clean --force \
     && rm -rf /var/lib/apt/lists/*
 
@@ -113,10 +113,14 @@ RUN npm install -g "playwright@${PLAYWRIGHT_VERSION}" \
 # Create user before setting HOME so installers (e.g. Grok CLI) can write $HOME.
 # The .npmrc prefix makes RUNTIME `npm i -g` a user-space self-serve (root
 # builds are unaffected: they run with HOME=/root above).
+# /opt/pw-browsers is DEV-OWNED (ADR-0023 fix round): PLAYWRIGHT_BROWSERS_PATH
+# points every install there, so a read-only dir would brick any browser the
+# base did not bake (measured: EACCES on __dirlock, AFTER the download).
+# Writable is safe — the container is disposable, corruption dies with the run.
 RUN useradd -m -u 1000 -d /home/dev -s /bin/bash dev \
     && mkdir -p /workspace /home/dev/.npm-global /home/dev/.local/bin \
     && printf 'prefix=/home/dev/.npm-global\n' > /home/dev/.npmrc \
-    && chown -R dev:dev /home/dev /workspace
+    && chown -R dev:dev /home/dev /workspace /opt/pw-browsers
 
 ENV HOME=/home/dev \
     PATH="/home/dev/.local/bin:/home/dev/.npm-global/bin:${PATH}"
@@ -138,9 +142,11 @@ RUN su dev -s /bin/sh -c ' \
             | head -1)"; \
         test -n "$shell" || { echo "no headless shell under /opt/pw-browsers" >&2; exit 1; }; \
         "$shell" --version; \
+        touch /opt/pw-browsers/.devcake-writable \
+            && rm /opt/pw-browsers/.devcake-writable; \
         python -c "import pandas, openpyxl"; \
         uv --version; \
-        command -v jq rg pandoc pdftotext sqlite3 unzip zip gcc make >/dev/null'
+        command -v tini jq rg pandoc pdftotext sqlite3 unzip zip gcc make >/dev/null'
 
 # Shared entrypoint façade + Dev-side package (domain/fault pure; more slices later).
 # Package root is `/` so `import devcake_dev` works; ENTRYPOINT path unchanged.
@@ -148,7 +154,12 @@ COPY common/devcake_dev /devcake_dev
 COPY common/dev_entrypoint.py /dev_entrypoint.py
 
 WORKDIR /workspace
-ENTRYPOINT ["python", "/dev_entrypoint.py"]
+# tini as PID 1 (ADR-0023 fix round): the entrypoint reaps nothing, and
+# browser process trees orphan children on unclean exits — over a multi-hour
+# run (longer still under ADR-0022 continuations) zombies and stray
+# headless-shells would otherwise accumulate. Dagu cannot pass --init
+# (container schema rejects HostConfig fields, docs/07 §7).
+ENTRYPOINT ["tini", "--", "python", "/dev_entrypoint.py"]
 
 # ── hello: CI stub — no git/forge CLIs needed ───────────────────────────────
 FROM ${PYTHON_IMAGE} AS hello


### PR DESCRIPTION
## What

Post-ship skeptical review of #76 found one confirmed regression and one structural gap; both fixed here, plus the docs corrected to match measured reality.

### 1. `/opt/pw-browsers` was a wall, not a floor (confirmed regression)

`PLAYWRIGHT_BROWSERS_PATH` redirects **every** playwright install into the shared dir, which shipped root-owned. Measured in the live image: `playwright install chromium` as dev downloads for minutes, then dies with `EACCES: permission denied, mkdir '/opt/pw-browsers/__dirlock'`. So any browser the base didn't bake — another pin's revision, full Chromium, Firefox/WebKit, headed runs — was flat-out uninstallable, which is *worse* than pre-#76 for those cases. Now dev-owned: mismatched pins self-heal by downloading beside the baked build; safe because containers are disposable. The build smoke asserts writability.

### 2. tini as PID 1

The entrypoint reaps nothing; chromium is a process tree whose orphans reparent to PID 1 and linger as zombies/strays across multi-hour runs (longer still under ADR-0022 continuations). Dagu can't pass `--init` (container schema rejects HostConfig fields), so the image wraps its own: `ENTRYPOINT ["tini", "--", "python", "/dev_entrypoint.py"]`.

### Docs truth sweep

- ADR-0023: the "degraded, never broken" fallback claim was false as shipped — corrected, with the measurement; consequences now record the founder-confirmed framing (image weight is disk not RAM; **memory is a capability cost that accrues only when a run launches the browser** — budget `concurrency × working set`), the PATH-shadow accept, the browser-as-wider-injection-intake note, and the CJK-fonts limitation.
- docs/07 §7/§7a, docs/14 §11 (egress radar + memory budgeting input), docs/16.

## Verified

Rebaked image: `/opt/pw-browsers` is `dev`-owned and writable as uid 1000 (probe passes); `docker inspect` Entrypoint = `[tini -- python /dev_entrypoint.py]`; build smoke (incl. new writability assertion) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)