### PR TITLE
fix: OAuth success stamps ended_at and never resurrects a terminal run

### DIFF
--- a/app/devcake/domain/oauth.py
+++ b/app/devcake/domain/oauth.py
@@ -15,7 +15,7 @@ from typing import Any, MutableMapping, Optional
 
 from ..harness import HARNESSES
 from .ids import make_run_id
-from .run import Run
+from .run import Run, utcnow
 
 log = logging.getLogger("devcake.oauth")
 
@@ -96,8 +96,24 @@ class OAuthManager:
         secrets_store.write_credential_file(
             s["dev_type"], s["secret_file"], payload["content"])
         s["state"] = "completed"
-        run.state = "finished"
-        self.runs.store.save(run)
+        # Terminal-ize ONLY a still-active run. A credential can land after
+        # the watchdog's 660 s kill (a slow human on the device-code page) or
+        # an operator stop — the credential is still stored above (the login
+        # DID succeed), but the run record's history is not rewritten: before
+        # this guard, a late oauth.result flipped a timed_out run back to
+        # "finished" while racing the kill's own save. And stamp ended_at:
+        # this was the ONE terminal transition in the codebase that omitted
+        # it, so every successful OAuth login's runtime grew forever in the
+        # Runs tab ((ended_at or now) - started_at, repriced every poll) and
+        # ranked as the longest run in history under the duration sort.
+        if run.state in ("dispatched", "running"):
+            run.state = "finished"
+            run.ended_at = utcnow()
+            self.runs.store.save(run)
+        else:
+            log.info("oauth: credential for %s landed after run %s already "
+                     "terminalled (%s) — record left as-is",
+                     s["dev_type"], run_id, run.state)
         await self.messaging.delete_run_user(run_id)
         await self.messaging.delete_reply_stream(run_id)
         # ADR-0025 Hook D: OAuth completion bypasses finalize AND kill, so

--- a/app/tests/test_oauth.py
+++ b/app/tests/test_oauth.py
@@ -101,3 +101,40 @@ def test_result_cleans_run_workspace(tmp_path, monkeypatch):
     run_id = run_coro(mgr._start_inner("main-dev"))["run_id"]
     run_coro(mgr._on_result_inner(run_id, {"content": "{}"}))
     assert cleaned == [run_id]
+
+
+def test_result_stamps_ended_at(tmp_path, monkeypatch):
+    """2026-08 reviewer catch: the OAuth success path was the ONE terminal
+    transition in the codebase that omitted ended_at, so every successful
+    login's runtime grew monotonically forever in the Runs tab
+    ((ended_at or now) - started_at, repriced on every 10 s poll) and
+    permanently topped the duration sort."""
+    mgr = make_mgr(tmp_path, monkeypatch)
+    run_id = run_coro(mgr._start_inner("main-dev"))["run_id"]
+    run_coro(mgr._on_result_inner(run_id, {"content": "{}"}))
+    saved = mgr.runs.store.get(run_id)
+    assert saved.state == "finished"
+    assert saved.ended_at is not None
+
+
+def test_late_result_does_not_resurrect_a_terminal_run(tmp_path, monkeypatch):
+    """A credential landing AFTER the watchdog's 660 s kill (slow human on
+    the device-code page) must still be stored — the login DID succeed — but
+    the run record's history is not rewritten: pre-guard, the late
+    oauth.result flipped a timed_out run back to "finished" while racing the
+    kill's own save."""
+    mgr = make_mgr(tmp_path, monkeypatch)
+    run_id = run_coro(mgr._start_inner("main-dev"))["run_id"]
+    killed = mgr.runs.store.get(run_id)
+    killed.state = "timed_out"
+    from devcake.domain.run import utcnow
+    killed.ended_at = utcnow()
+    mgr.runs.store.save(killed)
+
+    run_coro(mgr._on_result_inner(run_id, {"content": '{"late": 1}'}))
+    p = tmp_path / "secrets" / "main-dev" / "grok-auth.json"
+    assert p.read_text() == '{"late": 1}'          # credential still lands
+    assert mgr.sessions[run_id]["state"] == "completed"
+    saved = mgr.runs.store.get(run_id)
+    assert saved.state == "timed_out"              # history not rewritten
+    assert saved.ended_at == killed.ended_at


### PR DESCRIPTION
Reviewer report: "OAuth missions don't seem to finish ever — their runtime expands monotonically in the Runs tab."

**Root cause:** `OAuthManager._on_result_inner` set `run.state = "finished"` without stamping `ended_at` — the only terminal transition in the codebase that omitted it. The Runs tab computes runtime as `(ended_at or now) - started_at` and polls every 10 s, so finished OAuth runs ticked upward forever, topped the duration sort server-side, and were silently excluded from totals.

**Also fixed while here:** no terminal-state guard on the success handler — a credential arriving after the watchdog's 660 s kill flipped a `timed_out` run back to `finished` while racing the kill's own save. Now a late credential is still stored (the login did succeed; losing it would be operator-hostile) but the run record's history stands.

**Tests:** success stamps `ended_at`; late-credential-after-kill stores the credential, leaves the record terminal. Existing stuck records on disk are advisory state (docs/10 §5) — Clear Runs retires them; no migration.

Full suite green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)