### PR TITLE
refactor: the six evaluation architecture cleanups

### DIFF
--- a/app/devcake/adapters/gitea/adapter.py
+++ b/app/devcake/adapters/gitea/adapter.py
@@ -96,6 +96,8 @@ class GiteaForge:
         self.token = token
         self.reviewer_token = reviewer_token or None
         self._transport = transport        # tests inject MockTransport
+        from ..http import PooledClient
+        self._http = PooledClient(timeout=20, transport=transport)  # F16: keep-alive
 
     def _headers(self, reviewer: bool = False) -> dict[str, str]:
         token = self.reviewer_token if reviewer else self.token
@@ -107,15 +109,18 @@ class GiteaForge:
 
     async def _req(self, method: str, path: str, *, reviewer: bool = False,
                    **kwargs) -> Any:
-        async with httpx.AsyncClient(timeout=20, transport=self._transport) as client:
-            resp = await client.request(
-                method,
-                f"{self.api}/api/v1/repos/{self.owner}/{self.repo}{path}",
-                headers=self._headers(reviewer), **kwargs)
-            if resp.status_code >= 400:
-                raise ForgeError(f"{method} {path} → {resp.status_code}: "
-                                 f"{resp.text[:200]}", status=resp.status_code)
-            return resp.json() if resp.text else None
+        client = self._http.get()   # pooled (F16); adapter aclose() owns it
+        resp = await client.request(
+            method,
+            f"{self.api}/api/v1/repos/{self.owner}/{self.repo}{path}",
+            headers=self._headers(reviewer), **kwargs)
+        if resp.status_code >= 400:
+            raise ForgeError(f"{method} {path} → {resp.status_code}: "
+                             f"{resp.text[:200]}", status=resp.status_code)
+        return resp.json() if resp.text else None
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
 
     async def health_probe(self) -> ForgeHealth:
         repository = f"{self.owner}/{self.repo}"

--- a/app/devcake/adapters/gitea/provision.py
+++ b/app/devcake/adapters/gitea/provision.py
@@ -614,3 +614,27 @@ class GiteaProvisioner:
         if svc:
             self._register(svc)
         return svc
+
+    def mission_repo_binding(self, creds):
+        """(RepoInstance row, app-side adapter) for a provisioned mission
+        repo (port contract). Vendor knowledge stays HERE (2026-08 F9): the
+        app-side adapter uses the devcake-app SERVICE token (org owner:
+        write:issue for PR comments + write:repository for merge), NOT the
+        mission's Dev write token (write:repository only → issue-scope 403s;
+        review finding #1) — the mission's pair is the Dev's, via runspec.
+        model_construct: internal repo names carry hyphens / exceed the
+        operator-name pattern by design — synthesized, not input. Always
+        auto-merge: the zip deliverable only posts after merge, and no human
+        watches the internal Gitea (operators wanting doctrine control
+        create the repo as a config card instead — ADR-0020)."""
+        from ...config import RepoInstance
+        from ..registry import make_gitea_adapter   # keeps redaction registration
+        svc = self.service_tokens() or {}
+        adapter = make_gitea_adapter(creds.clone_url, svc.get("app_token"),
+                                     svc.get("reviewer_token"))
+        inst = RepoInstance.model_construct(
+            name=creds.repo_name, forge="gitea", url=creds.clone_url,
+            default_branch="main", api_base=None,
+            auto_merge=True, auto_resolve_merge_conflicts=True,
+            merge_retry_window_minutes=30)
+        return inst, adapter

--- a/app/devcake/adapters/gitea_issues/adapter.py
+++ b/app/devcake/adapters/gitea_issues/adapter.py
@@ -64,6 +64,8 @@ class GiteaIssuesAdapter:
         self._instance = instance
         self._token = token or ""
         self._transport = transport
+        from ..http import PooledClient
+        self._http = PooledClient(timeout=30, transport=transport)  # F16: keep-alive
         base = (api_base or "").strip().rstrip("/")
         if not base:
             # constructed only when configured; empty base fails loud on use
@@ -151,6 +153,9 @@ class GiteaIssuesAdapter:
             raise PMOTransient("gitea_issues: API token missing")
         return {"Authorization": f"token {self._token}"}
 
+    async def aclose(self) -> None:
+        await self._http.aclose()
+
     async def _req(
         self,
         method: str,
@@ -167,11 +172,9 @@ class GiteaIssuesAdapter:
         url = f"{self._api}{path}"
         hdrs = {**self._headers(), **(headers or {})}
         try:
-            async with httpx.AsyncClient(
-                    timeout=30, transport=self._transport) as client:
-                resp = await client.request(
-                    method, url, params=params, json=json, content=content,
-                    headers=hdrs)
+            resp = await self._http.get().request(   # pooled (F16)
+                method, url, params=params, json=json, content=content,
+                headers=hdrs)
         except httpx.HTTPError as e:
             raise PMOTransient(f"gitea_issues network: {e}") from e
         if resp.status_code in (429, 500, 502, 503, 504):

--- a/app/devcake/adapters/github/adapter.py
+++ b/app/devcake/adapters/github/adapter.py
@@ -54,6 +54,8 @@ class GitHubForge:
         self.token = token
         self.reviewer_token = reviewer_token or None
         self._transport = transport        # tests inject MockTransport
+        from ..http import PooledClient
+        self._http = PooledClient(timeout=20, transport=transport)  # F16: keep-alive
 
     def _headers(self, reviewer: bool = False) -> dict[str, str]:
         token = self.reviewer_token if reviewer else self.token
@@ -67,14 +69,17 @@ class GitHubForge:
 
     async def _req(self, method: str, path: str, *, reviewer: bool = False,
                    **kwargs) -> Any:
-        async with httpx.AsyncClient(timeout=20, transport=self._transport) as client:
-            resp = await client.request(
-                method, f"{self.api}/repos/{self.owner}/{self.repo}{path}",
-                headers=self._headers(reviewer), **kwargs)
-            if resp.status_code >= 400:
-                raise ForgeError(f"{method} {path} → {resp.status_code}: "
-                                 f"{resp.text[:200]}", status=resp.status_code)
-            return resp.json() if resp.text else None
+        client = self._http.get()   # pooled (F16); adapter aclose() owns it
+        resp = await client.request(
+            method, f"{self.api}/repos/{self.owner}/{self.repo}{path}",
+            headers=self._headers(reviewer), **kwargs)
+        if resp.status_code >= 400:
+            raise ForgeError(f"{method} {path} → {resp.status_code}: "
+                             f"{resp.text[:200]}", status=resp.status_code)
+        return resp.json() if resp.text else None
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
 
     async def health_probe(self) -> ForgeHealth:
         repository = f"{self.owner}/{self.repo}"

--- a/app/devcake/adapters/gitlab/adapter.py
+++ b/app/devcake/adapters/gitlab/adapter.py
@@ -65,6 +65,8 @@ class GitLabForge:
         self.token = token
         self.reviewer_token = reviewer_token or None
         self._transport = transport        # tests inject MockTransport
+        from ..http import PooledClient
+        self._http = PooledClient(timeout=20, transport=transport)  # F16: keep-alive
 
     def _headers(self, reviewer: bool = False) -> dict[str, str]:
         token = self.reviewer_token if reviewer else self.token
@@ -76,18 +78,21 @@ class GitLabForge:
 
     async def _req(self, method: str, path: str, *, reviewer: bool = False,
                    raw: bool = False, **kwargs) -> Any:
-        async with httpx.AsyncClient(timeout=20, transport=self._transport) as client:
-            resp = await client.request(
-                method, f"{self.base}/api/v4/projects/{self.project}{path}",
-                headers=self._headers(reviewer), **kwargs)
-            if resp.status_code >= 400:
-                # normalized error type across adapters (docs/06): callers
-                # handle ForgeError only, never httpx exceptions
-                raise ForgeError(f"{method} {path} → {resp.status_code}: "
-                                 f"{resp.text[:200]}", status=resp.status_code)
-            if raw:                       # file_content wants bytes, not JSON
-                return resp.content
-            return resp.json() if resp.text else None
+        client = self._http.get()   # pooled (F16); adapter aclose() owns it
+        resp = await client.request(
+            method, f"{self.base}/api/v4/projects/{self.project}{path}",
+            headers=self._headers(reviewer), **kwargs)
+        if resp.status_code >= 400:
+            # normalized error type across adapters (docs/06): callers
+            # handle ForgeError only, never httpx exceptions
+            raise ForgeError(f"{method} {path} → {resp.status_code}: "
+                             f"{resp.text[:200]}", status=resp.status_code)
+        if raw:                       # file_content wants bytes, not JSON
+            return resp.content
+        return resp.json() if resp.text else None
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
 
     async def health_probe(self) -> ForgeHealth:
         try:

--- a/app/devcake/adapters/http.py
+++ b/app/devcake/adapters/http.py
@@ -1,0 +1,64 @@
+"""Shared lazy HTTP client per adapter instance (2026-08 evaluation F16).
+
+Every adapter previously built a fresh `httpx.AsyncClient` per request — a
+full TCP+TLS handshake each time, the root cause of the 319-repo sweep
+incident that was mitigated with a semaphore + budget rather than fixed.
+`PooledClient` keeps ONE lazily-created client (connection keep-alive) for
+the adapter's hot `_req` path; special-purpose calls (large asset downloads
+with redirects, long-timeout uploads) deliberately stay per-call.
+
+Lifecycle: `ForgeRuntime.rebuild` fire-and-forget-closes the outgoing
+adapter set's clients (`aclose_adapters`); an adapter that is simply GC'd
+(tests, PMO manager rebuilds) closes nothing — httpx finalizers cover it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+
+log = logging.getLogger("devcake.adapters.http")
+
+# strong refs: the loop holds tasks weakly — a fire-and-forget close could
+# be GC'd before running (same idiom as security's alarm tasks)
+_CLOSE_TASKS: set = set()
+
+
+class PooledClient:
+    def __init__(self, *, timeout: float = 20,
+                 transport: "httpx.AsyncBaseTransport | None" = None):
+        self._timeout = timeout
+        self._transport = transport
+        self._client: httpx.AsyncClient | None = None
+
+    def get(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                timeout=self._timeout, transport=self._transport)
+        return self._client
+
+    async def aclose(self) -> None:
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+
+
+def aclose_adapters(adapters) -> None:
+    """Best-effort async close of an outgoing adapter set from a SYNC caller
+    (rebuild). No running loop (boot, sync tests) ⇒ skip — finalizers cover
+    it; never raises."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    for adapter in adapters:
+        close = getattr(adapter, "aclose", None)
+        if close is None:
+            continue
+        try:
+            task = loop.create_task(close())
+            _CLOSE_TASKS.add(task)
+            task.add_done_callback(_CLOSE_TASKS.discard)
+        except Exception:  # noqa: BLE001 — closing old clients must never break a config apply
+            log.debug("adapter close scheduling failed", exc_info=True)

--- a/app/devcake/adapters/linear/adapter.py
+++ b/app/devcake/adapters/linear/adapter.py
@@ -69,16 +69,21 @@ class LinearAdapter:
         self._headers = {"Authorization": api_key, "Content-Type": "application/json"}
         self._team_cache: dict[str, dict[str, Any]] = {}
         self._transport = transport  # tests inject a MockTransport (contract test 9)
+        from ..http import PooledClient
+        self._http = PooledClient(timeout=20, transport=transport)  # F16: keep-alive
         # the configured PMO-instance name this adapter serves (schema v3):
         # stamped on every Mission at normalization, so provenance can never
         # be missed by a fetch path
         self._instance = instance
 
+    async def aclose(self) -> None:
+        await self._http.aclose()
+
     async def _gql(self, query: str, variables: dict | None = None) -> dict:
         try:
-            async with httpx.AsyncClient(timeout=20, transport=self._transport) as client:
-                resp = await client.post(API, headers=self._headers,
-                                         json={"query": query, "variables": variables or {}})
+            resp = await self._http.get().post(   # pooled (F16)
+                API, headers=self._headers,
+                json={"query": query, "variables": variables or {}})
         except httpx.HTTPError as e:
             raise PMOTransient(f"network: {e}") from e
         if resp.status_code == 429 or resp.status_code >= 500:
@@ -752,7 +757,8 @@ class LinearAdapter:
         return PMOCapabilities(projects_supported=True, project_labels_supported=True,
                                attachment_max_bytes=50 * 1024 * 1024,
                                native_label_swap_atomic=True,
-                               relations_supported=True)
+                               relations_supported=True,
+                               global_ids=True)   # Linear pmo_ids are UUIDs
 
     # ── normalization ────────────────────────────────────────────────────────
 

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -180,6 +180,9 @@ def reload_connections() -> None:
     forge_runtime.rebuild(config.repos, make_forge)
     build_managers()
     reset_protection_cache()               # repos may have changed — reprobe
+    # the adapter set feeds secret_env_vars (descriptor env lists), so the
+    # redaction scan cache must rebuild with it (2026-08 F17)
+    security.invalidate_secret_scan()
 
     async def _ensure():
         for mgr in list(managers.values()):

--- a/app/devcake/domain/blocker_locator.py
+++ b/app/devcake/domain/blocker_locator.py
@@ -31,15 +31,15 @@ from .model import Mission, MissionRef
 # self-healing next cycle).
 PEER_GET_TIMEOUT_S = 5.0
 
-# Systems whose pmo_ids are globally unique across the vendor environment
-# (Linear UUIDs). Only these may resolve via PEER adapters, and only these
-# may accept peer run history on a locally-resolved foreign id. Colliding-id
-# systems (gitea_issues) never cross instances — hard refuse, not best-effort.
-GLOBAL_ID_SYSTEMS = frozenset({"linear"})
+# Whether a system's pmo_ids are globally unique (⇒ peer resolution legal)
+# is now the adapter-declared `PMOCapabilities.global_ids` (2026-08
+# evaluation F10): the old GLOBAL_ID_SYSTEMS vendor-name literal meant
+# adding a PMO required editing domain policy.
 
-# Pre-schema-v3 run records ("", "main") always count as local — hiding them
-# would orphan pre-v3 blocker work (mirrors MissionManager._run_is_ours).
-LEGACY_PMO_REFS = frozenset({"", "main"})
+# Pre-schema-v3 run records always count as local — hiding them would orphan
+# pre-v3 blocker work (mirrors MissionManager._run_is_ours). Definition lives
+# with the Run model; re-exported here for existing importers.
+from .run import LEGACY_PMO_REFS  # noqa: E402,F401 — deliberate re-export
 
 
 @dataclass(frozen=True)
@@ -73,7 +73,10 @@ class BlockerLocator:
 
     async def _resolve_uncached(self, bid: str, local_mgr) -> Resolved | None:
         system = local_mgr.instance.system
-        peers_allowed = system in GLOBAL_ID_SYSTEMS
+        try:
+            peers_allowed = bool(local_mgr.pmo.capabilities().global_ids)
+        except Exception:  # noqa: BLE001 — a capability probe failure must fail CLOSED (no peer resolution), never crash the locator
+            peers_allowed = False
         owner = self._owner_of(bid) if peers_allowed else None
         if peers_allowed:
             peer = self._managers.get(owner) if owner else None

--- a/app/devcake/domain/forge_runtime.py
+++ b/app/devcake/domain/forge_runtime.py
@@ -74,6 +74,15 @@ class ForgeRuntime:
             if name in self.forges and name not in live:
                 live[name] = self.forges[name]
                 insts[name] = self.instances[name]
+        # F16: the outgoing adapters hold pooled keep-alive clients — close
+        # them (fire-and-forget) instead of leaking sockets on every config
+        # PUT / secret write. Carried-over internal entries are the SAME
+        # objects in `live`, so only truly replaced adapters close.
+        outgoing = [f for n, f in self.forges.items()
+                    if live.get(n) is not f]
+        if outgoing:
+            from ..adapters.http import aclose_adapters
+            aclose_adapters(outgoing)
         self.forges, self.instances = live, insts
         for name in list(self.health):
             if name not in live:

--- a/app/devcake/domain/orchestrator/activity_payload.py
+++ b/app/devcake/domain/orchestrator/activity_payload.py
@@ -1,0 +1,287 @@
+"""Activity-mirror payload building (ADR-0014 D3/D4).
+
+Extracted from dispatch.py in the 2026-08 evaluation cleanups: this is pure
+content transformation — MISSION.md/ACTIVITY.md rendering, attachment
+materialization with the docs/07 §2 dedupe rules, zip-slip-hardened archive
+expansion, and the per-step activity-repo snapshot — with no dispatch
+coupling at all. Consumers: dispatch (pre-step snapshot push), manager
+(the RunFinalizer activity_payload seam), tests.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from datetime import datetime  # noqa: F401 — type context for Activity entries
+from pathlib import Path
+
+from ..model import MissionRef
+from .feed import _is_devcake_comment
+
+log = logging.getLogger("devcake.missions")
+
+
+def _tree_conflict(cand: str, used: set[str]) -> bool:
+    """True when `cand` cannot coexist with `used` as one file tree: exact
+    duplicate, `cand` names a file where used paths already form a directory,
+    or an ancestor directory of `cand` is already a file. A file and a
+    directory sharing a name is unrepresentable in a git tree and crashes
+    the entrypoint's mkdir/write."""
+    if cand in used:
+        return True
+    pre = cand + "/"
+    if any(u.startswith(pre) for u in used):
+        return True
+    parts = cand.split("/")
+    return any("/".join(parts[:i]) in used for i in range(1, len(parts)))
+
+
+def _unique_name(name: str, used: set[str]) -> str:
+    """docs/07 §2 collision rule: later duplicates get -2, -3, … suffixes.
+    A flat name also conflicts with an existing extraction DIRECTORY of the
+    same name (file-vs-dir is unrepresentable — `_tree_conflict`); the
+    suffix rule resolves that identically. Callers pass flat (basenamed)
+    names; extraction paths are reserved directly by the expansion loop."""
+    stem, dot, ext = name.rpartition(".")
+    cand, i = name, 1
+    while cand in used or any(u.startswith(cand + "/") for u in used):
+        i += 1
+        cand = f"{stem}-{i}.{ext}" if dot else f"{name}-{i}"
+    used.add(cand)
+    return cand
+
+
+def safe_activity_relpath(path: str) -> str | None:
+    """Normalize a feed-controllable relative path for the activity folder.
+    Rejects empty, absolute, `..`, and over-deep/long names (zip-slip)."""
+    if not path or not isinstance(path, str):
+        return None
+    raw = path.replace("\\", "/").strip()
+    if not raw or raw.startswith("/") or raw.startswith("~"):
+        return None
+    parts = [p for p in raw.split("/") if p not in ("", ".")]
+    if not parts or ".." in parts:
+        return None
+    if len(parts) > 20 or any(len(p) > 200 for p in parts):
+        return None
+    return "/".join(parts)
+
+
+def expand_zip_attachment(zip_name: str, data: bytes, *,
+                          max_bytes: int,
+                          max_files: int = 500) -> list[tuple[str, bytes]]:
+    """Extract zip members under `{stem}/…`. Best-effort: corrupt/oversize/
+    slip members are skipped; never raises into the payload builder."""
+    import io
+    import zipfile
+    from pathlib import PurePosixPath
+
+    stem = PurePosixPath(zip_name.replace("\\", "/")).name
+    if stem.lower().endswith(".zip"):
+        stem = stem[:-4]
+    stem = stem or "archive"
+    # stem itself must be a single safe segment
+    if safe_activity_relpath(stem) is None or "/" in stem:
+        stem = "archive"
+    out: list[tuple[str, bytes]] = []
+    emitted: set[str] = set()
+    used = 0
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(data))
+    except (zipfile.BadZipFile, OSError):
+        return []
+    try:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            if len(out) >= max_files:
+                break
+            member = safe_activity_relpath(info.filename)
+            if member is None:
+                continue
+            full = safe_activity_relpath(f"{stem}/{member}")
+            if full is None:
+                continue
+            # a crafted zip can hold both `x` and `x/y` (or duplicate
+            # names) — later members that conflict with an already-emitted
+            # path are dropped, keeping the extraction one valid file tree
+            if _tree_conflict(full, emitted):
+                continue
+            # Pre-check declared uncompressed size before read — a zip bomb
+            # must not force a multi-GB decompress into memory first. The
+            # header can lie; the post-read check below is the hard stop.
+            declared = getattr(info, "file_size", 0) or 0
+            if declared < 0:
+                continue
+            if declared and used + declared > max_bytes:
+                break
+            try:
+                content = zf.read(info)
+            except Exception:  # noqa: BLE001 — one bad member must not abort the rest
+                continue
+            if used + len(content) > max_bytes:
+                break
+            used += len(content)
+            emitted.add(full)
+            out.append((full, content))
+    finally:
+        zf.close()
+    return out
+
+
+def _activity_snapshot_files(payload: dict) -> list[dict]:
+    """Activity payload → the file list a snapshot commit mirrors
+    (identical layout to the Dev's /workspace/activity). Attachment paths
+    may be nested (zip extracts under `{stem}/…`); only safe relative
+    paths are kept."""
+    files = []
+    if payload.get("mission_md"):
+        files.append({"path": "MISSION.md", "content_b64": base64.b64encode(
+            payload["mission_md"].encode()).decode()})
+    files.append({"path": "ACTIVITY.md", "content_b64": base64.b64encode(
+        payload.get("activity_md", "").encode()).decode()})
+    for a in payload.get("attachments", []):
+        raw = a.get("filename") or "attachment.bin"
+        rel = safe_activity_relpath(raw)
+        if rel is None:
+            rel = Path(str(raw).replace("\\", "/")).name or "attachment.bin"
+            if rel in (".", ".."):
+                rel = "attachment.bin"
+        files.append({"path": rel, "content_b64": a["content_b64"]})
+    return files
+
+
+async def push_activity_repo(mgr, mission, mtype, seq: int) -> None:
+    """ADR-0014 D4: one snapshot commit per step dispatch. Any failure is
+    audited loudly and swallowed — the run proceeds on the Redis fallback;
+    Gitea down degrades to pre-ADR behavior, never to a halt."""
+    if mgr.internal_forge is None:
+        return
+    try:
+        payload = await activity_payload(mgr, mission.pmo_id, mission.pmo_kind)
+        name = await mgr.internal_forge.ensure_activity_repo(
+            mgr.instance_name, mission.key)
+        await mgr.internal_forge.push_activity_snapshot(
+            name, _activity_snapshot_files(payload),
+            f"step {seq} {mtype.value} dispatch")
+        log.info("activity repo %s: snapshot for step %d", name, seq)
+    except Exception as e:
+        log.exception("activity repo push failed for %s", mission.key)
+        mgr._audit(mission.pmo_id, "activity_repo_push_failed",
+                    f"{mission.key}: {type(e).__name__}: {str(e)[:180]}")
+
+
+def _mission_md(m, attachment_lines=()) -> str:
+    """ADR-0014 D3: MISSION.md — the brief. Stable regardless of feed length;
+    every step playbook points here."""
+    lines = [
+        f"# {m.key}: {m.title}",
+        f"> Kind: {m.pmo_kind} · Status: {m.status} · Priority: {m.priority} · URL: {m.url}",
+        f"> Labels: {', '.join(sorted(m.labels)) or '(none)'}", "",
+        "## Description", m.description or "(none)"]
+    if attachment_lines:
+        lines += ["", "## Mission attachments", *attachment_lines]
+    return "\n".join(lines)
+
+
+async def activity_payload(mgr, pmo_id: str, kind: str = "issue") -> dict:
+    """ADR-0014 D3: MISSION.md = the brief; ACTIVITY.md = a faithful MIRROR
+    of the feed — full bodies inline (never externalized), attachments by
+    name in feed order, reply nesting; every attachment's bytes ride as
+    sibling files."""
+    if kind == "project":
+        # projects have no comments/attachments: the brief IS the payload
+        m = await mgr.pmo.get(MissionRef(pmo_id, "project"))
+        md = "\n".join([
+            f"# {m.key}: {m.title}",
+            "> The mission brief lives in MISSION.md (same folder).", "",
+            "## Activity", "(projects carry no comment feed — see child issues)"])
+        return {"mission_md": _mission_md(m), "activity_md": md,
+                "attachments": []}
+    act = await mgr.pmo.get_activity(MissionRef(pmo_id, "issue"), full=True)
+    m = act.mission
+    attachments = []
+    used: set[str] = {"ACTIVITY.md", "MISSION.md"}   # docs/07 §2 dedupe seed
+
+    async def _materialize(att):
+        """Download one file attachment into the folder; return its index
+        line. The adapter resolves names (AttachmentRef.name) — the domain
+        never parses vendor asset URLs. `.zip` attachments are kept whole
+        and also extracted under `{stem}/` (zip-slip hardened, size-capped)."""
+        try:
+            data = await mgr.pmo.download_asset(att.url)
+        except Exception:  # noqa: BLE001 — attachment fetch degrades to an inline "unavailable" marker; the mirror build continues
+            return f"[attachment unavailable: {att.url}]"
+        # basename BEFORE dedupe: a slash-bearing link text ([v1/r.md](…))
+        # must yield the same name in the index, the snapshot commit, and
+        # the folder — a path-y name would desync them and trip the
+        # snapshot dup-path guard forever (full-diff review finding)
+        raw = (Path(att.name).name if att.name
+               else att.url.rsplit("/", 1)[-1][:80])
+        fname = _unique_name(raw or "attachment.bin", used)
+        attachments.append({"filename": fname,
+                            "content_b64": base64.b64encode(data).decode()})
+        if fname.lower().endswith(".zip"):
+            try:
+                cap = mgr._attachment_cap()
+            except Exception:  # noqa: BLE001 — expand is advisory; fall back to a fixed budget
+                cap = 50 * 1024 * 1024
+            pairs = expand_zip_attachment(fname, data, max_bytes=cap)
+            if pairs:
+                # the extraction dir must not collide with an existing flat
+                # name (file-vs-dir: unrepresentable in the snapshot's git
+                # tree, and a crash in the entrypoint's mkdir) — remap the
+                # whole extraction to `{stem}-2/…`, `-3/…` when it would
+                stem = pairs[0][0].split("/", 1)[0]
+                final, i = stem, 1
+                while _tree_conflict(final, used):
+                    i += 1
+                    final = f"{stem}-{i}"
+                for rel, content in pairs:
+                    rel = final + rel[len(stem):]
+                    if rel in used:      # unreachable once stems are unique
+                        continue
+                    used.add(rel)        # later attachments cannot collide
+                    attachments.append({
+                        "filename": rel,
+                        "content_b64": base64.b64encode(content).decode()})
+        return f"[attachment: {fname}]"
+
+    mission_lines = []
+    for att in act.mission_attachments:
+        if att.kind == "link":
+            mission_lines.append(f"[link: {att.name or att.url}]({att.url})")
+        else:
+            mission_lines.append(await _materialize(att))
+
+    lines = []
+    if act.truncated:   # the adapter's hard stop — never silent (ADR-0014)
+        lines += ["⚠ FEED TRUNCATED — the feed exceeded the full-history "
+                  "hard stop; the OLDEST entries are missing from this "
+                  "mirror.", ""]
+    lines += [
+        f"# {m.key}: {m.title}",
+        "> Brief: MISSION.md (same folder) — description, labels, mission attachments.", "",
+        "## Activity (chronological mirror of the PMO feed)",
+        "Entries marked 🧑 HUMAN are instructions/steering from a person — they",
+        "are authoritative. Entries marked 🤖 DevCake are DevCake's own records.",
+    ]
+    by_id = {e.entry_id: e for e in act.entries if e.entry_id}
+    for e in act.entries:
+        body = e.body or ""
+        # provenance is sentinel-based, never author-based (docs/03 §8a):
+        # DevCake may post with the operator's own PMO credentials
+        provenance = "🤖 DevCake" if _is_devcake_comment(body) else "🧑 HUMAN"
+        lines.append(f"### {e.ts:%Y-%m-%d %H:%M} — {e.author} — {provenance} ({e.kind})")
+        parent = by_id.get(e.parent_id) if e.parent_id else None
+        if parent is not None:
+            lines.append(f"↳ reply to {parent.author} @ {parent.ts:%Y-%m-%d %H:%M}")
+        elif e.parent_id:
+            lines.append("↳ reply to (deleted comment)")
+        lines.append(body)                # full body — the mirror never trims
+        for att in e.attachments:
+            lines.append(await _materialize(att))
+        lines.append("")
+    return {"mission_md": _mission_md(m, mission_lines),
+            "activity_md": "\n".join(lines), "attachments": attachments}
+

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -23,6 +23,7 @@ from ..run import Run, utcnow
 from ..workspaces import WorkspaceUnavailable
 from . import markers
 from . import schedule
+from .activity_payload import push_activity_repo
 from .feed import _is_devcake_comment, _stage_of, _unquoted
 from .markers import STEP_MARKER
 
@@ -142,7 +143,9 @@ async def resolve_blocker_work(
             continue
         if r.mission_type in ("MAPPER", "HELLO", "OAUTH"):
             continue
-        # legacy default "main" is not a real resolved work repo name on the
+        # legacy default "main" (see run.LEGACY_PMO_REFS — here it is a
+        # synthetic REPO name, deliberately narrower: "" is never a repo
+        # ref) is not a real resolved work repo name on the
         # sticky path (configured names are operator-chosen; internal names
         # are {instance}-{key}); skip the synthetic default so a pre-v3
         # record cannot invent a mount target.
@@ -384,7 +387,7 @@ async def dispatch(mgr, mission: Mission, mtype: MissionType,
 
     # ADR-0014 D4: refresh the mission's activity repo BEFORE the step — the
     # repo records what this Dev actually receives. NEVER gates dispatch.
-    await _push_activity_repo(mgr, live, mtype, seq)
+    await push_activity_repo(mgr, live, mtype, seq)
 
     blocker_note = _blocker_repos_note(mgr, blocker_entries, blocker_skips)
 
@@ -791,114 +794,6 @@ def _derive_seq(activity) -> int:
     return (max(steps) + 1) if steps else 1
 
 
-def _tree_conflict(cand: str, used: set[str]) -> bool:
-    """True when `cand` cannot coexist with `used` as one file tree: exact
-    duplicate, `cand` names a file where used paths already form a directory,
-    or an ancestor directory of `cand` is already a file. A file and a
-    directory sharing a name is unrepresentable in a git tree and crashes
-    the entrypoint's mkdir/write."""
-    if cand in used:
-        return True
-    pre = cand + "/"
-    if any(u.startswith(pre) for u in used):
-        return True
-    parts = cand.split("/")
-    return any("/".join(parts[:i]) in used for i in range(1, len(parts)))
-
-
-def _unique_name(name: str, used: set[str]) -> str:
-    """docs/07 §2 collision rule: later duplicates get -2, -3, … suffixes.
-    A flat name also conflicts with an existing extraction DIRECTORY of the
-    same name (file-vs-dir is unrepresentable — `_tree_conflict`); the
-    suffix rule resolves that identically. Callers pass flat (basenamed)
-    names; extraction paths are reserved directly by the expansion loop."""
-    stem, dot, ext = name.rpartition(".")
-    cand, i = name, 1
-    while cand in used or any(u.startswith(cand + "/") for u in used):
-        i += 1
-        cand = f"{stem}-{i}.{ext}" if dot else f"{name}-{i}"
-    used.add(cand)
-    return cand
-
-
-def safe_activity_relpath(path: str) -> str | None:
-    """Normalize a feed-controllable relative path for the activity folder.
-    Rejects empty, absolute, `..`, and over-deep/long names (zip-slip)."""
-    if not path or not isinstance(path, str):
-        return None
-    raw = path.replace("\\", "/").strip()
-    if not raw or raw.startswith("/") or raw.startswith("~"):
-        return None
-    parts = [p for p in raw.split("/") if p not in ("", ".")]
-    if not parts or ".." in parts:
-        return None
-    if len(parts) > 20 or any(len(p) > 200 for p in parts):
-        return None
-    return "/".join(parts)
-
-
-def expand_zip_attachment(zip_name: str, data: bytes, *,
-                          max_bytes: int,
-                          max_files: int = 500) -> list[tuple[str, bytes]]:
-    """Extract zip members under `{stem}/…`. Best-effort: corrupt/oversize/
-    slip members are skipped; never raises into the payload builder."""
-    import io
-    import zipfile
-    from pathlib import PurePosixPath
-
-    stem = PurePosixPath(zip_name.replace("\\", "/")).name
-    if stem.lower().endswith(".zip"):
-        stem = stem[:-4]
-    stem = stem or "archive"
-    # stem itself must be a single safe segment
-    if safe_activity_relpath(stem) is None or "/" in stem:
-        stem = "archive"
-    out: list[tuple[str, bytes]] = []
-    emitted: set[str] = set()
-    used = 0
-    try:
-        zf = zipfile.ZipFile(io.BytesIO(data))
-    except (zipfile.BadZipFile, OSError):
-        return []
-    try:
-        for info in zf.infolist():
-            if info.is_dir():
-                continue
-            if len(out) >= max_files:
-                break
-            member = safe_activity_relpath(info.filename)
-            if member is None:
-                continue
-            full = safe_activity_relpath(f"{stem}/{member}")
-            if full is None:
-                continue
-            # a crafted zip can hold both `x` and `x/y` (or duplicate
-            # names) — later members that conflict with an already-emitted
-            # path are dropped, keeping the extraction one valid file tree
-            if _tree_conflict(full, emitted):
-                continue
-            # Pre-check declared uncompressed size before read — a zip bomb
-            # must not force a multi-GB decompress into memory first. The
-            # header can lie; the post-read check below is the hard stop.
-            declared = getattr(info, "file_size", 0) or 0
-            if declared < 0:
-                continue
-            if declared and used + declared > max_bytes:
-                break
-            try:
-                content = zf.read(info)
-            except Exception:  # noqa: BLE001 — one bad member must not abort the rest
-                continue
-            if used + len(content) > max_bytes:
-                break
-            used += len(content)
-            emitted.add(full)
-            out.append((full, content))
-    finally:
-        zf.close()
-    return out
-
-
 def _aware(ts: datetime) -> datetime:
     """Anchor timestamps come from three sources (audit log, run records,
     PMO comments); a stray naive one must not crash the scheduler."""
@@ -906,21 +801,10 @@ def _aware(ts: datetime) -> datetime:
 
 
 def _last_giveup_at(pmo_id: str) -> datetime | None:
-    try:
-        ts = None
-        with open(markers.AUDIT_PATH) as f:
-            for line in f:
-                try:
-                    e = json.loads(line)
-                    if e.get("pmo_id") == pmo_id \
-                            and e.get("action") == "devcake_failed":
-                        ts = _aware(datetime.fromisoformat(e["ts"]))
-                except Exception:  # noqa: BLE001 — one bad audit line must never halt scheduling
-                    log.debug("_last_giveup_at: skipping unparseable audit line")
-                    continue
-        return ts
-    except FileNotFoundError:
-        return None
+    """Delegates to the incremental audit-tail reader (markers.last_giveup_at
+    — 2026-08 evaluation F8: the full-file rescan per candidate per cycle is
+    gone). Kept as a seam: tests and attempt_number call through here."""
+    return markers.last_giveup_at(pmo_id)
 
 
 # ADR-0018 — classes whose failures NEVER burn a mission's attempts. Both latch
@@ -1085,162 +969,6 @@ async def _give_up(mgr, mission: Mission, mtype: MissionType, attempts: int) -> 
     log.warning("DEVCAKE-FAILED applied to %s (%s)", mission.key, mtype.value)
 
 
-def _activity_snapshot_files(payload: dict) -> list[dict]:
-    """Activity payload → the file list a snapshot commit mirrors
-    (identical layout to the Dev's /workspace/activity). Attachment paths
-    may be nested (zip extracts under `{stem}/…`); only safe relative
-    paths are kept."""
-    files = []
-    if payload.get("mission_md"):
-        files.append({"path": "MISSION.md", "content_b64": base64.b64encode(
-            payload["mission_md"].encode()).decode()})
-    files.append({"path": "ACTIVITY.md", "content_b64": base64.b64encode(
-        payload.get("activity_md", "").encode()).decode()})
-    for a in payload.get("attachments", []):
-        raw = a.get("filename") or "attachment.bin"
-        rel = safe_activity_relpath(raw)
-        if rel is None:
-            rel = Path(str(raw).replace("\\", "/")).name or "attachment.bin"
-            if rel in (".", ".."):
-                rel = "attachment.bin"
-        files.append({"path": rel, "content_b64": a["content_b64"]})
-    return files
-
-
-async def _push_activity_repo(mgr, mission, mtype, seq: int) -> None:
-    """ADR-0014 D4: one snapshot commit per step dispatch. Any failure is
-    audited loudly and swallowed — the run proceeds on the Redis fallback;
-    Gitea down degrades to pre-ADR behavior, never to a halt."""
-    if mgr.internal_forge is None:
-        return
-    try:
-        payload = await activity_payload(mgr, mission.pmo_id, mission.pmo_kind)
-        name = await mgr.internal_forge.ensure_activity_repo(
-            mgr.instance_name, mission.key)
-        await mgr.internal_forge.push_activity_snapshot(
-            name, _activity_snapshot_files(payload),
-            f"step {seq} {mtype.value} dispatch")
-        log.info("activity repo %s: snapshot for step %d", name, seq)
-    except Exception as e:
-        log.exception("activity repo push failed for %s", mission.key)
-        mgr._audit(mission.pmo_id, "activity_repo_push_failed",
-                    f"{mission.key}: {type(e).__name__}: {str(e)[:180]}")
-
-
-def _mission_md(m, attachment_lines=()) -> str:
-    """ADR-0014 D3: MISSION.md — the brief. Stable regardless of feed length;
-    every step playbook points here."""
-    lines = [
-        f"# {m.key}: {m.title}",
-        f"> Kind: {m.pmo_kind} · Status: {m.status} · Priority: {m.priority} · URL: {m.url}",
-        f"> Labels: {', '.join(sorted(m.labels)) or '(none)'}", "",
-        "## Description", m.description or "(none)"]
-    if attachment_lines:
-        lines += ["", "## Mission attachments", *attachment_lines]
-    return "\n".join(lines)
-
-
-async def activity_payload(mgr, pmo_id: str, kind: str = "issue") -> dict:
-    """ADR-0014 D3: MISSION.md = the brief; ACTIVITY.md = a faithful MIRROR
-    of the feed — full bodies inline (never externalized), attachments by
-    name in feed order, reply nesting; every attachment's bytes ride as
-    sibling files."""
-    if kind == "project":
-        # projects have no comments/attachments: the brief IS the payload
-        m = await mgr.pmo.get(MissionRef(pmo_id, "project"))
-        md = "\n".join([
-            f"# {m.key}: {m.title}",
-            "> The mission brief lives in MISSION.md (same folder).", "",
-            "## Activity", "(projects carry no comment feed — see child issues)"])
-        return {"mission_md": _mission_md(m), "activity_md": md,
-                "attachments": []}
-    act = await mgr.pmo.get_activity(MissionRef(pmo_id, "issue"), full=True)
-    m = act.mission
-    attachments = []
-    used: set[str] = {"ACTIVITY.md", "MISSION.md"}   # docs/07 §2 dedupe seed
-
-    async def _materialize(att):
-        """Download one file attachment into the folder; return its index
-        line. The adapter resolves names (AttachmentRef.name) — the domain
-        never parses vendor asset URLs. `.zip` attachments are kept whole
-        and also extracted under `{stem}/` (zip-slip hardened, size-capped)."""
-        try:
-            data = await mgr.pmo.download_asset(att.url)
-        except Exception:  # noqa: BLE001 — attachment fetch degrades to an inline "unavailable" marker; the mirror build continues
-            return f"[attachment unavailable: {att.url}]"
-        # basename BEFORE dedupe: a slash-bearing link text ([v1/r.md](…))
-        # must yield the same name in the index, the snapshot commit, and
-        # the folder — a path-y name would desync them and trip the
-        # snapshot dup-path guard forever (full-diff review finding)
-        raw = (Path(att.name).name if att.name
-               else att.url.rsplit("/", 1)[-1][:80])
-        fname = _unique_name(raw or "attachment.bin", used)
-        attachments.append({"filename": fname,
-                            "content_b64": base64.b64encode(data).decode()})
-        if fname.lower().endswith(".zip"):
-            try:
-                cap = mgr._attachment_cap()
-            except Exception:  # noqa: BLE001 — expand is advisory; fall back to a fixed budget
-                cap = 50 * 1024 * 1024
-            pairs = expand_zip_attachment(fname, data, max_bytes=cap)
-            if pairs:
-                # the extraction dir must not collide with an existing flat
-                # name (file-vs-dir: unrepresentable in the snapshot's git
-                # tree, and a crash in the entrypoint's mkdir) — remap the
-                # whole extraction to `{stem}-2/…`, `-3/…` when it would
-                stem = pairs[0][0].split("/", 1)[0]
-                final, i = stem, 1
-                while _tree_conflict(final, used):
-                    i += 1
-                    final = f"{stem}-{i}"
-                for rel, content in pairs:
-                    rel = final + rel[len(stem):]
-                    if rel in used:      # unreachable once stems are unique
-                        continue
-                    used.add(rel)        # later attachments cannot collide
-                    attachments.append({
-                        "filename": rel,
-                        "content_b64": base64.b64encode(content).decode()})
-        return f"[attachment: {fname}]"
-
-    mission_lines = []
-    for att in act.mission_attachments:
-        if att.kind == "link":
-            mission_lines.append(f"[link: {att.name or att.url}]({att.url})")
-        else:
-            mission_lines.append(await _materialize(att))
-
-    lines = []
-    if act.truncated:   # the adapter's hard stop — never silent (ADR-0014)
-        lines += ["⚠ FEED TRUNCATED — the feed exceeded the full-history "
-                  "hard stop; the OLDEST entries are missing from this "
-                  "mirror.", ""]
-    lines += [
-        f"# {m.key}: {m.title}",
-        "> Brief: MISSION.md (same folder) — description, labels, mission attachments.", "",
-        "## Activity (chronological mirror of the PMO feed)",
-        "Entries marked 🧑 HUMAN are instructions/steering from a person — they",
-        "are authoritative. Entries marked 🤖 DevCake are DevCake's own records.",
-    ]
-    by_id = {e.entry_id: e for e in act.entries if e.entry_id}
-    for e in act.entries:
-        body = e.body or ""
-        # provenance is sentinel-based, never author-based (docs/03 §8a):
-        # DevCake may post with the operator's own PMO credentials
-        provenance = "🤖 DevCake" if _is_devcake_comment(body) else "🧑 HUMAN"
-        lines.append(f"### {e.ts:%Y-%m-%d %H:%M} — {e.author} — {provenance} ({e.kind})")
-        parent = by_id.get(e.parent_id) if e.parent_id else None
-        if parent is not None:
-            lines.append(f"↳ reply to {parent.author} @ {parent.ts:%Y-%m-%d %H:%M}")
-        elif e.parent_id:
-            lines.append("↳ reply to (deleted comment)")
-        lines.append(body)                # full body — the mirror never trims
-        for att in e.attachments:
-            lines.append(await _materialize(att))
-        lines.append("")
-    return {"mission_md": _mission_md(m, mission_lines),
-            "activity_md": "\n".join(lines), "attachments": attachments}
-
 
 async def resolve_repo_live(mgr, mission, all_runs=None):
     """(repo_name | None, gate_reason | None), UN-GATING zero-repo missions
@@ -1253,9 +981,6 @@ async def resolve_repo_live(mgr, mission, all_runs=None):
     mission change) is a real gate — never silently redirected internal."""
     from ..repo_routing import REASON_ZERO_REPO
     from ...ports.internal_forge import internal_repo_name
-    from ...adapters.registry import make_gitea_adapter
-
-    from ...config import RepoInstance
 
     if all_runs is None:
         all_runs = mgr.runs.store.all()
@@ -1263,30 +988,14 @@ async def resolve_repo_live(mgr, mission, all_runs=None):
     async def _provision() -> str:
         # ensure service accounts first (lazy retry — boot provisioning may
         # have failed against a not-yet-ready Gitea; review finding #7)
-        svc = mgr.internal_forge.service_tokens()
-        if not svc:
+        if not mgr.internal_forge.service_tokens():
             await mgr.internal_forge.ensure_service_accounts()
-            svc = mgr.internal_forge.service_tokens() or {}
         creds = await mgr.internal_forge.ensure_mission_repo(
             mgr.instance_name, mission.key)
-        # the APP-SIDE adapter uses the devcake-app SERVICE token (org owner:
-        # write:issue for PR comments + write:repository for merge), NOT the
-        # mission's Dev write token (write:repository only → issue-scope 403s;
-        # review finding #1). The mission's write/read pair is the Dev's,
-        # delivered via runspec.
-        adapter = make_gitea_adapter(creds.clone_url, svc.get("app_token"),
-                                     svc.get("reviewer_token"))
-        # model_construct: internal repo names carry hyphens / exceed the
-        # operator-name pattern by design — they are synthesized, not input.
-        # Always auto-merge: the zip deliverable only posts after merge, and
-        # no human watches the internal Gitea. Operators who want doctrine
-        # control create the repo as a config card ("gitea (internal) →
-        # + Create repository") instead (ADR-0020).
-        inst = RepoInstance.model_construct(
-            name=creds.repo_name, forge="gitea", url=creds.clone_url,
-            default_branch="main", api_base=None,
-            auto_merge=True, auto_resolve_merge_conflicts=True,
-            merge_retry_window_minutes=30)
+        # the row + app-side adapter come from the PORT (2026-08 F9): only
+        # the internal forge knows its own vendor — token choice, auto-merge
+        # doctrine and the synthesized-name RepoInstance live in the adapter
+        inst, adapter = mgr.internal_forge.mission_repo_binding(creds)
         mgr.forges.register_internal(creds.repo_name, inst, adapter)
         return creds.repo_name
 

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -30,8 +30,8 @@ from ..blocker_locator import LEGACY_PMO_REFS
 from ..runs import RunManager
 from typing import TYPE_CHECKING as _TC
 
-from . import (deliver, dispatch, feed, finalize, mapper, review, schedule,
-               sweeps)
+from . import (activity_payload as activity_payload_mod, deliver, dispatch,
+               feed, finalize, mapper, review, schedule, sweeps)
 
 if _TC:
     from ..forge_runtime import ForgeRuntime
@@ -187,7 +187,7 @@ class MissionManager:
         return dispatch.runspec_secret_payload(self, run)
 
     async def activity_payload(self, pmo_id: str, kind: str = 'issue'):
-        return await dispatch.activity_payload(self, pmo_id, kind)
+        return await activity_payload_mod.activity_payload(self, pmo_id, kind)
 
     async def resolve_repo_live(self, mission, all_runs=None):
         return await dispatch.resolve_repo_live(self, mission, all_runs)

--- a/app/devcake/domain/orchestrator/markers.py
+++ b/app/devcake/domain/orchestrator/markers.py
@@ -130,3 +130,45 @@ def at_decomposition_limit(mission, limit: int) -> bool:
     return depth is None or depth >= limit
 
 AUDIT_PATH = Path(os.environ.get("DEVCAKE_DATA_DIR", "/data")) / "state" / "events.jsonl"
+
+# ── give-up watermark reader (2026-08 evaluation F8) ─────────────────────────
+# The old reader re-parsed the ENTIRE append-only audit log once per candidate
+# mission per poll cycle — O(missions × log size) JSON on a file only
+# clear-runs ever truncates. This incremental reader parses only the appended
+# tail: the module-level state carries (path, byte offset, per-pmo marks) and
+# resets itself when the path changes (tests monkeypatch AUDIT_PATH) or the
+# file shrank (clear-runs truncation). Safe without locks: the writer
+# (feed._audit) is synchronous inside the one event loop, so a reader never
+# observes a partial line.
+_GIVEUP_STATE: dict = {"path": None, "offset": 0, "marks": {}}
+
+
+def last_giveup_at(pmo_id: str):
+    """Timestamp of the newest `devcake_failed` audit event for pmo_id, or
+    None. Incremental over AUDIT_PATH (see block comment)."""
+    import json as _json
+    from datetime import datetime as _dt, timezone as _tz
+    st = _GIVEUP_STATE
+    path = AUDIT_PATH
+    try:
+        size = path.stat().st_size
+    except OSError:
+        st.update(path=path, offset=0, marks={})
+        return None
+    if st["path"] != path or size < st["offset"]:
+        st.update(path=path, offset=0, marks={})
+    if size > st["offset"]:
+        with open(path) as f:
+            f.seek(st["offset"])
+            for line in f:
+                try:
+                    e = _json.loads(line)
+                    if e.get("action") == "devcake_failed":
+                        ts = _dt.fromisoformat(e["ts"])
+                        if ts.tzinfo is None:
+                            ts = ts.replace(tzinfo=_tz.utc)
+                        st["marks"][e.get("pmo_id")] = ts
+                except Exception:  # noqa: BLE001 — one bad audit line must never halt scheduling
+                    continue
+            st["offset"] = f.tell()
+    return st["marks"].get(pmo_id)

--- a/app/devcake/domain/orchestrator/router.py
+++ b/app/devcake/domain/orchestrator/router.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("devcake.router")
 
-_LEGACY_REFS = ("", "main")
+from ..run import LEGACY_PMO_REFS
 
 
 class FinalizerRouter:
@@ -38,7 +38,7 @@ class FinalizerRouter:
 
     def _mgr(self, run: Run) -> "MissionManager | None":
         mgr = self._managers.get(run.pmo_ref)
-        if mgr is None and run.pmo_ref in _LEGACY_REFS and len(self._managers) == 1:
+        if mgr is None and run.pmo_ref in LEGACY_PMO_REFS and len(self._managers) == 1:
             mgr = next(iter(self._managers.values()))
         return mgr
 

--- a/app/devcake/domain/run.py
+++ b/app/devcake/domain/run.py
@@ -11,6 +11,16 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
+# Pre-schema-v3 run records carry no real instance ref: `pmo_ref` is "" or
+# the old "main" default, and such records always count as LOCAL (hiding
+# them would orphan pre-v3 blocker work). THE one definition (2026-08
+# cleanup — copies had drifted into router/ports and could diverge);
+# consumers: MissionManager._run_is_ours, the blocker locator's locality
+# set, FinalizerRouter's single-manager fallback, ports.forge.run_branch's
+# legacy branch naming. (dispatch's blocker-mount guard deliberately checks
+# only "main" — there it is a synthetic REPO name, not a pmo_ref.)
+LEGACY_PMO_REFS = frozenset({"", "main"})
+
 RunState = Literal[
     "dispatched", "running", "finalizing", "finished", "failed", "timed_out", "orphaned"
 ]

--- a/app/devcake/ports/forge.py
+++ b/app/devcake/ports/forge.py
@@ -7,6 +7,8 @@ from typing import ClassVar, Literal, Optional, Protocol
 
 from pydantic import BaseModel
 
+from ..domain.run import LEGACY_PMO_REFS
+
 # THE branch-naming convention: one definition, imported by the orchestrator
 # and the prompt templates alike (docs/06 §2).
 BRANCH_PREFIX = "devcake/"
@@ -39,7 +41,7 @@ def run_branch(run) -> str:
     (pre-v3) records derive the unprefixed convention their Devs pushed."""
     if getattr(run, "branch", ""):
         return run.branch
-    if run.pmo_ref in ("", "main"):
+    if run.pmo_ref in LEGACY_PMO_REFS:
         return legacy_branch(run.mission_key)
     return mission_branch(run.pmo_ref, run.mission_key)
 

--- a/app/devcake/ports/internal_forge.py
+++ b/app/devcake/ports/internal_forge.py
@@ -84,6 +84,14 @@ class InternalForgePort(Protocol):
         attempts and rework (the M4 PR-reuse mechanics carry over)."""
         ...
 
+    def mission_repo_binding(self, creds: MissionRepoCredentials):
+        """(RepoInstance row, app-side ForgePort adapter) for a provisioned
+        mission repo — ready for ForgeRuntime.register_internal. Lives on the
+        port because ONLY the internal forge knows its own vendor: the old
+        call site built a named gitea adapter inside domain code, threading
+        the F1 tripwire's registry exemption (2026-08 evaluation F9)."""
+        ...
+
     def mission_credentials(self, repo_name: str) -> MissionRepoCredentials | None:
         """The stored per-mission token pair (runspec source; sync read)."""
         ...

--- a/app/devcake/ports/pmo.py
+++ b/app/devcake/ports/pmo.py
@@ -34,6 +34,13 @@ class PMOCapabilities(BaseModel):
     attachment_max_bytes: int
     native_label_swap_atomic: bool
     relations_supported: bool = False
+    # pmo_ids are globally unique across the vendor environment (Linear
+    # UUIDs) — only such systems may resolve blockers via PEER adapters or
+    # accept peer run history on a locally-resolved foreign id. Colliding-id
+    # systems (gitea_issues issue numbers) never cross instances. Declared
+    # here so the blocker locator branches on a CAPABILITY, not a vendor
+    # name (2026-08 evaluation F10 — adding a PMO no longer edits domain).
+    global_ids: bool = False
 
 
 class PMOPort(Protocol):

--- a/app/devcake/secrets.py
+++ b/app/devcake/secrets.py
@@ -63,6 +63,13 @@ def _atomic_write_bytes(path: Path, data: bytes) -> None:
         os.chmod(tmp, 0o600)
         os.replace(tmp, path)
         _fsync_dir(path.parent)          # make the rename itself durable
+        # 2026-08 evaluation F17: every store write funnels through here, so
+        # this ONE call keeps security's _known_values result cache exact in
+        # the direction that matters — a just-stored value is rescanned
+        # before the next redact(). Deletes deliberately do not invalidate
+        # (stale-extra masking is the safe direction).
+        from .security import invalidate_secret_scan
+        invalidate_secret_scan()
     except Exception:  # noqa: BLE001 — temp cleanup then re-raise (atomic write contract)
         with contextlib.suppress(FileNotFoundError):
             os.unlink(tmp)

--- a/app/devcake/security.py
+++ b/app/devcake/security.py
@@ -178,7 +178,33 @@ def _file_values(p) -> list[str]:
     return found
 
 
+# Result cache for _known_values (2026-08 evaluation F17): the glob + a stat
+# per file on EVERY redact() call was O(store size) on the finalize path,
+# which redacts multi-MB transcripts. The app is the store's only writer, so
+# event-driven invalidation from secrets.py's write choke point (and from
+# reload_connections, whose descriptor set feeds secret_env_vars) is EXACT in
+# the direction that matters: a just-stored value rescans before the next
+# redact. Deletions deliberately do NOT invalidate — "unregistering a
+# just-revoked value is the risky direction" — so a deleted file's values
+# keep masking until the next write-triggered rescan, strictly LONGER than
+# the old per-call glob ever kept them. NOT a TTL: a timer would open a
+# just-saved-secret-unmasked window, which is the one direction forbidden.
+_known_cache: tuple[str, list[str]] | None = None   # (scanned dir, values)
+
+
+def invalidate_secret_scan() -> None:
+    """Drop the _known_values result cache. Called by secrets.py's atomic
+    write choke point and by connection reloads; cheap and idempotent."""
+    global _known_cache
+    _known_cache = None
+
+
 def _known_values() -> list[str]:
+    global _known_cache
+    # keyed by the scanned dir so a monkeypatched _SECRETS_DIR (tests) can
+    # never serve another dir's scan
+    if _known_cache is not None and _known_cache[0] == str(_SECRETS_DIR):
+        return _known_cache[1]
     values = [v for var in secret_env_vars() if (v := os.environ.get(var, "").strip())]
     # credential file key material: every long-ish string value in stored JSONs
     live_paths = set()
@@ -191,7 +217,9 @@ def _known_values() -> list[str]:
             continue
     for stale in set(_scan_cache) - live_paths:      # deleted files drop out
         del _scan_cache[stale]
-    return sorted(set(values), key=len, reverse=True)  # longest first
+    result = sorted(set(values), key=len, reverse=True)  # longest first
+    _known_cache = (str(_SECRETS_DIR), result)
+    return result
 
 
 def redact(text: str, extra_values: list[str] | None = None) -> str:

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -182,3 +182,16 @@ def make_mission_manager(
     if noop_audit:
         mgr._audit = lambda *a, **k: None  # type: ignore[method-assign]
     return mgr
+
+
+def fake_pmo_capabilities(*, global_ids=True):
+    """Shared capability row for the test fakes. Default is Linear-shaped
+    (global ids ON, so peer-resolution tests exercise the allowed path);
+    colliding-id scenarios pass global_ids=False — the capability replaced
+    GLOBAL_ID_SYSTEMS in the 2026-08 cleanups."""
+    from devcake.ports.pmo import PMOCapabilities
+    return PMOCapabilities(
+        projects_supported=True, project_labels_supported=True,
+        attachment_max_bytes=50 * 1024 * 1024,
+        native_label_swap_atomic=True, relations_supported=True,
+        global_ids=global_ids)

--- a/app/tests/test_activity_zip.py
+++ b/app/tests/test_activity_zip.py
@@ -9,7 +9,7 @@ import zipfile
 from datetime import datetime, timezone
 
 from devcake.domain.model import Activity, ActivityEntry, AttachmentRef
-from devcake.domain.orchestrator import dispatch
+from devcake.domain.orchestrator import activity_payload as activity
 from test_mapper import MapPMO, run_coro
 
 NOW = datetime.now(timezone.utc)
@@ -24,18 +24,18 @@ def _zip_bytes(members: dict[str, bytes]) -> bytes:
 
 
 def test_safe_activity_relpath_rejects_slip():
-    assert dispatch.safe_activity_relpath("a/b.md") == "a/b.md"
-    assert dispatch.safe_activity_relpath("../evil") is None
-    assert dispatch.safe_activity_relpath("/abs") is None
-    assert dispatch.safe_activity_relpath("a/../../x") is None
-    assert dispatch.safe_activity_relpath("") is None
-    assert dispatch.safe_activity_relpath("..") is None
-    assert dispatch.safe_activity_relpath("ok.md") == "ok.md"
+    assert activity.safe_activity_relpath("a/b.md") == "a/b.md"
+    assert activity.safe_activity_relpath("../evil") is None
+    assert activity.safe_activity_relpath("/abs") is None
+    assert activity.safe_activity_relpath("a/../../x") is None
+    assert activity.safe_activity_relpath("") is None
+    assert activity.safe_activity_relpath("..") is None
+    assert activity.safe_activity_relpath("ok.md") == "ok.md"
 
 
 def test_expand_zip_attachment_happy_and_caps():
     data = _zip_bytes({"a.md": b"hello", "dir/b.txt": b"world"})
-    out = dispatch.expand_zip_attachment("report.zip", data,
+    out = activity.expand_zip_attachment("report.zip", data,
                                          max_bytes=10 * 1024 * 1024)
     paths = {p: c for p, c in out}
     assert paths["report/a.md"] == b"hello"
@@ -43,22 +43,22 @@ def test_expand_zip_attachment_happy_and_caps():
 
     # zip-slip members dropped
     evil = _zip_bytes({"../evil.txt": b"x", "ok.txt": b"y"})
-    out2 = dispatch.expand_zip_attachment("pack.zip", evil, max_bytes=1024)
+    out2 = activity.expand_zip_attachment("pack.zip", evil, max_bytes=1024)
     assert out2 == [("pack/ok.txt", b"y")]
 
     # corrupt
-    assert dispatch.expand_zip_attachment("x.zip", b"not-a-zip",
+    assert activity.expand_zip_attachment("x.zip", b"not-a-zip",
                                           max_bytes=1024) == []
 
     # byte cap stops early (small first member fits, large second does not)
     big = _zip_bytes({"small.txt": b"ab", "big.txt": b"x" * 100})
-    out3 = dispatch.expand_zip_attachment("c.zip", big, max_bytes=10)
+    out3 = activity.expand_zip_attachment("c.zip", big, max_bytes=10)
     assert out3 == [("c/small.txt", b"ab")]
 
     # declared uncompressed size alone can trip the pre-read cap (zip bomb
     # defense: do not decompress a member that cannot fit the remaining budget)
     bomb = _zip_bytes({"huge.txt": b"x" * 50})
-    out4 = dispatch.expand_zip_attachment("b.zip", bomb, max_bytes=10)
+    out4 = activity.expand_zip_attachment("b.zip", bomb, max_bytes=10)
     assert out4 == []
 
 
@@ -72,7 +72,7 @@ def test_expand_zip_attachment_drops_tree_conflicts():
         z.writestr("x/y", b"nested")      # conflicts with the file `x`
         z.writestr("dup.txt", b"one")
         z.writestr("dup.txt", b"two")     # duplicate member name
-    out = dispatch.expand_zip_attachment("p.zip", buf.getvalue(),
+    out = activity.expand_zip_attachment("p.zip", buf.getvalue(),
                                          max_bytes=1024)
     assert [p for p, _ in out] == ["p/x", "p/dup.txt"]
 
@@ -81,10 +81,10 @@ def test_unique_name_respects_extraction_dirs():
     """A flat attachment named like an existing extraction DIRECTORY gets
     the suffix rule — file-vs-dir is a tree conflict, not a coexistence."""
     used = {"ACTIVITY.md", "report/a.md"}
-    assert dispatch._unique_name("report", used) == "report-2"
-    assert dispatch._tree_conflict("report", {"report/a.md"})
-    assert dispatch._tree_conflict("report/a.md/x", {"report/a.md"})
-    assert not dispatch._tree_conflict("report-3", {"report/a.md"})
+    assert activity._unique_name("report", used) == "report-2"
+    assert activity._tree_conflict("report", {"report/a.md"})
+    assert activity._tree_conflict("report/a.md/x", {"report/a.md"})
+    assert not activity._tree_conflict("report-3", {"report/a.md"})
 
 
 def test_activity_payload_expands_zip(tmp_path):
@@ -124,7 +124,7 @@ def test_activity_snapshot_keeps_nested_paths():
              "content_b64": base64.b64encode(b"# r").decode()},
         ],
     }
-    files = dispatch._activity_snapshot_files(payload)
+    files = activity._activity_snapshot_files(payload)
     paths = {f["path"] for f in files}
     assert "T-1-deliverable/REPORT.md" in paths
     assert "T-1-deliverable.zip" in paths
@@ -134,7 +134,7 @@ def test_activity_snapshot_keeps_nested_paths():
 def _no_tree_conflicts(names: list[str]) -> bool:
     seen: set[str] = set()
     for n in names:
-        if dispatch._tree_conflict(n, seen):
+        if activity._tree_conflict(n, seen):
             return False
         seen.add(n)
     return True

--- a/app/tests/test_agnosticism.py
+++ b/app/tests/test_agnosticism.py
@@ -147,6 +147,53 @@ def _docstring_nodes(tree: ast.AST) -> set[int]:
     return ids
 
 
+def test_no_vendor_name_literals_in_domain():
+    """2026-08 evaluation F9/F10: the host-literal scan above missed
+    `forge=\"gitea\"` in dispatch and `GLOBAL_ID_SYSTEMS = {\"linear\"}` in
+    the blocker locator — the tripwire's predicate didn't match its stated
+    invariant. Domain code may not name a vendor AT ALL: identity-shaped
+    decisions belong to capabilities (ForgeCapabilities /
+    PMOCapabilities.global_ids) or to the adapter itself
+    (InternalForgePort.mission_repo_binding)."""
+    vendors = {"gitea", "github", "gitlab", "linear", "gitea_issues"}
+    offenders = []
+    for path in _package_files():
+        rel = path.relative_to(PKG_ROOT)
+        if rel.parts[0] != "domain":
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        doc_ids = _docstring_nodes(tree)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str) \
+                    and id(node) not in doc_ids and node.value in vendors:
+                offenders.append(f"{rel}:{node.lineno}: {node.value!r}")
+    assert not offenders, (
+        "vendor-name literals in domain/ — express the difference as a "
+        "capability or move it into the adapter:\n" + "\n".join(offenders))
+
+
+def test_no_vendor_factory_imports_in_domain():
+    """Companion tripwire: the registry module is exempt from the adapter-
+    import scan, so a vendor-NAMED factory (make_gitea_adapter) imported
+    into domain threaded straight through it (F9). Vendor-neutral factories
+    (make_pmo, make_forge, make_internal_forge) stay legal."""
+    import re as _re
+    vendor_named = _re.compile(r"make_(gitea|github|gitlab|linear)\w*")
+    offenders = []
+    for path in _package_files():
+        rel = path.relative_to(PKG_ROOT)
+        if rel.parts[0] != "domain":
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    if vendor_named.fullmatch(alias.name):
+                        offenders.append(f"{rel}:{node.lineno}: {alias.name}")
+    assert not offenders, (
+        "vendor-named factory imports in domain/ (F9):\n" + "\n".join(offenders))
+
+
 def test_no_forge_host_literals_outside_adapters():
     hosts = ("github.com", "gitlab.com")
     offenders = []

--- a/app/tests/test_blocker_locator.py
+++ b/app/tests/test_blocker_locator.py
@@ -35,10 +35,15 @@ def _mission(pmo_id, key, status="done", instance=""):
 
 
 class CountingPMO:
-    def __init__(self, missions=None, fail=False):
+    def __init__(self, missions=None, fail=False, global_ids=True):
         self.missions = missions or {}
         self.fail = fail
+        self.global_ids = global_ids
         self.gets: list[str] = []
+
+    def capabilities(self):
+        from fakes import fake_pmo_capabilities
+        return fake_pmo_capabilities(global_ids=self.global_ids)
 
     async def get(self, ref):
         self.gets.append(ref.pmo_id)
@@ -51,10 +56,13 @@ class CountingPMO:
 
 
 def _mgr(name, system="linear", missions=None, fail=False):
+    # global_ids rides the adapter capability now (2026-08 F10): the linear
+    # shape declares it, the colliding-id shape (gitea_issues) does not
     return SimpleNamespace(
         instance=SimpleNamespace(name=name, system=system),
         instance_name=name,
-        pmo=CountingPMO(missions, fail=fail))
+        pmo=CountingPMO(missions, fail=fail,
+                        global_ids=(system == "linear")))
 
 
 def _locator(managers, owner=None):

--- a/app/tests/test_blocker_work.py
+++ b/app/tests/test_blocker_work.py
@@ -40,8 +40,13 @@ def _run(mid, key, repo_ref, *, created=None):
 
 
 class BlockerPMO:
-    def __init__(self, missions: dict[str, Mission]):
+    def __init__(self, missions: dict[str, Mission], *, global_ids=True):
         self.missions = missions
+        self.global_ids = global_ids
+
+    def capabilities(self):
+        from fakes import fake_pmo_capabilities
+        return fake_pmo_capabilities(global_ids=self.global_ids)
 
     async def get(self, ref):
         m = self.missions.get(ref.pmo_id)
@@ -142,7 +147,7 @@ def test_resolve_blocker_work_colliding_gitea_id_never_mounts_peer(tmp_path):
     evil = _run("3", "#3", "evil-repo")
     evil.pmo_ref = "g2"                       # the OTHER gitea instance's #3
     mgr = make_mission_manager(
-        tmp_path, pmo=BlockerPMO({"3": a, "9": b}),
+        tmp_path, pmo=BlockerPMO({"3": a, "9": b}, global_ids=False),
         instance=PMOInstance(name="g1", system="gitea_issues",
                              team_key="o/r"),
         internal_forge=_ROInternal())
@@ -366,3 +371,4 @@ def test_prompt_includes_blocker_section():
                          blocker_repos=note)
     assert "Completed blocker work" in out
     assert "linear-t-a" in out
+

--- a/app/tests/test_dependencies.py
+++ b/app/tests/test_dependencies.py
@@ -22,6 +22,10 @@ class DepPMO:
         self.fail_ids = set(fail_ids)
         self.live_fetches = []
 
+    def capabilities(self):
+        from fakes import fake_pmo_capabilities
+        return fake_pmo_capabilities()   # global_ids=True — peer path enabled
+
     async def get(self, ref):
         self.live_fetches.append(ref.pmo_id)
         if ref.pmo_id in self.fail_ids:
@@ -310,3 +314,4 @@ def test_foreign_resolution_uses_peer_adapter_and_memoizes(tmp_path):
     assert dispatched == []
     assert cs_pmo.live_fetches == ["u1"]
     assert eng_pmo.live_fetches == []
+

--- a/app/tests/test_multi_instance.py
+++ b/app/tests/test_multi_instance.py
@@ -465,6 +465,10 @@ def test_locator_sees_owner_after_claim(tmp_path):
         def __init__(self, missions):
             self.missions = missions
 
+        def capabilities(self):
+            from fakes import fake_pmo_capabilities
+            return fake_pmo_capabilities()   # global_ids=True (linear-shaped)
+
         async def get(self, ref):
             m = self.missions.get(ref.pmo_id)
             if m is None:

--- a/app/tests/test_repo_routing.py
+++ b/app/tests/test_repo_routing.py
@@ -284,6 +284,20 @@ def test_resolve_repo_live_ungates_zero_repo_to_internal(tmp_path, monkeypatch):
                 repo_name=name, clone_url=f"http://gitea:3000/devcake-internal/{name}.git",
                 username=f"svc-{name}", token_write="w-tok", token_read="r-tok")
 
+        def mission_repo_binding(self, creds):
+            # port contract (2026-08 F9) — the REAL row doctrine is pinned by
+            # test_gitea_mission_repo_binding_row against the gitea adapter;
+            # this fake mirrors it so resolve_repo_live's registration path
+            # stays observable
+            from types import SimpleNamespace
+            from devcake.config import RepoInstance
+            inst = RepoInstance.model_construct(
+                name=creds.repo_name, forge="gitea", url=creds.clone_url,
+                default_branch="main", api_base=None,
+                auto_merge=True, auto_resolve_merge_conflicts=True,
+                merge_retry_window_minutes=30)
+            return inst, SimpleNamespace(name="fake-internal-adapter")
+
     class RT(FakeForgeRuntime):
         def register_internal(self, name, inst, forge):
             self.instances[name] = inst
@@ -308,7 +322,8 @@ def test_resolve_repo_live_ungates_zero_repo_to_internal(tmp_path, monkeypatch):
         runs=type("Runs", (), {"store": RunStore(tmp_path / "runs")})(),
     )
 
-    # zero-repo mission → internal (always auto-merge, ADR-0020)
+    # zero-repo mission → internal (always auto-merge, ADR-0020; the row
+    # doctrine itself is pinned by test_gitea_mission_repo_binding_row)
     name, reason = run_coro(mgr.resolve_repo_live(_m()))
     assert name == "linear-t-1" and reason is None
     assert provisioned == [("linear", "T-1")]
@@ -746,3 +761,30 @@ def test_reference_repos_all_stages_and_never_work_targets(tmp_path, monkeypatch
     out = execute_prompt("ID", m, "a", "pr {branch}", reference_repos=note)
     assert "Reference repositories (read-only)" in out
     assert "Reference repositories" in plan_prompt("ID", m, reference_repos=note)
+
+
+def test_gitea_mission_repo_binding_row(monkeypatch):
+    """2026-08 F9: the internal mission-repo row doctrine moved from domain
+    into the gitea adapter — pin it at its new home. Always auto-merge (the
+    zip deliverable only posts after merge; no human watches the internal
+    Gitea), synthesized name via model_construct, app-side adapter on the
+    service token."""
+    from devcake.adapters.gitea.provision import GiteaProvisioner
+    from devcake.ports.internal_forge import MissionRepoCredentials
+
+    prov = GiteaProvisioner(url="http://gitea:3000", admin_user="a",
+                            admin_password="p")
+    monkeypatch.setattr(prov, "service_tokens",
+                        lambda: {"app_token": "app-tok",
+                                 "reviewer_token": "rev-tok"})
+    creds = MissionRepoCredentials(
+        repo_name="linear-t-9",
+        clone_url="http://gitea:3000/devcake-internal/linear-t-9.git",
+        username="svc-linear-t-9", token_write="w", token_read="r")
+    inst, adapter = prov.mission_repo_binding(creds)
+    assert inst.name == "linear-t-9"
+    assert inst.url == creds.clone_url
+    assert inst.auto_merge is True
+    assert inst.auto_resolve_merge_conflicts is True
+    assert inst.merge_retry_window_minutes == 30
+    assert adapter is not None and hasattr(adapter, "merge")

--- a/app/tests/test_security.py
+++ b/app/tests/test_security.py
@@ -215,10 +215,12 @@ def test_dev_type_secret_env_values_redacted(tmp_path, monkeypatch):
 
 
 def test_known_values_cache_invalidates_on_change(tmp_path, monkeypatch):
-    """Audit A28: redact() re-globbed and re-parsed every /data/secrets JSON
-    on every call (the hot path grows with mission count — M11 adds one file
-    per internal mission). The mtime/size cache must still see changed,
-    added, and removed files immediately."""
+    """Audit A28 + 2026-08 F17: the per-file mtime/size cache still sees
+    changed, added, and removed files — but the RESULT cache in front of it
+    (the glob+stat per redact() call is gone) rescans only on
+    invalidate_secret_scan(), which the store's atomic writer calls. Direct
+    file writes (this test) must invalidate explicitly — outside the app's
+    single-writer contract, that is the documented deal."""
     import json as _json
     from devcake import security
     monkeypatch.setattr(security, "_SECRETS_DIR", tmp_path / "secrets")
@@ -226,12 +228,33 @@ def test_known_values_cache_invalidates_on_change(tmp_path, monkeypatch):
     d.mkdir(parents=True)
     f = d / "repo-main.json"
     f.write_text(_json.dumps({"token": "first-secret-value-123"}))
+    security.invalidate_secret_scan()
     assert "first-secret-value-123" not in security.redact("x first-secret-value-123")
     f.write_text(_json.dumps({"token": "second-secret-value-98765"}))
+    security.invalidate_secret_scan()
     assert "second-secret-value-98765" not in security.redact("x second-secret-value-98765")
     f.unlink()
-    # removed file's values drop out of the scan (runtime registry unaffected)
+    # a removed file's values persist in the RESULT cache until the next
+    # write-triggered rescan — deliberately the SAFE direction (stale-extra
+    # masking; "unregistering a just-revoked value is the risky direction")
+    assert "second-secret-value-98765" not in security.redact("x second-secret-value-98765")
+    security.invalidate_secret_scan()
+    # after a rescan the removed file's values drop out of the scan
     assert "first-secret-value-123" in security.redact("x first-secret-value-123")
+
+
+def test_store_writes_invalidate_the_scan_cache(tmp_path, monkeypatch):
+    """The load-bearing half of F17: a value stored through secrets.py must
+    be redacted IMMEDIATELY — no manual invalidation, no TTL window. The
+    atomic write choke point owns the cache flush."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import secrets as s, security
+    monkeypatch.setattr(security, "_SECRETS_DIR", tmp_path / "secrets")
+    security.redact("warm the cache")                       # populate
+    s.write_connection_secret("repo", "hot", "token",
+                              "just-stored-value-45678901")
+    assert "just-stored-value-45678901" not in security.redact(
+        "x just-stored-value-45678901")
 
 
 def test_register_all_boot_coverage_and_key_scheme(tmp_path, monkeypatch):

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -30,6 +30,10 @@ class FakePMO:
         from devcake.domain.model import MissionRef
         assert isinstance(ref, MissionRef), f"port called with {ref!r}, not a MissionRef"
 
+    def capabilities(self):
+        from fakes import fake_pmo_capabilities
+        return fake_pmo_capabilities()   # global_ids=True — peer path enabled
+
     def __init__(self, mission):
         self.mission = mission
         self.comments = []
@@ -2235,3 +2239,4 @@ def test_explicit_error_class_wins_over_the_state_default(tmp_path):
     run_coro(mgr.runs.kill(run, "failed", "stopped by operator (stop all)",
                            error_class="DEV_OPERATOR_STOP"))
     assert store.get(run.run_id).error_class == "DEV_OPERATOR_STOP"
+


### PR DESCRIPTION
## What

PR F of the 2026-08 evaluation fix campaign — all six approved cleanups (founder: "include everything").

| Cleanup | Shape |
|---|---|
| `activity_payload.py` extraction | pure move out of dispatch.py (~260 lines); manager delegates; tests re-pointed |
| `LEGACY_PMO_REFS` | one definition (with the Run model); router/ports import it |
| `PMOCapabilities.global_ids` | vendor-name check in domain → adapter-declared capability, fail-closed probe |
| `mission_repo_binding` port method | internal-forge row + adapter construction moves into the gitea provisioner; **two new tripwires** (no vendor literals in domain, no vendor-named factory imports) make the F1 invariant match its predicate |
| Incremental give-up watermark | audit-tail reader with offset tracking — the per-cycle full-log parse is gone |
| Redaction scan cache | event-driven invalidate-on-write from the secrets store choke point (deliberately **not** a TTL — the just-stored-secret window is the forbidden direction); deletes keep masking |
| `PooledClient` | keep-alive client per adapter on the hot `_req` path; rebuild closes replaced adapters |

## Verification

Suite **1444 passed** (new pins: the gitea binding row at its new home, store-writes-redact-immediately, both tripwires, capability-driven peer resolution incl. the colliding-id refusal) · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)