### PR TITLE
pytest_app.sh: throwaway redis when the compose stack is down

### DIFF
--- a/scripts/pytest_app.sh
+++ b/scripts/pytest_app.sh
@@ -5,8 +5,11 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-# Optional Redis for live messaging tests (compose network). If the network
-# is missing, pytest still runs; live-redis tests skip or fail on connection.
+# Redis for the live messaging tests (test_messaging_live.py — 14 tests that
+# otherwise fail on ConnectionError). Preference order:
+#   1. the compose network's redis when the stack is up (devcake_control);
+#   2. a throwaway redis on a scratch network, exactly like ci.yml runs it,
+#      torn down on exit. A cold machine gets the same green as CI.
 REDIS_PASSWORD="${REDIS_PASSWORD:-}"
 if [[ -f .env ]]; then
   # shellcheck disable=SC1091
@@ -22,12 +25,38 @@ docker buildx bake -f docker-bake.hcl app-test
 
 TAG="${DEVCAKE_TAG:-latest}"
 NET_ARGS=()
-ENV_ARGS=()
+ENV_ARGS=(-e "OTEL_SDK_DISABLED=true")  # no openobserve teardown noise in tests
+SCRATCH_NET="devcake-pytest"
+SCRATCH_REDIS="devcake-pytest-redis"
+# Pin matches ci.yml so local and CI grade the same redis.
+REDIS_IMAGE="redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99"
+
+cleanup() {
+  docker rm -f "${SCRATCH_REDIS}" >/dev/null 2>&1 || true
+  docker network rm "${SCRATCH_NET}" >/dev/null 2>&1 || true
+}
+
 if docker network inspect devcake_control >/dev/null 2>&1; then
   NET_ARGS=(--network devcake_control)
   if [[ -n "${REDIS_PASSWORD:-}" ]]; then
-    ENV_ARGS=(-e "REDIS_URL=redis://redis:6379/0" -e "REDIS_PASSWORD=${REDIS_PASSWORD}")
+    ENV_ARGS+=(-e "REDIS_URL=redis://redis:6379/0" -e "REDIS_PASSWORD=${REDIS_PASSWORD}")
   fi
+else
+  echo "── compose network absent: starting throwaway redis (as ci.yml does)"
+  trap cleanup EXIT
+  cleanup
+  docker network create "${SCRATCH_NET}" >/dev/null
+  docker run -d --name "${SCRATCH_REDIS}" --network "${SCRATCH_NET}" \
+    --network-alias redis "${REDIS_IMAGE}" \
+    redis-server --requirepass ci-redis-pass --appendonly no >/dev/null
+  for _ in $(seq 1 30); do
+    if docker exec "${SCRATCH_REDIS}" redis-cli --no-auth-warning -a ci-redis-pass ping 2>/dev/null | grep -q PONG; then
+      break
+    fi
+    sleep 1
+  done
+  NET_ARGS=(--network "${SCRATCH_NET}")
+  ENV_ARGS+=(-e "REDIS_URL=redis://redis:6379/0" -e "REDIS_PASSWORD=ci-redis-pass")
 fi
 
 echo "── pytest via devcake/app-test:${TAG}"


### PR DESCRIPTION
## What

`scripts/pytest_app.sh` starts a throwaway redis (same pinned `redis:7-alpine` as ci.yml, scratch network, torn down on exit) whenever the `devcake_control` compose network is absent, and sets `OTEL_SDK_DISABLED=true` for the test run.

## Why

On a cold machine the documented script failed 14 `test_messaging_live.py` tests with ConnectionError — they only need a redis, which CI provides but local runs didn't. The OTLP exporter's `openobserve:5080` traceback at teardown read like a test failure and wasn't one.

## Verification

Ran the modified script from a cold checkout (no compose stack): baked app-test, started redis, `1116 passed, 1 skipped, 0 failed`, scratch container and network confirmed removed afterwards.
