### PR TITLE
deliver: mark + reword the deliverable-zip feed note

### DIFF
--- a/app/devcake/domain/orchestrator/deliver.py
+++ b/app/devcake/domain/orchestrator/deliver.py
@@ -19,6 +19,7 @@ import zipfile
 
 from ...ports.forge import PRFile, run_branch
 from . import feed
+from .markers import DELIVERABLE_MARKER
 
 log = logging.getLogger("devcake.deliver")
 
@@ -95,8 +96,11 @@ async def _deliver_core(mgr, repo_ref, mission_key, pmo_id, pmo_kind, pr
         name = f"{mission_key}-deliverable.zip"
         url = await mgr.pmo.upload_attachment(pmo_id, name, zip_bytes)
         is_internal = repo_ref in mgr.forges.internal
-        note = (f"📦 Deliverable attached: {len(files) - len(omitted)} file(s) "
-                f"from the approved merge — [{name}]({url}).")
+        note = (f"{DELIVERABLE_MARKER}\n"
+                f"📦 For the record: archived the merged change set — "
+                f"{len(files) - len(omitted)} file(s) in [{name}]({url}), "
+                f"attached to this issue. This zip is the audit copy, not "
+                f"the answer.")
         if not is_internal:
             note += (f" Snapshot of the merged change set; the forge PR is "
                      f"canonical: {state.url}.")
@@ -113,6 +117,7 @@ async def _deliver_core(mgr, repo_ref, mission_key, pmo_id, pmo_kind, pr
         try:
             await mgr._feed(
                 pmo_id, pmo_kind,
+                f"{DELIVERABLE_MARKER}\n"
                 "⚠️ Deliverable packaging failed — the merged files remain "
                 f"available in the repository ({repo_ref}).")
         except Exception:

--- a/app/devcake/domain/orchestrator/markers.py
+++ b/app/devcake/domain/orchestrator/markers.py
@@ -66,6 +66,12 @@ FEED_INLINE_MAX = 2048
 # back into the thread.
 REPLY_MARKER = "<!-- DEVCAKE-REPLY -->"
 
+# The deliverable-zip feed note, marked so the concierge can classify it as
+# bookkeeping instead of scraping it into Slack as the mission's "Findings" —
+# which is exactly how users ended up shown an auth-walled zip link as the
+# answer. Same startswith contract as REPLY_MARKER.
+DELIVERABLE_MARKER = "<!-- DEVCAKE-DELIVERABLE -->"
+
 # docs/03 §4.1 — merge-failure state markers, counted/located from the feed
 # so the state stays fully PMO-derivable (no local clocks or counters). The
 # comments carrying them are short by construction (< FEED_INLINE_MAX): the

--- a/app/tests/test_repo_routing.py
+++ b/app/tests/test_repo_routing.py
@@ -12,6 +12,7 @@ from devcake.domain.repo_routing import (REASON_ZERO_REPO, marker_repo,
                                          resolve_repo)
 from devcake.domain.run import Run
 from devcake.domain.orchestrator import dispatch, sweeps
+from devcake.domain.orchestrator.markers import DELIVERABLE_MARKER
 
 
 def run_coro(c):
@@ -431,7 +432,7 @@ def test_internal_zip_delivery(tmp_path, monkeypatch):
     assert "report/REPORT.md" in names and "report/data.bin" in names
     assert "gone.txt" not in names                 # removed files excluded
     assert z.read("report/data.bin") == b"\x00\x01\x02"   # binary intact
-    assert any("Deliverable attached" in f for f in feed)
+    assert any(DELIVERABLE_MARKER in f for f in feed)
     assert "deliver:zip" in run.finalized_steps    # idempotency recorded
     # idempotent: a second call does nothing
     uploaded.clear()
@@ -496,7 +497,7 @@ def test_mission_zip_delivery_ignores_quoted_deliverable_marker(tmp_path):
         tmp_path, "> attaching `T-1-deliverable.zip` next\n`devcake:v1`")
     run_coro(mgr.deliver_internal_zip_for_mission(m, pr))
     assert "T-1-deliverable.zip" in uploaded
-    assert any("Deliverable attached" in f for f in feed)
+    assert any(DELIVERABLE_MARKER in f for f in feed)
 
 
 def test_mission_zip_delivery_skips_on_unquoted_marker(tmp_path):
@@ -573,7 +574,7 @@ def test_external_zip_delivery_gated_by_toggle(tmp_path):
     run_coro(mgr.deliver_internal_zip(run, pr))
     assert "T-1-deliverable.zip" in uploaded
     assert "deliver:zip" in run.finalized_steps
-    assert any("Deliverable attached" in f for f in feed)
+    assert any(DELIVERABLE_MARKER in f for f in feed)
 
 
 def test_external_mission_zip_respects_toggle(tmp_path):
@@ -742,3 +743,16 @@ def test_reference_repos_all_stages_and_never_work_targets(tmp_path, monkeypatch
     out = execute_prompt("ID", m, "a", "pr {branch}", reference_repos=note)
     assert "Reference repositories (read-only)" in out
     assert "Reference repositories" in plan_prompt("ID", m, reference_repos=note)
+
+
+def test_deliverable_note_is_marked_and_honest(tmp_path):
+    """The feed note opens with DELIVERABLE_MARKER (concierge classifies on
+    startswith) and says what the zip IS — the audit copy — so no reader,
+    human or bot, mistakes it for the mission's answer."""
+    mgr, uploaded, feed, m, pr = _mission_delivery_setup(
+        tmp_path, "unrelated earlier comment")
+    run_coro(mgr.deliver_internal_zip_for_mission(m, pr))
+    note = next(f for f in feed if DELIVERABLE_MARKER in f)
+    assert note.startswith(DELIVERABLE_MARKER)
+    assert "T-1-deliverable.zip" in note
+    assert "audit copy, not the answer" in note


### PR DESCRIPTION
## What

Stacked on #105. The deliverable-zip feed note now opens with `<!-- DEVCAKE-DELIVERABLE -->` (same startswith contract as `REPLY_MARKER`) and says what the zip is: "the audit copy, not the answer". The packaging-failure note carries the marker too. The zip filename stays in the unquoted body, so the merge-sweep idempotency probe is unchanged.

## Why

The concierge was scraping this note into Slack as the mission's "Findings" — users were shown an unclickable, Linear-auth-walled zip link as the result. The concierge classifies both the marked and the legacy wording (mixed fleet versions are safe, deploy order doesn't matter), but the marker makes it deterministic forever.

## Verification

`tests/test_repo_routing.py` extended (marker present, first line, honest copy; 21 passed) — full container suite 1121 passed / 0 failed with redis attached (see #107 for making that the default local experience). Consumer: devcake-concierge MR !11.
