### PR TITLE
refactor: the composition root becomes a factory (ADR-0028)

### DIFF
--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -1,215 +1,65 @@
-"""DevCake main app: wiring, lifespan (startup reconciliation), and the API.
+"""DevCake main app: the API surface and the startup lifespan.
 
 Loops: poll cycle (derive + dispatch + sweeps), ingress consumer, watchdog.
 Endpoints: health, config, connections, missions, runs, credentials/OAuth,
 and the hello debug dispatch (permanent CI fixture — scripts/ci_suite.sh).
+
+ADR-0028: importing this module builds NOTHING — the service graph lives in
+`api/services.build_services()`, called once by the lifespan. Module scope
+is defs + pure wiring (the AST guard in test_structure_guards pins it), so
+a corrupt config.yaml now crashes at STARTUP, not import — same
+fail-loudly, new log position. Routes reach the graph through `svc()`; an
+authenticated request before the lifespan completes would get its named
+RuntimeError (a 500), which is unreachable in prod — uvicorn serves only
+after startup — and intended in tests, where the graph is installed via
+`fakes.make_services(...)`. After shutdown `services` stays bound: teardown
+paths (and tests driving the lifespan directly) may still read it.
 """
 
 import asyncio
-import base64
 import contextlib
 import logging
 import os
-import re
-import time
-from datetime import datetime, timezone
 
-import httpx
-import yaml
-import redis.asyncio as aioredis
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
+from opentelemetry import trace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
-from ..adapters.dagu import DAGU_URL, DaguExecutor, DuplicateRun
-from ..adapters.files import RunLogStore, RunStore
-from ..adapters.redis import Messaging
-from ..adapters.registry import make_forge, make_internal_forge, make_pmo
-from .. import profiles as profiles_store
+from ..adapters.dagu import DuplicateRun
 from .. import secrets as secrets_store
 from .. import security
-from ..settings_bundle import (BundleError, MAX_BUNDLE_BYTES, SETUP_ENV_VARS,
-                               apply_bundle, audit_event, diff_bundle,
-                               dry_run_adapters, generate_env_file,
-                               protect_bundle, serialize_current,
-                               unprotect_bundle, validate_bundle,
-                               validate_config_semantics)
-from ..settings_crypto import MIN_PASSPHRASE_LEN, DecryptError
-from ..config import (HARNESS_VAR_PATTERN, AppConfig, Assignment, DevType,
-                      _INSTANCE_NAME_RE, deep_merge, delete_dev_type,
-                      load_config, load_dev_types, reject_stale_patch,
-                      save_config, save_dev_type)
-from ..domain.blocker_locator import BlockerLocator
-from ..domain.model import ALL_LABELS, derive
-from ..domain.oauth import OAuthManager
-from ..domain.orchestrator import (FinalizerRouter, MapperBusy, MapperService,
-                                   MapperUnconfigured, MissionManager)
-from ..domain.forge_runtime import ForgeRuntime
+from ..domain.model import ALL_LABELS
+from ..domain.orchestrator import MapperBusy, MapperUnconfigured
 from ..domain.reconcile import reconcile_runs
-from ..domain.repo_mirror import RepoCache
-from ..domain.workspaces import WorkspaceStore
-from ..domain.runs import RunManager
-from ..domain.skills import SkillService, SkillStoreError
 from ..domain.watchdog import watchdog_loop
-from ..harness import HARNESSES, dev_type_status
-from ..ports.forge import mission_branch
 from ..prompts import templates as prompt_templates
-from ..ports.pmo import PMOTransient
-from ..telemetry import OO_URL, setup_telemetry
+from ..telemetry import setup_telemetry
 from ..telemetry.oo_provision import ensure_oo_ingest_user_at_boot
 from .auth import credentials_configured, enforce_control_plane_auth
 from . import (connections_service, devtypes_service, internal_repos_service,
                profiles_service, settings_transfer)
 from .config_service import apply_config_patch, set_pmo_intake
-from .health import build_health_payload, reset_protection_cache
-from .poll import PollRuntime
+from .health import build_health_payload
+from .services import Services, _log_task_death, build_services
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
 log = logging.getLogger("devcake")
 
-REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
-REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD", "")
+# ProxyTracer (api/poll.py precedent): resolves the real provider per span
+# start, so module scope needs no telemetry install
+tracer = trace.get_tracer("devcake")
 
-tracer = setup_telemetry()
-
-config = load_config()
-dev_types = load_dev_types()
-prompt_templates.seed_default_templates()   # /data defaults (v0.1.1)
-prompt_templates.seed_devtype_prompts(dev_types)   # per-dev-type (2026-07-15)
-store = RunStore()
-messaging = Messaging(REDIS_URL, REDIS_PASSWORD)
-executor = DaguExecutor()
-# ADR-0025: per-run workspace tree on the host bind (compose mounts
-# $DEVCAKE_WS_HOST here rw; the dev-run DAG binds per-run subdirs)
-workspaces = WorkspaceStore("/workspaces")
-manager = RunManager(store, messaging, executor, workspaces=workspaces)
-
-# ── multi-instance wiring (schema v3, ADR-0009; repos plural per M10) ───────
-# One MissionManager per CONFIGURED PMO instance; shared state is injected:
-# the RunManager/store (global concurrency), ONE dev-type breakers dict
-# (credentials are DevCake-global), and ONE ForgeRuntime (repos belong to
-# the deployment — missions from any instance can route to any repo).
-shared_breakers: dict[str, str] = {}
-# dev_type → reason (ADR-0018). Same injected-shared-dict idiom as
-# shared_breakers, but a DIFFERENT thing: it throttles a dev type to one probe
-# run when its model backend looks sick, and clears itself when runs succeed.
-# PollRuntime is the sole writer; managers only read it.
-shared_backend_degraded: dict[str, str] = {}
-managers: dict[str, MissionManager] = {}
-mappers: dict[str, MapperService] = {}
-forge_runtime = ForgeRuntime()
-# ADR-0024: the ONE deployment-wide source mirror (repos are deployment-
-# global, so the mirror is too — same shared-runtime idiom as forge_runtime)
-repo_cache = RepoCache(config, forge_runtime)
-# the bundled internal fallback forge (M11): provisioner is admin-credentialed
-# (GITEA_ADMIN_*); None disables the zero-repo un-gating when Gitea is absent
-internal_forge = make_internal_forge() if os.environ.get("GITEA_ADMIN_PASSWORD") else None
-# skill store (docs/16 skill store v1): store-first reads via the internal
-# forge; bundled copies keep built-in skills working forge-less
-skill_service = SkillService(internal_forge)
+services: Services | None = None
 
 
-def _mission_owner_of(bid: str) -> str | None:
-    """PollRuntime's durable claim map, read at call time — `poll_rt` is
-    defined below (module-global late binding: blocker resolution only runs
-    inside poll/dispatch, long after startup)."""
-    return poll_rt.mission_owner.get(bid)
-
-
-# Deployment-wide blocker resolution (ADR-0009 amendment): ONE locator over
-# the LIVE managers dict, so a native blocked_by edge to a peer instance's
-# mission gates and inherits exactly like a local one (Linear v1; read-only —
-# never claims, never writes). Same live-reference pattern as FinalizerRouter.
-blocker_locator = BlockerLocator(managers, _mission_owner_of)
-
-
-def build_managers() -> None:
-    """(Re)build the manager set IN PLACE to match config.pmos: existing
-    managers keep their advisory state (grace, anomalies, merge windows) and
-    get repointed adapters; removed instances drop theirs — never leaked."""
-    live = {i.name: i for i in config.pmos if i.configured}
-    for name in [n for n in managers if n not in live]:
-        managers.pop(name)
-        mappers.pop(name, None)
-    for name, inst in live.items():
-        p = make_pmo(inst)
-        if name in managers:
-            mgr = managers[name]
-            mgr.pmo, mgr.forges, mgr.config = p, forge_runtime, config
-            mgr.instance, mgr.instance_name = inst, name
-            mgr.internal_forge = internal_forge
-            mgr.skills = skill_service
-            mgr.blocker_locator = blocker_locator
-            mgr.repo_cache = repo_cache
-        else:
-            managers[name] = MissionManager(
-                config, dev_types, p, forge_runtime, manager, messaging,
-                instance=inst, breakers=shared_breakers,
-                internal_forge=internal_forge, skills=skill_service,
-                backend_degraded=shared_backend_degraded,
-                blocker_locator=blocker_locator, repo_cache=repo_cache)
-            mappers[name] = MapperService(config, dev_types, managers[name])
-
-
-def _managers_in_config_order() -> list[MissionManager]:
-    return [managers[i.name] for i in config.pmos if i.name in managers]
-
-
-forge_runtime.rebuild(config.repos, make_forge)
-build_managers()
-router = FinalizerRouter(managers, store, messaging)
-manager.set_finalizer(router)  # RunFinalizer seam: routes on run.pmo_ref
-
-
-async def refresh_forge_health() -> dict[str, dict]:
-    """Probe every configured repo; the runtime latches/clears per repo."""
-    return await forge_runtime.refresh_all()
-
-
-def _log_task_death(t: asyncio.Task) -> None:
-    if not t.cancelled() and t.exception():
-        log.error("background task %s DIED", t.get_name(), exc_info=t.exception())
-
-
-def reload_connections() -> None:
-    """Hot-reload adapters after a config PUT: rebuild the forge, reconcile
-    the manager set, and re-ensure the managed labels per instance —
-    bootstrap is otherwise startup-only, so a hot-swapped team_key would run
-    unlabeled until restart."""
-    forge_runtime.rebuild(config.repos, make_forge)
-    build_managers()
-    reset_protection_cache()               # repos may have changed — reprobe
-    # the adapter set feeds secret_env_vars (descriptor env lists), so the
-    # redaction scan cache must rebuild with it (2026-08 F17)
-    security.invalidate_secret_scan()
-
-    async def _ensure():
-        for mgr in list(managers.values()):
-            try:
-                await mgr.pmo.ensure_labels(mgr.instance.team_key, ALL_LABELS)
-            except Exception:
-                log.exception("ensure_labels after config reload failed for "
-                              "instance %s — ensured on next restart",
-                              mgr.instance_name)
-        await refresh_forge_health()
-    asyncio.create_task(_ensure(), name="ensure_labels_reload") \
-        .add_done_callback(_log_task_death)
-oauth_mgr = OAuthManager(manager, messaging, dev_types,
-                         breakers=shared_breakers)
-manager.oauth_mgr = oauth_mgr
-runlog = RunLogStore()
-manager.runlog = runlog
-
-# The poll machinery (ownership claims, cycle driver, missions cache, loop)
-# lives in api/poll.py — constructed ONCE with live references and never
-# rebuilt on config reload (ADR-0015 Decision 2). `poll_rt.missions_cache`
-# keeps one stable list identity; /api/v1/missions serves it by reference.
-poll_rt = PollRuntime(
-    config=config, managers=managers, mappers=mappers, store=store,
-    forge_runtime=forge_runtime, refresh_forge_health=refresh_forge_health,
-    managers_in_config_order=_managers_in_config_order,
-    backend_degraded=shared_backend_degraded, repo_cache=repo_cache)
+def svc() -> Services:
+    if services is None:
+        raise RuntimeError(
+            "service graph not built — the lifespan has not run; tests "
+            "install one via fakes.make_services(...)")
+    return services
 
 
 def _refuse_insecure_passwords() -> None:
@@ -262,9 +112,9 @@ def _refuse_insecure_passwords() -> None:
             "dashboard/alerts).")
 
 
-def _security_warnings() -> list[dict]:
+def _security_warnings(config) -> list[dict]:
     """Credential-posture warnings — body lives in security.security_warnings
-    so the copy is testable without this module's singletons (F1 tripwire)."""
+    so the copy is testable without the service graph (F1 tripwire)."""
     return security.security_warnings(config)
 
 
@@ -273,12 +123,22 @@ async def lifespan(app: FastAPI):
     if not credentials_configured():
         raise RuntimeError("ADMIN_USER and ADMIN_PASSWORD must both be configured")
     _refuse_insecure_passwords()
+    # telemetry BEFORE the graph: httpx instrumentation must wrap the
+    # adapter clients build_services constructs (idempotent — TestClient
+    # lifespans re-enter this)
+    setup_telemetry()
+    global services
+    services = build_services()
+    s = services
     secrets_store.register_all()   # redaction coverage for GUI-stored secrets (M12)
+    # /data template seeding, moved here from import time (ADR-0028)
+    prompt_templates.seed_default_templates()   # /data defaults (v0.1.1)
+    prompt_templates.seed_devtype_prompts(s.dev_types)   # per-dev-type (2026-07-15)
     log.info("boot: schema_version=%s dagu pull_policy=missing image tags "
              "devcake/dev-*:%s — re-run `docker buildx bake all` lockstep "
-             "with app upgrades", config.schema_version,
+             "with app upgrades", s.config.schema_version,
              os.environ.get("DEVCAKE_TAG", "latest"))
-    for warn in _security_warnings():   # loud at boot; dismissable in the SPA
+    for warn in _security_warnings(s.config):   # loud at boot; dismissable in the SPA
         log.warning("%s — %s", warn["title"], warn["body"])
     # OpenObserve ingest service account (ISSUES #13): non-negotiable.
     # Compose only seeds root; boot creates/resyncs OO_INGEST_* so telemetry
@@ -288,34 +148,35 @@ async def lifespan(app: FastAPI):
     # corrupt run records must never wedge boot; a quarantined record is
     # FORGOTTEN, so best-effort teardown of anything it may have left live
     # (container, per-run ACL user, reply stream) — the run id is the handle
-    for run_id in store.quarantine_unreadable():
+    for run_id in s.store.quarantine_unreadable():
         with contextlib.suppress(Exception):
-            await executor.stop(run_id)
+            await s.executor.stop(run_id)
         with contextlib.suppress(Exception):
-            await messaging.delete_run_user(run_id)
+            await s.messaging.delete_run_user(run_id)
         with contextlib.suppress(Exception):
-            await messaging.delete_reply_stream(run_id)
+            await s.messaging.delete_reply_stream(run_id)
         # ADR-0025 Hook F: a quarantined record is FORGOTTEN — its dir would
         # otherwise only fall to the sweep's record-absent predicate later
         with contextlib.suppress(Exception):
-            workspaces.cleanup(run_id)
+            s.workspaces.cleanup(run_id)
     # internal fallback forge (M11): provision org + service accounts. Best
     # effort — a Gitea outage degrades only zero-repo missions, never boot
-    if internal_forge is not None:
+    if s.internal_forge is not None:
         try:
-            await internal_forge.ensure_service_accounts()
+            await s.internal_forge.ensure_service_accounts()
             log.info("internal forge: service accounts ensured")
         except Exception:
             log.exception("internal forge provisioning failed — zero-repo "
                           "missions will retry once Gitea is reachable")
         try:
-            await internal_forge.ensure_skill_store(skill_service.builtin_seed())
+            await s.internal_forge.ensure_skill_store(
+                s.skill_service.builtin_seed())
             log.info("internal forge: skill store ensured")
         except Exception:
             log.exception("skill store seeding failed — skills fall back to "
                           "bundled copies (POST /api/v1/skills/sync re-seeds)")
     # startup reconciliation (docs/04 §6) — labels per configured instance
-    for mgr in list(managers.values()):
+    for mgr in list(s.managers.values()):
         try:
             await mgr.pmo.ensure_labels(mgr.instance.team_key, ALL_LABELS)   # step 2
             log.info("labels ensured in team %s (instance %s)",
@@ -326,18 +187,19 @@ async def lifespan(app: FastAPI):
     # forge sweep deliberately NOT awaited here (incident 2026-08-01: it held
     # the listen socket O(N repos) and failed the compose healthcheck) — the
     # poll task runs it before its first cycle; /health `forge_probe` tracks it
-    await reconcile_runs(manager)
+    await reconcile_runs(s.manager)
     # ADR-0024: synchronous writability probe only (no network, no sync) —
     # mirror warm-up belongs to the poll task, NEVER awaited at boot
-    repo_cache.verify_writable()
+    s.repo_cache.verify_writable()
     # ADR-0025: same probe for the workspace base — first-touched-by-dockerd
     # (or a uid≠1000 mkdir) means root-owned and every dispatch would fail
-    workspaces.verify_writable()
+    s.workspaces.verify_writable()
     tasks = [
-        asyncio.create_task(poll_rt.loop(), name="poll_loop"),
-        asyncio.create_task(messaging.consume_forever(manager.handle, manager.verify_auth),
-                            name="ingress_consumer"),
-        asyncio.create_task(watchdog_loop(manager), name="watchdog"),
+        asyncio.create_task(s.poll_rt.loop(), name="poll_loop"),
+        asyncio.create_task(
+            s.messaging.consume_forever(s.manager.handle, s.manager.verify_auth),
+            name="ingress_consumer"),
+        asyncio.create_task(watchdog_loop(s.manager), name="watchdog"),
     ]
     for t in tasks:
         t.add_done_callback(_log_task_death)
@@ -362,13 +224,14 @@ FastAPIInstrumentor.instrument_app(app)
 
 @app.get("/api/v1/health")
 async def health():
+    s = svc()
     return await build_health_payload(
-        config=config, dev_types=dev_types, managers=managers,
-        mappers=mappers, forge_runtime=forge_runtime,
-        shared_breakers=shared_breakers, store=store,
-        internal_forge=internal_forge, poll_rt=poll_rt,
-        backend_degraded=shared_backend_degraded, repo_cache=repo_cache,
-        workspaces=workspaces)
+        config=s.config, dev_types=s.dev_types, managers=s.managers,
+        mappers=s.mappers, forge_runtime=s.forge_runtime,
+        shared_breakers=s.shared_breakers, store=s.store,
+        internal_forge=s.internal_forge, poll_rt=s.poll_rt,
+        backend_degraded=s.shared_backend_degraded, repo_cache=s.repo_cache,
+        workspaces=s.workspaces)
 
 
 @app.get("/api/v1/health/live")
@@ -381,9 +244,10 @@ async def list_missions():
     """Current derived Missions (poll-cycle snapshot; advisory cache — INV-1)."""
     # rows carry per-instance provenance ("instance"/"team" fields);
     # `teams` maps every configured instance for group-by consumers
-    return {"teams": {i.name: i.team_key for i in config.pmos if i.configured},
-            "adoption_mode": config.adoption_mode,
-            "missions": poll_rt.missions_cache}
+    s = svc()
+    return {"teams": {i.name: i.team_key for i in s.config.pmos if i.configured},
+            "adoption_mode": s.config.adoption_mode,
+            "missions": s.poll_rt.missions_cache}
 
 
 @app.get("/api/v1/runs")
@@ -393,7 +257,8 @@ async def list_runs(limit: int = 25, offset: int = 0,
                     created_to: str | None = None, sort: str | None = None,
                     dir: str | None = None, group_by: str | None = None):
     from .runs_service import list_runs_response
-    return list_runs_response(store, config.cost_inputs, limit=limit,
+    s = svc()
+    return list_runs_response(s.store, s.config.cost_inputs, limit=limit,
                               offset=offset, mission_key=mission_key,
                               pmo_ref=pmo_ref, created_from=created_from,
                               created_to=created_to, sort=sort,
@@ -403,10 +268,10 @@ async def list_runs(limit: int = 25, offset: int = 0,
 @app.get("/api/v1/runs/{run_id}")
 async def get_run(run_id: str):
     from .runs_service import run_detail
-    run = store.get(run_id)
+    run = svc().store.get(run_id)
     if run is None:
         raise HTTPException(404)
-    return run_detail(run, config.cost_inputs)
+    return run_detail(run, svc().config.cost_inputs)
 
 
 TERMINAL_STATES = {"finished", "failed", "timed_out", "orphaned"}
@@ -429,8 +294,10 @@ class _SteeringBody(BaseModel):
 async def mission_action(pmo_id: str, body: _MissionActionBody):
     """Retry / park / unpark / resume via label swap. Returns projected labels."""
     from .mission_actions import label_action
+    s = svc()
     return await label_action(pmo_id, body.action,
-                              missions_cache=poll_rt.missions_cache, managers=managers)
+                              missions_cache=s.poll_rt.missions_cache,
+                              managers=s.managers)
 
 
 @app.post("/api/v1/missions/{pmo_id}/comment")
@@ -438,8 +305,10 @@ async def mission_comment(pmo_id: str, body: _SteeringBody):
     """Post an operator steering comment. NOT signed with the DevCake sentinel —
     the next poll classifies it as HUMAN and resets the attempt counter."""
     from .mission_actions import post_steering
+    s = svc()
     return await post_steering(pmo_id, body.body,
-                               missions_cache=poll_rt.missions_cache, managers=managers)
+                               missions_cache=s.poll_rt.missions_cache,
+                               managers=s.managers)
 
 
 @app.post("/api/v1/poll/run")
@@ -455,25 +324,28 @@ async def force_poll_route():
     anyway. Mirrors `POST /api/v1/relations-mapper/run` (docs/11 §1).
     """
     from .mission_actions import force_poll_now
+    rt = svc().poll_rt
     return await force_poll_now(
-        lock=poll_rt.lock,
-        next_cycle_id=poll_rt.next_cycle_id,
-        run_cycle=poll_rt.run_cycle)
+        lock=rt.lock,
+        next_cycle_id=rt.next_cycle_id,
+        run_cycle=rt.run_cycle)
 
 
 @app.post("/api/v1/runs/{run_id}/stop")
 async def stop_run_route(run_id: str):
     """Kill an in-flight run (counts as a failed attempt — UI copy says so)."""
     from .mission_actions import stop_run
-    return await stop_run(run_id, run_manager=manager, run_store=store)
+    s = svc()
+    return await stop_run(run_id, run_manager=s.manager, run_store=s.store)
 
 
 @app.get("/api/v1/runs/{run_id}/log")
 async def get_run_log(run_id: str, tail: int | None = None):
     """Condensed harness output relayed live by the Dev (docs/11 §2a)."""
-    if store.get(run_id) is None:
+    s = svc()
+    if s.store.get(run_id) is None:
         raise HTTPException(404)
-    _seq, text = runlog.read(run_id, tail)
+    _seq, text = s.runlog.read(run_id, tail)
     return PlainTextResponse(text)
 
 
@@ -481,15 +353,16 @@ async def get_run_log(run_id: str, tail: int | None = None):
 async def stream_run_log(run_id: str):
     """SSE follow: replays the stored log, then live lines until the run ends.
     X-Accel-Buffering disables nginx proxy buffering for this response."""
-    if store.get(run_id) is None:
+    s = svc()
+    if s.store.get(run_id) is None:
         raise HTTPException(404)
 
     def is_terminal() -> bool:
-        r = store.get(run_id)
+        r = s.store.get(run_id)
         return r is None or r.state in TERMINAL_STATES
 
     return StreamingResponse(
-        runlog.stream(run_id, is_terminal),
+        s.runlog.stream(run_id, is_terminal),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
@@ -500,7 +373,8 @@ async def stop_runs_route():
     """Stop every in-flight run without wiping anything (Clear-Runs
     hardening): finalizing runs are skipped and named in the response."""
     from .mission_actions import stop_all_runs
-    return await stop_all_runs(run_manager=manager, run_store=store)
+    s = svc()
+    return await stop_all_runs(run_manager=s.manager, run_store=s.store)
 
 
 @app.post("/api/v1/system/clear-runs")
@@ -511,6 +385,7 @@ async def clear_runs():
     In-flight Devs are stopped first. See docs/11 §3 and docs/10 §5.
     """
     from .clear import clear_all
+    s = svc()
     with tracer.start_as_current_span("system.clear_runs") as span:
         # Serialize the wipe against EVERY dispatch path (audit D5 #2/#8 +
         # re-audit #0/#6). Two locks, acquired in a fixed order:
@@ -524,18 +399,18 @@ async def clear_runs():
         # Order poll_rt.lock → dispatch_lock matches the poll loop's own order
         # (run_cycle holds poll_rt.lock, then launch takes dispatch_lock), so
         # there is no lock-ordering inversion / deadlock.
-        async with poll_rt.lock, manager.bootstrap.dispatch_lock:
-            result = await clear_all(store, executor, messaging, runlog,
-                                     internal_forge=internal_forge,
-                                     run_manager=manager)
-        poll_rt.missions_cache.clear()
-        for mgr in managers.values():
+        async with s.poll_rt.lock, s.manager.bootstrap.dispatch_lock:
+            result = await clear_all(s.store, s.executor, s.messaging, s.runlog,
+                                     internal_forge=s.internal_forge,
+                                     run_manager=s.manager)
+        s.poll_rt.missions_cache.clear()
+        for mgr in s.managers.values():
             mgr._grace.clear()
             mgr._grace_next.clear()
         # ADR-0018: the backend-degraded map IS run history, so "start fresh"
         # legitimately forgets it — and clearing it now avoids throttling with
         # zero evidence until the next poll cycle recomputes.
-        shared_backend_degraded.clear()
+        s.shared_backend_degraded.clear()
         # auth breakers stay — they reflect live credential health, not run history
         span.set_attribute("devcake.clear.runs_deleted",
                            int((result.get("local") or {}).get("runs_deleted") or 0))
@@ -549,46 +424,53 @@ async def clear_runs():
 
 @app.get("/api/v1/config")
 async def get_config():
-    data = config.model_dump()
+    data = svc().config.model_dump()
     return data
 
 
 @app.put("/api/v1/config")
 async def put_config(body: dict):
-    return await apply_config_patch(body, config=config, dev_types=dev_types,
-                                    managers=managers, reload=reload_connections,
-                                    repo_cache=repo_cache)
+    s = svc()
+    return await apply_config_patch(body, config=s.config, dev_types=s.dev_types,
+                                    managers=s.managers,
+                                    reload=s.reload_connections,
+                                    repo_cache=s.repo_cache)
 
 
 @app.put("/api/v1/config/pmos/{name}/intake")
 async def put_pmo_intake(name: str, body: dict):
     """Flip one PMO's intake switch without rewriting the pmos list (docs/11)."""
-    return set_pmo_intake(name=name, paused=body.get("paused"), config=config)
+    return set_pmo_intake(name=name, paused=body.get("paused"),
+                          config=svc().config)
 
 
 # ── config profiles (ADR-0013): named snapshots — bodies in profiles_service ─
 
 @app.get("/api/v1/profiles")
 async def list_profiles():
-    return profiles_service.list_profiles_rows(config, dev_types)
+    s = svc()
+    return profiles_service.list_profiles_rows(s.config, s.dev_types)
 
 
 @app.get("/api/v1/profiles/{name}")
 async def get_profile(name: str):
-    return profiles_service.get_profile_payload(name, config, dev_types)
+    s = svc()
+    return profiles_service.get_profile_payload(name, s.config, s.dev_types)
 
 
 @app.post("/api/v1/profiles")
 async def save_profile(body: dict):
-    return profiles_service.save_profile_body(body, config, dev_types)
+    s = svc()
+    return profiles_service.save_profile_body(body, s.config, s.dev_types)
 
 
 @app.post("/api/v1/profiles/{name}/apply")
 async def apply_profile(name: str):
+    s = svc()
     return profiles_service.apply_profile_body(
-        name, config=config, dev_types=dev_types, store=store,
-        reload=reload_connections, shared_breakers=shared_breakers,
-        forge_breakers=forge_runtime.breakers, managers=managers)
+        name, config=s.config, dev_types=s.dev_types, store=s.store,
+        reload=s.reload_connections, shared_breakers=s.shared_breakers,
+        forge_breakers=s.forge_runtime.breakers, managers=s.managers)
 
 
 @app.post("/api/v1/profiles/{name}/rename")
@@ -605,25 +487,29 @@ async def delete_profile(name: str):
 
 @app.post("/api/v1/settings/export")
 async def export_settings(body: dict):
+    s = svc()
     return await settings_transfer.export_settings_body(
-        body, config=config, dev_types=dev_types, skill_service=skill_service)
+        body, config=s.config, dev_types=s.dev_types,
+        skill_service=s.skill_service)
 
 
 @app.get("/api/v1/settings/export/summary")
 async def export_summary():
-    return await settings_transfer.export_summary_body(skill_service=skill_service)
+    return await settings_transfer.export_summary_body(
+        skill_service=svc().skill_service)
 
 
 @app.post("/api/v1/settings/import/preview")
 async def import_preview(body: dict):
-    return settings_transfer.import_preview_body(body, config=config,
-                                                 dev_types=dev_types)
+    s = svc()
+    return settings_transfer.import_preview_body(body, config=s.config,
+                                                 dev_types=s.dev_types)
 
 
 @app.post("/api/v1/settings/import")
 async def import_settings(body: dict):
     return await settings_transfer.import_settings_body(
-        body, skill_service=skill_service)
+        body, skill_service=svc().skill_service)
 
 
 @app.post("/api/v1/settings/import/env")
@@ -632,12 +518,13 @@ async def import_env(body: dict):
 
 
 # ── per-Mission-Type prompt templates (v0.1.1) + Dev Types — bodies in
-# devtypes_service; forwards pass the singletons at call time ────────────────
+# devtypes_service; forwards pass the graph's objects at call time ───────────
 
 @app.get("/api/v1/prompt-templates")
 async def get_prompt_templates():
-    return await devtypes_service.get_prompt_templates(config=config,
-                                                       dev_types=dev_types)
+    s = svc()
+    return await devtypes_service.get_prompt_templates(config=s.config,
+                                                       dev_types=s.dev_types)
 
 
 @app.put("/api/v1/prompt-templates/{mission_type}/{name}")
@@ -648,19 +535,19 @@ async def put_prompt_template(mission_type: str, name: str, body: dict):
 @app.delete("/api/v1/prompt-templates/{mission_type}/{name}")
 async def delete_prompt_template(mission_type: str, name: str):
     return await devtypes_service.delete_prompt_template(mission_type, name,
-                                                         config=config)
+                                                         config=svc().config)
 
 
 @app.put("/api/v1/devtype-prompts/{dev_type}/{name}")
 async def put_devtype_prompt(dev_type: str, name: str, body: dict):
-    return await devtypes_service.put_devtype_prompt(dev_type, name, body,
-                                                     dev_types=dev_types)
+    return await devtypes_service.put_devtype_prompt(
+        dev_type, name, body, dev_types=svc().dev_types)
 
 
 @app.delete("/api/v1/devtype-prompts/{dev_type}/{name}")
 async def delete_devtype_prompt(dev_type: str, name: str):
     return await devtypes_service.delete_devtype_prompt(dev_type, name,
-                                                        config=config)
+                                                        config=svc().config)
 
 
 @app.get("/api/v1/harnesses")
@@ -670,44 +557,48 @@ async def list_harnesses():
 
 @app.get("/api/v1/dev-types")
 async def list_dev_types():
-    return await devtypes_service.list_dev_types(dev_types=dev_types)
+    return await devtypes_service.list_dev_types(dev_types=svc().dev_types)
 
 
 @app.post("/api/v1/dev-types")
 @app.put("/api/v1/dev-types/{name}")
 async def upsert_dev_type(body: dict, name: str | None = None):
     return await devtypes_service.upsert_dev_type(body, name,
-                                                  dev_types=dev_types)
+                                                  dev_types=svc().dev_types)
 
 
 @app.post("/api/v1/dev-types/{name}/rename")
 async def rename_dev_type(name: str, body: dict):
+    s = svc()
     return await devtypes_service.rename_dev_type(
-        name, body, config=config, dev_types=dev_types,
-        shared_breakers=shared_breakers)
+        name, body, config=s.config, dev_types=s.dev_types,
+        shared_breakers=s.shared_breakers)
 
 
 @app.delete("/api/v1/dev-types/{name}")
 async def remove_dev_type(name: str):
-    return await devtypes_service.remove_dev_type(name, config=config,
-                                                  dev_types=dev_types)
+    s = svc()
+    return await devtypes_service.remove_dev_type(name, config=s.config,
+                                                  dev_types=s.dev_types)
 
 
 @app.post("/api/v1/dev-types/{name}/credentials")
 async def upload_credentials(name: str, body: dict):
+    s = svc()
     return await devtypes_service.upload_credentials(
-        name, body, dev_types=dev_types, shared_breakers=shared_breakers)
+        name, body, dev_types=s.dev_types, shared_breakers=s.shared_breakers)
 
 
 @app.get("/api/v1/assignments")
 async def get_assignments():
-    return await devtypes_service.get_assignments(config=config)
+    return await devtypes_service.get_assignments(config=svc().config)
 
 
 @app.put("/api/v1/assignments")
 async def put_assignments(body: dict):
-    return await devtypes_service.put_assignments(body, config=config,
-                                                  dev_types=dev_types)
+    s = svc()
+    return await devtypes_service.put_assignments(body, config=s.config,
+                                                  dev_types=s.dev_types)
 
 
 # ── GUI-stored secrets (M12, F5) + connection tests — bodies (and the
@@ -715,22 +606,25 @@ async def put_assignments(body: dict):
 
 @app.put("/api/v1/secrets/{scope}/{instance}/{field}")
 async def put_secret(scope: str, instance: str, field: str, body: dict):
+    s = svc()
     return await connections_service.put_secret(
         scope, instance, field, body,
-        forge_runtime=forge_runtime, reload=reload_connections)
+        forge_runtime=s.forge_runtime, reload=s.reload_connections)
 
 
 @app.delete("/api/v1/secrets/{scope}/{instance}/{field}")
 async def delete_secret(scope: str, instance: str, field: str):
+    s = svc()
     return await connections_service.delete_secret(
         scope, instance, field,
-        forge_runtime=forge_runtime, reload=reload_connections)
+        forge_runtime=s.forge_runtime, reload=s.reload_connections)
 
 
 @app.put("/api/v1/harness-secrets/{var}")
 async def put_harness_secret(var: str, body: dict):
+    s = svc()
     return await connections_service.put_harness_secret(
-        var, body, dev_types=dev_types, shared_breakers=shared_breakers)
+        var, body, dev_types=s.dev_types, shared_breakers=s.shared_breakers)
 
 
 @app.delete("/api/v1/harness-secrets/{var}")
@@ -752,9 +646,11 @@ async def secrets_inventory():
 @app.post("/api/v1/secrets/clear")
 async def clear_secrets(body: dict):
     """Delete operator-selected secrets (harness / connections / credential files)."""
+    s = svc()
     return await connections_service.clear_secrets(
-        body, forge_runtime=forge_runtime, reload=reload_connections,
-        config=config, shared_breakers=shared_breakers, dev_types=dev_types)
+        body, forge_runtime=s.forge_runtime, reload=s.reload_connections,
+        config=s.config, shared_breakers=s.shared_breakers,
+        dev_types=s.dev_types)
 
 
 @app.get("/api/v1/connections/registry")
@@ -764,14 +660,16 @@ async def connections_registry():
 
 @app.post("/api/v1/connections/pmo/{name}/test")
 async def test_pmo(name: str):
-    return await connections_service.test_pmo(name, config=config,
-                                              managers=managers)
+    s = svc()
+    return await connections_service.test_pmo(name, config=s.config,
+                                              managers=s.managers)
 
 
 @app.post("/api/v1/connections/forge/{name}/test")
 async def test_forge(name: str):
-    return await connections_service.test_forge(name, config=config,
-                                                forge_runtime=forge_runtime)
+    s = svc()
+    return await connections_service.test_forge(name, config=s.config,
+                                                forge_runtime=s.forge_runtime)
 
 
 # ── internal-forge repos + skill store (M11, docs/16) — bodies in
@@ -780,55 +678,58 @@ async def test_forge(name: str):
 @app.get("/api/v1/internal-repos")
 async def list_internal_repos():
     return await internal_repos_service.list_internal_repos(
-        internal_forge=internal_forge)
+        internal_forge=svc().internal_forge)
 
 
 @app.post("/api/v1/internal-repos/create")
 async def create_internal_repo(body: dict):
     return await internal_repos_service.create_internal_repo(
-        body, internal_forge=internal_forge)
+        body, internal_forge=svc().internal_forge)
 
 
 @app.get("/api/v1/skills")
 async def list_skills():
-    return await internal_repos_service.list_skills(skill_service=skill_service)
+    return await internal_repos_service.list_skills(
+        skill_service=svc().skill_service)
 
 
 @app.get("/api/v1/skills/{name}")
 async def get_skill(name: str):
     return await internal_repos_service.get_skill(
-        name, skill_service=skill_service)
+        name, skill_service=svc().skill_service)
 
 
 @app.post("/api/v1/skills")
 async def create_skill(body: dict):
     return await internal_repos_service.create_skill(
-        body, skill_service=skill_service)
+        body, skill_service=svc().skill_service)
 
 
 @app.post("/api/v1/skills/import")
 async def import_skill(body: dict):
     return await internal_repos_service.import_skill(
-        body, skill_service=skill_service)
+        body, skill_service=svc().skill_service)
 
 
 @app.delete("/api/v1/skills/{name}")
 async def delete_skill_endpoint(name: str):
     return await internal_repos_service.delete_skill_endpoint(
-        name, skill_service=skill_service)
+        name, skill_service=svc().skill_service)
 
 
 @app.post("/api/v1/skills/sync")
 async def sync_skills():
+    s = svc()
     return await internal_repos_service.sync_skills(
-        internal_forge=internal_forge, skill_service=skill_service)
+        internal_forge=s.internal_forge, skill_service=s.skill_service)
 
 
 @app.delete("/api/v1/internal-repos/{name}")
 async def delete_internal_repo(name: str):
+    s = svc()
     return await internal_repos_service.delete_internal_repo(
-        name, internal_forge=internal_forge, store=store,
-        forge_runtime=forge_runtime)
+        name, internal_forge=s.internal_forge, store=s.store,
+        forge_runtime=s.forge_runtime)
 
 
 @app.post("/api/v1/relations-mapper/run")
@@ -836,14 +737,15 @@ async def run_mapper(instance: str | None = None):
     """Manual trigger (docs/11): works regardless of the enabled toggle — the
     toggle governs only the periodic service. Requires a valid dev_type.
     ?instance= selects the PMO instance; default = the first configured."""
-    names = [i.name for i in config.pmos if i.name in mappers]
+    s = svc()
+    names = [i.name for i in s.config.pmos if i.name in s.mappers]
     if not names:
         raise HTTPException(422, "no configured PMO instance")
     target = instance or names[0]
-    if target not in mappers:
+    if target not in s.mappers:
         raise HTTPException(404, f"no PMO instance named {target!r}")
     try:
-        run = await mappers[target].run_now()
+        run = await s.mappers[target].run_now()
     except MapperUnconfigured as e:
         raise HTTPException(422, str(e))
     except MapperBusy as e:
@@ -858,14 +760,14 @@ async def oauth_start(name: str):
     """Per-dev-type device-code login: the credential lands in THIS Dev Type's
     /data/secrets dir (two Dev Types on one harness = two accounts)."""
     try:
-        return await oauth_mgr.start(name)
+        return await svc().oauth_mgr.start(name)
     except ValueError as e:
         raise HTTPException(422, str(e))
 
 
 @app.get("/api/v1/oauth/status/{run_id}")
 async def oauth_status(run_id: str):
-    s = oauth_mgr.status(run_id)
+    s = svc().oauth_mgr.status(run_id)
     if s is None:
         raise HTTPException(404)
     return s
@@ -877,7 +779,7 @@ async def dispatch_hello(sleep: int = 3, payload_kb: int = 1,
     """Dispatches the hello stub Dev through the full pipeline (Dagu → container
     → Redis → finalize). Permanent debug/CI fixture — scripts/ci_suite.sh."""
     try:
-        run = await manager.dispatch_hello(sleep, payload_kb, timeout_seconds)
+        run = await svc().manager.dispatch_hello(sleep, payload_kb, timeout_seconds)
     except DuplicateRun as e:
         raise HTTPException(409, f"duplicate dagRunId {e}")
     return {"run_id": run.run_id, "state": run.state}

--- a/app/devcake/api/services.py
+++ b/app/devcake/api/services.py
@@ -1,0 +1,234 @@
+"""The service graph: every live object the app is made of (ADR-0028).
+
+`build_services()` is THE composition root — the module-scope body that
+api/main.py used to execute at import time, moved behind an explicit
+factory call. Importing api.main (or this module) builds NOTHING: no /data
+reads-that-write, no adapter/client construction, no threads. The lifespan
+calls `build_services()` once; tests install a `fakes.make_services(...)`
+instead and never touch the real factory (it reads /data and writes
+config.yaml).
+
+Two invariants carried over from ADR-0015 (identity is the contract):
+
+* Hot reload MUTATES in place, never rebinds — `apply_config_patch` setattrs
+  fields on the stable `config` object, `build_managers` reconciles the
+  `managers`/`mappers` dicts in place, and the shared dicts
+  (`shared_breakers`, `shared_backend_degraded`) keep one identity that
+  every MissionManager holds. Nothing outside build_services() may replace
+  these objects.
+* `poll_rt` is constructed ONCE with live references and never rebuilt on
+  config reload (ADR-0015 Decision 2). Building it BEFORE the
+  BlockerLocator dissolves the old `_mission_owner_of` module-global
+  late-binding hack — the locator's owner lookup closes over the already-
+  constructed runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from ..adapters.dagu import DaguExecutor
+from ..adapters.files import RunLogStore, RunStore
+from ..adapters.redis import Messaging
+from ..adapters.registry import make_forge, make_internal_forge, make_pmo
+from .. import security
+from ..config import AppConfig, DevType, load_config, load_dev_types
+from ..domain.blocker_locator import BlockerLocator
+from ..domain.model import ALL_LABELS
+from ..domain.oauth import OAuthManager
+from ..domain.orchestrator import FinalizerRouter, MapperService, MissionManager
+from ..domain.forge_runtime import ForgeRuntime
+from ..domain.repo_mirror import RepoCache
+from ..domain.workspaces import WorkspaceStore
+from ..domain.runs import RunManager
+from ..domain.skills import SkillService
+from .health import reset_protection_cache
+from .poll import PollRuntime
+
+log = logging.getLogger("devcake")
+
+
+def _log_task_death(t: asyncio.Task) -> None:
+    if not t.cancelled() and t.exception():
+        log.error("background task %s DIED", t.get_name(), exc_info=t.exception())
+
+
+@dataclass
+class Services:
+    """The live object graph. Deliberately NOT frozen and NOT slotted:
+    tests monkeypatch per instance (a stub `reload_connections` becomes an
+    instance attribute shadowing the method — the sanctioned seam)."""
+
+    config: AppConfig
+    dev_types: dict[str, DevType]
+    store: RunStore
+    runlog: RunLogStore
+    messaging: Messaging
+    executor: DaguExecutor
+    workspaces: WorkspaceStore
+    manager: RunManager
+    shared_breakers: dict[str, str]
+    shared_backend_degraded: dict[str, str]
+    managers: dict[str, MissionManager]
+    mappers: dict[str, MapperService]
+    forge_runtime: ForgeRuntime
+    repo_cache: RepoCache
+    internal_forge: Any
+    skill_service: SkillService
+    # wired by build_services() after construction (poll_rt must exist
+    # before the locator; the router/oauth manager hold the finished graph)
+    poll_rt: Optional[PollRuntime] = None
+    blocker_locator: Optional[BlockerLocator] = None
+    finalizer: Optional[FinalizerRouter] = None
+    oauth_mgr: Optional[OAuthManager] = None
+
+    def build_managers(self) -> None:
+        """(Re)build the manager set IN PLACE to match config.pmos: existing
+        managers keep their advisory state (grace, anomalies, merge windows)
+        and get repointed adapters; removed instances drop theirs — never
+        leaked."""
+        live = {i.name: i for i in self.config.pmos if i.configured}
+        for name in [n for n in self.managers if n not in live]:
+            self.managers.pop(name)
+            self.mappers.pop(name, None)
+        for name, inst in live.items():
+            p = make_pmo(inst)
+            if name in self.managers:
+                mgr = self.managers[name]
+                mgr.pmo, mgr.forges, mgr.config = p, self.forge_runtime, self.config
+                mgr.instance, mgr.instance_name = inst, name
+                mgr.internal_forge = self.internal_forge
+                mgr.skills = self.skill_service
+                mgr.blocker_locator = self.blocker_locator
+                mgr.repo_cache = self.repo_cache
+            else:
+                self.managers[name] = MissionManager(
+                    self.config, self.dev_types, p, self.forge_runtime,
+                    self.manager, self.messaging,
+                    instance=inst, breakers=self.shared_breakers,
+                    internal_forge=self.internal_forge,
+                    skills=self.skill_service,
+                    backend_degraded=self.shared_backend_degraded,
+                    blocker_locator=self.blocker_locator,
+                    repo_cache=self.repo_cache)
+                self.mappers[name] = MapperService(
+                    self.config, self.dev_types, self.managers[name])
+
+    def managers_in_config_order(self) -> list[MissionManager]:
+        return [self.managers[i.name] for i in self.config.pmos
+                if i.name in self.managers]
+
+    async def refresh_forge_health(self) -> dict[str, dict]:
+        """Probe every configured repo; the runtime latches/clears per repo."""
+        return await self.forge_runtime.refresh_all()
+
+    def reload_connections(self) -> None:
+        """Hot-reload adapters after a config PUT: rebuild the forge,
+        reconcile the manager set, and re-ensure the managed labels per
+        instance — bootstrap is otherwise startup-only, so a hot-swapped
+        team_key would run unlabeled until restart."""
+        self.forge_runtime.rebuild(self.config.repos, make_forge)
+        self.build_managers()
+        reset_protection_cache()           # repos may have changed — reprobe
+        # the adapter set feeds secret_env_vars (descriptor env lists), so the
+        # redaction scan cache must rebuild with it (2026-08 F17)
+        security.invalidate_secret_scan()
+
+        async def _ensure():
+            for mgr in list(self.managers.values()):
+                try:
+                    await mgr.pmo.ensure_labels(mgr.instance.team_key,
+                                                ALL_LABELS)
+                except Exception:
+                    log.exception(
+                        "ensure_labels after config reload failed for "
+                        "instance %s — ensured on next restart",
+                        mgr.instance_name)
+            await self.refresh_forge_health()
+        asyncio.create_task(_ensure(), name="ensure_labels_reload") \
+            .add_done_callback(_log_task_death)
+
+
+def build_services() -> Services:
+    """Construct the whole graph — the moved api/main.py module body.
+
+    Only the lifespan calls this (once, at startup): it reads /data, WRITES
+    config.yaml (`load_config`'s normalize-on-load), and constructs live
+    adapters. A corrupt config.yaml therefore crashes at STARTUP now, not at
+    import — same fail-loudly, new log position (ADR-0028 release note).
+    Tests wire `fakes.make_services(...)` instead.
+    """
+    config = load_config()
+    dev_types = load_dev_types()
+    store = RunStore()
+    runlog = RunLogStore()
+    # REDIS_* read HERE — no longer frozen at import time
+    messaging = Messaging(os.environ.get("REDIS_URL", "redis://redis:6379/0"),
+                          os.environ.get("REDIS_PASSWORD", ""))
+    executor = DaguExecutor()
+    # ADR-0025: per-run workspace tree on the host bind (compose mounts
+    # $DEVCAKE_WS_HOST here rw; the dev-run DAG binds per-run subdirs)
+    workspaces = WorkspaceStore("/workspaces")
+    manager = RunManager(store, messaging, executor, workspaces=workspaces)
+
+    # ── multi-instance wiring (schema v3, ADR-0009; repos plural per M10) ──
+    # One MissionManager per CONFIGURED PMO instance; shared state is
+    # injected: the RunManager/store (global concurrency), ONE dev-type
+    # breakers dict (credentials are DevCake-global), and ONE ForgeRuntime
+    # (repos belong to the deployment — missions from any instance can route
+    # to any repo). shared_backend_degraded is the same injected-shared-dict
+    # idiom but a DIFFERENT thing: it throttles a dev type to one probe run
+    # when its model backend looks sick (ADR-0018). PollRuntime is the sole
+    # writer; managers only read it.
+    forge_runtime = ForgeRuntime()
+    # ADR-0024: the ONE deployment-wide source mirror (repos are
+    # deployment-global, so the mirror is too — same shared-runtime idiom)
+    repo_cache = RepoCache(config, forge_runtime)
+    # the bundled internal fallback forge (M11): provisioner is admin-
+    # credentialed (GITEA_ADMIN_*); None disables the zero-repo un-gating
+    # when Gitea is absent
+    internal_forge = (make_internal_forge()
+                      if os.environ.get("GITEA_ADMIN_PASSWORD") else None)
+    # skill store (docs/16 skill store v1): store-first reads via the
+    # internal forge; bundled copies keep built-in skills working forge-less
+    s = Services(
+        config=config, dev_types=dev_types, store=store, runlog=runlog,
+        messaging=messaging, executor=executor, workspaces=workspaces,
+        manager=manager, shared_breakers={}, shared_backend_degraded={},
+        managers={}, mappers={}, forge_runtime=forge_runtime,
+        repo_cache=repo_cache, internal_forge=internal_forge,
+        skill_service=SkillService(internal_forge))
+
+    # The poll machinery (ownership claims, cycle driver, missions cache,
+    # loop) lives in api/poll.py — constructed ONCE with live references and
+    # never rebuilt on config reload (ADR-0015 Decision 2).
+    # `poll_rt.missions_cache` keeps one stable list identity;
+    # /api/v1/missions serves it by reference.
+    s.poll_rt = PollRuntime(
+        config=config, managers=s.managers, mappers=s.mappers, store=store,
+        forge_runtime=s.forge_runtime,
+        refresh_forge_health=s.refresh_forge_health,
+        managers_in_config_order=s.managers_in_config_order,
+        backend_degraded=s.shared_backend_degraded, repo_cache=s.repo_cache)
+    poll_rt = s.poll_rt
+    # Deployment-wide blocker resolution (ADR-0009 amendment): ONE locator
+    # over the LIVE managers dict, so a native blocked_by edge to a peer
+    # instance's mission gates and inherits exactly like a local one (Linear
+    # v1; read-only — never claims, never writes). poll_rt already exists,
+    # so its durable claim map is read directly — no late binding.
+    s.blocker_locator = BlockerLocator(
+        s.managers, lambda bid: poll_rt.mission_owner.get(bid))
+
+    s.forge_runtime.rebuild(config.repos, make_forge)
+    s.build_managers()
+    s.finalizer = FinalizerRouter(s.managers, store, messaging)
+    manager.set_finalizer(s.finalizer)  # RunFinalizer seam: routes on run.pmo_ref
+    s.oauth_mgr = OAuthManager(manager, messaging, dev_types,
+                               breakers=s.shared_breakers)
+    manager.oauth_mgr = s.oauth_mgr
+    manager.runlog = runlog
+    return s

--- a/app/devcake/telemetry/__init__.py
+++ b/app/devcake/telemetry/__init__.py
@@ -52,6 +52,15 @@ async def push_oo_log(stream: str, record: dict) -> bool:
 
 
 def setup_telemetry() -> trace.Tracer:
+    # ADR-0028: idempotent — the call moved from import time into the app
+    # lifespan, so every `with TestClient(app)` re-enters it. Without this
+    # guard each entry would install another BatchSpanProcessor WORKER
+    # THREAD and re-instrument httpx (the SDK ignores a second
+    # set_tracer_provider anyway, logging an error). A real provider
+    # already installed means telemetry is up: return the tracer and touch
+    # nothing.
+    if isinstance(trace.get_tracer_provider(), TracerProvider):
+        return trace.get_tracer("devcake")
     provider = TracerProvider(resource=Resource.create({"service.name": SERVICE_NAME}))
     exporter = OTLPSpanExporter(
         endpoint=f"{OO_URL}/api/{OO_ORG}/v1/traces",

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -195,3 +195,48 @@ def fake_pmo_capabilities(*, global_ids=True):
         attachment_max_bytes=50 * 1024 * 1024,
         native_label_swap_atomic=True, relations_supported=True,
         global_ids=global_ids)
+
+
+# ── ADR-0028: the test-side service graph ────────────────────────────────────
+
+class _Unwired:
+    """Explode-on-touch sentinel for Services slots a test did not wire.
+    Reading an attribute or calling it names the missing slot instead of
+    failing three frames later on a None."""
+
+    def __init__(self, slot: str):
+        object.__setattr__(self, "_slot", slot)
+
+    def __getattr__(self, attr):
+        raise AssertionError(
+            f"test touched services.{self._slot}.{attr} — wire it via "
+            f"make_services({self._slot}=...)")
+
+    def __call__(self, *a, **k):
+        raise AssertionError(
+            f"test called services.{self._slot} — wire it via "
+            f"make_services({self._slot}=...)")
+
+
+def make_services(**overrides):
+    """A Services instance for tests: named slots wired, everything else an
+    explode-on-touch sentinel. NEVER calls the real build_services() — that
+    reads /data, writes config.yaml, and constructs live adapters."""
+    import dataclasses
+
+    from devcake.api.services import Services
+
+    # methods stubbable as instance attributes (the sanctioned seam — the
+    # dataclass is deliberately unslotted)
+    method_overrides = {
+        name: overrides.pop(name)
+        for name in ("reload_connections", "refresh_forge_health",
+                     "build_managers", "managers_in_config_order")
+        if name in overrides}
+    names = [f.name for f in dataclasses.fields(Services)]
+    unknown = set(overrides) - set(names)
+    assert not unknown, f"make_services: unknown Services fields {sorted(unknown)}"
+    s = Services(**{n: overrides.get(n, _Unwired(n)) for n in names})
+    for name, stub in method_overrides.items():
+        setattr(s, name, stub)
+    return s

--- a/app/tests/test_dispatch_chokepoint.py
+++ b/app/tests/test_dispatch_chokepoint.py
@@ -104,8 +104,9 @@ def test_prod_wires_a_real_workspace_store():
     no-op) so the existing suite stays untouched — therefore prod composition
     MUST inject the real WorkspaceStore, or every dispatch would run onto an
     unmanaged workspace with no pre-create, cleanup, or fail-closed gate.
-    Guard the wiring so dropping it fails CI rather than silently degrading."""
-    src = (ROOT / "api" / "main.py").read_text()
+    Guard the wiring so dropping it fails CI rather than silently degrading.
+    ADR-0028: the composition root lives in api/services.py now."""
+    src = (ROOT / "api" / "services.py").read_text()
     assert "WorkspaceStore(" in src, "prod must construct a real WorkspaceStore"
     assert "workspaces=workspaces" in src, \
         "RunManager must be wired with the real workspace store"

--- a/app/tests/test_multi_instance.py
+++ b/app/tests/test_multi_instance.py
@@ -400,25 +400,25 @@ def test_config_put_survives_secret_cleanup_failure(tmp_path, monkeypatch):
     monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
     from devcake.api import main as app_main
     from devcake.api import config_service
-    from devcake.config import RepoInstance
+    from devcake.config import AppConfig, RepoInstance
+    from fakes import make_services
 
     def boom(scope, name):
         raise RuntimeError("disk error")
 
-    monkeypatch.setattr(app_main, "reload_connections", lambda: None)
     # save_config is called by config_service after the C5 split — patch it
     # THERE, not on app_main (audit D5 #3: the app_main patch is dead, so the
     # PUT persisted repos:[] to the real config path).
     monkeypatch.setattr(config_service, "save_config", lambda c: None)
     monkeypatch.setattr(app_main.secrets_store, "delete_connection_instance", boom)
-    original_repos = app_main.config.repos
-    app_main.config.repos = [RepoInstance(name="gone",
-                                          url="https://github.com/o/r")]
-    try:
-        out = run_coro(app_main.put_config({"repos": []}))   # must not raise
-        assert out["repos"] == []
-    finally:
-        app_main.config.repos = original_repos
+    # ADR-0028: a fresh per-test graph — no module-global repos to restore
+    monkeypatch.setattr(app_main, "services", make_services(
+        config=AppConfig(repos=[RepoInstance(name="gone",
+                                             url="https://github.com/o/r")]),
+        dev_types={}, managers={}, repo_cache=None,
+        reload_connections=lambda: None))
+    out = run_coro(app_main.put_config({"repos": []}))   # must not raise
+    assert out["repos"] == []
 
 
 def test_hello_and_oauth_runs_stamp_sys_pmo_ref():
@@ -495,14 +495,14 @@ def test_main_wires_one_shared_locator():
     """build_managers must hand the ONE shared locator to BOTH branches
     (create + reconcile) — a missed branch is the silent 'half multi-PMO'
     wiring bug the required-dependency rule exists to prevent. Source-pinned
-    (the dispatch-stamp precedent above) without importing api.main's
-    import-time singletons."""
+    against api/services.py (ADR-0028: the composition root moved there;
+    importing it stays side-effect-free)."""
     from pathlib import Path
     import devcake
-    src = (Path(devcake.__file__).parent / "api" / "main.py").read_text()
-    assert "blocker_locator = BlockerLocator(managers, _mission_owner_of)" in src
-    assert "mgr.blocker_locator = blocker_locator" in src        # reconcile
-    assert "blocker_locator=blocker_locator" in src              # create
+    src = (Path(devcake.__file__).parent / "api" / "services.py").read_text()
+    assert "s.blocker_locator = BlockerLocator(" in src
+    assert "mgr.blocker_locator = self.blocker_locator" in src   # reconcile
+    assert "blocker_locator=self.blocker_locator" in src         # create
 
 
 def test_merged_cache_resolves_foreign_blocker_keys(tmp_path):

--- a/app/tests/test_profiles.py
+++ b/app/tests/test_profiles.py
@@ -176,15 +176,14 @@ def test_divergence_flips_on_config_edit_and_secret_rewrite(monkeypatch, tmp_pat
 def _wire_app(monkeypatch, tmp_path):
     sb, profiles, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
     from devcake.api import main as app_main
+    from fakes import make_services
     cfg, dts = _small_world(config_mod, secrets)
     tpl.seed_devtype_prompts(dts)
-    monkeypatch.setattr(app_main, "config", cfg)
-    monkeypatch.setattr(app_main, "dev_types", dts)
-    monkeypatch.setattr(app_main, "reload_connections", lambda: None)
-    monkeypatch.setattr(app_main, "store",
-                        SimpleNamespace(active=lambda: []))
-    monkeypatch.setattr(app_main, "shared_breakers", {})
-    monkeypatch.setattr(app_main.forge_runtime, "breakers", {})
+    # ADR-0028: one test graph instead of six module-global patches
+    monkeypatch.setattr(app_main, "services", make_services(
+        config=cfg, dev_types=dts, reload_connections=lambda: None,
+        store=SimpleNamespace(active=lambda: []), shared_breakers={},
+        forge_runtime=SimpleNamespace(breakers={}), managers={}))
     return sb, profiles, secrets, config_mod, app_main
 
 
@@ -209,10 +208,10 @@ def test_endpoint_flow_save_list_get_apply_rename_delete(monkeypatch, tmp_path):
     assert detail["secrets_present"]["connections"] == {"repo-main": ["token"]}
     assert "diff" in detail
 
-    app_main.config.poll_interval_seconds = 77   # drift before the apply
+    app_main.services.config.poll_interval_seconds = 77   # drift before the apply
     out = run_coro(app_main.apply_profile("base"))
     assert sorted(out["applied"]) == ["config", "secrets"]
-    assert app_main.config.poll_interval_seconds == 30
+    assert app_main.services.config.poll_interval_seconds == 30
     rows = run_coro(app_main.list_profiles())["profiles"]
     assert rows[0]["last_applied_at"] and rows[0]["diverged"] is False
 
@@ -234,9 +233,8 @@ def test_apply_blocked_while_runs_active(monkeypatch, tmp_path):
     from fastapi import HTTPException
     sb, profiles, secrets, config_mod, app_main = _wire_app(monkeypatch, tmp_path)
     run_coro(app_main.save_profile({"name": "base"}))
-    monkeypatch.setattr(
-        app_main, "store",
-        SimpleNamespace(active=lambda: [SimpleNamespace(state="running")]))
+    app_main.services.store = SimpleNamespace(
+        active=lambda: [SimpleNamespace(state="running")])
     with pytest.raises(HTTPException) as e:
         run_coro(app_main.apply_profile("base"))
     assert e.value.status_code == 409
@@ -248,7 +246,7 @@ def test_apply_blocked_while_runs_active(monkeypatch, tmp_path):
 
 def test_save_warns_on_configured_instance_without_secret(monkeypatch, tmp_path):
     sb, profiles, secrets, config_mod, app_main = _wire_app(monkeypatch, tmp_path)
-    app_main.config.pmos = [config_mod.PMOInstance(
+    app_main.services.config.pmos = [config_mod.PMOInstance(
         name="linear", team_key="ENG", repos=["main"])]
     out = run_coro(app_main.save_profile({"name": "gappy"}))
     assert any("no stored API key" in w for w in out["warnings"])

--- a/app/tests/test_prompt_templates.py
+++ b/app/tests/test_prompt_templates.py
@@ -279,30 +279,29 @@ def test_rename_dev_type_moves_templates_and_refs(monkeypatch, tmp_path):
     monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
     from devcake.api import devtypes_service
     from devcake.api import main as app_main
-    from devcake.config import DevType
+    from devcake.config import AppConfig, Assignment, DevType
+    from fakes import make_services
     monkeypatch.setattr(devtypes_service, "save_config", lambda c: None)
     monkeypatch.setattr(devtypes_service, "save_dev_type", lambda d: None)
     monkeypatch.setattr(devtypes_service, "delete_dev_type", lambda n: None)
     dt = DevType(name="olddev", harness_template="codex",
                  identifying_prompt="I am old.")
-    app_main.dev_types["olddev"] = dt
-    app_main.config.assignments["EXECUTE"].dev_type = "olddev"
-    app_main.config.active_devtype_prompts["olddev"] = "Customer Success"
+    # ADR-0028: a fresh per-test graph — the old try/finally that restored
+    # the module-global config/dev_types is gone with the globals themselves
+    cfg = AppConfig(assignments={"EXECUTE": Assignment(dev_type="olddev")})
+    cfg.active_devtype_prompts = {"olddev": "Customer Success"}
+    monkeypatch.setattr(app_main, "services", make_services(
+        config=cfg, dev_types={"olddev": dt}, shared_breakers={}))
     d = tmp_path / "config" / "devtype_prompt_templates" / "olddev"
     d.mkdir(parents=True)
     (d / "Development.yaml").write_text("name: Development\ntemplate: I am old.\n")
-    try:
-        out = run_coro(app_main.rename_dev_type("olddev", {"new_name": "newdev"}))
-        assert out["renamed"] and "newdev" in app_main.dev_types
-        assert "olddev" not in app_main.dev_types
-        assert app_main.config.assignments["EXECUTE"].dev_type == "newdev"
-        assert app_main.config.active_devtype_prompts == {"newdev": "Customer Success"}
-        assert (tmp_path / "config" / "devtype_prompt_templates" / "newdev"
-                / "Development.yaml").exists()
-    finally:
-        app_main.dev_types.pop("newdev", None)
-        app_main.config.assignments["EXECUTE"].dev_type = "main-dev"
-        app_main.config.active_devtype_prompts.pop("newdev", None)
+    out = run_coro(app_main.rename_dev_type("olddev", {"new_name": "newdev"}))
+    assert out["renamed"] and "newdev" in app_main.services.dev_types
+    assert "olddev" not in app_main.services.dev_types
+    assert app_main.services.config.assignments["EXECUTE"].dev_type == "newdev"
+    assert app_main.services.config.active_devtype_prompts == {"newdev": "Customer Success"}
+    assert (tmp_path / "config" / "devtype_prompt_templates" / "newdev"
+            / "Development.yaml").exists()
 
 
 def test_remove_dev_type_clears_active_prompt_and_sidecar_dirs(monkeypatch, tmp_path):

--- a/app/tests/test_secrets_store.py
+++ b/app/tests/test_secrets_store.py
@@ -71,7 +71,19 @@ def test_harness_delete_unlinks(monkeypatch, tmp_path):
 
 def _main(monkeypatch, tmp_path):
     monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from types import SimpleNamespace
+
     from devcake.api import main as app_main
+    from devcake.config import AppConfig
+    from fakes import make_services
+
+    # ADR-0028: install a test graph — routes resolve svc() at call time.
+    # Unwired slots explode with their name; these are the ones the
+    # secrets/connections routes actually reach.
+    monkeypatch.setattr(app_main, "services", make_services(
+        config=AppConfig(), dev_types={}, shared_breakers={},
+        forge_runtime=SimpleNamespace(breakers={}),
+        reload_connections=lambda: None))
     return app_main
 
 
@@ -95,12 +107,9 @@ def test_public_config_response_never_echoes_stored_secrets(monkeypatch,
     s.write_harness_secret("ANTHROPIC_API_KEY", harness_secret)
     planted = {pmo_secret, *repo_secrets.values(), harness_secret}
 
-    monkeypatch.setattr(
-        app_main, "config",
-        AppConfig(
-            pmos=[PMOInstance(name="linear", team_key="DEV")],
-            repos=[RepoInstance(name="main", url="https://example.test/o/r")],
-        ),
+    app_main.services.config = AppConfig(
+        pmos=[PMOInstance(name="linear", team_key="DEV")],
+        repos=[RepoInstance(name="main", url="https://example.test/o/r")],
     )
     probe = FastAPI()
     probe.add_api_route("/api/v1/config", app_main.get_config, methods=["GET"])
@@ -288,7 +297,7 @@ def test_secrets_clear_deletes_selected_only(monkeypatch, tmp_path):
     assert (d / "other.json").exists()
     # omit pause_intake → API default false; intake unchanged
     assert out["intake_paused"] is False
-    assert app_main.config.intake_paused is False
+    assert app_main.services.config.intake_paused is False
 
 
 def test_secrets_clear_rejects_traversal_and_empty(monkeypatch, tmp_path):
@@ -320,14 +329,14 @@ def test_secrets_clear_pause_intake_default_and_explicit(monkeypatch, tmp_path):
     app_main = _main(monkeypatch, tmp_path)
     s = _store(monkeypatch, tmp_path)
     s.write_harness_secret("XAI_API_KEY", "v-pause-test")
-    app_main.config.intake_paused = False
+    app_main.services.config.intake_paused = False
 
     out = run_coro(app_main.clear_secrets({
         "harness": ["XAI_API_KEY"],
         "pause_intake": False,
     }))
     assert out["intake_paused"] is False
-    assert app_main.config.intake_paused is False
+    assert app_main.services.config.intake_paused is False
 
     s.write_harness_secret("XAI_API_KEY", "v-pause-test-2")
     out = run_coro(app_main.clear_secrets({
@@ -335,7 +344,7 @@ def test_secrets_clear_pause_intake_default_and_explicit(monkeypatch, tmp_path):
         "pause_intake": True,
     }))
     assert out["intake_paused"] is True
-    assert app_main.config.intake_paused is True
+    assert app_main.services.config.intake_paused is True
 
 
 def test_secrets_clear_pause_first_aborts_deletes_on_save_failure(
@@ -344,7 +353,7 @@ def test_secrets_clear_pause_first_aborts_deletes_on_save_failure(
     app_main = _main(monkeypatch, tmp_path)
     s = _store(monkeypatch, tmp_path)
     s.write_harness_secret("XAI_API_KEY", "must-survive")
-    app_main.config.intake_paused = False
+    app_main.services.config.intake_paused = False
 
     def boom(_cfg):
         raise OSError("disk full")
@@ -356,7 +365,7 @@ def test_secrets_clear_pause_first_aborts_deletes_on_save_failure(
             "pause_intake": True,
         }))
     assert s.harness_status("XAI_API_KEY")["present"] is True
-    assert app_main.config.intake_paused is True  # in-memory set before save
+    assert app_main.services.config.intake_paused is True  # in-memory set before save
 
 
 def test_secrets_clear_clears_breakers_and_audits(monkeypatch, tmp_path):
@@ -373,17 +382,17 @@ def test_secrets_clear_clears_breakers_and_audits(monkeypatch, tmp_path):
     d.mkdir(parents=True)
     (d / "auth.json").write_text("file-sentinel")
 
-    app_main.dev_types = {
+    app_main.services.dev_types = {
         "coder": DevType(name="coder", harness_template=ht),
     }
-    app_main.shared_breakers["coder"] = "DEV_AUTH"
+    app_main.services.shared_breakers["coder"] = "DEV_AUTH"
 
     out = run_coro(app_main.clear_secrets({
         "harness": [var],
         "credential_files": [{"dev_type": "coder", "filename": "auth.json"}],
     }))
     assert out["ok"] is True
-    assert "coder" not in app_main.shared_breakers
+    assert "coder" not in app_main.services.shared_breakers
 
     audit = (tmp_path / "state" / "events.jsonl")
     # audit may live under DATA_DIR/state — ensure it was written somewhere
@@ -414,7 +423,7 @@ def test_secrets_clear_repo_pops_forge_breaker_and_reloads(monkeypatch, tmp_path
     reloads = []
     resets = []
     fr = _FR()
-    monkeypatch.setattr(app_main, "forge_runtime", fr)
+    app_main.services.forge_runtime = fr
     # clear_secrets binds reload/forge_runtime at the route — call the service
     # with fakes so we can assert the side effects without full composition.
     from devcake.api import connections_service as cs
@@ -426,9 +435,9 @@ def test_secrets_clear_repo_pops_forge_breaker_and_reloads(monkeypatch, tmp_path
             {"scope": "repo", "instance": "main", "field": "token"}]},
         forge_runtime=fr,
         reload=lambda: reloads.append(True),
-        config=app_main.config,
-        shared_breakers=app_main.shared_breakers,
-        dev_types=app_main.dev_types,
+        config=app_main.services.config,
+        shared_breakers=app_main.services.shared_breakers,
+        dev_types=app_main.services.dev_types,
     ))
     assert out["ok"] is True
     assert "main" not in fr.breakers

--- a/app/tests/test_settings_transfer.py
+++ b/app/tests/test_settings_transfer.py
@@ -36,11 +36,16 @@ def _wire_app(monkeypatch, tmp_path: Path):
     secrets.write_connection_secret("repo", "main", "token",
                                     "ghp_transfer_secret_value_01")
     secrets.write_harness_secret("ANTHROPIC_API_KEY", "sk-ant-transfer-02")
-    monkeypatch.setattr(app_main, "config", cfg)
-    monkeypatch.setattr(app_main, "dev_types", dts)
-    monkeypatch.setattr(app_main, "reload_connections", lambda: None)
-    monkeypatch.setattr(app_main, "store", SimpleNamespace(active=lambda: []))
-    monkeypatch.setattr(app_main, "shared_breakers", {})
+    from devcake.domain.skills import SkillService
+    from fakes import make_services
+    # ADR-0028: one test graph instead of five module-global patches.
+    # SkillService(None) serves the bundled skills forge-less, exactly as
+    # the old module global did in a GITEA-less test env.
+    monkeypatch.setattr(app_main, "services", make_services(
+        config=cfg, dev_types=dts, reload_connections=lambda: None,
+        store=SimpleNamespace(active=lambda: []), shared_breakers={},
+        managers={}, forge_runtime=SimpleNamespace(breakers={}),
+        skill_service=SkillService(None)))
     return app_main, config_mod, secrets
 
 
@@ -160,7 +165,7 @@ def test_import_lands_as_profile_then_apply_restores(monkeypatch, tmp_path):
     text = run_coro(app_main.export_settings(
         {"sections": ALL, "encryption": ENC})).body.decode()
     # drift the live world, then import + apply the bundle
-    app_main.config.poll_interval_seconds = 99
+    app_main.services.config.poll_interval_seconds = 99
     secrets.write_harness_secret("ANTHROPIC_API_KEY", "sk-rotated-03")
     out = run_coro(app_main.import_settings(
         {"content_b64": _b64(text), "passphrase": "correct horse",
@@ -169,9 +174,9 @@ def test_import_lands_as_profile_then_apply_restores(monkeypatch, tmp_path):
     assert out["sections"] == ["config", "secrets"]
     assert out["has_setup_env"] is False
     # nothing applied yet
-    assert app_main.config.poll_interval_seconds == 99
+    assert app_main.services.config.poll_interval_seconds == 99
     run_coro(app_main.apply_profile("imported"))
-    assert app_main.config.poll_interval_seconds == 30
+    assert app_main.services.config.poll_interval_seconds == 30
     assert secrets.read_harness_secret("ANTHROPIC_API_KEY") == "sk-ant-transfer-02"
 
 

--- a/app/tests/test_structure_guards.py
+++ b/app/tests/test_structure_guards.py
@@ -59,21 +59,29 @@ def test_lifespan_never_awaits_the_forge_sweep():
     """Incident 2026-08-01: `await refresh_forge_health()` inside lifespan
     held the listen socket for O(N repos) of probe I/O and failed the compose
     healthcheck. The sweep belongs to the poll task (before its first cycle);
-    this guard keeps the boot regression from coming back silently."""
+    this guard keeps the boot regression from coming back silently.
+
+    ADR-0028: matches BOTH call shapes — the old bare name and the factored
+    `s.refresh_forge_health()` / `forge_runtime.refresh_all()` attribute
+    calls the Services move introduced (a Name-only guard would go blind the
+    day the sweep becomes a method)."""
     tree = ast.parse(MAIN.read_text())
     lifespan = next(node for node in ast.walk(tree)
                     if isinstance(node, ast.AsyncFunctionDef)
                     and node.name == "lifespan")
+    sweep_names = {"refresh_forge_health", "refresh_all"}
     offenders = [
         node.lineno for node in ast.walk(lifespan)
         if isinstance(node, ast.Await)
         and isinstance(node.value, ast.Call)
-        and isinstance(node.value.func, ast.Name)
-        and node.value.func.id == "refresh_forge_health"
+        and ((isinstance(node.value.func, ast.Name)
+              and node.value.func.id in sweep_names)
+             or (isinstance(node.value.func, ast.Attribute)
+                 and node.value.func.attr in sweep_names))
     ]
     assert not offenders, (
-        "lifespan awaits refresh_forge_health again (lines "
-        f"{offenders}) — boot must not block on the forge sweep")
+        "lifespan awaits the forge sweep again (lines "
+        f"{offenders}) — boot must not block on it")
 
 
 def test_lifespan_never_awaits_mirror_warmup():
@@ -114,3 +122,66 @@ def test_main_route_bodies_stay_thin():
     assert not offenders, (
         "main.py route bodies grew past 4 statements — move the behavior to "
         "an api/ service module (ADR-0015 Decision 3): " + "; ".join(offenders))
+
+
+# ── ADR-0028: the composition root is a factory, not an import side effect ───
+
+def test_importing_main_is_side_effect_free(tmp_path):
+    """Importing api.main must build NOTHING: no /data reads-that-write, no
+    adapter construction, no config.yaml write. A subprocess is required —
+    the in-process module cache would hide a second import's effects. The
+    env is hostile on purpose: ADMIN_* unset, a fresh empty DEVCAKE_DATA_DIR
+    — a side-effecting import either crashes or leaves files, and both fail
+    here."""
+    import os
+    import subprocess
+    import sys
+
+    data = tmp_path / "data"
+    data.mkdir()
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("ADMIN_USER", "ADMIN_PASSWORD")}
+    env["DEVCAKE_DATA_DIR"] = str(data)
+    proc = subprocess.run(
+        [sys.executable, "-c", "import devcake.api.main"],
+        capture_output=True, text=True, env=env,
+        cwd=str(Path(__file__).parents[1]))
+    assert proc.returncode == 0, (
+        f"import devcake.api.main failed in a bare env:\n{proc.stderr[-2000:]}")
+    created = sorted(str(p.relative_to(data)) for p in data.rglob("*"))
+    assert not created, (
+        f"importing api.main wrote into DEVCAKE_DATA_DIR: {created} — "
+        "construction belongs in build_services() (ADR-0028)")
+
+
+def test_main_module_level_is_wiring_only():
+    """The filesystem probe above cannot see a re-added `Messaging(...)` at
+    module scope (client construction writes nothing). This AST allowlist
+    can: every top-level call in api/main.py must be pure wiring."""
+    ALLOWED = {"logging.basicConfig", "logging.getLogger", "trace.get_tracer",
+               "FastAPI", "app.middleware", "FastAPIInstrumentor.instrument_app"}
+
+    def _name(func) -> str:
+        if isinstance(func, ast.Name):
+            return func.id
+        if isinstance(func, ast.Attribute):
+            base = _name(func.value)
+            return f"{base}.{func.attr}" if base else func.attr
+        if isinstance(func, ast.Call):        # app.middleware("http")(fn)
+            return _name(func.func)
+        return ""
+
+    tree = ast.parse(MAIN.read_text())
+    offenders = []
+    for node in tree.body:
+        # defs/classes run at CALL time; only bare module-level statements
+        # execute on import
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef, ast.Import, ast.ImportFrom)):
+            continue
+        for call in ast.walk(node):
+            if isinstance(call, ast.Call) and _name(call.func) not in ALLOWED:
+                offenders.append(f"line {call.lineno}: {_name(call.func)}()")
+    assert not offenders, (
+        "api/main.py module scope grew non-wiring calls — move them into "
+        "build_services() / lifespan (ADR-0028): " + "; ".join(offenders))

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -88,8 +88,11 @@ app/devcake/
     dagu/          #   ExecutorPort impl
     files/         #   StatePort impl (+ runlog.py, owner_store.py) (10)
     redis/         #   MessagingPort impl — ingress + replies (09)
-  api/             # FastAPI (11, ADR-0015): main.py = composition root +
-                   #   ≤4-statement route forwards; behavior in service
+  api/             # FastAPI (11, ADR-0015/0028): services.py = the
+                   #   composition root (Services graph + build_services(),
+                   #   called by the lifespan — importing main.py builds
+                   #   NOTHING); main.py = ≤4-statement route forwards via
+                   #   svc(); behavior in service
                    #   modules — poll.py (PollRuntime), health.py,
                    #   mission_actions.py, clear.py, config_service.py,
                    #   profiles_service.py, settings_transfer.py,
@@ -108,7 +111,7 @@ app/devcake/
 
 The app boots via `uvicorn devcake.api.main:app`. `config.py`, `security.py`, and `harness.py` sit at the package root because they are cross-cutting concerns, not layer members.
 
-**Ports today:** vendor seams (`PMOPort`, `ForgePort` — ADR-0008; `InternalForgePort` — ADR-0010) and run-infrastructure seams (`ExecutorPort`, `StatePort`, `MessagingPort`, `RunFinalizer`). Production adapters: Linear, GitHub/GitLab/Gitea, Dagu, files, Redis Streams; `MissionManager` satisfies `RunFinalizer`. Composition root (`api/main.py`) builds adapters (incl. optional `make_internal_forge()` when Gitea admin creds are set), injects them into `RunManager` / per-instance `MissionManager`s, then `manager.set_finalizer(…)` so ingress/kill never type against the concrete orchestrator. Skill-store + per-mission repo routing (`resolve_repo` / `resolve_repo_live`) ride the same composition. All four dispatch flavors (hello, mission, mapper, OAuth) call `RunBootstrap.launch` for the durable-intent-before-trigger spine (`04-orchestrator.md` §3.1).
+**Ports today:** vendor seams (`PMOPort`, `ForgePort` — ADR-0008; `InternalForgePort` — ADR-0010) and run-infrastructure seams (`ExecutorPort`, `StatePort`, `MessagingPort`, `RunFinalizer`). Production adapters: Linear, GitHub/GitLab/Gitea, Dagu, files, Redis Streams; `MissionManager` satisfies `RunFinalizer`. Composition root (`api/services.build_services()`, ADR-0028 — called once by the lifespan, never at import) builds adapters (incl. optional `make_internal_forge()` when Gitea admin creds are set), injects them into `RunManager` / per-instance `MissionManager`s, then `manager.set_finalizer(…)` so ingress/kill never type against the concrete orchestrator. Skill-store + per-mission repo routing (`resolve_repo` / `resolve_repo_live`) ride the same composition. All four dispatch flavors (hello, mission, mapper, OAuth) call `RunBootstrap.launch` for the durable-intent-before-trigger spine (`04-orchestrator.md` §3.1).
 
 **Rule:** the domain core is testable with fakes of the ports; adapters never leak vendor types upward (normalized DTOs only, `02-domain-model.md`). Domain modules depend on **port Protocols**, not adapter packages.
 

--- a/docs/adr/0028-composition-root-factory.md
+++ b/docs/adr/0028-composition-root-factory.md
@@ -1,0 +1,88 @@
+# ADR-0028 — The composition root becomes a factory
+
+- **Status:** accepted (2026-08-04). Amends ADR-0015 (which fixed WHERE
+  behavior lives; this fixes WHEN objects are built).
+- **Context:** `api/main.py` constructed ~18 mutable singletons as module
+  globals **at import time** — including `load_config()` (which WRITES
+  config.yaml), template seeding (/data writes), `setup_telemetry()` (a
+  global TracerProvider + a BatchSpanProcessor worker thread + httpx
+  instrumentation), and live adapter clients — with late-binding hacks for
+  cycles (`_mission_owner_of` forward-referencing a `poll_rt` defined 95
+  lines later). Importing the module WAS half-booting the app: tests
+  monkeypatched module globals, no two isolated instances could exist, and
+  the 2026-08 evaluation found the composition root NEVER instantiated by
+  any test. Nothing inside app/devcake imports api.main (only the
+  Dockerfile CMD); exactly six test files did, five of them by patching
+  globals.
+
+## Decision
+
+### 1 — `api/services.py`: the graph and its factory
+
+A plain `Services` dataclass (deliberately NOT frozen, NOT slotted — tests
+stub methods as instance attributes) holds every live object; the moved
+module methods (`build_managers`, `reload_connections`,
+`refresh_forge_health`, `managers_in_config_order`) become methods on it.
+`build_services()` is the moved module body, with one structural
+improvement: `poll_rt` is built BEFORE the `BlockerLocator`, so the
+locator's owner lookup closes over the constructed runtime and the
+`_mission_owner_of` late-binding hack dissolves. Two ADR-0015 invariants
+carry over verbatim and are documented in the module: hot reload MUTATES in
+place (config setattr, in-place manager reconcile, stable shared-dict
+identities), and `poll_rt` is constructed once, never rebuilt on reload.
+
+### 2 — main.py: wiring-only module scope + `svc()`
+
+"Side-effect-free import" is an ALLOWLIST, not purity: `FastAPI()`,
+middleware attach, `FastAPIInstrumentor.instrument_app`, logging setup and
+`trace.get_tracer` (ProxyTracer — resolves the provider per span, the
+api/poll.py precedent) legitimately run at import. The real invariant: no
+/data reads-that-write or writes, no adapter/client construction, no global
+telemetry install, no threads. Routes reach the graph through
+`svc()` — inline it costs zero statements, so the ADR-0015 ≤4-statement
+ratchet survives with its allowlist UNCHANGED; multi-service routes open
+with `s = svc()`. Route names, signatures, and docstrings are unchanged
+(the forwards are the test seam).
+
+Lifespan order: credentials check → password floors → `setup_telemetry()`
+(BEFORE the graph — httpx instrumentation must wrap the adapter clients;
+now idempotent, since TestClient lifespans re-enter it) →
+`services = build_services()` → secrets registration → template seeding
+(moved from import) → the unchanged boot sequence → the task trio.
+`services` stays bound after shutdown.
+
+### 3 — Enforcement (test_structure_guards)
+
+- `test_importing_main_is_side_effect_free`: subprocess import against a
+  hostile env (ADMIN_* unset, fresh empty DEVCAKE_DATA_DIR) — must exit 0
+  and leave the dir EMPTY.
+- `test_main_module_level_is_wiring_only`: AST allowlist over top-level
+  calls — catches what the filesystem probe can't (a re-added
+  `Messaging(...)` at module scope writes nothing).
+- The forge-sweep lifespan guard now matches attribute calls too
+  (`s.refresh_forge_health()` / `refresh_all`) — a Name-only guard would
+  have gone blind the day the sweep became a method.
+
+### 4 — Tests: `fakes.make_services`
+
+Five test files traded their module-global monkeypatch clusters for ONE
+graph install: `monkeypatch.setattr(app_main, "services",
+make_services(config=..., dev_types=..., ...))`. Unwired slots are
+explode-on-touch sentinels that NAME the missing slot. The old globals are
+DELETED, so a stale patch fails loudly (no shims). `make_services` never
+calls the real factory — that reads /data and writes config.yaml.
+
+## Consequences
+
+- Two isolated app instances are now constructible; the composition root
+  is exercisable in-process (a TestClient lifespan runs the real factory).
+- **Accepted behavior shift (release note):** a corrupt config.yaml crashes
+  at STARTUP, not at import — same fail-loudly, new log position.
+- An authenticated request before the lifespan completes raises `svc()`'s
+  named RuntimeError (→500). Unreachable in prod (uvicorn serves only
+  after startup); intended in tests.
+- Source-pinned wiring guards (shared blocker locator, real
+  WorkspaceStore) now point at services.py.
+- main.py: 883 → 785 lines (services.py holds the moved 234), and main's
+  40+ dead legacy imports (pre-ADR-0015 vestiges F401 would have flagged)
+  are gone.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@
 | [0012](0012-decomposition-depth-and-edge-inheritance.md) | Decomposition depth + edge inheritance | Accepted |
 | [0013](0013-settings-bundle-profiles-and-export.md) | Settings bundle, profiles, export | Accepted |
 | [0014](0014-activity-feed-fidelity-and-activity-repos.md) | Activity feed fidelity + activity repos | Accepted |
-| [0015](0015-orchestrator-module-functions-and-api-composition.md) | Orchestrator module functions + composition root | Accepted. Close-out inventory drifted (the guard test allows seven residual forwards, the prose said nine — the ratchet is the truth) |
+| [0015](0015-orchestrator-module-functions-and-api-composition.md) | Orchestrator module functions + composition root | Accepted, **amended by ADR-0028** (the composition root moved behind `build_services()`; the route-forward ratchet is unchanged). Close-out inventory drifted (the guard test allows seven residual forwards, the prose said nine — the ratchet is the truth) |
 | [0016](0016-skills-and-prompt-assembly.md) | Skills and prompt assembly | Accepted |
 | [0017](0017-blocker-work-ro-mounts-and-optional-pmo-zip.md) | Blocker work "RO mounts" + optional PMO zip | Accepted, **amended** (cross-instance). Read the body, not the title: the mechanism is an RO **token** + prompt contract in ordinary writable clone dirs — falling back to the write token when no `token_ro` is configured — not a filesystem mount |
 | [0018](0018-harness-fault-classification-and-backend-brake.md) | Harness fault classification + backend brake | Accepted. The exit-11 "known gap" is now an operator toggle (ADR-0026) |
@@ -35,4 +35,5 @@
 | [0025](0025-provisioned-workspaces.md) | Provisioned workspaces | Accepted — supersedes ADR-0024 §5's risk posture |
 | [0026](0026-attempt-reset-policy-and-bad-output-brake.md) | Attempt-reset policy + opt-in bad-output brake | Accepted (2026-08-04) |
 | [0027](0027-failure-taxonomy-as-data.md) | Failure taxonomy as data | Accepted (2026-08-04) |
+| [0028](0028-composition-root-factory.md) | Composition-root factory (`build_services()` + wiring-only main.py) | Accepted (2026-08-04); amends ADR-0015 |
 | [0029](0029-normalized-result-shapes.md) | Normalized result shapes (TokenReport v1 + SQL-readiness) | Accepted (2026-08-04). Numbered 0029 but landed before 0028: it touches finalize/costing/runs_service, which the composition-root rewrite then leaves alone |


### PR DESCRIPTION
## What

Workstream 2 (final PR) of the structural-debt campaign — the 2026-08 evaluation's "composition-root decomposition" deferred candidate. Amends ADR-0015: that ADR fixed WHERE behavior lives; this fixes WHEN objects are built.

**Before:** importing `api/main.py` WAS half-booting the app — ~18 mutable singletons at module scope, `load_config()` writing config.yaml on import, a telemetry worker thread, live adapter clients, and a `_mission_owner_of` late-binding hack forward-referencing `poll_rt` 95 lines down. No test ever instantiated the composition root; five test files monkeypatched module globals.

**Now:**
- `api/services.py`: the `Services` dataclass (deliberately unslotted/unfrozen — instance-attribute stubbing is the sanctioned test seam) + `build_services()`, the moved module body. `poll_rt` is built before the `BlockerLocator`, dissolving the late-binding hack. The two ADR-0015 identity invariants (hot reload mutates in place; poll_rt never rebuilt) carry over, documented in-module.
- `api/main.py`: wiring-only module scope + `svc()` accessor. All route names/signatures/docstrings unchanged; the ≤4-statement ratchet survives with its allowlist **unchanged**. Lifespan: `setup_telemetry()` (now idempotent) → `build_services()` → seeding (moved from import) → the unchanged boot sequence.
- `fakes.make_services(**overrides)`: one graph install replaces the per-file monkeypatch clusters; unwired slots are explode-on-touch sentinels that name the missing slot. Old globals are DELETED — stale patches fail loudly, no shims.

## Enforcement

- `test_importing_main_is_side_effect_free`: subprocess import, hostile env (ADMIN_* unset, fresh empty DEVCAKE_DATA_DIR) — exit 0, dir stays empty.
- `test_main_module_level_is_wiring_only`: AST allowlist over top-level calls (catches a re-added `Messaging(...)` the filesystem probe can't see).
- Forge-sweep lifespan guard extended to attribute calls (`s.refresh_forge_health()` / `refresh_all`) — the Name-only guard would have gone blind after this move.
- Wiring source-pins (shared blocker locator, real WorkspaceStore) repointed at services.py.

## Accepted behavior shift (release note)

A corrupt config.yaml crashes at **startup**, not import — same fail-loudly, new log position. An authenticated request before lifespan completion gets `svc()`'s named RuntimeError (unreachable in prod; intended in tests).

## Verification

- 1519 passed, 1 skipped (pre-existing), ruff clean, `bake ci` green
- INV-1 clean: no new persistent state; the move changes WHEN objects are built, not where truth lives
- docs/01 §3 + ADR-0015 README row amended; ADR-0028 added

🤖 Generated with [Claude Code](https://claude.com/claude-code)