### PR TITLE
feat(spa): Limits & Traffic regroup — four story-grouped cards, auto-restart row deleted

### DIFF
--- a/admin/spa/src/components/LimitsSection.jsx
+++ b/admin/spa/src/components/LimitsSection.jsx
@@ -18,14 +18,21 @@ const ATTEMPT_RESET_DESC = {
     "Never gives up — DevCake retries failed steps indefinitely and warns about cost.",
 };
 
+// 2026-08 reviewer round: one 11-row scroll became four story-grouped
+// sections — what bounds the fleet, what burns attempts, what rescues a
+// result-less run, and how source mirrors stay fresh. Same knobs, same
+// fields, same route (#/config/limits); the informational "Service
+// auto-restart" row is gone (it was a knob-shaped non-knob — the restart
+// policy is compose's, documented in docs/13).
 export default function LimitsSection() {
   const { dr } = useSharedDraft();
   const cfg = dr.draft.cfg;
   const setField = dr.setField;
 
   return (
-      <Section id="limits" title="Limits"
-        description="Global concurrency and safety ceilings.">
+    <>
+      <Section id="limits" title="Concurrency & timeouts"
+        description="What bounds the Dev fleet at any moment.">
         <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
           <SettingRow label="Global max Devs"
             desc="Effective ceiling = min(global, Σ per-type caps)."
@@ -41,6 +48,12 @@ export default function LimitsSection() {
               aria-label="Dev run timeout (minutes)"
               onChange={(e) => setField("cfg.dev_timeout_minutes", Number(e.target.value))} />
           </SettingRow>
+        </div>
+      </Section>
+
+      <Section id="limits-attempts" title="Attempts & retries"
+        description="What burns a step's attempts, what grants fresh ones, and when DevCake warns.">
+        <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
           <SettingRow label="Attempt reset"
             desc={ATTEMPT_RESET_DESC[cfg.attempt_reset] || `${cfg.attempt_reset} (set via API)`}
             help="A DevCake idiosyncrasy worth understanding: each pipeline step retries up to the attempt limit, and certain events grant FRESH attempts — the count restarts. Removing DEVCAKE-FAILED and a later step finishing always reset. What else resets is this policy. Strict (default): only a comment containing the literal DEVCAKE-RETRY — the deliberate human gesture. Any comment: every non-DevCake comment resets, which reads naturally ('a human intervened') but lets a chatty integration (a Linear↔GitHub sync bot, a CI notifier) keep the counter at 1 forever — the mission then never fails AND never stops, retrying at token cost indefinitely. Unlimited: DevCake never applies DEVCAKE-FAILED at all — an explicit choice for self-hosted models where retries cost watts, not dollars; a cumulative-cost warning posts to the mission feed at the review-loop cadence so the mode stays loud. DEVCAKE-SKIP always stops a mission regardless of policy.">
@@ -77,6 +90,12 @@ export default function LimitsSection() {
               aria-label="Review-loop warning every N rejections"
               onChange={(e) => setField("cfg.review_loop_warning_every", Number(e.target.value))} />
           </SettingRow>
+        </div>
+      </Section>
+
+      <Section id="limits-recovery" title="Result recovery"
+        description="What happens when a run ends without its result file.">
+        <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
           <SettingRow label="Accept misplaced result files"
             desc={cfg.recover_misplaced_result
               ? "ON — a result file written elsewhere in the workspace still counts."
@@ -116,11 +135,17 @@ export default function LimitsSection() {
               aria-label="Max continuations per run"
               onChange={(e) => setField("cfg.max_continuations", Number(e.target.value))} />
           </SettingRow>
+        </div>
+      </Section>
+
+      <Section id="limits-mirrors" title="Repository mirrors"
+        description="How the app-maintained source mirrors stay fresh.">
+        <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
           <SettingRow label="Mirror sync max age"
             desc={Number(cfg.repo_mirror?.sync_max_age_seconds) === 0
               ? "0 — mirrors sync before every dispatch."
               : `Mirrors synced within ${cfg.repo_mirror?.sync_max_age_seconds}s count as fresh.`}
-            help="Every configured repository is served to Devs from an app-maintained mirror (mandatory — there is no off switch). A successful sync is a fail-closed precondition: a mission whose mirrors cannot be freshened does not dispatch that cycle and retries on the next poll. 0 (default) syncs before every dispatch; a higher value reduces forge requests between rapid-fire mission steps at the cost of bounded staleness.">
+            help="Every configured repository is served to Devs from an app-maintained mirror. A successful sync is a fail-closed precondition: a mission whose mirrors cannot be freshened does not dispatch that cycle and retries on the next poll. 0 (default) syncs before every dispatch; a higher value reduces forge requests between rapid-fire mission steps at the cost of bounded staleness.">
             <Input type="number" className="w-24" min={0}
               value={cfg.repo_mirror?.sync_max_age_seconds ?? 0}
               aria-label="Mirror sync max age (seconds)"
@@ -135,12 +160,8 @@ export default function LimitsSection() {
               label="Mirror LFS content"
               onClick={() => setField("cfg.repo_mirror.lfs", !cfg.repo_mirror?.lfs)} />
           </SettingRow>
-          <SettingRow label="Service auto-restart"
-            desc="Long-lived services restart unless stopped (compose-managed)."
-            help='Services use restart: unless-stopped in docker-compose.yml. This panel cannot rewrite compose — set restart: "no" in the file to disable.'>
-            <span className="text-sm text-neutral-500 dark:text-neutral-400">managed in compose</span>
-          </SettingRow>
         </div>
       </Section>
+    </>
   );
 }

--- a/admin/spa/tests/settings.mjs
+++ b/admin/spa/tests/settings.mjs
@@ -50,6 +50,19 @@ await withPage(async (page) => {
     await page.locator("#limits").count() === 1 &&
     await page.locator("#traffic").count() === 1 &&
     await page.locator("#dev-types").count() === 0);
+  // 2026-08 reviewer round: the one 11-row scroll became four story-grouped
+  // cards; the knob-shaped non-knob ("Service auto-restart" / "managed in
+  // compose") is gone; the mirror help no longer scolds about the off switch
+  check("Limits view renders the four story-grouped cards",
+    await page.locator("#limits").count() === 1 &&
+    await page.locator("#limits-attempts").count() === 1 &&
+    await page.locator("#limits-recovery").count() === 1 &&
+    await page.locator("#limits-mirrors").count() === 1);
+  check("the Service auto-restart informational row is gone",
+    (await page.locator("text=managed in compose").count()) === 0 &&
+    (await page.locator("text=Service auto-restart").count()) === 0);
+  check("mirror help no longer says 'no off switch'",
+    (await page.locator("text=there is no off switch").count()) === 0);
 
   // 4b: ADR-0026 spend-discipline rows render with explainer help and the
   // shipped defaults (strict reset, brake off) — the nuance lives in `help`,

--- a/docs/11-admin-panel.md
+++ b/docs/11-admin-panel.md
@@ -242,6 +242,11 @@ Named snapshots of the runtime settings AND secret values (ADR-0013). **Entirely
 Mission-type **playbook templates** (`GET/PUT/DELETE /prompt-templates/{TYPE}/{name}`) and per-Dev-Type **identifying-prompt templates** (`/devtype-prompts/{dev}/{name}`). Template create/edit/delete is **Immediate** (own Save in the modal); only the **active** selection per mission type / Dev Type rides the unified config draft (`active_prompt_templates` / `active_devtype_prompts`). Missing actives fall back to the built-in default; unresolved actives surface as `prompt_template_warnings` on `/health`. **View** uses the same **Rendered** / **Source** dialog as Skills (Markdown reading aid; unsubstituted `{var}` placeholders; Source is the stored template).
 
 ### Limits (rendered inside Limits & Traffic, above the Traffic card)
+
+Four story-grouped cards since the 2026-08 reviewer round (same knobs, same
+fields, same route): **Concurrency & timeouts**, **Attempts & retries**,
+**Result recovery**, **Repository mirrors**.
+
 - **Global max Devs** integer (help text: effective ceiling = min(global, sum of per-type caps)).
 - **Dev run timeout** minutes (default 120).
 - **Review-loop warning** cadence (every N rejections; also the cadence of the `unlimited` attempt-reset warning below).
@@ -251,7 +256,7 @@ Mission-type **playbook templates** (`GET/PUT/DELETE /prompt-templates/{TYPE}/{n
 - **Continuation policy** select (ADR-0022, `continuation_policy`): Auto / Resume only / Fresh only / Off; the help text states that resume-only fails as before when resume is unavailable and that plan runs never continue.
 - **Max continuations per run** integer (ADR-0022, `max_continuations`, default 2, `0` = off, no upper bound): the help text names the two operator-relevant facts — the budget is the ONLY terminator (stalls escalate resume→fresh, never stop), and each relaunch resets the harness's own `--max-turns` (effective turn budget = (budget + 1) × max-turns).
 - **Mirror sync max age** seconds (ADR-0024, `repo_mirror.sync_max_age_seconds`, default 0 = every dispatch) and **Mirror LFS content** toggle (`repo_mirror.lfs`, default off). The mirror itself is mandatory — these only tune it; the help text states the fail-closed dispatch gate.
-- Service auto-restart is compose-managed (read-only note). **`max_attempts` is a config field** (`config.yaml` / `PUT /config`) but is **not** exposed on the Limits UI today — edit via API/YAML or leave the default 3.
+- **`max_attempts` is a config field** (`config.yaml` / `PUT /config`) but is **not** exposed on the Limits UI today — edit via API/YAML or leave the default 3. (The old "Service auto-restart" read-only row is gone — a knob-shaped non-knob; container restart policy is compose's, `13-deployment.md` §1.)
 
 ## 4. Runs page
 

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -14,7 +14,9 @@ Bake builds images; Compose runs the stack only (never builds `devcake/*`).
 ## 1. Service names, volumes, network (normative — these are DNS names other docs reference)
 
 - Services: `app`, `dagu`, `redis`, `openobserve`, `admin`, `otel-collector`,
-  `fluentbit`, `gitea` (internal fallback forge).
+  `fluentbit`, `gitea` (internal fallback forge). Long-lived services carry
+  `restart: unless-stopped` in compose — a compose fact, not an app knob
+  (there is deliberately no UI control for it).
 - Volumes: `devcake_data` (→ `app:/data` — **secrets + config + state**),
   `devcake_mirrors` (→ `app:/mirrors` rw + the Dev **provision** container
   `:ro` — ADR-0024 source mirrors; DISPOSABLE cache, excluded from backups,


### PR DESCRIPTION
Reviewer round, three of the nine items:

1. **Limits & Traffic reorganized** — the 11-row scroll becomes four story-grouped `Section` cards: *Concurrency & timeouts* (global max Devs, run timeout), *Attempts & retries* (attempt reset, bad-output brake, review-loop warning), *Result recovery* (misplaced results, continuation policy + budget), *Repository mirrors* (sync max age, LFS). Same knobs, same draft fields, same route; the Traffic card (breakdown depth + Relations Mapper) follows unchanged.
2. **"Service auto-restart" row deleted** — it was a knob-shaped non-knob (a grey "managed in compose" span; the panel cannot rewrite docker-compose.yml, and a switch that switches nothing is the honesty-as-theater pattern the evaluation dinged). The fact moves to docs/13 §1.
3. **Mirror sync copy softened** — the "(mandatory — there is no off switch)" parenthetical is gone from the UI; the mandatory doctrine stays in docs/ADR-0024.

UI suite: settings.mjs +3 checks (cards render, row gone, copy gone); full suite green (211 checks). docs/11 updated (zero-drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)