### PR TITLE
docs: truth sweep — every drift the 2026-08 evaluation confirmed, corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,12 @@ PMO (Linear / Gitea Issues) ──poll / labels──► app (orchestrator)
 Self-hosted, single operator, loopback by default. Stack passwords live in
 `.env`; **operator secrets** (PMO keys, forge tokens, model credentials) are
 entered through the admin UI's Configuration, Repositories and PMO pages and stored
-on the app volume — never echoed back.
+on the app volume — never echoed back. Be clear-eyed about what "GUI secret
+store" means: values rest as **plaintext files (mode 0600) on the `/data`
+volume** — there is no vault and no at-rest encryption (a key would have to
+live on the same host); anyone with host root or a volume backup reads
+everything. Treat `/data` backups like a password-manager export
+([`docs/14-security.md`](docs/14-security.md) §4).
 
 Agents are powerful by design. The app enforces outcome legality and never lets
 Devs write the PMO directly; it **warns** on weak posture (write token on every

--- a/admin/spa/src/components/LimitsSection.jsx
+++ b/admin/spa/src/components/LimitsSection.jsx
@@ -29,7 +29,7 @@ export default function LimitsSection() {
         <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
           <SettingRow label="Global max Devs"
             desc="Effective ceiling = min(global, Σ per-type caps)."
-            help="Primary host-protection control. Dagu 2.10.5 cannot apply Docker CPU/memory/PID limits to Dev containers — this cap is the effective throttle; hard per-container limits are planned.">
+            help="Primary host-protection control. Dagu (verified through 2.11.3) cannot apply Docker CPU/memory/PID limits to Dev containers — this cap is the effective throttle; hard per-container limits are planned.">
             <Input type="number" className="w-24" value={cfg.concurrency.global_max}
               aria-label="Global max Devs"
               onChange={(e) => setField("cfg.concurrency.global_max", Number(e.target.value))} />

--- a/app/devcake/config.py
+++ b/app/devcake/config.py
@@ -220,9 +220,10 @@ class RepoInstance(BaseModel):
 
 
 class Concurrency(BaseModel):
-    # concurrency caps are the real host-protection throttle: Dagu 2.10.5
-    # cannot apply Docker HostConfig limits to Dev containers (docs/07 §7);
-    # per-container hard limits return with Dagu host-config support (v0.1)
+    # concurrency caps are the real host-protection throttle: Dagu (measured
+    # at 2.10.5, re-verified at the pinned 2.11.3) cannot apply Docker
+    # HostConfig limits to Dev containers (docs/07 §7); per-container hard
+    # limits return with Dagu host-config support
     global_max: int = Field(3, ge=1)
 
 

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -72,8 +72,11 @@ The complete set of ten managed labels is defined in `02-domain-model.md` §5 an
 ## 4. Core invariants
 
 These are **behavioral** contracts (not the full security model — that is
-`14-security.md`). They are referenced by ID (`INV-n`) throughout the docs and
-covered by automated tests (`16-roadmap.md`, M7).
+`14-security.md`). They are referenced by ID (`INV-n`) throughout the docs;
+the *behaviors* they name are pinned by the unit suite (`16-roadmap.md`, M7),
+though there is no invariant-indexed test map — coverage is by behavior, not
+by `INV-n` key (2026-08 truth sweep: the earlier wording implied an index
+that does not exist).
 
 - **INV-1 — The PMO System is the single source of truth.** All Mission status, labels, and priority are read live from the PMO System. No local data is ever deemed current; local state (`/data/state`) is advisory telemetry that can be wiped without corrupting the system (consequences of a wipe are documented in `10-persistence.md`).
 - **INV-2 — At most one stage label per Mission.** A Mission carrying two or more stage labels is in conflict: DevCake refuses to schedule it (`LABEL_CONFLICT` — unschedulable gate reason only; no auto-comment; `15-errors-and-retries.md`).
@@ -167,5 +170,5 @@ Operating duties — once at setup and recurring — live in
 | `17-positioning.md` | Outward voice — must not outclaim `14` |
 | `18-operator-contract.md` | What the operator owns — setup pointer + recurring duties + rotation |
 | `19-thesis.md` | Why DevCake — the thesis: four claims with evidence status, scope doctrine (ordering vs originating), falsifiers |
-| `adr/` | Records of significant architectural decisions |
+| `adr/` | Records of significant architectural decisions — index with per-ADR status: [`adr/README.md`](adr/README.md) |
 | `tutorials/` | Operator path (includes supply-chain checklist) |

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -45,14 +45,28 @@ app/devcake/
   domain/          # pure logic — depends on ports, not adapters
     model.py       #   entities, Mission Type derivation, label set (02)
     run.py         #   Run record + state machine
-    run_bootstrap.py#  dispatch spine: ACL → digest → durable save → executor.start (04 §3.1)
+    run_bootstrap.py#  dispatch spine: workspace gate → ACL → digest → durable
+                   #   save → workspace dir → executor.start (04 §3.1, ADR-0025)
     orchestrator/  #   package: MissionManager (DI + verbs) + module functions (04, ADR-0015)
                    #     manager, schedule, dispatch, finalize, transitions,
                    #     review, decomposition, sweeps, feed, markers, mapper
     mapper_service.py  # Relations Mapper cadence (ADR-0007; ISSUES #36 first cut)
     runs.py        #   ingress, kill, hello dispatch; holds RunBootstrap + RunFinalizer
     oauth.py       #   harness OAuth flows (launches via RunBootstrap)
-    watchdog.py    #   timeout/zombie detection
+    watchdog.py    #   timeout/zombie detection + workspace sweep cadence
+    reconcile.py   #   boot reconciliation: adopt/orphan runs vs the Dagu API (04 §6)
+    workspaces.py  #   WorkspaceStore — per-run host-bind tree, fail-closed
+                   #   volume gate, sweep (ADR-0025)
+    repo_mirror.py #   RepoCache — mandatory source mirrors, freshness gate,
+                   #   needed_for (ADR-0024)
+    forge_runtime.py   # ForgeRuntime — live adapter set, per-repo breakers,
+                   #   bounded health sweeps (M10)
+    repo_routing.py    # mission → work-repo resolution (M10 markers)
+    blocker_locator.py #  deployment-wide blocked_by resolution (ADR-0009)
+    backend_health.py  #  model-backend brake predicates (ADR-0018/0026)
+    skills.py      #   skill store reads + prompt assembly (ADR-0016)
+    costing.py     #   app-side cost estimation vs the rate card (ADR-0021)
+    asset_fetch.py #   PMO attachment/zip fetching for activity repos (ADR-0014/0017)
     ids.py         #   id generation
   ports/           # Protocols + the DTOs that cross them
     pmo.py         #   PMOPort, PMOHealth, PMOCapabilities, PMOTransient (05)
@@ -79,7 +93,10 @@ app/devcake/
                    #   mission_actions.py, clear.py, config_service.py,
                    #   profiles_service.py, settings_transfer.py,
                    #   devtypes_service.py, connections_service.py,
-                   #   internal_repos_service.py
+                   #   internal_repos_service.py, runs_service.py,
+                   #   auth.py (basic-auth + intent-header middleware —
+                   #   attached in main.py; load-bearing, tested via
+                   #   tests/test_api_surface.py)
   telemetry/       # OTel setup, devcake.* attribute helpers (12)
   prompts/         # playbook prompt templates (03 §7)
   config.py        # single pydantic schema authority for config.yaml (root-level:

--- a/docs/04-orchestrator.md
+++ b/docs/04-orchestrator.md
@@ -71,10 +71,20 @@ Mission-specific fields (prompt, attempts, stage label, PMO refs) are built by t
 ```
 def launch(run, *, image):                         # RunBootstrap — all four flavors
   async with dispatch_lock:                        # clear-runs holds this for the full wipe
-    password = messaging.create_run_user(run.run_id)  # MessagingPort
+    if workspaces.volume_error:                       # (0) ADR-0025 fail-closed gate:
+        raise WorkspaceUnavailable(...)               #     an unusable workspace base
+        # refuses BEFORE any side effect — callers (dispatch, mapper) catch
+        # this and surface a blocked_reason; NO attempt burns, NO
+        # poll_degraded (the AUD-001/002 fix — fail-closed for real)
+    password = messaging.create_run_user(run.run_id)  # MessagingPort (+ ACL SAVE, 09 §1a)
     run.auth_digest = sha256(password)                # never persist the raw ACL secret
     run.store_gen = store.wipe_generation             # clear-runs generation guard
     state.save(run)                                   # (1) durable intent BEFORE side effects
+    try:
+        workspaces.create(run.run_id)                 # (1b) per-run host-bind dir, 0700
+    except OSError:                                   #      record-BEFORE-dir makes the
+        state.delete(run); messaging.delete_run_user  #      sweep predicate sound; a create
+        raise WorkspaceUnavailable(...)               #      failure UNWINDS record + ACL
     executor.start(params={                           # (2) ExecutorPort (Dagu in prod)
         "RUN_ID": run.run_id, "IMAGE": image,         #     non-secret params only (13 §4)
         "TRACEPARENT": run.traceparent or "",
@@ -93,10 +103,16 @@ def dispatch(mission, dev_type):                   # MissionManager — mission 
               spec_env=protocol_spec_env(...), ...)
     run.spec_prompt = resolve_prompt(mission, dev_type)  # includes {blocker_repos}
     run.blocker_work = resolve_blocker_work(...)         # ADR-0017: done blockers' repo_refs
+    run.mirror_repos = needed                            # the mirror gate's proven set,
+    #                                                      snapshotted (2026-08: the runspec
+    #                                                      serves mirrors from THIS, never
+    #                                                      from live config — 09 §3)
     bootstrap.launch(run, image=harness_image(dev_type))
-    # launch = ACL user → durable Run file BEFORE the Dagu trigger; the image
-    # param is a plain tag (e.g. devcake/dev-claude-code:latest — no digest
-    # pinning; 13-deployment.md §6), and Dagu receives only non-secret params
+    # launch = workspace gate → ACL user → durable Run file → workspace dir
+    # BEFORE the Dagu trigger (WorkspaceUnavailable at any of those steps is
+    # an unschedulable reason, not a failed attempt); the image param is a
+    # plain tag (e.g. devcake/dev-claude-code:latest — no digest pinning;
+    # 13-deployment.md §6), and Dagu receives only non-secret params
     # runspec later attaches RO tokens for blocker_work as extra_repos
     if live.status == "backlog":
         pmo.set_status(mission.ref, "in_progress")      # (3) reflect pull in PMO

--- a/docs/07-dev-runtime.md
+++ b/docs/07-dev-runtime.md
@@ -1,6 +1,6 @@
 # 07 — Dev Runtime: The Container Contract
 
-> **Audience:** implementers and harness-image authors. Anyone should be able to build a new Dev image from this document alone.
+> **Audience:** implementers and harness-image authors. This document plus `08-harness-templates.md` and `09-messaging.md` are the complete image contract — build against the three together (the 2026-08 truth sweep retired the older "this document alone" claim; the protocol payloads live in 09).
 > **Depends on:** `02-domain-model.md` (Run, DevType), `03-mission-lifecycle.md` (`result.json`), `08-harness-templates.md` (per-harness specifics), `09-messaging.md` (Redis protocol).
 
 A **Dev container** is an ephemeral Docker container that performs exactly one Mission Step and exits. It is spawned by Dagu as a sibling of the compose stack (`13-deployment.md`), named `dev-{run_id}`, and attached to the **`devcake_runtime`** network so it reaches `redis`, `otel-collector`, and (when used) internal Gitea by service name. **OpenObserve is not on the runtime network** — Devs export OTLP to the collector only (`12-observability.md`, `14` §10).
@@ -14,6 +14,13 @@ Devs are **pure functions from (workspace, prompt) to artifacts**: they never wr
   repo/                  # fresh `git clone` of the configured repository, directory named
                          #   exactly after the repository (standard clone output).
                          #   The ONLY place the harness may do its work (INV-6).
+    {slug}/              # ZERO OR MORE extra clones (ADR-0017/0024): the routing
+                         #   set's other repos (ONBOARD), the instance's reference
+                         #   repos (every stage), and done blockers' work repos —
+                         #   cloned by provision from `extra_repos` (mirror file://
+                         #   or RO-token https). Read-only BY TOKEN + prompt
+                         #   contract, not by filesystem mode; extra-clone
+                         #   failures are non-fatal (noted, run proceeds).
   activity/
     MISSION.md           # the brief: key/title/meta/labels, FULL description, mission
                          #   attachments (ADR-0014 — every playbook points here)
@@ -188,10 +195,15 @@ PROVISION container (prov-<run_id>, DEVCAKE_PHASE=provision, /mirrors RO)
   ▼
 HARNESS container (dev-<run_id>, DEVCAKE_PHASE=harness, workspace ONLY)
   │ 3a. heartbeat sidecar starts, THEN fetch run spec `{phase: harness}` →
-  │      full spec; verify sentinel + `provisioned` marker (else exit 20 WITH
-  │      artifacts — forensic owner/mode/listing); re-adopt the askpass +
-  │      git identity/LFS posture (fresh HOME)
-  │ 4. install harness credentials (env passthrough or credential-file content → harness path)
+  │      full spec
+  │ 4. install harness credentials (env passthrough or credential-file
+  │      content → harness path). NOTE the order (2026-08 truth sweep):
+  │      credentials land BEFORE the workspace identity check below —
+  │      they go to $HOME, not the workspace, so a wrong-bind exit never
+  │      leaves secrets in the disputed tree
+  │ 4a. verify sentinel + `provisioned` marker (else exit 20 WITH artifacts —
+  │      forensic owner/mode/listing); re-adopt the askpass + git
+  │      identity/LFS posture (fresh HOME)
   │ 4b. install skill-store skills from the runspec `skills` field → the
   │      harness's skills dir from runspec `skills_dir` (home-relative;
   │      default ~/.claude/skills — never into the repo clone, the Dev would
@@ -268,7 +280,7 @@ DevCake is **not** a multi-tenant sandbox product (`14-security.md` §6). Isolat
 - **No `docker.sock`:** Dev containers never receive the Docker socket (`14-security.md` §5).
 - **User:** the entire entrypoint runs as a non-root user (uid 1000) — verified hard requirement at M3: Claude Code refuses `--dangerously-skip-permissions` under root. PID 1 is `tini` (ADR-0023 fix round): the entrypoint reaps no orphans, and browser process trees would otherwise accumulate zombies over multi-hour runs; Dagu cannot pass `--init` (see **Resources** below).
 - **MCP / extra CLI args:** admin-configured free-text commands run with `shell=True` / harness flags before/with the agent — **admin-equivalent ACE** inside the disposable container (`11-admin-panel.md`).
-- **Resources:** Dagu 2.10.5 step `container:` does **not** support Docker HostConfig CPU/memory/PID fields (schema `additionalProperties: false`). The DAG sets best-effort process-level `resources.limits` (`cpu: "2"`, `memory: "4g"`) where the host enforces cgroups on the DAG run process — this is **not** a guaranteed limit on the sibling Dev container (**engineering debt**, `14` §11). Primary throttle is app concurrency (`concurrency.global_max` + per-Dev-Type caps).
+- **Resources:** Dagu step `container:` does **not** support Docker HostConfig CPU/memory/PID fields (schema `additionalProperties: false`; measured at 2.10.5 and re-verified at the pinned 2.11.3 — `13-deployment.md`). The DAG sets best-effort process-level `resources.limits` (`cpu: "2"`, `memory: "4g"`) where the host enforces cgroups on the DAG run process — this is **not** a guaranteed limit on the sibling Dev container (**engineering debt**, `14` §11). Primary throttle is app concurrency (`concurrency.global_max` + per-Dev-Type caps).
 
 ### 7a. Toolchain floor (ADR-0023, normative — identical across harness images)
 

--- a/docs/10-persistence.md
+++ b/docs/10-persistence.md
@@ -3,7 +3,7 @@
 > **Audience:** implementers and operators.
 > **Decision record:** `adr/0002-file-based-persistence.md` (files over a database), `adr/0003-pmo-as-single-source-of-truth.md`.
 
-All local app data lives as plain files on one named volume (`devcake_data`, mounted at `/data`) so it is trivially inspectable, diffable, and recoverable. **Backup story: back up `/data`; everything else is reconstructible.**
+All local app **state** lives as plain files on the `devcake_data` volume (mounted at `/data`) so it is trivially inspectable, diffable, and recoverable. Since ADR-0024/0025 the app also holds two **non-state** stores this document is not the authority on: the `/mirrors` volume (bare source mirrors — a DISPOSABLE cache that re-warms) and the `$DEVCAKE_WS_HOST` host bind (`/workspaces` in-container — per-run scratch, reclaimed at run end). **Backup story: back up `/data` (via `scripts/backup_data.sh`) AND `gitea_data`; mirrors and workspaces are reconstructible and deliberately excluded** — the full story, including why the excluded trees still deserve host-snapshot care (they hold repo source), is `13-deployment.md` §8.
 
 Run records are accessed through **`StatePort`** (`ports/state.py`); the production adapter is `adapters/files/run_store.py`. A future SQLite (or other) store is an adapter swap behind that port (`adr/0002`, `16-roadmap.md`) — not a domain change.
 
@@ -167,3 +167,5 @@ Direct file edits are tolerated but take effect on the next app start, when `loa
 | `/data/secrets` | Dev Types whose harness credential files / harness secret VALUES lived here fail auth (exit 12 → circuit breaker) until re-uploaded or re-entered. GUI-stored connection secrets and profile secret snapshots are gone — re-enter via the Configuration page or re-import a bundle. |
 | `/data/config` | The app blocks startup pending reconfiguration (admin panel first-run flow). |
 | `/data/config/profiles` + `/data/secrets/profiles` | Saved profile snapshots are gone; **live settings are untouched** (profiles are fire-and-forget snapshots, ADR-0013). |
+| the `/mirrors` volume (`docker volume rm devcake_mirrors`, stack stopped) | Nothing durable lost — the mirror is a mandatory but DISPOSABLE cache (ADR-0024): the next dispatch's fail-closed freshness gate re-clones every needed repo (one full re-fetch per repo of cost). Deleting it while the stack runs instead trips the volume error → dispatch refuses with a visible reason until `verify_writable` clears. |
+| the `$DEVCAKE_WS_HOST` tree | Per-run scratch only (ADR-0025). In-flight runs' containers lose their bind and fail (counted per docs/15); terminal residue is exactly what the periodic sweep reclaims anyway. Never part of the backup set. |

--- a/docs/12-observability.md
+++ b/docs/12-observability.md
@@ -27,6 +27,7 @@ observability gap.
 | Span | Parent | Emitted by | Content |
 |---|---|---|---|
 | `poll.cycle` | root | app | counts: missions seen/candidates/dispatched; `PMO_TRANSIENT`/`cycle_error` outcomes |
+| `poll.instance` | `poll.cycle` | app | one child per configured PMO instance (`devcake.instance`); a per-instance failure marks THIS span, not the cycle |
 | `mission.dispatch` | `poll.cycle` (mapper runs: `mapper.periodic`) | app | `devcake.mission.*`, `devcake.run.id`, `devcake.dev_type`; covers the ACL-user creation, run persist, and Dagu trigger |
 | `mission.give_up` | `poll.cycle` | app | ERROR status; covers the `DEVCAKE-FAILED` label write + feed post |
 | `sweep.merge` | `poll.cycle` | app | emitted only when the sweep acts (`merged`/`closed`); covers the PMO writes |

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -57,6 +57,11 @@ services:
     env_file: .env                       # bootstrap secrets ONLY (schema v4)
     volumes:
       - devcake_data:/data               # NO docker.sock — kill/reconcile via Dagu API
+      - mirrors:/mirrors                 # ADR-0024 source mirrors (app = only writer)
+      - ${DEVCAKE_WS_HOST}:/workspaces   # ADR-0025 per-run workspace base (host bind)
+      - ./images/common:/srv/images/common:ro   # TEST FIXTURE ONLY — entrypoint-render
+                                         #   tests read the real Dev entrypoint tree;
+                                         #   the running app never imports from it
     networks: [control]
     # no host ports — reach API only via admin proxy
 

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -227,7 +227,7 @@ branch protection is weak or absent**, or exfiltrating tokens.
 
 1. Secrets never in images, never in git, never in Run JSON, and **never in Dagu
    DAG params or YAML** — trigger params are rendered unmasked in the Dagu UI
-   (verified on v2.10.5). Dagu receives `RUN_ID`, `IMAGE`, `TRACEPARENT`, plus
+   (verified on v2.10.5, unchanged at the pinned 2.11.3). Dagu receives `RUN_ID`, `IMAGE`, `TRACEPARENT`, plus
    one deliberate exception: the per-run scoped Redis ACL credential, revoked at
    finalization. Secret material is rebuilt on authenticated `runspec.get`
    (`09-messaging.md` §§3, 5).
@@ -318,8 +318,9 @@ Not claimed:
 
 - Multi-tenant isolation between hostile customers.
 - Egress allowlists (optional future ops hardening, §11).
-- **Docker HostConfig** CPU/memory/PID limits on the Dev container — Dagu 2.10.5
-  `container:` schema has no HostConfig fields; DAG `resources.limits` is
+- **Docker HostConfig** CPU/memory/PID limits on the Dev container — Dagu's
+  `container:` schema has no HostConfig fields (measured at 2.10.5, re-verified
+  at the pinned 2.11.3); DAG `resources.limits` is
   process-cgroup only. That is **engineering debt** (noisy-neighbor / fork bomb
   on the dedicated host), not adult-operator philosophy.
 - MCP free-text commands and harness “skip permissions” flags are powerful on

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -20,14 +20,17 @@
 > **⏳ live-pending** = built, live end-to-end still owed ·
 > milestone `[x]` checkboxes mark exit criteria verified at that milestone's close.
 >
-> **Where we are (2026-07-26):** layers 1–2 closed through tag **v0.2** (and
-> patch tags through `v0.2.4` on `main`). The product loop (poll → dispatch →
-> harness → finalize → forge/PMO) is operational with three harness templates
-> (`claude-code`, `grok-build`, `codex`), multi-PMO / multi-repo / internal
-> Gitea, skills (ADR-0016), settings profiles/export (ADR-0013), fault
-> classification + backend brake (ADR-0018), and a package-split Dev entrypoint
-> (`images/common/devcake_dev/`). Unit suite is on the order of **~800+** tests
-> (815 counted 2026-07-26; do not treat any single count as a permanent claim).
+> **Where we are (2026-08-04):** layers 1–2 closed through tag **v0.2**;
+> release tags through **v0.2.5 "Hummingbird"** on `main`. The product loop
+> (poll → dispatch → harness → finalize → forge/PMO) is operational with three
+> harness templates (`claude-code`, `grok-build`, `codex`), multi-PMO /
+> multi-repo / internal Gitea, skills (ADR-0016), settings profiles/export
+> (ADR-0013), fault classification + backend brake (ADR-0018/0026), mandatory
+> source mirrors + provisioned workspaces (ADR-0024/0025), in-container
+> continuation (ADR-0022), and the 2026-08 evaluation fix campaign (spend
+> discipline, TOCTOU guards, composition-root tests, ops hardening — entries
+> below). Unit suite is on the order of **~1400+** tests (1421 counted
+> 2026-08-04; do not treat any single count as a permanent claim).
 > Ongoing append-only tracking: [Living log (after v0.2)](#living-log-after-v02).
 
 ## History — Layer 1: Milestone era (M0–M12)
@@ -456,6 +459,56 @@ vocabulary at the top of this file).
   Run/API/feed/OTel, rig `--resume-prompt-file` mode + six
   `*_resume_nudge*` capture fixtures. **built**.
 
+- **External audit + evaluation fix campaign** (2026-08-03…04): Grok's
+  tag-range audit (AUD-001…AUD-034; its report file was deleted from the
+  root 2026-08-03 — **this entry is the AUD-ID ledger** code comments
+  resolve against) landed as PR #81; the four-review critical evaluation
+  (architecture / tests / docs drift / ops) then drove PRs #82–#87:
+  - **ADR-0026 spend discipline** (#82): `attempt_reset` (strict
+    `label-ops` default + `DEVCAKE-RETRY` gesture / `any-comment` /
+    `unlimited` with cumulative-cost warnings) closing the
+    chatty-integration attempt-reset hole; opt-in `brake_on_bad_output`;
+    first-class Limits & Traffic UX. **Deliberate behavior change**
+    (strict default) — release-noted. **built**.
+  - **TOCTOU + parity** (#83): watchdog timeout/liveness kill branches
+    re-read before killing; `_kill_inner` aborts save + restore when the
+    state moved (the mover wins); the mirror gate's `needed_for` set is
+    snapshotted on `run.mirror_repos` and the runspec serves mirrors from
+    the snapshot only. **built**.
+  - **Enforcement** (#84): `test_api_surface.py` (TestClient over the real
+    app — 401/403 on every route; the auth middleware is finally
+    load-bearing), `test_repo_structural.py` (+RO mounts in both pytest
+    runners: /mirrors isolation, workspace binds, RUN_ID fence, no Dagu
+    auto-retry, single-uvicorn-worker premise), CI contract lane (compose
+    smoke stack + bundled Gitea runs BOTH batteries per PR), UI-suite
+    honesty (15 tautologies → `checked()` predicates, helpers suites wired
+    into check:ui). **built**.
+  - **Ops hardening** (#86 + hotfix #87): redis aclfile + per-op `ACL SAVE`
+    (dev users survive a redis-only restart — drill-verified; with an
+    aclfile redis IGNORES --requirepass, measured, so the default user
+    lives in the file, boot-regenerated from .env), `maxmemory 1gb +
+    noeviction` flood backstop, `chmod 600 .env` enforced, bake-failure
+    dagu-restart trap, `backup_data.sh`/`restore_data.sh`, vendored grok
+    installer, ADMIN_PASSWORD ≥12 (**deliberate breaking change**,
+    release-noted). #87 also REVERTED the attempted WS_HOST DAG
+    precondition: Dagu 2.11.3 loads but never expands service env in
+    `condition:` — every dev-run sat `dispatched` to the startup-grace
+    kill (measured live); an inverse structural test bars unverified
+    reintroduction. **built**.
+  - **AUD disposition:** fixed in #81 (`df08c9a`): AUD-001/002 (workspace
+    fail-closed real), 003 (stop-dagu-before-bake half; the DAG-precondition
+    half was attempted in #86 and reverted in #87 — the daemon-autocreate
+    residue is tracked debt again), 004 (tag lockstep), 005/006 (merge
+    wedges), 007 (sweep budget), 008 (doc overclaim deleted), 010
+    (tristate trust in sweep), 011 (fence `{6,64}`), 017 (costing bool
+    guard), 018 (parse-cache clear). Fixed in this campaign: 015-adjacent
+    kill/finalize races (#83), backup-pair gap (§ above), 029 (vendored
+    installer). Still open, honestly: **AUD-009** (provision phase is
+    honor-system — accepted, documented), **AUD-012** (relative WS_HOST via
+    plain `docker compose up` — up.sh asserts, compose alone does not),
+    **AUD-020** (hard-coded `devcake_mirrors` volume name — doc warning
+    only), **AUD-022** (no Dev cgroup HostConfig — docs/14 §11 debt).
+
 ### Still open (residuals)
 
 Not new features — demos or proofs still owed from Layers 1–2 (milestones or
@@ -641,6 +694,20 @@ long-lived incomplete dialect API.
 
 ### Deferred (later / conditional)
 
+- **2026-08 evaluation candidates** (recorded with the campaign entry above;
+  file:line evidence in the evaluation ledger): **per-run Dev networks**
+  (closes cross-Dev reachability incl. the post-ADR-0023 DevTools scenario —
+  ICC-off measured broken: it severs Dev→Redis) · **per-run ingress
+  streams** (closes the malicious-`MAXLEN` trim vector for good) · **brake
+  cycle-skip backoff** so the ADR-0018 throttle arm acts at
+  `max_concurrency: 1` (founder kept current design) · **composition-root
+  decomposition** (`api/main.py` builds 15+ import-time singletons) ·
+  **unifying the three failure-taxonomy encodings** (numeric exit /
+  `error_class` string / reconcile's stderr regex) · **config-PUT lock**
+  (a poll cycle can read mixed old/new config across awaits) ·
+  **conftest.py / event-loop test hygiene** (module-import loop ownership) ·
+  **`${VAR:-default}`-guarded volume name in dev-run.yaml** (AUD-020 —
+  verify Dagu expansion support first; see the #87 lesson).
 - **Webhook ingestion** — PMO `watch()` / webhook `ChangeEvent` seam replacing
   polling (+ tunnel guide). Multi-PMO multiplies poll cost; strong candidate
   among deferred items, independent of any harness-platform work.

--- a/docs/19-thesis.md
+++ b/docs/19-thesis.md
@@ -76,10 +76,10 @@ psychology, but as an engineering checklist:
 | Condition for deep work | DevCake mechanism (held) | Where |
 |---|---|---|
 | A clear goal | The Mission spec and its PLAN artifact — one goal per session | `03-mission-lifecycle.md` |
-| A task sized to ability | Bounded decomposition: work is cut until a unit fits one session | ADR-0012 |
-| Ordered, uncontaminated information | Fresh container per step; a curated activity mirror; quoting quarantine; read-only mounts of exactly the relevant upstream trees | ADR-0014, ADR-0017, INV-6 |
+| A task sized to ability | Bounded decomposition: work is cut toward session-sized units, to a configured depth (default two generations — a bound, not a proof of fit) | ADR-0012 |
+| Ordered, uncontaminated information | Fresh container per step; a curated activity mirror; quoting quarantine; curated clones of exactly the relevant upstream trees, held read-only by token scope and prompt contract (the only kernel-RO mount is the provision-phase source mirror — ADR-0025) | ADR-0014, ADR-0017, INV-6 |
 | Immediate feedback | The workspace's own compilers and tests; a skeptical REVIEW step | `03`, `17` §1 |
-| No interruption mid-task | Intervention lands only at step boundaries — a human edit always beats an in-flight agent *between* steps, never by breaking into one | INV-3 |
+| No interruption mid-task | Intervention lands only at step boundaries — a human edit always beats an in-flight agent *between* steps, never by breaking into one. One deliberate carve-out (ADR-0022): an in-container *continuation* re-prompts inside a step, by design — it fires only after a clean stop with no result, a nudge at a natural pause, not a poke into flight | INV-3 |
 
 Two disciplines keep the conditions true at the seams:
 
@@ -87,9 +87,11 @@ Two disciplines keep the conditions true at the seams:
 it. Decomposition conserves scope — children may neither invent work their
 parent never asked for nor drop work it did. Summaries match the outbound
 signal to what the next session can absorb — a raw context dump into the next
-step is a mismatch, and we removed exactly that (ADR-0014). Read-only mounts
-are one-way valves — downstream work can never push mutations into upstream
-truth. Mismatches at these seams do not fail loudly at the boundary; they
+step is a mismatch, and we removed exactly that (ADR-0014). Read-only upstream
+context is a one-way valve — downstream work can never push mutations into
+upstream truth (the valve is credential scope plus instruction, not
+filesystem mode — stated here because this document must not claim a
+stronger mechanism than the code holds). Mismatches at these seams do not fail loudly at the boundary; they
 *reflect*, surfacing later as retries, review rejections, and rework. That
 reflection is measurable, and §4 says how.
 
@@ -99,10 +101,13 @@ before a step, review after a step, never a poke inside one.
 
 **Status, honestly.** The mechanisms above are held — they are how the system
 is built, and a large test suite pins them. The *conclusion* — that this
-envelope produces better deep work than the alternatives — is observed: daily
-internal use on this project's own development, and early trials on
-non-software deep work that went qualitatively better than we expected. None
-of it is blind-judged or baselined. A controlled comparison — same task, same
+envelope produces better deep work than the alternatives — is observed:
+DevCake is exercised on portions of its own board, and early trials on
+non-software deep work went qualitatively better than we expected. To be
+precise about provenance: the majority of this project's own development is
+the founder driving harness sessions directly — DevCake did not build
+DevCake, and this document must not imply it did. None of the observations
+are blind-judged or baselined. A controlled comparison — same task, same
 model, envelope on versus off — is the planned instrument, and until it
 exists, this section is a belief we act on, not a result we report.
 

--- a/docs/adr/0002-file-based-persistence.md
+++ b/docs/adr/0002-file-based-persistence.md
@@ -19,3 +19,11 @@ Plain files on one `/data` volume: YAML for human-edited config, JSON-per-file f
 ## Consequences
 
 Backup = copy `/data`. Every consumer must use the atomic-write recipe. Escape hatch documented: if run history outgrows files, `state/runs/` swaps to SQLite behind `StatePort` without touching anything else (post-v0 backlog).
+
+> **Amendment (2026-08-04):** "backup = copy `/data`" predates the app's two
+> non-state stores — the `/mirrors` volume (ADR-0024, disposable cache) and
+> the `$DEVCAKE_WS_HOST` workspace bind (ADR-0025, per-run scratch). The
+> file-over-database decision stands unchanged; the backup sentence is
+> superseded by `13-deployment.md` §8 (back up `/data` + `gitea_data`;
+> mirrors/workspaces excluded by design), with `scripts/backup_data.sh` as
+> the shipped vehicle.

--- a/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
+++ b/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
@@ -52,13 +52,13 @@ as forwards with **unchanged coroutine names and signatures** — tests call
 them directly (`app_main.save_profile(...)`), so the forward layer is the
 API's stable test seam. No `APIRouter`: it would be a second routing idiom for
 zero behavior. Every `@app.<verb>` body is ≤ 4 statements, AST-guarded with an
-allowlist that may only shrink, never grow. At C6 close-out it holds nine
-read-side residuals — `dispatch_hello` (CI fixture), the `run_mapper`/`oauth`
-trio, and the small `runs`/`log`/`clear-runs` endpoints whose bodies are
-inherently a few statements (`list_runs`, `get_run`, `get_run_log`,
-`stream_run_log`, `clear_runs`) — not the single-entry end state an earlier
-draft imagined; the guard test (`test_structure_guards.py`) is the source of
-truth. Poll machinery lives in `api/poll.py` as `PollRuntime`; health probes
+allowlist that may only shrink, never grow. It holds **seven** read-side
+residuals — `dispatch_hello` (CI fixture), the `run_mapper`/`oauth` trio,
+and `get_run_log`/`stream_run_log`/`clear_runs` — not the single-entry end
+state an earlier draft imagined. (The C6 close-out counted nine; `list_runs`
+and `get_run` were since forwarded — the ratchet shrank and this prose
+lagged until the 2026-08 truth sweep.) The guard test
+(`test_structure_guards.py`) is the source of truth. Poll machinery lives in `api/poll.py` as `PollRuntime`; health probes
 in `api/health.py`.
 
 ## Decision 4 — module-public functions are the sanctioned test seam

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,36 @@
+# ADR Index
+
+> The corpus's navigation layer (2026-08 truth sweep — 26 ADRs with prose-only
+> supersession had outgrown `grep -i supersed`). One row per ADR; the
+> **Status** column is the ledger. "Amended"/"partially superseded" rows carry
+> the change inline in the ADR itself — this table names where to look.
+> New ADR ⇒ new row; superseding an ADR ⇒ update BOTH its row and its header.
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-redis-streams-for-dev-callback.md) | Redis Streams for the Dev → App channel | Accepted. Notes its own vaporware honestly (`devcake-relay` never shipped). ACL durability added 2026-08 (docs/09 §1a) |
+| [0002](0002-file-based-persistence.md) | File-based local persistence | Accepted. **Amended 2026-08-04**: the backup sentence is superseded by docs/13 §8 (mirrors + workspaces exist now) |
+| [0003](0003-pmo-as-single-source-of-truth.md) | PMO as single source of truth | Accepted — INV-1's home |
+| [0004](0004-label-namespace-and-versioning.md) | Label namespace and versioning | Accepted |
+| [0005](0005-no-lock-atomicity-via-pmo-state.md) | No-lock atomicity via PMO state | Accepted. The single-process premise is now test-enforced (`test_repo_structural.py`) |
+| [0006](0006-projects-always-decompose.md) | Projects always decompose | Accepted |
+| [0007](0007-mission-ordering-and-human-handoff.md) | Mission ordering + human hand-off | Accepted |
+| [0008](0008-pluggable-pmo-and-forge-adapters.md) | Pluggable PMO and forge adapters | **Partially superseded** — three decisions struck in-body (schema v4, ADR-0009, multi-PMO) |
+| [0009](0009-manager-per-pmo-instance.md) | One MissionManager per PMO instance | Accepted, **amended** (cross-instance blocker resolution) |
+| [0010](0010-internal-fallback-forge.md) | Internal fallback forge (bundled Gitea) | Accepted |
+| [0011](0011-gui-only-secret-store.md) | GUI-only secret store | Accepted. Store is plaintext-at-rest by design (0600 files; docs/14 §4) |
+| [0012](0012-decomposition-depth-and-edge-inheritance.md) | Decomposition depth + edge inheritance | Accepted |
+| [0013](0013-settings-bundle-profiles-and-export.md) | Settings bundle, profiles, export | Accepted |
+| [0014](0014-activity-feed-fidelity-and-activity-repos.md) | Activity feed fidelity + activity repos | Accepted |
+| [0015](0015-orchestrator-module-functions-and-api-composition.md) | Orchestrator module functions + composition root | Accepted. Close-out inventory drifted (the guard test allows seven residual forwards, the prose said nine — the ratchet is the truth) |
+| [0016](0016-skills-and-prompt-assembly.md) | Skills and prompt assembly | Accepted |
+| [0017](0017-blocker-work-ro-mounts-and-optional-pmo-zip.md) | Blocker work "RO mounts" + optional PMO zip | Accepted, **amended** (cross-instance). Read the body, not the title: the mechanism is an RO **token** + prompt contract in ordinary writable clone dirs — falling back to the write token when no `token_ro` is configured — not a filesystem mount |
+| [0018](0018-harness-fault-classification-and-backend-brake.md) | Harness fault classification + backend brake | Accepted. The exit-11 "known gap" is now an operator toggle (ADR-0026) |
+| [0019](0019-per-pmo-assignment-overrides.md) | Per-PMO assignment overrides | Accepted |
+| [0020](0020-per-repo-merge-doctrine.md) | Per-repository merge doctrine | Accepted |
+| [0021](0021-app-side-estimated-cost-and-operator-rate-card.md) | App-side estimated cost + rate card | Accepted |
+| [0022](0022-in-container-run-continuation.md) | In-container run continuation | Accepted |
+| [0023](0023-dev-toolchain-floor.md) | Dev container toolchain floor | Accepted |
+| [0024](0024-mandatory-repo-source-mirror.md) | Mandatory repo source mirror | Accepted; **§5's ambient mirror-read superseded by ADR-0025** (banner in-body) |
+| [0025](0025-provisioned-workspaces.md) | Provisioned workspaces | Accepted — supersedes ADR-0024 §5's risk posture |
+| [0026](0026-attempt-reset-policy-and-bad-output-brake.md) | Attempt-reset policy + opt-in bad-output brake | Accepted (2026-08-04) |


### PR DESCRIPTION
## What

PR E of the 2026-08 evaluation fix campaign — the documentation truth sweep. Every confirmed drift corrected against post-campaign code; the ADR corpus gains its missing navigation layer (`docs/adr/README.md` with per-ADR status); the living log becomes the AUD-ID ledger (the audit report file was already deleted from the root by the founder — code comments citing AUD-nnn now resolve to docs/16); the thesis stops overclaiming its own mechanisms (RO-by-token stated as such, the ADR-0022 carve-out inherited, development provenance stated plainly).

Highlights per file in the commit message. Notable honesty items:
- docs/04 §3.1 described the pre-P0 dispatch spine — the exact passage a new implementer would have copied.
- docs/10 promised "back up /data; everything else is reconstructible" while the app holds three stores.
- ADR-0017's title promises mounts; the index row now points readers at the body's real mechanism.

## Verification

Suite **1440 passed** · ruff clean · SPA builds (help-text change rides along) · all internal doc links resolve to files present in-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)