### PR TITLE
fix: the ingress consumer survives a redis restart (deploy-drill catch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ dagu/dags/.dag.index
 
 # Gitea credential-bearing backup tarballs (scripts/backup_gitea.sh) — never commit
 devcake-gitea-*.tar.gz
+
+# never commit env backups (2026-08-04 incident)
+.env.*
+.env.bak*
+*.env.bak

--- a/app/devcake/adapters/redis/messaging.py
+++ b/app/devcake/adapters/redis/messaging.py
@@ -6,6 +6,7 @@
 - envelope auth verification (forgery guard) and chunked-payload reassembly
 """
 
+import asyncio
 import json
 import hashlib
 import logging
@@ -17,7 +18,9 @@ from typing import Any, Awaitable, Callable, Optional
 import redis.asyncio as aioredis
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
-from redis.exceptions import ResponseError
+from redis.exceptions import (ConnectionError as RedisConnectionError,
+                              ResponseError,
+                              TimeoutError as RedisTimeoutError)
 
 from ...security import MASK, register_runtime_secret, unregister_runtime_secret
 
@@ -160,9 +163,28 @@ class Messaging:
         await self.setup()
         last_reclaim = time.monotonic()
         while True:
-            entries = await self.redis.xreadgroup(
-                GROUP, CONSUMER, {INGRESS: ">"}, count=10, block=5000
-            )
+            # Connection-level failures must not kill the loop (2026-08
+            # redis-restart drill: a `compose restart redis` raised
+            # ConnectionError out of the blocking XREADGROUP, the task died
+            # silently, and every later run.artifacts sat unconsumed — runs
+            # parked in `running` forever while the aclfile durability work
+            # kept their CREDENTIALS alive). The client reconnects on the
+            # next call; setup() re-ensures the group (BUSYGROUP-tolerant)
+            # in case the restart lost an un-AOF'd group create.
+            try:
+                entries = await self.redis.xreadgroup(
+                    GROUP, CONSUMER, {INGRESS: ">"}, count=10, block=5000
+                )
+            # redis-py's ConnectionError does NOT subclass the builtin —
+            # a bare `except ConnectionError` silently misses it (measured)
+            except (RedisConnectionError, RedisTimeoutError, OSError) as e:
+                log.warning("ingress: redis unavailable (%s) — retrying in 2s", e)
+                await asyncio.sleep(2)
+                try:
+                    await self.setup()
+                except Exception:  # noqa: BLE001 — still down; next loop retries
+                    pass
+                continue
             for _stream, messages in entries or []:
                 for entry_id, fields in messages:
                     try:

--- a/app/tests/test_messaging_reconnect.py
+++ b/app/tests/test_messaging_reconnect.py
@@ -1,0 +1,84 @@
+"""The ingress consumer survives a redis restart (2026-08 live drill).
+
+The deploy drill measured the exact failure: `docker compose restart redis`
+raised redis-py's ConnectionError out of the blocking XREADGROUP, the
+consumer task died silently, and every later run.artifacts sat unconsumed —
+runs parked in `running` forever while the aclfile durability work kept
+their CREDENTIALS alive. Two pins here: the loop retries through connection
+loss, and the exception classes are redis-py's own (they do NOT subclass
+the builtins — a bare `except ConnectionError` misses them, measured)."""
+
+import asyncio
+
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from devcake.adapters.redis.messaging import Messaging
+
+_LOOP = asyncio.new_event_loop()
+asyncio.set_event_loop(_LOOP)
+
+
+def run_coro(c):
+    return _LOOP.run_until_complete(c)
+
+
+class RestartingRedis:
+    """xreadgroup dies with redis-py's ConnectionError once (the restart),
+    then delivers one entry; xgroup_create tracks the re-ensure calls."""
+
+    def __init__(self):
+        self.reads = 0
+        self.group_creates = 0
+
+    async def xgroup_create(self, *a, **kw):
+        self.group_creates += 1
+
+    async def xreadgroup(self, *a, **kw):
+        # the real client always yields at the socket — a fake that returns
+        # without yielding turns consume_forever into a starvation loop
+        await asyncio.sleep(0)
+        self.reads += 1
+        if self.reads == 1:
+            raise RedisConnectionError("Connection closed by server.")
+        return []
+
+
+def test_consumer_survives_a_redis_restart(monkeypatch):
+    m = Messaging.__new__(Messaging)
+    m.redis = RestartingRedis()
+    m._chunks = {}
+
+    # patching module-attr sleep patches the SHARED asyncio module, so the
+    # replacement must still yield to the loop or nothing else ever runs
+    real_sleep = asyncio.sleep
+
+    async def instant_sleep(_s):
+        await real_sleep(0)
+
+    monkeypatch.setattr(
+        "devcake.adapters.redis.messaging.asyncio.sleep", instant_sleep)
+
+    async def run_three_iterations():
+        task = asyncio.get_event_loop().create_task(
+            m.consume_forever(handler=None, verify_auth=None))
+        # yield until the loop has survived the error and read again
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if m.redis.reads >= 3:
+                break
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    run_coro(run_three_iterations())
+    assert m.redis.reads >= 3, "the loop must retry through ConnectionError"
+    # setup() ran at start AND re-ran after the connection loss (the restart
+    # may have lost an un-AOF'd group create)
+    assert m.redis.group_creates >= 2
+
+
+def test_redis_exception_classes_do_not_subclass_builtins():
+    """The trap that would silently revert this fix in a refactor."""
+    assert not issubclass(RedisConnectionError, ConnectionError)


### PR DESCRIPTION
The campaign's mandated redis-restart drill did its job: with the aclfile durability live, the Dev's credentials survived the restart — but the app's ingress consumer task died on redis-py's `ConnectionError` (not a builtin subclass) and nothing consumed artifacts again until an app restart. The drill's hello run sat in `running` with its container gone.

`consume_forever` now retries through connection loss (log → 2s → re-`setup()` → continue). Two pins: the loop survives a mid-read `ConnectionError`, and `RedisConnectionError` not subclassing the builtin (the trap that would silently revert this in a refactor).

Suite 1446 passed · ruff clean. After merge: redeploy app, confirm the stranded drill run finalizes via boot reclaim, re-run the drill to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)