### PR TITLE
feat: the failure taxonomy as data (ADR-0027)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
             -v "${{ github.workspace }}/images/common:/srv/images/common:ro" \
             -v "${{ github.workspace }}/dagu/dags:/srv/dagu-dags:ro" \
             -v "${{ github.workspace }}/app/Dockerfile:/srv/app.Dockerfile:ro" \
+            -v "${{ github.workspace }}/docs:/srv/docs:ro" \
             -w /srv \
             "devcake/app-test:${DEVCAKE_TAG}" \
             python -m pytest tests/ -q --tb=short

--- a/app/devcake/api/clear.py
+++ b/app/devcake/api/clear.py
@@ -18,6 +18,7 @@ import httpx
 from ..adapters.dagu import DaguExecutor
 from ..adapters.files import RunLogStore, RunStore
 from ..adapters.redis import INGRESS, Messaging
+from ..domain import failure_taxonomy
 from ..telemetry import OO_ORG, OO_URL
 
 log = logging.getLogger("devcake.clear")
@@ -62,8 +63,9 @@ async def stop_and_drain(store: RunStore, executor: DaguExecutor,
         if run is None or run.state not in ("dispatched", "running"):
             continue                                    # gone / finalizing / terminal
         try:
-            await run_manager.kill(run, "failed", "operator clear-runs",
-                                   error_class="DEV_OPERATOR_STOP")
+            await run_manager.kill(
+                run, "failed", "operator clear-runs",
+                error_class=failure_taxonomy.DEV_OPERATOR_STOP)
             stopped.append(run.run_id)
         except Exception:  # noqa: BLE001 — best-effort teardown: a kill failure is logged; the drain below still waits on Dagu's view
             log.exception("clear: kill failed for %s — continuing", run.run_id)

--- a/app/devcake/api/mission_actions.py
+++ b/app/devcake/api/mission_actions.py
@@ -33,6 +33,7 @@ from typing import Any, Awaitable, Callable, Protocol
 
 from fastapi import HTTPException
 
+from ..domain import failure_taxonomy
 from ..domain.model import MissionRef
 from ..ports.pmo import PMOTransient
 from ..security import redact
@@ -231,8 +232,9 @@ async def stop_run(
                    "DevCake is finishing bookkeeping; it completes or fails "
                    "on its own")
 
-    await run_manager.kill(run, "failed", "stopped by operator from the admin UI",
-                           error_class="DEV_OPERATOR_STOP")
+    await run_manager.kill(
+        run, "failed", "stopped by operator from the admin UI",
+        error_class=failure_taxonomy.DEV_OPERATOR_STOP)
     return {"ok": True, "run_id": run_id, "state": "failed"}
 
 
@@ -268,8 +270,9 @@ async def stop_all_runs(
             skipped.append(run.run_id)                  # finalizing/terminal
             continue
         try:
-            await run_manager.kill(run, "failed", "stopped by operator (stop all)",
-                                   error_class="DEV_OPERATOR_STOP")
+            await run_manager.kill(
+                run, "failed", "stopped by operator (stop all)",
+                error_class=failure_taxonomy.DEV_OPERATOR_STOP)
             stopped.append(run.run_id)
         except Exception as e:  # noqa: BLE001 — one kill failure must not abort the batch or lose accounting; recorded per-run
             log.exception("stop_all_runs: kill failed for %s", run.run_id)

--- a/app/devcake/domain/backend_health.py
+++ b/app/devcake/domain/backend_health.py
@@ -13,19 +13,22 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from . import failure_taxonomy
+
 WINDOW = 3                  # most recent TERMINAL runs of a dev type
 MIN_DISTINCT_MISSIONS = 2   # correlation needs evidence from ≥2 missions
 SOLO_THROTTLE_STREAK = 3    # consecutive faults on one mission ⇒ throttle only
 DEGRADED_CONCURRENCY = 1    # the probe that makes the condition self-clearing
 MAX_EXCUSALS_PER_STEP = 3   # escape hatch: bounds the livelock (see below)
 
-FAULT_CLASS = "DEV_HARNESS_FAULT"
-BAD_OUTPUT_CLASS = "DEV_BAD_OUTPUT"
-DEFAULT_CLASSES = frozenset({FAULT_CLASS})
+FAULT_CLASS = failure_taxonomy.DEV_HARNESS_FAULT
+BAD_OUTPUT_CLASS = failure_taxonomy.DEV_BAD_OUTPUT
+DEFAULT_CLASSES = failure_taxonomy.BRAKE_ALWAYS_CLASSES
 
 
 def fault_classes(brake_on_bad_output: bool) -> frozenset[str]:
-    """Evidence classes the brake correlates on (ADR-0026).
+    """Evidence classes the brake correlates on (ADR-0026), derived from the
+    taxonomy table's `brake_evidence` column (ADR-0027).
 
     The set is shared by every arm — window faults, correlation, degradation —
     so a mixed cascade (some containers exit 15, others 11) reads as ONE
@@ -33,8 +36,9 @@ def fault_classes(brake_on_bad_output: bool) -> frozenset[str]:
     exit 11 is invisible to the brake.
     """
     if brake_on_bad_output:
-        return frozenset({FAULT_CLASS, BAD_OUTPUT_CLASS})
-    return DEFAULT_CLASSES
+        return (failure_taxonomy.BRAKE_ALWAYS_CLASSES
+                | failure_taxonomy.BRAKE_OPT_IN_CLASSES)
+    return failure_taxonomy.BRAKE_ALWAYS_CLASSES
 
 # Successes are INCLUDED on purpose: they are what evicts fault evidence from the
 # window, which is the entire clearing mechanism ("two greens clear it"). The

--- a/app/devcake/domain/failure_taxonomy.py
+++ b/app/devcake/domain/failure_taxonomy.py
@@ -1,0 +1,171 @@
+"""THE run-failure taxonomy, as data (ADR-0027).
+
+One frozen row per `DEV_*` class stamped on Run records. Before this module
+the taxonomy lived in three hand-synchronized encodings — the
+`finalize.dev_failure_error` branch ladder, reconcile's stderr regex, and
+the membership sets in dispatch / backend_health / runs — whose agreement
+was enforced only by discipline, across the app/image version-skew boundary.
+Adding one exit code meant editing four-plus places. Now the consumers are
+DERIVED views of this table, and `test_failure_taxonomy.py` makes the
+pairing doctrine, the app/image parity, and the docs/15 table executable
+invariants.
+
+The asymmetries between rows are DELIBERATE — each carries an incident.
+They are fields here, not flattened: `counting` is four-valued because
+DEV_FORGE's bound and DEV_AUTH's breaker exemption are different safety
+arguments; `excusal_requires_structured_class` differs between exits 15 and
+11 because skew tolerance points in opposite directions for them; exit 12
+is not orphan-recoverable because a stale post-mortem must never trip a
+breaker. Scope: the `DEV_*` family only — docs/15 §1's flow outcomes
+(`PMO_*`, `FORGE_*`, `ILLEGAL_OUTCOME`, …) are not run-record classes and
+stay prose.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# The class-name constants. Everything in app/devcake that stamps or matches
+# a class imports these — a bare "DEV_*" literal outside this module fails
+# the structural scan, so a typo'd class can no longer silently never match.
+DEV_CRASH = "DEV_CRASH"
+DEV_BAD_OUTPUT = "DEV_BAD_OUTPUT"
+DEV_AUTH = "DEV_AUTH"
+DEV_FORGE = "DEV_FORGE"
+DEV_FORGE_AUTH = "DEV_FORGE_AUTH"
+DEV_MCP_SETUP = "DEV_MCP_SETUP"
+DEV_HARNESS_FAULT = "DEV_HARNESS_FAULT"
+DEV_TURN_BUDGET = "DEV_TURN_BUDGET"
+DEV_TIMEOUT = "DEV_TIMEOUT"
+DEV_ORPHANED = "DEV_ORPHANED"
+DEV_KILLED = "DEV_KILLED"
+DEV_OPERATOR_STOP = "DEV_OPERATOR_STOP"
+
+
+@dataclass(frozen=True)
+class FailureRow:
+    error_class: str
+    # Container-produced exit codes; () = app-side-only (kill/orphan paths,
+    # which never leave a container exit behind).
+    exit_codes: tuple[int, ...]
+    # The class is stamped ONLY when the container's structured `error_class`
+    # matches (DEV_FORGE_AUTH); the bare code falls to the sibling row.
+    structured_only: bool
+    # "always"        — every failure burns an attempt (deterministic codes).
+    # "never"         — exempt with NO cap; safe only because the row also
+    #                   latches a breaker (the dispatch.py pairing doctrine,
+    #                   enforced as an invariant test).
+    # "excusable"     — counted unless backend-correlated with excusals left
+    #                   (ADR-0018 §4a; opt-in for exit 11 via ADR-0026's
+    #                   brake_on_bad_output — see brake_evidence).
+    # "forge-bounded" — uncounted while the step has excusals, counted once
+    #                   spent: plain exit 13 latches no breaker, so the
+    #                   unconditional exemption would re-dispatch forever on a
+    #                   bad branch name / DNS failure / 500 (founder call
+    #                   reversed in ADR-0018 — see dispatch.py's doctrine).
+    counting: str
+    # "dev_type" | "repo" | None. Every "never" row MUST have one — both
+    # halt dispatch entirely, which is what makes "uncounted" livelock-free.
+    breaker: str | None
+    # Exit 15's skew rule: correlation — and therefore excusing an attempt —
+    # requires the STRUCTURED class from the container; a reconcile-
+    # synthesized orphan payload carries the numeric code only, so it earns
+    # the label and contributes evidence but is never itself excused. Exit 11
+    # is deliberately False (ADR-0026): it has no in-band structured class —
+    # the exit code IS the classification (app-side), so an orphan carries
+    # the same evidence value as a live finalize.
+    excusal_requires_structured_class: bool
+    # "always" | "opt-in" | "never" — feeds backend_health.fault_classes():
+    # which rows count as brake evidence (window faults, correlation,
+    # degradation). "opt-in" = only under cfg.brake_on_bad_output.
+    brake_evidence: str
+    # Membership in reconcile's post-mortem stderr regex. Exit 12 is
+    # deliberately False: dev_failure_error latches the dev-type auth breaker
+    # for it, and a stale orphan post-mortem must never trip a breaker from
+    # reconcile.
+    orphan_recoverable: bool
+    # The kill state this row classifies at RunManager._kill_inner
+    # (None = not a kill class, or passed explicitly by operator-stop
+    # callers). DEV_KILLED doubles as the catch-all for unnamed states.
+    kill_state: str | None = None
+    # Fallback error detail when the artifact carries none (finalize's
+    # per-arm messages). Empty for rows whose message is fully bespoke.
+    default_detail: str = ""
+
+
+TABLE: tuple[FailureRow, ...] = (
+    FailureRow(DEV_CRASH, (10, 20), False, "always", None, False, "never",
+               True),
+    FailureRow(DEV_BAD_OUTPUT, (11,), False, "excusable", None, False,
+               "opt-in", True,
+               default_detail="result.json missing or invalid"),
+    FailureRow(DEV_AUTH, (12,), False, "never", "dev_type", False, "never",
+               False),
+    FailureRow(DEV_FORGE, (13,), False, "forge-bounded", None, False, "never",
+               True, default_detail="clone/push setup failed"),
+    FailureRow(DEV_FORGE_AUTH, (13,), True, "never", "repo", False, "never",
+               False, default_detail="repository credential rejected"),
+    FailureRow(DEV_MCP_SETUP, (14,), False, "always", None, False, "never",
+               True, default_detail="MCP setup command failed"),
+    FailureRow(DEV_HARNESS_FAULT, (15,), False, "excusable", None, True,
+               "always", True, default_detail="model backend unavailable"),
+    FailureRow(DEV_TURN_BUDGET, (16,), False, "always", None, False, "never",
+               True,
+               default_detail="harness stopped at its configured turn cap"),
+    FailureRow(DEV_TIMEOUT, (), False, "always", None, False, "never", False,
+               kill_state="timed_out"),
+    FailureRow(DEV_ORPHANED, (), False, "always", None, False, "never", False,
+               kill_state="orphaned"),
+    FailureRow(DEV_KILLED, (), False, "always", None, False, "never", False,
+               kill_state="failed"),
+    FailureRow(DEV_OPERATOR_STOP, (), False, "always", None, False, "never",
+               False),
+)
+
+BY_CLASS: dict[str, FailureRow] = {r.error_class: r for r in TABLE}
+
+# Exit-code lookup for the BARE (no structured class) case: structured_only
+# rows never match a bare code, so 13 resolves to DEV_FORGE here.
+BY_EXIT_CODE: dict[int, FailureRow] = {
+    code: r for r in TABLE if not r.structured_only for code in r.exit_codes}
+
+
+def classify(exit_code, structured_class: str) -> FailureRow | None:
+    """The row a Dev failure artifact resolves to, or None (unknown code —
+    finalize's fallback arm). A structured_only row is selected only when the
+    container's own classification names it AND the exit code agrees — auth
+    *wording* alone falls through to the bare row (see DEV_FORGE_AUTH's
+    docstring trail in finalize.py)."""
+    row = BY_CLASS.get(structured_class)
+    if row is not None and row.structured_only and exit_code in row.exit_codes:
+        return row
+    return BY_EXIT_CODE.get(exit_code)
+
+
+# ── Derived views (the old hand-synchronized encodings) ──────────────────────
+
+# dispatch.counts_toward_attempts: classes whose failures NEVER burn attempts.
+UNCOUNTED_CLASSES: frozenset[str] = frozenset(
+    r.error_class for r in TABLE if r.counting == "never")
+
+# backend_health.fault_classes(): brake evidence, unconditional vs opt-in.
+BRAKE_ALWAYS_CLASSES: frozenset[str] = frozenset(
+    r.error_class for r in TABLE if r.brake_evidence == "always")
+BRAKE_OPT_IN_CLASSES: frozenset[str] = frozenset(
+    r.error_class for r in TABLE if r.brake_evidence == "opt-in")
+
+# reconcile's post-mortem enrichment: the codes recoverable from Dagu's
+# node-error string. Sorted so the regex is deterministic.
+ORPHAN_RECOVERABLE_EXIT_CODES: tuple[int, ...] = tuple(sorted(
+    {code for r in TABLE if r.orphan_recoverable for code in r.exit_codes}))
+
+# runs._kill_inner: error class per kill target state (DEV_KILLED is the
+# catch-all for any state not named — applied at the chokepoint).
+KILL_CLASSES: dict[str, str] = {
+    r.kill_state: r.error_class for r in TABLE if r.kill_state}
+
+# The container-produced (exit_code, error_class) surface — compared verbatim
+# against the image package's self-declared `fault.PRODUCED` manifest by the
+# parity test, bridging the two packages without coupling them.
+CONTAINER_PRODUCED: frozenset[tuple[int, str]] = frozenset(
+    (code, r.error_class) for r in TABLE for code in r.exit_codes)

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -17,6 +17,7 @@ from ...harness import HARNESSES, missing_referenced_secret_env
 from ...ports.forge import mission_branch
 from ...telemetry import OTEL_COLLECTOR_URL
 from ...config import DevType, assignment_for
+from .. import failure_taxonomy
 from ..model import (Activity, LABEL_FAILED, Mission, MissionRef, MissionType,
                      STAGE_LABELS, derive)
 from ..run import Run, utcnow
@@ -809,17 +810,19 @@ def _last_giveup_at(pmo_id: str) -> datetime | None:
 
 # ADR-0018 — classes whose failures NEVER burn a mission's attempts. Both latch
 # a breaker, so the mission stops being dispatched at all and cannot livelock:
-# that pairing is what makes "uncounted" safe.
+# that pairing is what makes "uncounted" safe — and since ADR-0027 it is an
+# executable invariant over the taxonomy table (`counting == "never" ⇒
+# breaker`), from which this set is derived.
 #
 # DEV_FORGE is deliberately NOT here. Making it unconditionally uncounted was
 # the founder's call, but plain exit 13 latches no breaker (only the
 # DEV_FORGE_AUTH arm calls forges.latch), so it would re-dispatch every poll
 # interval forever on a bad branch name, a DNS failure or a 500 — the exact
 # livelock `excusals_left` exists to bound. It gets the bounded treatment
-# instead: uncounted while the step has excusals, counted once they are spent,
-# so a forge outage costs no attempts but a permanent misconfiguration still
-# reaches DEVCAKE-FAILED.
-UNCOUNTED_CLASSES = frozenset({"DEV_AUTH", "DEV_FORGE_AUTH"})
+# instead ("forge-bounded" in the table): uncounted while the step has
+# excusals, counted once they are spent, so a forge outage costs no attempts
+# but a permanent misconfiguration still reaches DEVCAKE-FAILED.
+UNCOUNTED_CLASSES = failure_taxonomy.UNCOUNTED_CLASSES
 
 
 def counts_toward_attempts(r) -> bool:

--- a/app/devcake/domain/orchestrator/finalize.py
+++ b/app/devcake/domain/orchestrator/finalize.py
@@ -9,7 +9,7 @@ from opentelemetry import trace
 from opentelemetry.trace import SpanKind, Status, StatusCode
 
 from ...security import redact, redact_value
-from .. import backend_health, costing
+from .. import backend_health, costing, failure_taxonomy
 from ..model import MissionRef
 from ..run import Run, utcnow
 from . import transitions
@@ -161,13 +161,13 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
                 await mgr.messaging.delete_reply_stream(run.run_id)
                 run.result = redact_value(result)
                 run.state = "failed"
-                run.error = redact(f"DEV_BAD_OUTPUT: {e}")
+                run.error = redact(f"{failure_taxonomy.DEV_BAD_OUTPUT}: {e}")
                 # ADR-0018: this path bypasses dev_failure_error, so it stamps
                 # its own class. It matters more here than elsewhere — `e` can
                 # embed Dev-authored text verbatim (decomposition.py raises with
                 # the Dev's blocked_by list), which is exactly the injection the
                 # structured field exists to defeat.
-                run.error_class = "DEV_BAD_OUTPUT"
+                run.error_class = failure_taxonomy.DEV_BAD_OUTPUT
                 run.ended_at = utcnow()
                 mgr.runs.store.save(run)
                 span.set_attribute("devcake.verdict", f"failed: {run.error}")
@@ -200,113 +200,133 @@ def dev_failure_error(mgr, run: Run, payload: dict) -> str:
     """Classify a Dev failure artifact into `run.error`, and stamp the
     STRUCTURED `run.error_class` / `run.attempt_counted` (ADR-0018).
 
-    Every branch stamps a class. Stamping only the new ones would leave 12/13/14
+    ADR-0027: which row an exit code resolves to — including the exit-13
+    structured/bare split — comes from `failure_taxonomy.classify`; only the
+    genuinely behavioral arms (breaker trips, the correlated-excusal
+    accounting) live here, keyed on the row. Adding a code/class is a table
+    row plus, at most, a handler.
+
+    Every row stamps a class. Stamping only the new ones would leave 12/13/14
     at `error_class == ""` post-upgrade, dropping them into the legacy
     `error`-prefix branch of `attempt_number` — where `DEV_FORGE` matches
     nothing and keeps counting, making `UNCOUNTED_CLASSES` dead code.
     """
     # public: part of the RunFinalizer port (reconcile enriches pre-harness orphans)
     exit_code = payload.get("exit_code")
-    if exit_code == 12:
-        run.error_class = "DEV_AUTH"
-        mgr._trip_breaker(run.dev_type, f"auth failure in {run.run_id}")
-        return "DEV_AUTH (does not count toward attempts; breaker tripped)"
     detail = redact(str(payload.get("error_detail") or ""))
     detail = " ".join(detail.split())[:500]
-    error_class = str(payload.get("error_class") or "")
-    if exit_code == 13 and error_class == "DEV_FORGE_AUTH":
-        # ONLY the structured Dev classification gets this class — and with it
-        # the breaker latch AND the unconditional exemption of
-        # UNCOUNTED_CLASSES. The pairing is the whole safety argument
-        # (dispatch.py: "both latch a breaker … cannot livelock"), so the class
-        # may never be stamped on evidence that latches nothing: a bare
-        # "403"/"401" can be a push rate limit or an incidental URL fragment,
-        # and a pre-taxonomy image sends no class at all — either way the run
-        # would be uncounted, breaker-less and re-dispatched FOREVER. Auth
-        # *wording* alone therefore falls through to the bounded exit-13 branch
-        # below (the detail still names it), which terminates.
-        run.error_class = "DEV_FORGE_AUTH"
-        # latch only THIS run's repo (M10): a bad credential on repo A
-        # must never stop repo B's missions
-        mgr.forges.latch(
-            run.repo_ref, f"repository credential rejected in {run.run_id}")
-        return "DEV_FORGE_AUTH: " + (detail or "repository credential rejected")
-    if exit_code == 13:
-        # Uncounted while the step has excusals — a forge outage should not burn
-        # missions — but bounded, because plain exit 13 latches no breaker and
-        # would otherwise re-dispatch forever on a permanent misconfiguration.
-        # An orphaned or skew-dropped GENUINE credential failure lands here too:
-        # a terminating path is the safe-by-construction degradation.
-        run.error_class = "DEV_FORGE"
-        run.attempt_counted = not backend_health.excusals_left(
-            mgr.runs.store.all(), run, error_class="DEV_FORGE")
-        return "DEV_FORGE: " + (detail or "clone/push setup failed")
-    if exit_code == 14:
-        # operator-configured MCP setup failed in-container (docs/15 §1,
-        # counted attempt): the detail names the command + stderr tail so
-        # the fix is obvious from the Runs page
-        run.error_class = "DEV_MCP_SETUP"
-        return "DEV_MCP_SETUP: " + (detail or "MCP setup command failed")
-    if exit_code == 16:
-        # Deterministic by nature: the harness hit a turn cap WE configured, so
-        # retrying against the same cap cannot help and this must never be
-        # mistaken for a transient shared fault. Always counted, never evidence.
-        run.error_class = "DEV_TURN_BUDGET"
-        return "DEV_TURN_BUDGET: " + (
-            detail or "harness stopped at its configured turn cap")
-    if exit_code == 15:
-        run.error_class = "DEV_HARNESS_FAULT"
-        # Correlation — and therefore excusing an attempt — requires the
-        # STRUCTURED class from the container. A reconcile-synthesized orphan
-        # payload carries the numeric code only: it earns the label and the
-        # evidence, and contributes to future correlation, but is never itself
-        # excused. That is the skew-safe direction.
-        if error_class == "DEV_HARNESS_FAULT":
-            runs = mgr.runs.store.all()
-            correlated = backend_health.backend_correlated(
-                runs, run.dev_type,
-                classes=backend_health.fault_classes(
-                    mgr.config.brake_on_bad_output))
-            # Count when the failure is NOT correlated, OR when this step has
-            # spent its excusals. The operator must be `or`: with `and`,
-            # exhausting the budget would produce MORE excusing (inverting the
-            # escape hatch) and a solitary failure on an exhausted step would
-            # stop counting.
-            run.attempt_counted = (correlated is None
-                                   or not backend_health.excusals_left(runs, run))
-            if correlated and not run.attempt_counted:
-                return ("DEV_HARNESS_FAULT (correlated fleet failure; does not "
-                        "count toward attempts): "
-                        + (detail or "model backend unavailable"))
-        return "DEV_HARNESS_FAULT: " + (detail or "model backend unavailable")
-    if exit_code in (10, 20):
-        run.error_class = "DEV_CRASH"
-        return "DEV_CRASH: " + (
-            detail or f"harness or entrypoint failure (exit {exit_code})")
-    if exit_code == 11:
-        run.error_class = "DEV_BAD_OUTPUT"
-        # ADR-0026 (opt-in): with the brake widened to exit 11, a correlated
-        # fleet-wide bad-output cascade excuses attempts exactly like exit 15.
-        # Unlike 15 there is NO container-class precondition: exit 11 has no
-        # in-band structured class — the exit code IS the classification
-        # (app-side), so a reconcile-synthesized orphan carries the same
-        # evidence value as a live finalize. Excusals bound the loop per step.
-        if mgr.config.brake_on_bad_output:
-            runs = mgr.runs.store.all()
-            correlated = backend_health.backend_correlated(
-                runs, run.dev_type,
-                classes=backend_health.fault_classes(True))
-            run.attempt_counted = (correlated is None
-                                   or not backend_health.excusals_left(
-                                       runs, run,
-                                       error_class="DEV_BAD_OUTPUT"))
-            if correlated and not run.attempt_counted:
-                return ("DEV_BAD_OUTPUT (correlated fleet failure; does not "
-                        "count toward attempts): "
-                        + (detail or "result.json missing or invalid"))
-        return "DEV_BAD_OUTPUT: " + (detail or "result.json missing or invalid")
-    run.error_class = run.error_class or "DEV_CRASH"
-    return f"dev failure artifact (exit {exit_code})"
+    structured = str(payload.get("error_class") or "")
+    row = failure_taxonomy.classify(exit_code, structured)
+    if row is None:
+        run.error_class = run.error_class or failure_taxonomy.DEV_CRASH
+        return f"dev failure artifact (exit {exit_code})"
+    run.error_class = row.error_class
+    return _ROW_HANDLERS.get(row.error_class, _detail_only)(
+        mgr, run, row, detail, structured, exit_code)
+
+
+def _detail_only(mgr, run, row, detail, structured, exit_code):
+    """Rows with no behavior beyond the stamp (14 MCP setup; 16 turn budget —
+    deterministic by nature: retrying the same cap cannot help, so the table
+    marks it always-counted and never brake evidence)."""
+    return f"{row.error_class}: " + (detail or row.default_detail)
+
+
+def _auth(mgr, run, row, detail, structured, exit_code):
+    mgr._trip_breaker(run.dev_type, f"auth failure in {run.run_id}")
+    return (f"{row.error_class} (does not count toward attempts; "
+            "breaker tripped)")
+
+
+def _forge_auth(mgr, run, row, detail, structured, exit_code):
+    # The row is structured_only: ONLY the container's structured
+    # classification reaches this handler — and with it the breaker latch AND
+    # the unconditional exemption of UNCOUNTED_CLASSES. The pairing is the
+    # whole safety argument (dispatch.py: "both latch a breaker … cannot
+    # livelock"), so the class may never be stamped on evidence that latches
+    # nothing: a bare "403"/"401" can be a push rate limit or an incidental
+    # URL fragment, and a pre-taxonomy image sends no class at all — either
+    # way the run would be uncounted, breaker-less and re-dispatched FOREVER.
+    # Auth *wording* alone therefore falls through to the bounded DEV_FORGE
+    # row (classify's bare-sibling rule; the detail still names it), which
+    # terminates.
+    #
+    # latch only THIS run's repo (M10): a bad credential on repo A
+    # must never stop repo B's missions
+    mgr.forges.latch(
+        run.repo_ref, f"repository credential rejected in {run.run_id}")
+    return f"{row.error_class}: " + (detail or row.default_detail)
+
+
+def _forge(mgr, run, row, detail, structured, exit_code):
+    # "forge-bounded": uncounted while the step has excusals — a forge outage
+    # should not burn missions — but bounded, because plain exit 13 latches no
+    # breaker and would otherwise re-dispatch forever on a permanent
+    # misconfiguration. An orphaned or skew-dropped GENUINE credential failure
+    # lands here too: a terminating path is the safe-by-construction
+    # degradation.
+    run.attempt_counted = not backend_health.excusals_left(
+        mgr.runs.store.all(), run, error_class=row.error_class)
+    return f"{row.error_class}: " + (detail or row.default_detail)
+
+
+def _correlated_excusal(mgr, run, row, detail, structured, exit_code):
+    """The ADR-0018 §4a accounting, shared by exits 15 and 11 — the rows
+    differ only in table fields, which encode two deliberate asymmetries:
+
+    * `excusal_requires_structured_class` (15 True, 11 False): for 15,
+      correlation — and therefore excusing an attempt — requires the
+      STRUCTURED class from the container. A reconcile-synthesized orphan
+      payload carries the numeric code only: it earns the label and the
+      evidence, and contributes to future correlation, but is never itself
+      excused. That is the skew-safe direction. Exit 11 has no in-band
+      structured class — the exit code IS the classification (app-side), so
+      an orphan carries the same evidence value as a live finalize (ADR-0026).
+    * `brake_evidence` (15 "always", 11 "opt-in"): the 11 arm runs only under
+      `brake_on_bad_output`, widening the brake to a correlated fleet-wide
+      bad-output cascade exactly like exit 15. Excusals bound the loop per
+      step either way.
+    """
+    enabled = (row.brake_evidence == "always"
+               or (row.brake_evidence == "opt-in"
+                   and mgr.config.brake_on_bad_output))
+    skew_ok = (not row.excusal_requires_structured_class
+               or structured == row.error_class)
+    if enabled and skew_ok:
+        runs = mgr.runs.store.all()
+        correlated = backend_health.backend_correlated(
+            runs, run.dev_type,
+            classes=backend_health.fault_classes(
+                mgr.config.brake_on_bad_output))
+        # Count when the failure is NOT correlated, OR when this step has
+        # spent its excusals. The operator must be `or`: with `and`,
+        # exhausting the budget would produce MORE excusing (inverting the
+        # escape hatch) and a solitary failure on an exhausted step would
+        # stop counting.
+        run.attempt_counted = (
+            correlated is None
+            or not backend_health.excusals_left(
+                runs, run, error_class=row.error_class))
+        if correlated and not run.attempt_counted:
+            return (f"{row.error_class} (correlated fleet failure; does not "
+                    "count toward attempts): "
+                    + (detail or row.default_detail))
+    return f"{row.error_class}: " + (detail or row.default_detail)
+
+
+def _crash(mgr, run, row, detail, structured, exit_code):
+    return f"{row.error_class}: " + (
+        detail or f"harness or entrypoint failure (exit {exit_code})")
+
+
+_ROW_HANDLERS = {
+    failure_taxonomy.DEV_AUTH: _auth,
+    failure_taxonomy.DEV_FORGE_AUTH: _forge_auth,
+    failure_taxonomy.DEV_FORGE: _forge,
+    failure_taxonomy.DEV_HARNESS_FAULT: _correlated_excusal,
+    failure_taxonomy.DEV_BAD_OUTPUT: _correlated_excusal,
+    failure_taxonomy.DEV_CRASH: _crash,
+}
 
 
 async def restore_after_failure(mgr, run: Run) -> None:

--- a/app/devcake/domain/orchestrator/router.py
+++ b/app/devcake/domain/orchestrator/router.py
@@ -17,6 +17,7 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING
 
+from .. import failure_taxonomy
 from ..run import Run, utcnow
 
 if TYPE_CHECKING:
@@ -61,7 +62,7 @@ class FinalizerRouter:
         # it stamps its own class. The state is "failed" but the condition is a
         # genuine orphan (the run's PMO instance is gone from config) — the
         # state/class mismatch is pre-existing and deliberate.
-        run.error_class = "DEV_ORPHANED"
+        run.error_class = failure_taxonomy.DEV_ORPHANED
         run.ended_at = utcnow()
         self._store.save(run)
 

--- a/app/devcake/domain/reconcile.py
+++ b/app/devcake/domain/reconcile.py
@@ -4,7 +4,16 @@ lifespan so the ordering contract is unit-testable (ISSUES #26)."""
 import logging
 import re
 
+from . import failure_taxonomy
+
 log = logging.getLogger("devcake.reconcile")
+
+# ADR-0027: the recoverable-code list is a table derivation, not a hand-list.
+# Exit 12's absence is a table FIELD (orphan_recoverable=False on DEV_AUTH) —
+# see the enrichment comment below for why — and test_crash_recovery pins the
+# membership (10/11/20 recovered, 12 refused) independently of this regex.
+_EXIT_RE = re.compile(r"exit status (%s)" % "|".join(
+    str(c) for c in failure_taxonomy.ORPHAN_RECOVERABLE_EXIT_CODES))
 
 
 def _restamp_store_gen(store, run) -> None:
@@ -74,8 +83,7 @@ async def reconcile_runs(manager) -> None:
                 # DELIBERATELY excluded — dev_failure_error latches the dev-type
                 # auth breaker for it, and a stale orphan post-mortem must never
                 # trip a breaker from reconcile.
-                exit_m = re.search(r"exit status (10|11|13|14|15|16|20)",
-                                   detail.lower())
+                exit_m = _EXIT_RE.search(detail.lower())
                 if finalizer and exit_m:
                     r.error = finalizer.dev_failure_error(
                         r, {"exit_code": int(exit_m.group(1)),

--- a/app/devcake/domain/runs.py
+++ b/app/devcake/domain/runs.py
@@ -22,6 +22,7 @@ from ..ports.finalizer import RunFinalizer
 from ..ports.messaging import MessagingPort
 from ..ports.state import StatePort
 from ..telemetry import OTEL_COLLECTOR_URL
+from . import failure_taxonomy
 from .ids import make_run_id
 from .run import Run, auth_digest, utcnow
 from .run_bootstrap import RunBootstrap
@@ -43,8 +44,8 @@ RUN_FAILURES_STREAM = "run_failures"
 # for a future one nobody remembers to add), so no kill path can leave a run
 # unclassified and silently fall back to the legacy `error`-prefix matching in
 # `attempt_number`. Operator-initiated stops pass DEV_OPERATOR_STOP explicitly.
-KILL_CLASSES = {"timed_out": "DEV_TIMEOUT", "orphaned": "DEV_ORPHANED",
-                "failed": "DEV_KILLED"}
+# ADR-0027: the mapping is the taxonomy table's `kill_state` column.
+KILL_CLASSES = failure_taxonomy.KILL_CLASSES
 
 
 def failure_record(run: "Run", outcome: str, reason: str,
@@ -486,7 +487,8 @@ class RunManager:
                 # default plus the DEV_KILLED catch-all means a future kill
                 # site cannot silently produce an unclassified run.
                 run.error_class = (error_class
-                                   or KILL_CLASSES.get(new_state, "DEV_KILLED"))
+                                   or KILL_CLASSES.get(
+                                       new_state, failure_taxonomy.DEV_KILLED))
                 if current is not None:
                     self.store.save(run)
             # ADR-0025 Hook B: every kill path (watchdog ×3, reconcile

--- a/app/tests/test_crash_recovery.py
+++ b/app/tests/test_crash_recovery.py
@@ -603,6 +603,52 @@ def test_recon_enriches_exit14_mcp_setup(tmp_path):
     assert saved.error == "DEV_MCP_SETUP: claude mcp add …: exit 1"
 
 
+@pytest.mark.parametrize("code,recovered", [
+    (10, True), (11, True), (20, True), (12, False)])
+def test_recon_enrichment_regex_membership(tmp_path, code, recovered):
+    """ADR-0027 gap-closure pin, taken BEFORE the regex became a table
+    derivation: the informational exits 10/11/20 ARE recovered from Dagu's
+    post-mortem string (AUD-015), and exit 12 is REFUSED — dev_failure_error
+    latches the dev-type auth breaker for 12, and a stale orphan post-mortem
+    must never trip a breaker from reconcile. The 13/14 arms are pinned by
+    the two tests above; membership itself was previously untested."""
+    from devcake.domain.reconcile import reconcile_runs
+
+    store = RunStore(tmp_path / "runs")
+    messaging = FakeMessaging()
+
+    class Executor(FakeExecutor):
+        async def status(self, rid):
+            return {"dagRunDetails": {"status": "failed",
+                                      "statusLabel": "failed"}}
+
+        async def node_errors(self, rid):
+            return [{"step": "run_dev", "status": "failed",
+                     "error": f"exit status {code}: boom"}]
+
+    mgr = RunManager(store, messaging, Executor())
+    mgr._ship_failure = AsyncMock()  # type: ignore[method-assign]
+    seen = []
+
+    class MM:
+        def dev_failure_error(self, run, payload):
+            seen.append(payload["exit_code"])
+            return f"enriched exit {payload['exit_code']}"
+
+    dead = _make_run(store, state="running", run_id=f"DEAD-{code}")
+
+    async def reclaim(handler, verify_auth):
+        pass
+
+    messaging.reclaim_pending = reclaim
+    mgr.set_finalizer(MM())
+    run_coro(reconcile_runs(mgr))
+    saved = store.get(dead.run_id)
+    assert saved.state == "orphaned"
+    assert (seen == [code]) is recovered, (
+        f"exit {code}: enrichment {'expected' if recovered else 'FORBIDDEN'}")
+
+
 def test_recon_reclaims_even_when_a_kill_blows_up(tmp_path):
     """A raising executor.status/kill must not stop reconciliation — the other
     runs are still processed and reclaim still happens."""

--- a/app/tests/test_failure_taxonomy.py
+++ b/app/tests/test_failure_taxonomy.py
@@ -1,0 +1,261 @@
+"""ADR-0027 — the failure taxonomy's doctrine, made executable.
+
+Four layers, one table (`domain/failure_taxonomy.py`):
+
+1. Row invariants — the pairing doctrine ("uncounted ⇒ breaker"), code/class
+   uniqueness, the structured-only sibling rule.
+2. Derivation pins — the views the old hand-synchronized encodings became
+   (UNCOUNTED_CLASSES, the reconcile regex codes, KILL_CLASSES, the brake
+   evidence sets) asserted against their pre-ADR-0027 literal values, so the
+   tableization provably preserved membership.
+3. App/image parity — the image package DECLARES its exit contract
+   (`fault.PRODUCED`); we import it through the images/common mount and
+   compare real objects across the version-skew boundary. An AST honesty
+   check keeps the manifest true against dev_entrypoint.py's actual exit
+   sites. No text scraping of the entrypoint's logic — the H1 dialect
+   restructuring must not break this file.
+4. Docs parity — docs/15 §1's table names exactly the classes that exist.
+
+Plus the structural scan: no bare `DEV_*` string constant may exist in
+app/devcake outside the table module — a typo'd class string used to
+silently never match; now it fails here.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+from devcake.domain import failure_taxonomy as ft
+
+# host checkout: repo/app/tests → repo/…; app container: /srv/tests → /srv/…
+_ROOTS = [Path(__file__).parents[2], Path(__file__).parents[1]]
+IMAGES_COMMON = next(
+    (r / "images" / "common" for r in _ROOTS
+     if (r / "images" / "common" / "devcake_dev").is_dir()),
+    _ROOTS[0] / "images" / "common")
+DOCS_15 = next(
+    (r / "docs" / "15-errors-and-retries.md" for r in _ROOTS
+     if (r / "docs" / "15-errors-and-retries.md").exists()),
+    _ROOTS[0] / "docs" / "15-errors-and-retries.md")
+APP_PKG = Path(__file__).parents[1] / "devcake"
+
+MOUNT_HINT = ("mount missing — the pytest runner must bind {src} "
+              "(see scripts/pytest_app.sh / ci.yml)")
+
+CONTAINER_ROWS = [r for r in ft.TABLE if r.exit_codes]
+APP_SIDE_ROWS = [r for r in ft.TABLE if not r.exit_codes]
+
+
+# ── 1. row invariants ────────────────────────────────────────────────────────
+
+def test_uncounted_rows_always_latch_a_breaker():
+    """The dispatch.py pairing doctrine, previously a comment: "never counts"
+    is livelock-safe ONLY because the same row halts dispatch entirely."""
+    for row in ft.TABLE:
+        if row.counting == "never":
+            assert row.breaker in ("dev_type", "repo"), (
+                f"{row.error_class} is uncounted but latches no breaker — "
+                "it would be re-dispatched forever (the DEV_FORGE lesson)")
+
+
+def test_bounded_rows_never_latch_and_never_exempt():
+    """excusable / forge-bounded rows are the LEDGER-bounded arm: excusals_left
+    bounds them per (mission, mission_type, class). A breaker or an
+    UNCOUNTED_CLASSES membership on the same row would bypass that bound."""
+    for row in ft.TABLE:
+        if row.counting in ("excusable", "forge-bounded"):
+            assert row.breaker is None
+            assert row.error_class not in ft.UNCOUNTED_CLASSES
+
+
+def test_excusable_rows_are_brake_visible():
+    """An 'excusable' row's evidence must feed the brake (that correlation IS
+    the excusal predicate); forge-bounded's bound is the excusal ledger alone."""
+    for row in ft.TABLE:
+        if row.counting == "excusable":
+            assert row.brake_evidence in ("always", "opt-in")
+        else:
+            assert row.brake_evidence == "never"
+
+
+def test_class_strings_and_kill_states_are_unique():
+    assert len(ft.BY_CLASS) == len(ft.TABLE)
+    kill_states = [r.kill_state for r in ft.TABLE if r.kill_state]
+    assert len(kill_states) == len(set(kill_states))
+
+
+def test_exit_codes_are_unique_up_to_the_structured_pair():
+    """A code owned by two rows would make classification ambiguous. The one
+    legal share: a structured_only row rides its bare sibling's code (13 —
+    DEV_FORGE_AUTH over DEV_FORGE) and is selected only by the container's
+    own structured classification."""
+    for code in {c for r in CONTAINER_ROWS for c in r.exit_codes}:
+        owners = [r for r in CONTAINER_ROWS if code in r.exit_codes]
+        bare = [r for r in owners if not r.structured_only]
+        assert len(bare) == 1, f"exit {code} has {len(bare)} bare owners"
+
+
+def test_structured_only_rows_have_a_bare_sibling():
+    """Without a bare sibling on the same code, a pre-taxonomy image (no
+    structured class) would make that exit code unclassifiable."""
+    for row in CONTAINER_ROWS:
+        if row.structured_only:
+            assert any(code in ft.BY_EXIT_CODE for code in row.exit_codes)
+
+
+def test_excusal_precondition_only_where_excusals_exist():
+    """excusal_requires_structured_class is exit 15's skew rule; on a row the
+    brake never sees, the flag would be dead — flag it as a table bug."""
+    for row in ft.TABLE:
+        if row.excusal_requires_structured_class:
+            assert row.counting == "excusable"
+
+
+def test_app_side_rows_are_kill_or_operator_paths():
+    for row in APP_SIDE_ROWS:
+        assert not row.orphan_recoverable  # nothing to recover from stderr
+        assert not row.structured_only
+        assert row.kill_state or row.error_class == ft.DEV_OPERATOR_STOP
+
+
+def test_classify_resolves_the_structured_pair():
+    assert ft.classify(13, "").error_class == ft.DEV_FORGE
+    assert ft.classify(13, ft.DEV_FORGE_AUTH).error_class == ft.DEV_FORGE_AUTH
+    # a MISMATCHED structured class falls to the bare row for the code —
+    # wording/skew can never stamp the breaker-latching class
+    assert ft.classify(13, ft.DEV_HARNESS_FAULT).error_class == ft.DEV_FORGE
+    assert ft.classify(15, ft.DEV_FORGE_AUTH).error_class == ft.DEV_HARNESS_FAULT
+    assert ft.classify(17, "") is None          # emitted by nothing
+    assert ft.classify(None, "") is None        # payload without exit_code
+
+
+# ── 2. derivation pins (pre-ADR-0027 literal values) ─────────────────────────
+
+def test_uncounted_classes_membership_is_preserved():
+    assert ft.UNCOUNTED_CLASSES == frozenset({ft.DEV_AUTH, ft.DEV_FORGE_AUTH})
+
+
+def test_orphan_recoverable_codes_match_the_old_regex():
+    """reconcile's hand-written `exit status (10|11|13|14|15|16|20)` — 12
+    deliberately absent (a stale orphan post-mortem must never trip the
+    dev-type auth breaker from reconcile)."""
+    assert ft.ORPHAN_RECOVERABLE_EXIT_CODES == (10, 11, 13, 14, 15, 16, 20)
+    assert 12 not in ft.ORPHAN_RECOVERABLE_EXIT_CODES
+
+
+def test_kill_classes_membership_is_preserved():
+    assert ft.KILL_CLASSES == {"timed_out": ft.DEV_TIMEOUT,
+                               "orphaned": ft.DEV_ORPHANED,
+                               "failed": ft.DEV_KILLED}
+
+
+def test_brake_evidence_sets_match_adr_0026():
+    assert ft.BRAKE_ALWAYS_CLASSES == frozenset({ft.DEV_HARNESS_FAULT})
+    assert ft.BRAKE_OPT_IN_CLASSES == frozenset({ft.DEV_BAD_OUTPUT})
+
+
+def test_backend_health_derives_from_the_table():
+    from devcake.domain import backend_health
+    assert backend_health.fault_classes(False) == frozenset(
+        {ft.DEV_HARNESS_FAULT})
+    assert backend_health.fault_classes(True) == frozenset(
+        {ft.DEV_HARNESS_FAULT, ft.DEV_BAD_OUTPUT})
+
+
+# ── 3. app/image parity ──────────────────────────────────────────────────────
+
+def _image_fault():
+    assert (IMAGES_COMMON / "devcake_dev").is_dir(), MOUNT_HINT.format(
+        src="images/common → /srv/images/common")
+    if str(IMAGES_COMMON) not in sys.path:
+        sys.path.insert(0, str(IMAGES_COMMON))
+    from devcake_dev.domain import fault
+    return fault
+
+
+def test_image_manifest_equals_the_table():
+    """The version-skew tripwire: the image package's self-declared exit
+    contract must be exactly the table's container-produced surface. Real
+    objects on both sides — no scraping, so the H1 dialect restructuring
+    only has to keep PRODUCED true."""
+    assert _image_fault().PRODUCED == ft.CONTAINER_PRODUCED
+
+
+def _const_exit_codes(tree: ast.AST) -> set[int]:
+    codes = set()
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "exit"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "sys"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, int)):
+            codes.add(node.args[0].value)
+    return codes
+
+
+def _dev_class_constants(tree: ast.AST) -> set[str]:
+    return {node.value for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+            and re.fullmatch(r"DEV_[A-Z_]+", node.value)}
+
+
+def test_image_manifest_honesty():
+    """PRODUCED stays true: every constant sys.exit() site and every DEV_*
+    class literal in the image package is covered by the manifest. The two
+    artifact-less bare exits (oauth-login 12, unknown-phase 20) are declared
+    in BARE_EXIT_CODES and ride codes the manifest already lists."""
+    fault = _image_fault()
+    entrypoint = ast.parse((IMAGES_COMMON / "dev_entrypoint.py").read_text())
+    produced_codes = {c for c, _ in fault.PRODUCED}
+    produced_classes = {cls for _, cls in fault.PRODUCED}
+    assert fault.BARE_EXIT_CODES <= produced_codes
+    exits = _const_exit_codes(entrypoint) - {0}
+    assert exits <= produced_codes, (
+        f"dev_entrypoint exits {sorted(exits - produced_codes)} missing from "
+        "fault.PRODUCED — extend the manifest AND the app-side table")
+    classes = set()
+    for rel in ("dev_entrypoint.py", "devcake_dev/domain/fault.py",
+                "devcake_dev/workspace/clone.py"):
+        classes |= _dev_class_constants(
+            ast.parse((IMAGES_COMMON / rel).read_text()))
+    assert classes <= produced_classes, (
+        f"image classes {sorted(classes - produced_classes)} missing from "
+        "fault.PRODUCED")
+
+
+# ── 4. docs parity ───────────────────────────────────────────────────────────
+
+def test_docs_15_error_table_names_exactly_the_classes():
+    """Set comparison over a regex extract of §1's region — never parse
+    markdown structure; prose edits must not false-fail this."""
+    assert DOCS_15.exists(), MOUNT_HINT.format(src="docs → /srv/docs")
+    text = DOCS_15.read_text()
+    section = text.split("## 1. Error classes", 1)[1].split("\n## 2.", 1)[0]
+    documented = set(re.findall(r"\bDEV_[A-Z_]+\b", section))
+    assert documented == set(ft.BY_CLASS), (
+        f"docs/15 §1 vs table — undocumented: "
+        f"{sorted(set(ft.BY_CLASS) - documented)}; "
+        f"stale: {sorted(documented - set(ft.BY_CLASS))}")
+
+
+# ── structural scan: the table is the only source of class literals ──────────
+
+def test_no_bare_dev_class_literals_outside_the_table():
+    """Pre-ADR-0027, a typo'd class string silently never matched. Now every
+    stamp/match imports the table's constants; an exact DEV_* string constant
+    anywhere else in app/devcake fails here. (Tests and images/ are exempt —
+    the image package is a separate deploy unit, bridged by the parity test.)"""
+    offenders = []
+    for path in sorted(APP_PKG.rglob("*.py")):
+        if path.name == "failure_taxonomy.py":
+            continue
+        found = _dev_class_constants(ast.parse(path.read_text()))
+        if found:
+            offenders.append(f"{path.relative_to(APP_PKG)}: {sorted(found)}")
+    assert not offenders, (
+        "bare DEV_* literals (import failure_taxonomy constants instead):\n"
+        + "\n".join(offenders))

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -1903,8 +1903,10 @@ def _save_failed(store, run_id, *, error_class, mission="p1", mtype="EXECUTE",
     ({"exit_code": 10}, "DEV_CRASH"),
     ({"exit_code": 20}, "DEV_CRASH"),
     ({"exit_code": 11}, "DEV_BAD_OUTPUT"),
+    ({"exit_code": 12}, "DEV_AUTH"),
     ({"exit_code": 13}, "DEV_FORGE"),
     ({"exit_code": 14}, "DEV_MCP_SETUP"),
+    ({"exit_code": 15}, "DEV_HARNESS_FAULT"),
     ({"exit_code": 16}, "DEV_TURN_BUDGET"),
 ])
 def test_every_exit_code_stamps_a_structured_class(tmp_path, payload, expected_class):

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -64,6 +64,7 @@ app/devcake/
     repo_routing.py    # mission → work-repo resolution (M10 markers)
     blocker_locator.py #  deployment-wide blocked_by resolution (ADR-0009)
     backend_health.py  #  model-backend brake predicates (ADR-0018/0026)
+    failure_taxonomy.py #  THE DEV_* failure table — consumers derive from it (ADR-0027)
     skills.py      #   skill store reads + prompt assembly (ADR-0016)
     costing.py     #   app-side cost estimation vs the rate card (ADR-0021)
     asset_fetch.py #   PMO attachment/zip fetching for activity repos (ADR-0014/0017)

--- a/docs/15-errors-and-retries.md
+++ b/docs/15-errors-and-retries.md
@@ -8,6 +8,14 @@
 
 ## 1. Error classes
 
+The `DEV_*` family below is **authoritative in code**: one row per class in
+`domain/failure_taxonomy.py` (ADR-0027), from which the consumers (finalize
+ladder, reconcile's post-mortem regex, the counting/brake/kill membership
+sets) are derived — and `test_failure_taxonomy.py` pins this section's class
+set against that table, so adding a class means a table row AND a row here.
+The non-`DEV_*` rows are flow outcomes, not Run-record classes; they stay
+prose.
+
 | Class | Examples / mapping | Nature |
 |---|---|---|
 | `PMO_TRANSIENT` | Linear 429/`RATELIMITED`, 5xx, network — adapters signal it by raising `PMOTransient` (`ports/pmo.py`) | retryable |
@@ -18,6 +26,9 @@
 | `DEV_CRASH` | exit 10 (harness crash), 20 (entrypoint — incl. the ADR-0025 sentinel/marker family: provision found the wrong bind dir, or the harness step found no/mismatched `provisioned` marker — the artifact carries owner/mode/listing forensics); vanished container | counted attempt |
 | `DEV_MCP_SETUP` | exit 14: an `mcp_setup_commands` entry failed or hit the 300 s per-command cap; `run.error` carries the command + stderr tail | counted attempt |
 | `DEV_TIMEOUT` | app watchdog kill via Dagu stop → Run `timed_out` (not an entrypoint exit code) | counted attempt |
+| `DEV_ORPHANED` | reconciliation found the Dagu run dead while the app was away → Run `orphaned` (post-mortem enrichment may then upgrade `run.error` to a classified exit — §2 note); also stamped by the multi-instance router on a run whose PMO instance is no longer configured (state `failed`, deliberately — the condition is a genuine orphan) | counted attempt |
+| `DEV_KILLED` | the kill-chokepoint **catch-all** (`_kill_inner`): any kill path that names no more specific state/class lands here, so a future kill site cannot produce an unclassified run | counted attempt |
+| `DEV_OPERATOR_STOP` | operator-initiated stop (admin UI stop run / stop all, clear-runs drain) — passed explicitly by those callers, never a default | counted attempt — a stopped attempt burns like a failed one; pause or re-label the mission if that is not what you want |
 | `DEV_AUTH` | exit 12 — harness credential failure per the §4 precedence contract (stream 401/403 and/or distinctive stderr markers; generic markers only when no in-band fault already explains the run) | circuit breaker (§4) — **not** a counted attempt |
 | `DEV_FORGE` | exit 13 without the structured `DEV_FORGE_AUTH` class (transient forge/clone/push failure, or auth-ish wording without the structured class) | counted only after per-step excusals are spent (§4a) — **not** a latched breaker |
 | `DEV_FORGE_AUTH` | exit 13 carrying the Dev's **structured** `DEV_FORGE_AUTH` classification (auth wording in the detail alone is `DEV_FORGE`) | **per-repo** forge circuit breaker (`repo:{name}`); that repo's missions stop dispatching until the token can push |
@@ -41,6 +52,9 @@
 | `DEV_CRASH` | yes — by natural rescheduling (INV-3) | **yes** | scheduler (next cycle) | after cap: `DEVCAKE-FAILED` (§3) |
 | `DEV_MCP_SETUP` | yes — same (a transient install/network failure deserves retries; the deterministic missing-secret case never dispatches at all, `14` §8) | **yes** | scheduler | same |
 | `DEV_TIMEOUT` | yes — same | **yes** | scheduler | same |
+| `DEV_ORPHANED` | yes — same (the mission's label never advanced) | **yes** | scheduler | same |
+| `DEV_KILLED` | yes — same | **yes** | scheduler | same |
+| `DEV_OPERATOR_STOP` | yes — the mission stays schedulable; stop the *mission*, not just the run, to prevent re-dispatch | **yes** | scheduler | Runs page names the operator stop |
 | `DEV_BAD_OUTPUT` | yes — same | **yes** | scheduler | same |
 | `DEV_HARNESS_FAULT` | yes — same | **yes**, unless correlated (§4a) | scheduler | `dev_backend_degraded` in `/health` + SPA warning while throttled |
 | `DEV_TURN_BUDGET` | yes — but retrying the same cap cannot help; raise `--max-turns` (claude-code and grok-build take it; **codex has none** — §2a) or assign a stronger Dev Type | **yes** | scheduler | `run.error` names the cap and where to change it |

--- a/docs/adr/0027-failure-taxonomy-as-data.md
+++ b/docs/adr/0027-failure-taxonomy-as-data.md
@@ -1,0 +1,92 @@
+# ADR-0027 — The failure taxonomy as data
+
+- **Status:** accepted (2026-08-04)
+- **Context:** One run-failure taxonomy lived in three hand-synchronized
+  encodings. The Dev container speaks numeric exit codes (docs/07 §4);
+  `finalize.dev_failure_error` mapped them to `error_class` strings through
+  a branch ladder with per-class carve-outs; `reconcile.py` recovered
+  classes for orphans by regexing Dagu's stderr against its **own**
+  hand-maintained code list; and `dispatch.UNCOUNTED_CLASSES`,
+  `backend_health`'s brake-evidence sets, and `runs.KILL_CLASSES` each
+  restated membership rules. Adding one exit code or class meant editing
+  four-plus places whose agreement was enforced only by discipline — across
+  the app/image version-skew boundary, where the two sides deploy as
+  separate artifacts. The 2026-08 evaluation named this a structural debt
+  that every future change quietly taxes. Crucially, the asymmetries
+  between the arms are DELIBERATE — each has an incident behind it (the
+  DEV_FORGE livelock, the exit-15 skew rule, reconcile's exit-12 refusal) —
+  so a naive unification that flattens them would re-open closed incidents.
+
+## Decision
+
+### 1 — One table (`domain/failure_taxonomy.py`)
+
+A frozen `FailureRow` per `DEV_*` class. The nuance becomes **fields**, not
+prose: `counting` is four-valued (`always` / `never` / `excusable` /
+`forge-bounded`) because DEV_FORGE's excusal bound and DEV_AUTH's breaker
+exemption are different safety arguments; `excusal_requires_structured_class`
+differs between exits 15 and 11 because skew tolerance points in opposite
+directions for them (ADR-0026); `orphan_recoverable` is False for exit 12
+because a stale orphan post-mortem must never trip a breaker from
+reconcile; `structured_only` encodes the exit-13 bare/structured split that
+keeps DEV_FORGE_AUTH stampable only on the container's own classification.
+Every class-name literal in app code is now an import of the table's
+constants.
+
+Scope: the `DEV_*` family only — the classes stamped on Run records.
+docs/15 §1's other rows (`PMO_*`, `FORGE_*`, `ILLEGAL_OUTCOME`, …) are flow
+outcomes, not run-record classes; they stay prose.
+
+### 2 — Consumers are derivations
+
+- `finalize.dev_failure_error`: `failure_taxonomy.classify(exit_code,
+  structured)` picks the row (including the 13 split); only genuinely
+  behavioral arms remain, as small handlers keyed on the row. The exits
+  15 and 11 arms collapsed into ONE `_correlated_excusal` handler — their
+  differences were exactly the two table fields.
+- `reconcile`: the post-mortem regex is built from
+  `ORPHAN_RECOVERABLE_EXIT_CODES` — the hand-list is gone.
+- `dispatch.UNCOUNTED_CLASSES` := rows with `counting == "never"`.
+- `backend_health.fault_classes()` := `brake_evidence == "always"` ∪
+  (`"opt-in"` under `brake_on_bad_output`).
+- `runs.KILL_CLASSES` := the table's `kill_state` column (DEV_KILLED stays
+  the catch-all at the `_kill_inner` chokepoint).
+
+### 3 — The doctrine becomes executable (`test_failure_taxonomy.py`)
+
+- Pairing invariant: every uncounted row latches a breaker (previously a
+  dispatch.py comment).
+- Derivation pins: each derived view is asserted equal to its
+  pre-ADR-0027 literal value, so the tableization provably preserved
+  membership (the reconcile 10/11/20-recovered / 12-refused behavior is
+  additionally pinned end-to-end in `test_crash_recovery`).
+- **App/image parity by declared manifest, not text-scraping:** the image
+  package declares its own exit contract — `fault.PRODUCED`, the set of
+  `(exit_code, error_class)` pairs a Dev can hand the app — and the parity
+  test imports it through the images/common test mount and asserts equality
+  with the table's container-produced surface. Real objects across the
+  skew boundary; future HarnessDialect modules keep the manifest. An
+  AST honesty check (constant `sys.exit` sites + class literals ⊆ manifest,
+  with the two artifact-less bare exits declared in `BARE_EXIT_CODES`)
+  keeps `PRODUCED` true.
+- Docs parity: docs/15 §1's `DEV_*` set must equal the table's classes
+  (regex extract — prose edits cannot false-fail it). This closed a real
+  gap: `DEV_ORPHANED`, `DEV_KILLED`, `DEV_OPERATOR_STOP` existed in code
+  and were documented nowhere.
+- Structural scan: no bare `DEV_*` string constant outside the table
+  module — a typo'd class used to silently never match; now it fails CI.
+
+## Consequences
+
+- Adding an exit code or class is one table row (+ a handler only if it has
+  new behavior), and the invariants force the docs row and the image
+  manifest to move in the same commit.
+- The `RunFinalizer` port surface is unchanged (`dev_failure_error`'s
+  signature and payload contract); reconcile still passes no `error_class`
+  key, so the 15-excusal and 13-auth arms remain unreachable from
+  reconcile **by construction**.
+- The pytest runners (scripts/pytest_app.sh, ci.yml) now bind `docs/` into
+  the test container read-only, following the existing structural-mount
+  pattern (a missing mount fails, never skips).
+- No behavior change: the ADR-0018/0026 pin suites pass unmodified, plus
+  the two new stamp rows (exits 12/15) added to the parametrize.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@
 | [0024](0024-mandatory-repo-source-mirror.md) | Mandatory repo source mirror | Accepted; **§5's ambient mirror-read superseded by ADR-0025** (banner in-body) |
 | [0025](0025-provisioned-workspaces.md) | Provisioned workspaces | Accepted — supersedes ADR-0024 §5's risk posture |
 | [0026](0026-attempt-reset-policy-and-bad-output-brake.md) | Attempt-reset policy + opt-in bad-output brake | Accepted (2026-08-04) |
+| [0027](0027-failure-taxonomy-as-data.md) | Failure taxonomy as data | Accepted (2026-08-04) |

--- a/images/common/devcake_dev/domain/fault.py
+++ b/images/common/devcake_dev/domain/fault.py
@@ -9,6 +9,29 @@ from __future__ import annotations
 import json
 import re as _re
 
+# ── the declared exit contract (ADR-0027) ─────────────────────────────────
+# Every (exit code, error class) pair a Dev container can hand the app in a
+# failure artifact. This is the IMAGE side's single source: the app-side
+# taxonomy table (`domain/failure_taxonomy.py`) is asserted EQUAL to it by
+# test_failure_taxonomy's parity test — real objects across the version-skew
+# boundary, no text scraping — and an AST honesty check keeps this manifest
+# true against dev_entrypoint.py's actual exit sites. Future HarnessDialect
+# modules keep it. Two artifact-less bare exits ride codes already listed:
+# dev_entrypoint's oauth-login exit 12 and unknown-phase exit 20 send no
+# artifact, so they carry no class of their own (BARE_EXIT_CODES).
+PRODUCED = frozenset({
+    (10, "DEV_CRASH"),
+    (11, "DEV_BAD_OUTPUT"),
+    (12, "DEV_AUTH"),
+    (13, "DEV_FORGE"),
+    (13, "DEV_FORGE_AUTH"),
+    (14, "DEV_MCP_SETUP"),
+    (15, "DEV_HARNESS_FAULT"),
+    (16, "DEV_TURN_BUDGET"),
+    (20, "DEV_CRASH"),
+})
+BARE_EXIT_CODES = frozenset({12, 20})
+
 # ── stderr auth classification (docs/15 §4) ───────────────────────────────
 # Word-boundary regexes, NOT substrings: plain `"signed out" in text` matches
 # "de|signed out|put"; a false 12 pauses the whole Dev Type — never over-match.

--- a/scripts/pytest_app.sh
+++ b/scripts/pytest_app.sh
@@ -37,6 +37,7 @@ docker run --rm \
   -v "$(pwd)/images/common:/srv/images/common:ro" \
   -v "$(pwd)/dagu/dags:/srv/dagu-dags:ro" \
   -v "$(pwd)/app/Dockerfile:/srv/app.Dockerfile:ro" \
+  -v "$(pwd)/docs:/srv/docs:ro" \
   -w /srv \
   "devcake/app-test:${TAG}" \
   python -m pytest tests/ -q "$@"


### PR DESCRIPTION
## What

Workstream 1 of the structural-debt campaign (the 2026-08 evaluation's "taxonomy unification" deferred candidate).

One run-failure taxonomy previously lived in three hand-synchronized encodings — the `finalize.dev_failure_error` branch ladder, reconcile's hand-maintained stderr regex, and the membership sets in dispatch / backend_health / runs — whose agreement was enforced only by discipline, across the app/image version-skew boundary.

**Now:** `domain/failure_taxonomy.py` holds one frozen `FailureRow` per `DEV_*` class; every consumer derives from it. The deliberate asymmetries (each with an incident behind it) become **fields**, not flattened prose: four-valued `counting`, the exit-15 vs exit-11 `excusal_requires_structured_class` split, exit 12's `orphan_recoverable=False`, the exit-13 `structured_only` pair.

- finalize walks `classify()` + per-row handlers; the 15/11 arms collapsed into ONE correlated-excusal handler (their differences were exactly two table fields)
- reconcile's regex is built from `ORPHAN_RECOVERABLE_EXIT_CODES`
- `UNCOUNTED_CLASSES`, `fault_classes()`, `KILL_CLASSES` read table columns
- app/image parity by **declared manifest** (`fault.PRODUCED`, real objects through the images/common test mount — no text scraping; an AST honesty check keeps the manifest true)
- docs/15 §1 class-set parity + structural scan forbidding bare `DEV_*` literals outside the table

## Gap-closures (inventory findings)

1. exits **12/15** added to the stamp parametrize (were missing)
2. reconcile regex **membership pinned end-to-end** (10/11/20 recovered, 12 refused) BEFORE the regex became a derivation
3. `DEV_ORPHANED` / `DEV_KILLED` / `DEV_OPERATOR_STOP` documented in docs/15 §1/§2 (existed in code, documented nowhere)

## Behavior

None changed — the ADR-0018/0026 pin suites pass unmodified; derivation pins assert each view equals its pre-ADR literal value. `RunFinalizer` port surface frozen; reconcile still passes no `error_class` key (15-excusal/13-auth arms unreachable from reconcile by construction). No new persistent state (INV-1 clean).

## Verification

- 1470 passed, 1 skipped (pre-existing `.env.example` skip), ruff clean
- `docker buildx bake -f docker-bake.hcl -f docker-bake.ci.hcl ci` green
- pytest runners (script + ci.yml) now bind `docs/` RO — the existing structural-mount pattern (missing mount fails, never skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)