### PR TITLE
ci: GHA cache export degrades instead of failing the bake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           sbom: false
           set: |
             *.cache-from=type=gha,scope=devcake-ci
-            *.cache-to=type=gha,mode=max,scope=devcake-ci
+            *.cache-to=type=gha,mode=max,scope=devcake-ci,ignore-error=true
 
       - name: Assert prod app has no pytest
         run: |

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -53,7 +53,7 @@ jobs:
           sbom: false
           set: |
             *.cache-from=type=gha,scope=devcake-images
-            *.cache-to=type=gha,mode=max,scope=devcake-images
+            *.cache-to=type=gha,mode=max,scope=devcake-images,ignore-error=true
 
       - name: Smoke harness CLIs (pinned versions)
         # `sh -ec 'a && b'`: without -e (and with `;` separators) only the

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,7 +56,7 @@ jobs:
           sbom: true
           set: |
             *.cache-from=type=gha,scope=devcake-publish
-            *.cache-to=type=gha,mode=max,scope=devcake-publish
+            *.cache-to=type=gha,mode=max,scope=devcake-publish,ignore-error=true
             app.tags=${{ steps.meta.outputs.prefix }}/app:${{ steps.meta.outputs.sha }}
             app.tags=${{ steps.meta.outputs.prefix }}/app:latest
             admin.tags=${{ steps.meta.outputs.prefix }}/admin:${{ steps.meta.outputs.sha }}

--- a/docker-bake.ci.hcl
+++ b/docker-bake.ci.hcl
@@ -9,5 +9,7 @@
 
 target "_common" {
   cache-from = ["type=gha,scope=devcake"]
-  cache-to   = ["type=gha,mode=max,scope=devcake"]
+  # ignore-error: a GHA cache-service outage degrades to an uncached build
+  # instead of failing the bake (2026-08 outage kept main unverifiable).
+  cache-to   = ["type=gha,mode=max,scope=devcake,ignore-error=true"]
 }


### PR DESCRIPTION
## Why

The GitHub Actions cache-service outage (2026-08-06 onward) killed every bake with `error writing layer blob: failed to reserve cache` while the builds themselves were mid-flight and healthy — three identical failures including two retries on 2026-08-11. Result: **main has been unverifiable since 5330e9e** (the three flow-campaign merges have no green CI).

Cache *export* is a convenience, not a correctness surface. Per the fail-closed-where-it-matters / degrade-where-it-doesn't doctrine, a cache outage should cost a slower uncached build, not a red CI that blocks verification of merges.

## What

Append `ignore-error=true` to the `*.cache-to=type=gha,...` line in all three lanes (`ci.yml`, `docker-images.yml`, `docker-publish.yml`) and in `docker-bake.ci.hcl` (the local CI overlay). `cache-from` untouched — read misses were already non-fatal.

## Evidence

This PR's own CI run is the live proof: the bake must sail past the exact step that has died three times with the same signature. If GitHub's cache backend has recovered meanwhile, the run is still the harmless-path proof (flag present, export succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)