### PR TITLE
test: make the composition root, DAG isolation, and UI checks load-bearing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
             -e REDIS_URL=redis://redis:6379/0 \
             -e REDIS_PASSWORD=ci-redis-pass \
             -v "${{ github.workspace }}/images/common:/srv/images/common:ro" \
+            -v "${{ github.workspace }}/dagu/dags:/srv/dagu-dags:ro" \
+            -v "${{ github.workspace }}/app/Dockerfile:/srv/app.Dockerfile:ro" \
             -w /srv \
             "devcake/app-test:${DEVCAKE_TAG}" \
             python -m pytest tests/ -q --tb=short
@@ -114,6 +116,9 @@ jobs:
           export DEVCAKE_TAG="${DEVCAKE_TAG}"
           export DOCKER_GID
           DOCKER_GID="$(stat -c %g /var/run/docker.sock)"
+          # 2026-08 evaluation: the contract batteries ride this same stack,
+          # so it now includes the bundled Gitea (zero external tokens)
+          export CI_COMPOSE_WITH_GITEA=1
           chmod +x scripts/ci_compose_for_dispatch.sh scripts/ci_dispatch_hello.sh
           ./scripts/ci_compose_for_dispatch.sh
 
@@ -126,6 +131,16 @@ jobs:
           # Cold CI: allow more polls (30 × 3s default may be tight under load)
           export DEVCAKE_HELLO_POLLS=40
           ./scripts/ci_dispatch_hello.sh
+
+      - name: Forge + PMO contract batteries (bundled Gitea lane)
+        run: |
+          set -euo pipefail
+          # The strongest integration artifacts in the repo, previously run
+          # only from a hand-raised local stack (2026-08 evaluation): real
+          # repos, PRs, merges, labels — inside the app container, against
+          # the bundled Gitea, zero external tokens. Exit code is the verdict.
+          docker compose exec -T app python - < scripts/contract_tests_forge.py
+          docker compose exec -T app python - < scripts/contract_tests_pmo.py
 
       - name: Teardown compose stack
         if: always()

--- a/admin/spa/DESIGN.md
+++ b/admin/spa/DESIGN.md
@@ -282,10 +282,15 @@ A UI change is done when you have personally seen:
 3. `npm --prefix admin/spa run check:ui` green — the committed behavioral
    suite (`admin/spa/tests/`: settings model, action hierarchy, redesign
    invariants; it boots vite itself and needs the live backend on :8080).
-   It never confirms a Save and cancels every destructive dialog, so it is
-   safe against live config. New interactions get assertions added here
-   (menu opens, dialog reached, draft counts edits), not just screenshots.
-   Local-only for now — CI has no live stack to run it against.
+   It cancels every destructive dialog, and every suite except one never
+   confirms a Save — the honest exception is `pmo_intake.mjs`, which
+   REALLY saves (a poll-interval tweak plus intake flips, restoring both
+   to as-found) to prove the save-revert regression; run it against
+   stacks whose config you own. New interactions get
+   real predicates added here (`checked(name, fn)` — never `check(name,
+   true)` after a bare wait), not just screenshots. Local-only for now —
+   CI has no live stack to run it against; the pure-node helper suites
+   (markdown/format) ride every run and need nothing live.
 4. For prod: `docker buildx bake admin && docker compose up -d admin` + load.
 
 Name anything left unproven (OAuth wizard, real save-PUT, etc.) instead of

--- a/admin/spa/tests/assignments.mjs
+++ b/admin/spa/tests/assignments.mjs
@@ -3,7 +3,7 @@
 // assignment wholesale, an inherit row follows the global table. Never
 // confirms a Save — the flow restores the original selection so the dirty
 // bar clears and live config is untouched.
-import { check, gotoFresh, skip, summary, withPage } from "./harness.mjs";
+import { check, checked, gotoFresh, skip, summary, withPage } from "./harness.mjs";
 
 const MTS = ["ONBOARD", "PLAN", "EXECUTE", "REVIEW"];
 
@@ -41,8 +41,12 @@ await withPage(async (page) => {
       skip("override flip", "only one dev type configured — nothing to flip to");
     } else {
       await sel.selectOption(target);
-      await page.waitForSelector('span:has-text("Unsaved changes")');
-      check("setting an override dirties the draft", true);
+      await checked("setting an override dirties the draft", async () => {
+        await page.waitForSelector('span:has-text("Unsaved changes")',
+          { timeout: 8000 });
+        return (await page.locator(
+          'span:has-text("Unsaved changes")').count()) >= 1;
+      });
       check("an overridden row exposes its own CLI-args input",
         (await page.locator("#mission-types table").nth(1)
           .locator('input[placeholder="e.g. --max-turns 15"]').count()) >= 1);
@@ -56,9 +60,13 @@ await withPage(async (page) => {
       await dlg.locator('button:has-text("Cancel")').click();
 
       await sel.selectOption(original);
-      await page.waitForSelector('span:has-text("Unsaved changes")',
-        { state: "detached", timeout: 5000 });
-      check("restoring the selection clears the dirty bar (symmetric diff)", true);
+      await checked("restoring the selection clears the dirty bar (symmetric diff)",
+        async () => {
+          await page.waitForSelector('span:has-text("Unsaved changes")',
+            { state: "detached", timeout: 5000 });
+          return (await page.locator(
+            'span:has-text("Unsaved changes")').count()) === 0;
+        });
     }
   }
 });

--- a/admin/spa/tests/costs.mjs
+++ b/admin/spa/tests/costs.mjs
@@ -2,7 +2,7 @@
 // the Cost Inputs modal reached from the ⋯ menu. Asserts STRUCTURE, never
 // specific rate values (the live stack's card may be operator-edited), and
 // always CANCELS — this suite never saves rates, never mutates config.
-import { check, gotoFresh, skip, summary, withPage } from "./harness.mjs";
+import { check, checked, gotoFresh, skip, summary, withPage } from "./harness.mjs";
 
 await withPage(async (page) => {
   await gotoFresh(page, "#/runs");
@@ -55,7 +55,8 @@ await withPage(async (page) => {
   if ((await page.locator('[data-testid="mission-group"]').count()) === 0) {
     skip("grouped mode clusters runs under mission rows", "no runs on this stack");
   } else {
-    check("grouped mode clusters runs under mission rows", true);
+    check("grouped mode clusters runs under mission rows",
+      (await page.locator('[data-testid="mission-group"]').count()) >= 1);
     check("pagination speaks missions when grouped",
       /of \d+ missions/.test(await page.innerText("main")));
   }

--- a/admin/spa/tests/devtypes.mjs
+++ b/admin/spa/tests/devtypes.mjs
@@ -2,7 +2,7 @@
 // tile) and the editor modal keep the draft semantics — edits ride the
 // page-level Save, never a per-modal save. All dialogs are cancelled and the
 // draft is discarded — nothing is ever saved or destroyed.
-import { check, gotoFresh, skip, summary, withPage } from "./harness.mjs";
+import { check, checked, gotoFresh, skip, summary, withPage } from "./harness.mjs";
 
 await withPage(async (page) => {
   await gotoFresh(page, "#/config/dev-types");
@@ -25,8 +25,10 @@ await withPage(async (page) => {
         >= (await tiles.count()));
     // 2: tile opens the editor modal with the full config surface
     await tiles.first().click();
-    await page.waitForSelector('[role="dialog"]');
-    check("tile opens the editor dialog", true);
+    await checked("tile opens the editor dialog", async () => {
+      await page.waitForSelector('[role="dialog"]', { timeout: 8000 });
+      return (await page.locator('[role="dialog"]').count()) >= 1;
+    });
     check("editor has harness/model fields",
       (await page.locator('[role="dialog"] :text("Harness template")').count()) >= 1 &&
       (await page.locator('[role="dialog"] :text-is("Model")').count()) >= 1);
@@ -48,8 +50,12 @@ await withPage(async (page) => {
     const before = await model.inputValue();
     await model.fill(`${before}-uicheck`);
     await page.locator('[role="dialog"] button:has-text("Close")').click();
-    await page.waitForSelector(':text("Unsaved changes")');
-    check("closing the editor keeps the edit in the draft (DirtyBar)", true);
+    await checked("closing the editor keeps the edit in the draft (DirtyBar)",
+      async () => {
+        await page.waitForSelector(':text("Unsaved changes")',
+          { timeout: 8000 });
+        return (await page.locator(':text("Unsaved changes")').count()) >= 1;
+      });
     // roster is a table (2026-08-02 re-decision): the badge is a sibling
     // cell of the edit button, so assert row-scoped, not button-descendant
     check("the edited row is badged",
@@ -62,8 +68,12 @@ await withPage(async (page) => {
 
   // 4: dashed row reaches the create dialog — cancelled
   await page.locator('#dev-types button:has-text("New Dev Type")').last().click();
-  await page.waitForSelector('[role="dialog"]:has-text("New Dev Type")');
-  check("dashed row reaches the create dialog", true);
+  await checked("dashed row reaches the create dialog", async () => {
+    await page.waitForSelector('[role="dialog"]:has-text("New Dev Type")',
+      { timeout: 8000 });
+    return (await page.locator(
+      '[role="dialog"]:has-text("New Dev Type")').count()) === 1;
+  });
   await page.click('[role="dialog"] button:has-text("Cancel")');
 });
 

--- a/admin/spa/tests/harness.mjs
+++ b/admin/spa/tests/harness.mjs
@@ -48,6 +48,17 @@ export function check(name, ok, detail = "") {
   else { failures += 1; console.error(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`); }
 }
 
+// Predicate-with-containment (2026-08 evaluation): a throwing predicate —
+// selector timeout, detached element — records a NAMED failure instead of
+// crashing the file and silently skipping every later check.
+export async function checked(name, fn, detail = "") {
+  try {
+    check(name, await fn(), detail);
+  } catch (e) {
+    check(name, false, String(e).split("\n")[0]);
+  }
+}
+
 export function skip(name, why) {
   skips += 1;
   console.log(`  - ${name} (skipped: ${why})`);
@@ -72,6 +83,13 @@ export async function withPage(fn, { width = 1280, height = 900 } = {}) {
   });
   try {
     await fn(page);
+  } catch (e) {
+    // An escape from the suite body is a recorded failure, not a crash: the
+    // suite's summary() still runs, later suites are unaffected, and the
+    // report names what broke instead of a bare stack trace (2026-08
+    // evaluation — a throw used to abort the file and silently skip every
+    // remaining check).
+    check("suite body ran to completion", false, String(e).split("\n")[0]);
   } finally {
     await browser.close();
   }

--- a/admin/spa/tests/hierarchy.mjs
+++ b/admin/spa/tests/hierarchy.mjs
@@ -2,7 +2,7 @@
 // rest behind a ⋯ MoreMenu whose items still reach their confirm/prompt
 // dialogs, and full keyboard operation of the menu. All dialogs are
 // cancelled — nothing destructive ever runs.
-import { check, gotoFresh, skip, summary, withPage } from "./harness.mjs";
+import { check, checked, gotoFresh, skip, summary, withPage } from "./harness.mjs";
 
 await withPage(async (page) => {
   // 1: no bare secondary/destructive buttons on the redesigned surfaces
@@ -28,14 +28,22 @@ await withPage(async (page) => {
   } else {
     await devMenu.click();
     await page.click('[role="menuitem"]:has-text("Rename")');
-    await page.waitForSelector('[role="dialog"]:has-text("Rename Dev Type")');
-    check("⋯ → Rename reaches the prompt dialog", true);
+    await checked("⋯ → Rename reaches the prompt dialog", async () => {
+      await page.waitForSelector('[role="dialog"]:has-text("Rename Dev Type")',
+        { timeout: 8000 });
+      return (await page.locator(
+        '[role="dialog"]:has-text("Rename Dev Type")').count()) === 1;
+    });
     await page.click('[role="dialog"] button:has-text("Cancel")');
 
     await devMenu.click();
     await page.click('[role="menuitem"]:has-text("Delete Dev Type")');
-    await page.waitForSelector('[role="dialog"]:has-text("Delete dev type")');
-    check("⋯ → Delete reaches the confirm dialog", true);
+    await checked("⋯ → Delete reaches the confirm dialog", async () => {
+      await page.waitForSelector('[role="dialog"]:has-text("Delete dev type")',
+        { timeout: 8000 });
+      return (await page.locator(
+        '[role="dialog"]:has-text("Delete dev type")').count()) === 1;
+    });
     await page.click('[role="dialog"] button:has-text("Cancel")');
 
     // 4: keyboard operation — open, arrows move focus, Esc returns to trigger
@@ -68,8 +76,12 @@ await withPage(async (page) => {
     (await page.locator('a:has-text("Open Dagu")').count()) === 1);
   await page.click('button[aria-label="More run actions"]');
   await page.click('[role="menuitem"]:has-text("Clear run history")');
-  await page.waitForSelector('[role="dialog"]:has-text("Clear all run history?")');
-  check("⋯ → Clear run history still confirms", true);
+  await checked("⋯ → Clear run history still confirms", async () => {
+    await page.waitForSelector(
+      '[role="dialog"]:has-text("Clear all run history?")', { timeout: 8000 });
+    return (await page.locator(
+      '[role="dialog"]:has-text("Clear all run history?")').count()) === 1;
+  });
   await page.click('[role="dialog"] button:has-text("Cancel")');
 
   // 6: Skills header — one primary; secondary actions in ⋯ or a lone ghost

--- a/admin/spa/tests/missions.mjs
+++ b/admin/spa/tests/missions.mjs
@@ -7,7 +7,7 @@
 // page never scrolls horizontally at ANY width, and the sidebar collapse
 // toggle works on Missions (the force-collapse exception died with the
 // board). Read-only — everything is route-mocked or a plain GET.
-import { check, gotoFresh, summary, withPage } from "./harness.mjs";
+import { check, checked, gotoFresh, summary, withPage } from "./harness.mjs";
 
 const LONG_KEY = "PLATFORM-999999";
 const LONG_TITLE =
@@ -148,8 +148,12 @@ async function assertList(width, height) {
 
     // row click opens the drawer (drawer itself unchanged)
     await page.locator('section[aria-label="Done"] [role="button"]').first().click();
-    await page.waitForSelector('button[aria-label="Close drawer"]', { timeout: 5000 });
-    check(`row click opens the mission drawer at ${width}`, true);
+    await checked(`row click opens the mission drawer at ${width}`, async () => {
+      await page.waitForSelector('button[aria-label="Close drawer"]',
+        { timeout: 5000 });
+      return (await page.locator(
+        'button[aria-label="Close drawer"]').count()) === 1;
+    });
     await page.click('button[aria-label="Close drawer"]');
   }, { width, height });
 }

--- a/admin/spa/tests/profiles.mjs
+++ b/admin/spa/tests/profiles.mjs
@@ -4,7 +4,7 @@
 // profile (`zz-uitest-profile`) and deletes it again, so the operator's real
 // profiles and live settings are untouched. The apply flow is opened for its
 // preview diff and then CANCELLED — this suite never clicks "Apply profile".
-import { BASE, check, gotoFresh, summary, withPage } from "./harness.mjs";
+import { BASE, check, checked, gotoFresh, summary, withPage } from "./harness.mjs";
 
 const NAME = "zz-uitest-profile";
 const NAME2 = "zz-uitest-renamed";
@@ -41,8 +41,11 @@ await withPage(async (page) => {
   await saveDlg.waitFor();
   await saveDlg.locator("input").fill(NAME);
   await saveDlg.locator('button:has-text("Save")').click();
-  await rowFor(page, NAME).waitFor({ timeout: 8000 });
-  check("Save current as profile creates the snapshot row", true);
+  await checked("Save current as profile creates the snapshot row",
+    async () => {
+      await rowFor(page, NAME).waitFor({ timeout: 8000 });
+      return (await rowFor(page, NAME).count()) === 1;
+    });
 
   // 3 — it appears in the Apply select
   const applyOpt = page.locator('select[aria-label="Profile to apply"] option',
@@ -61,8 +64,10 @@ await withPage(async (page) => {
   check("Apply shows the change-preview before anything applies",
     (await preview.count()) >= 1);
   await applyDlg.locator('button:has-text("Cancel")').click();
-  await applyDlg.waitFor({ state: "detached", timeout: 8000 });
-  check("Apply preview cancels cleanly — no world-swap", true);
+  await checked("Apply preview cancels cleanly — no world-swap", async () => {
+    await applyDlg.waitFor({ state: "detached", timeout: 8000 });
+    return (await applyDlg.count()) === 0;
+  });
 
   // 5 — Rename via the row action
   const row = rowFor(page, NAME);

--- a/admin/spa/tests/redesign.mjs
+++ b/admin/spa/tests/redesign.mjs
@@ -1,7 +1,7 @@
 // Redesign suite: masthead answers first, oven strip, manual dark mode,
 // click-popover help, and the RunTerminal dialog behavior (when the stack
 // has runs). Read-only — no config edits, no destructive actions.
-import { check, gotoFresh, skip, summary, withPage } from "./harness.mjs";
+import { check, checked, gotoFresh, skip, summary, withPage } from "./harness.mjs";
 
 await withPage(async (page) => {
   // 1: Overview opens with the answer masthead + eyebrow, not a status dump
@@ -47,8 +47,12 @@ await withPage(async (page) => {
     skip("RunTerminal dialog behavior", "no runs recorded on this stack");
   } else {
     await runBtn.click();
-    await page.waitForSelector('[role="dialog"][aria-label^="Run terminal"]');
-    check("run id opens the terminal dialog", true);
+    await checked("run id opens the terminal dialog", async () => {
+      await page.waitForSelector('[role="dialog"][aria-label^="Run terminal"]',
+        { timeout: 8000 });
+      return (await page.locator(
+        '[role="dialog"][aria-label^="Run terminal"]').count()) === 1;
+    });
     await page.keyboard.press("Escape");
     await page.waitForTimeout(100);
     check("Esc closes the terminal",

--- a/admin/spa/tests/run.mjs
+++ b/admin/spa/tests/run.mjs
@@ -11,6 +11,12 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 const spa = join(here, "..");
 const SUITES = [
+  // Pure-node helper suites first (no browser, no backend): previously only
+  // reachable via `npm run test:helpers`, which nothing invoked — including
+  // the safeHref XSS guard (2026-08 evaluation). Now every check:ui run
+  // carries them.
+  "markdown_helpers.mjs",
+  "format_helpers.mjs",
   "settings.mjs",
   "hierarchy.mjs",
   "devtypes.mjs",

--- a/admin/spa/tests/settings.mjs
+++ b/admin/spa/tests/settings.mjs
@@ -3,7 +3,7 @@
 // 2026-08-02 nav reorg), legacy-route redirects, nav guard, mobile chips.
 // Never confirms a Save — every flow ends in Cancel/Discard so live config
 // is untouched.
-import { BASE, check, gotoFresh, summary, withPage } from "./harness.mjs";
+import { BASE, check, checked, gotoFresh, summary, withPage } from "./harness.mjs";
 
 const POLL = 'input[aria-label="Poll interval (seconds)"]';
 const GLOBAL_MAX = 'input[aria-label="Global max Devs"]';
@@ -96,8 +96,12 @@ await withPage(async (page) => {
 
   // 8: nav guard on leaving Config dirty; Esc = Stay
   await page.click('aside a[href="#/runs"]');
-  await page.waitForSelector("text=You have 2 unsaved changes");
-  check("nav guard appears when leaving Config dirty", true);
+  await checked("nav guard appears when leaving Config dirty", async () => {
+    await page.waitForSelector("text=You have 2 unsaved changes",
+      { timeout: 8000 });
+    return (await page.locator(
+      "text=You have 2 unsaved changes").count()) >= 1;
+  });
   await page.keyboard.press("Escape");
   await page.waitForTimeout(150);
   check("Esc on the nav guard stays on Config",
@@ -125,8 +129,12 @@ await withPage(async (page) => {
   await poll2.fill(String(Number(await poll2.inputValue()) + 1));
   await page.waitForSelector('span:has-text("Unsaved changes")');
   await page.click('aside a[href="#/runs"]');
-  await page.waitForSelector("text=You have 1 unsaved change");
-  check("nav guard also fires leaving the PMO page dirty", true);
+  await checked("nav guard also fires leaving the PMO page dirty", async () => {
+    await page.waitForSelector("text=You have 1 unsaved change",
+      { timeout: 8000 });
+    return (await page.locator(
+      "text=You have 1 unsaved change").count()) >= 1;
+  });
   await page.click('button:has-text("Discard & leave")');
   await page.waitForTimeout(200);
   check("discard-and-leave lands on Runs with a clean draft",

--- a/app/tests/test_api_surface.py
+++ b/app/tests/test_api_surface.py
@@ -1,0 +1,97 @@
+"""The composition root, exercised as an ASGI app (2026-08 evaluation).
+
+Every prior suite tested route helpers as plain functions, so the ONE line
+wiring auth onto the app — `app.middleware("http")(enforce_control_plane_auth)`
+in api/main.py — had no test: deleting it left the whole suite green while
+disabling control-plane auth on a system whose admin password is
+host-root-equivalent (settings export carries DAGU_PASSWORD → docker.sock).
+These tests build a real TestClient over the REAL `devcake.api.main:app` and
+walk `app.routes`, so a route added tomorrow is covered the day it lands.
+
+No lifespan: the client is used without a context manager, so boot (Redis,
+label ensure, reconcile) never runs — and the middleware answers 401/403
+BEFORE any handler executes, so no handler side effects are possible either.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.routing import APIRoute          # noqa: E402
+from fastapi.testclient import TestClient     # noqa: E402
+
+LIVE_PATH = "/api/v1/health/live"
+MUTATING = {"POST", "PUT", "PATCH", "DELETE"}
+_AUTH = ("ci-admin", "ci-secret-for-surface-tests")
+
+
+def _app():
+    from devcake.api import main as app_main
+    return app_main.app
+
+
+def _routes():
+    """(method, concrete_path) for every APIRoute, path params filled with a
+    plain token — validation happens after the middleware, so the fill only
+    needs to produce a routable URL."""
+    out = []
+    for route in _app().routes:
+        if not isinstance(route, APIRoute):
+            continue
+        path = route.path
+        for part in [p for p in path.split("/") if p.startswith("{")]:
+            path = path.replace(part, "param")
+        for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
+            out.append((method, path, route.path))
+    return out
+
+
+ROUTES = _routes()
+
+
+def test_the_surface_is_the_real_one():
+    """A wiring regression that emptied the app would green every parametrized
+    case below — pin the floor (52 route templates at time of writing; grows
+    freely, and a drop below 50 means the surface itself broke)."""
+    assert len({tpl for _m, _p, tpl in ROUTES}) >= 50
+
+
+@pytest.mark.parametrize("method,path,template", ROUTES,
+                         ids=[f"{m} {t}" for m, _p, t in ROUTES])
+def test_every_route_requires_auth(monkeypatch, method, path, template):
+    """401 without credentials on EVERY route except liveness — this is the
+    test that makes api/main.py's middleware attachment load-bearing."""
+    monkeypatch.setenv("ADMIN_USER", _AUTH[0])
+    monkeypatch.setenv("ADMIN_PASSWORD", _AUTH[1])
+    client = TestClient(_app(), raise_server_exceptions=False)
+    r = client.request(method, path)
+    if template == LIVE_PATH:
+        assert r.status_code == 200
+    else:
+        assert r.status_code == 401, f"{method} {template} answered without auth"
+        assert r.headers.get("www-authenticate", "").startswith("Basic")
+
+
+@pytest.mark.parametrize(
+    "method,path,template",
+    [(m, p, t) for m, p, t in ROUTES if m in MUTATING],
+    ids=[f"{m} {t}" for m, p, t in ROUTES if m in MUTATING])
+def test_mutating_routes_require_intent_header(monkeypatch, method, path,
+                                               template):
+    """Authenticated but header-less mutation → 403 (the CSRF closure: a
+    browser form can carry cached basic auth but can never set the header)."""
+    monkeypatch.setenv("ADMIN_USER", _AUTH[0])
+    monkeypatch.setenv("ADMIN_PASSWORD", _AUTH[1])
+    client = TestClient(_app(), raise_server_exceptions=False)
+    r = client.request(method, path, auth=_AUTH)
+    assert r.status_code == 403, \
+        f"{method} {template} mutated without the intent header"
+
+
+def test_unconfigured_credentials_fail_closed(monkeypatch):
+    """Empty ADMIN env answers 401 even to an empty-credential probe — the
+    _valid_basic_auth 'bool(expected…)' term, exercised through the app."""
+    monkeypatch.delenv("ADMIN_USER", raising=False)
+    monkeypatch.delenv("ADMIN_PASSWORD", raising=False)
+    client = TestClient(_app(), raise_server_exceptions=False)
+    assert client.get("/api/v1/health").status_code == 401
+    assert client.get("/api/v1/health", auth=("", "")).status_code == 401

--- a/app/tests/test_repo_structural.py
+++ b/app/tests/test_repo_structural.py
@@ -1,0 +1,88 @@
+"""Repo-level structural guards (2026-08 evaluation): claims that lived as
+"probe-verified" prose in comments become executable rules.
+
+These files sit OUTSIDE the app tree, so the runners mount them read-only
+(`scripts/pytest_app.sh` and ci.yml both add the mounts). A missing mount
+FAILS — a skip here would silently un-enforce the isolation contract.
+"""
+
+from pathlib import Path
+
+import yaml
+
+DAG = Path("/srv/dagu-dags/dev-run.yaml")
+DOCKERFILE = Path("/srv/app.Dockerfile")
+
+MOUNT_HINT = ("mount missing — the pytest runner must bind {src} "
+              "(see scripts/pytest_app.sh / ci.yml)")
+
+
+def _dag():
+    assert DAG.exists(), MOUNT_HINT.format(src="dagu/dags → /srv/dagu-dags")
+    return yaml.safe_load(DAG.read_text())
+
+
+def _steps():
+    doc = _dag()
+    return {s["id"]: s for s in doc["steps"]}
+
+
+def test_agent_step_never_mounts_the_mirrors():
+    """ADR-0025's whole point, previously enforced by a comment ("no mirrors
+    line; that is the point") and a one-time manual probe: the agent's
+    container must not see /mirrors — only the provision step may, and only
+    read-only."""
+    steps = _steps()
+    prov = steps["provision"]["container"]["volumes"]
+    dev = steps["run_dev"]["container"]["volumes"]
+    assert any(v == "devcake_mirrors:/mirrors:ro" for v in prov), \
+        "provision must mount the mirror volume READ-ONLY"
+    assert not any("/mirrors" in v for v in dev), \
+        "the agent container must never see /mirrors (ADR-0025)"
+
+
+def test_both_steps_share_exactly_the_per_run_workspace():
+    steps = _steps()
+    ws = "$DEVCAKE_WS_HOST/${params.RUN_ID}:/workspace"
+    for sid in ("provision", "run_dev"):
+        vols = steps[sid]["container"]["volumes"]
+        assert ws in vols, f"{sid} must bind the per-run workspace"
+    # and nothing else rides into the agent container
+    assert steps["run_dev"]["container"]["volumes"] == [ws]
+
+
+def test_run_id_precondition_fences_the_charset():
+    doc = _dag()
+    pres = {p.get("condition"): p.get("expected") for p in doc["preconditions"]}
+    assert pres.get("${params.RUN_ID}") == "re:^[A-Za-z0-9_-]{6,64}$", \
+        "the RUN_ID charset fence must match WorkspaceStore/docs (AUD-011)"
+
+
+def test_no_dagu_auto_retry():
+    """retry_policy limit 0 — Dagu retries would fight DevCake's own attempt
+    counting (M1 field note)."""
+    doc = _dag()
+    for s in doc["steps"]:
+        rp = s.get("retry_policy") or doc.get("retry_policy") or {}
+        assert rp.get("limit", 0) == 0
+
+
+def test_app_runs_one_uvicorn_worker():
+    """The no-lock design (RunStore parse cache, process-local dispatch lock,
+    'the app is ONE process') is only sound single-worker. The premise was
+    stated in comments; this makes it a rule."""
+    assert DOCKERFILE.exists(), \
+        MOUNT_HINT.format(src="app/Dockerfile → /srv/app.Dockerfile")
+    text = DOCKERFILE.read_text()
+    uvicorn_lines = [ln for ln in text.splitlines()
+                     if "uvicorn" in ln and ln.strip().startswith("CMD")]
+    assert uvicorn_lines, "app CMD must start uvicorn"
+    assert all("--workers" not in ln for ln in uvicorn_lines), \
+        "multi-worker uvicorn breaks the single-process store premise"
+    assert "gunicorn" not in text
+
+
+def test_structural_mounts_are_enforced_not_optional():
+    """Belt for the belt: both mounted files must exist — if a runner drops a
+    mount, every test above must fail loudly rather than skip silently."""
+    assert DAG.exists() and DOCKERFILE.exists()

--- a/scripts/ci_compose_for_dispatch.sh
+++ b/scripts/ci_compose_for_dispatch.sh
@@ -98,6 +98,15 @@ fi
 SERVICES=(fluentbit openobserve redis dagu otel-collector app admin)
 THIRD_PARTY=(fluentbit openobserve redis dagu otel-collector)
 
+# Opt-in Gitea (CI contract-battery lane, 2026-08 evaluation): the forge +
+# PMO batteries run inside the app container against the bundled instance —
+# zero external tokens — but need gitea up. Off by default to keep the
+# dispatch smoke minimal.
+if [[ "${CI_COMPOSE_WITH_GITEA:-0}" == "1" ]]; then
+  SERVICES+=(gitea)
+  THIRD_PARTY+=(gitea)
+fi
+
 # Resolve compose image refs once (digest-pinned in docker-compose.yml).
 # Prints "service<TAB>image" lines for the given service names.
 _third_party_images() {
@@ -188,6 +197,9 @@ wait_service redis healthy 40
 wait_service dagu healthy 40
 wait_service app healthy 60
 wait_service admin healthy 40
+if [[ "${CI_COMPOSE_WITH_GITEA:-0}" == "1" ]]; then
+  wait_service gitea healthy 60
+fi
 
 echo "── wait for authenticated control plane via admin :8080"
 BASE_URL="${DEVCAKE_BASE_URL:-http://127.0.0.1:8080}"

--- a/scripts/pytest_app.sh
+++ b/scripts/pytest_app.sh
@@ -35,6 +35,8 @@ docker run --rm \
   "${NET_ARGS[@]}" \
   "${ENV_ARGS[@]}" \
   -v "$(pwd)/images/common:/srv/images/common:ro" \
+  -v "$(pwd)/dagu/dags:/srv/dagu-dags:ro" \
+  -v "$(pwd)/app/Dockerfile:/srv/app.Dockerfile:ro" \
   -w /srv \
   "devcake/app-test:${TAG}" \
   python -m pytest tests/ -q "$@"


### PR DESCRIPTION
## What

PR C of the 2026-08 evaluation fix campaign — the enforcement layer.

- **`test_api_surface.py`**: the first tests to instantiate the real app. 401 asserted on all 52 route templates (parametrized over `app.routes`, so new routes are covered the day they land), 403 intent-header on every mutating verb, fail-closed empty-credential probe. This makes `api/main.py`'s middleware attachment load-bearing — deleting it now fails 100+ cases instead of zero.
- **`test_repo_structural.py`** + RO mounts in both runners: ADR-0025's `/mirrors`-isolation, the per-run workspace binds, the RUN_ID fence, no-Dagu-auto-retry, and the single-worker premise move from "probe-verified" comments to executable rules. A missing mount fails loudly — never skips.
- **CI contract lane**: the existing compose-smoke stack gains the bundled Gitea (`CI_COMPOSE_WITH_GITEA=1`) and both contract batteries run on every PR — the strongest integration artifacts in the repo, formerly local-only. Slim by construction: reuses the already-baked app image; Gitea is the only added pull.
- **UI suite honesty**: 15 `check(x, true)` tautologies → real predicates via `checked(name, fn)` (throwing predicates become named failures); suite-body escapes no longer abort the file's remaining output; `markdown_helpers`/`format_helpers` (incl. the `safeHref` XSS guard) join `run.mjs`; DESIGN.md's stale save-safety claim corrected.

## Verification

Suite **1419 passed** (base was 1304) · ruff clean · `node --check` clean on all touched suites. The new CI steps run on this PR itself — the contract-lane feasibility proof is this PR's own checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)