### PR TITLE
docs: identity + honesty pass — name settled, meta-harness, clean room, field evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ handles configuration and operations.
 > and whether the **app** may auto-merge after REVIEW. Full contract:
 > [`docs/14-security.md`](docs/14-security.md).
 
-Product voice and pitch variants: [`docs/17-positioning.md`](docs/17-positioning.md)
-(*name is provisional* — §6).
+Product voice and pitch variants: [`docs/17-positioning.md`](docs/17-positioning.md).
 
 ---
 
@@ -33,19 +32,24 @@ Product voice and pitch variants: [`docs/17-positioning.md`](docs/17-positioning
 The deepest AI-assisted work today happens in CLI harnesses — Claude Code,
 Grok Build, Codex — with an expert invisibly orchestrating each session:
 curating context, sizing the task, sequencing the work, verifying the output.
-DevCake mechanizes that orchestration for board-shaped work. It is not a new
-coding agent; it is a session made repeatable, without the expert chained to
-the keyboard.
+DevCake mechanizes that orchestration for board-shaped work. It is a
+**meta-harness** — a CLI agent orchestrator that staffs those harnesses rather
+than competing with them: not a new coding agent, but a session made
+repeatable, without the expert chained to the keyboard.
 
 The method is context hygiene, engineered: one clear goal per session, tasks
 decomposed until they fit, fresh containers, curated read-only mounts of
 exactly the relevant prior work, feedback at step boundaries — never
 interruption inside one. We call it putting AI to work in a state of flow,
-and we treat the conditions for it as a design target, not a hope.
+and we treat the conditions for it as a design target, not a hope. In one
+phrase: **the clean room for delegated deep work** — as capability gets
+cheap, the scarce thing is accountability, and the envelope supplies it,
+domain-free ([`docs/17-positioning.md`](docs/17-positioning.md) §1c).
 
-We believe this works; we have not yet proven it. The mechanisms are built
-and tested; the results so far are our own use. The full argument — its
-evidence status stated claim by claim, and what would change our mind — is
+We believe this works; we have not yet proven it publicly. The mechanisms are
+built and tested; the evidence so far is our own production use, self-reported
+([`docs/16-roadmap.md`](docs/16-roadmap.md), living log). The full argument —
+its evidence status stated claim by claim, and what would change our mind — is
 [`docs/19-thesis.md`](docs/19-thesis.md).
 
 ---

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -1,15 +1,22 @@
 # 00 — Overview: Vision, Glossary, and Core Invariants
 
 > **Audience:** everyone. Every other document in `docs/` assumes you have read this one.
-> **Status:** technical preview.
+> **Status:** early production (dedicated host). Field evidence to date is
+> operator-self-reported ([`16-roadmap.md`](16-roadmap.md), living log); a
+> receipted public evidence run gates v1. Packaging is single-operator
+> self-host — not multi-tenant GA.
 > **Security:** the product security contract lives in [`14-security.md`](14-security.md) — this file must not claim a stronger posture.
 
 ## 1. What DevCake is
 
-DevCake is a **CLI agent orchestrator** for automating ticket resolutions, designed for a
+DevCake is a **meta-harness** — a CLI agent orchestrator for automating
+ticket resolutions — designed for a
 **single operator on a dedicated host**. It runs automated coding agents
 ("**Devs**") inside Docker containers that systematically resolve work items
 ("**Missions**") pulled from a project-management system ("**PMO System**"). Devs are scheduled through [Dagu](https://docs.dagu.sh), talk back to the main app through Redis Streams and a Gitea internal server, and telemetry lands in OpenObserve.
+The CLI coding agents it runs (Claude Code, Grok Build, Codex) are the
+**harnesses**; DevCake is the envelope that staffs, sequences, isolates, and
+accounts for their sessions — it is not itself a CLI coding agent.
 
 **Deployment premise:** one machine you control; host `docker.sock` on Dagu;
 admin + secrets ≅ host trust. Not multi-tenant SaaS. Ticket writers and repo
@@ -61,6 +68,7 @@ The following are explicitly **out of scope** (see also `14-security.md` and
 | **Dev** | An ephemeral Docker container running a Dev Type's selected model through its harness CLI to perform one Mission Step, then exit. |
 | **Dev Type** | A named configuration: harness template + model selection + identifying prompt + MCP servers + credentials + concurrency cap + optional domain skills. v0 seeds three role vehicles: **judgment** (Claude Fable / Claude Code — ONBOARD/PLAN/REVIEW), **implementer** (Grok 4.5 / Grok Build — EXECUTE), and **steward** (Claude Haiku / Claude Code — Relations Steward default). The model belongs to the Dev Type; multiple Dev Types may share one harness. |
 | **Harness Template** | One of three registry-backed runtime adapters: `claude-code`, `grok-build`, or `codex`. A template selects the CLI image, credential/OAuth contract, invocation and artifact parsing, and skills directory — not a fixed model. `DevType.model` selects the model; empty uses the registry or CLI default. Specified in `08-harness-templates.md`. |
+| **Meta-harness** | What DevCake is: the outer envelope that staffs, sequences, isolates, and accounts for harness sessions as board-shaped Missions. The harnesses (Claude Code, Grok Build, Codex) are the workers; DevCake is not itself a CLI coding agent. |
 | **PMO System** | The external project-management system holding the Missions. Adapters are pluggable (registered in `adapters/registry.py`); in-tree: **Linear** and **Gitea Issues**. A stack may configure **0..N** PMO instances; **each instance is scoped to exactly one team** (Linear team key, or Gitea `owner/repo` board). Accessed only through the `PMOPort` adapter (`05-pmo-adapter.md`). |
 | **Forge** | The code-hosting platform holding the configured repository: GitHub, GitLab, or Gitea (including the bundled internal Gitea for zero-repo missions). Accessed only through the `ForgePort` adapter (`06-forge-adapter.md`). |
 | **Run** | The locally persisted record of one Mission Step attempt: telemetry, timing, outcome, token report. Advisory data only — never authoritative (see INV-1). |

--- a/docs/08-harness-templates.md
+++ b/docs/08-harness-templates.md
@@ -6,7 +6,9 @@
 > locations named in §9.
 > **Depends on:** `07-dev-runtime.md` (container contract), `02-domain-model.md` (DevType, TokenReport).
 
-A **harness template** describes how one CLI runs inside a Dev container:
+A **harness template** describes how one CLI runs inside a Dev container —
+these are the *inner* model harnesses that the DevCake meta-harness staffs
+(`00-overview.md` §3):
 image, credentials, invocation, artifact parsing, OAuth, and skills delivery.
 It does **not** own a fixed model. Exactly three templates exist as entries in
 the harness registry (`app/devcake/harness.py`, `HARNESSES` — §2). Adding a

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -346,12 +346,19 @@ continuation of “since v0.1” (that window is closed in Layer 2).
 | Subsection | What it is |
 |---|---|
 | **Shipped after v0.2** | Chronological log of merges on `main` after the closed cut |
+| **Field evidence (self-reported)** | Production use reported by the operator — evidence class stated, deploy pinned |
 | **Still open** | Residuals / demos still owed from Layers 1–2 — not new features |
 | **Candidates** | Design we may invest in; **not** an ordered sprint queue |
 | **Deferred / Discarded** | Longer-term or rejected ideas |
 
 Honesty rule: a feature is not *done* until the live box proves it (status
 vocabulary at the top of this file).
+
+Versioning doctrine: below v1 the project carries **no backwards/legacy-compat
+obligation** — an upgrade may require a wipe-and-re-onboard instead of a
+migration. v1 is gated on a **pre-registered, receipted evidence run on public
+material**, executed on the release candidate and reported in these docs;
+until that run exists, field evidence below stays operator-self-reported.
 
 ### Shipped after v0.2
 
@@ -509,19 +516,98 @@ vocabulary at the top of this file).
     **AUD-020** (hard-coded `devcake_mirrors` volume name — doc warning
     only), **AUD-022** (no Dev cgroup HostConfig — docs/14 §11 debt).
 
+- **Post-evaluation campaigns** (2026-08-04…06, PRs #88–#112): docs truth
+  sweep + the six architecture cleanups (#88–#89); ingress consumer survives
+  a Redis restart (#90); **ADR-0027 failure taxonomy as data** (#91);
+  **ADR-0029 TokenReport v1 + SQL-readiness** (#92); **ADR-0028
+  composition-root factory** (#93); OAuth success stamps `ended_at` and never
+  resurrects a terminal run (#94); harness-CLI + infra pin bumps (#95–#96);
+  the SPA overhaul and **ADR-0030 default board + New Mission composer**
+  (#97–#103); control-plane auth/backup/CI hardening (#104); the
+  REPLY/DELIVERABLE marker generalization — core names no downstream
+  environment (#105/#108); **ADR-0031 phase 1 — the Freshness Gate** on
+  REVIEW's context-closing finalize (#109); **ADR-0032 mission handoff
+  notes** — the closing narrative flows with the graph (#112); the
+  **MAPPER → STEWARD rename** with persisted-state migrations (#111).
+  **built** — hermetic suite green; these merges landed during the 2026-08
+  GHA cache-service outage, so CI re-verification came only with the
+  cache-export resilience fix (#113, `ignore-error=true` on `type=gha`
+  cache-to across all three lanes); the live stack has **not** yet been
+  redeployed onto them (R9 ritual + image rebake owed).
+- **Discovery routing: designed, not shipped.** ADR-0031's elevated-marker
+  seam ships deliberately empty (`ELEVATED_MARKERS = []` — nothing is
+  elevated implicitly), and STEWARD's only duty is proposing missing
+  `blocked_by` edges (ADR-0007). No code reads, collects, or routes a
+  `DISCOVERY.md` today. This is a **different lane** from HANDOFF notes
+  (ADR-0032, shipped): a handoff closes a *finished* mission's narrative for
+  graph-ordered readers; discovery routing would push *mid-work* findings to
+  downstream/sibling missions. STEWARD finalization + discovery routing is
+  the next planned code work — it graduates only with red→green tests at the
+  public seam plus a live multi-mission smoke.
+
+### Field evidence (operator-self-reported)
+
+Production use reported by the founder-operator, 2026-08. Evidence class:
+**self-reported** — the work substrates are proprietary, so no receipts are
+published; shapes only, no invented metrics. Each picture is pinned to the
+deploy that ran it, and none of it credits ADRs merged after that deploy.
+
+- **Multirepo legacy delivery** (deploy: **v0.3** `df08c9a`; Linear + GitLab;
+  ~20-hour composed run): a ~500k-line legacy multirepo product took a
+  brand-new customer-facing feature from scratch — one Linear project
+  decomposed into eight issues, each routed to its own work repo (the 0-or-1
+  rule, not N repos per mission), with merge requests opened on three GitLab
+  repositories. Staffing: Claude Code (Fable) on ONBOARD/PLAN/REVIEW, Grok
+  Build (Grok 4.5) on EXECUTE. Outcome: end-to-end delivery; not green on
+  first merge — the follow-up adaptations needed were genuinely small.
+- **Dual-board multi-PMO production** (same deploy and window): two Linear
+  teams as two PMO instances on one stack — Development carried the multirepo
+  delivery while Customer Success ran deep research on point customer tasks.
+  Operator judgment: stable under concurrent dual-team production use. This
+  is multi-instance on one dedicated host, not multi-tenant SaaS; the
+  colliding-identifier completion below stays open.
+- **Limited model + Gitea Issues corpus run** (deploy: **v0.2.5** `d3361f2`,
+  post-ADR-0018 fault-classification hardening — before ADR-0026/0027
+  existed): a local stack pointed the Grok Build harness at **Qwen3.6-27B**
+  on a local vLLM OpenAI-compatible endpoint (`08` §8) and worked a **Gitea
+  Issues** board over a large messy text corpus (~150 folders / ~3k files /
+  ~2M lines of *input* material), extracting dialogue snippets. Run errors
+  still occur and stay localized; fault classification and re-dispatch kept
+  the loop productive. Operator judgment: works uncannily well for similar
+  tasks on limited models and experimented harness pairings — field comfort
+  with the recovery envelope, not a claim of zero failures or universal
+  model support.
+
+What these do **not** claim: injection-proofness (`14` §3); multi-tenancy;
+zero harness failures; that every local model works; a controlled comparison
+against bare CLI sessions (`19` §7); or anything about features merged after
+the pinned deploys (ADR-0026/0027, the freshness gate, and handoff notes
+among them).
+
 ### Still open (residuals)
 
 Not new features — demos or proofs still owed from Layers 1–2 (milestones or
 the v0.2 trailer list).
 
-- **M9 additivity proof** (two Linear instances on one DevCake, full colliding-
-  id completion): architecture and hermetic tests done; live dual-team /
-  dual-key proof still **⏳** (sandbox plan limits / founder credentials).
+- **M9 additivity residuals**: dual-Linear production use is field-reported
+  (Field evidence above) — the operational proof is no longer owed. Still
+  open, specifically: a deliberate **colliding-identifier completion** across
+  two instances (instance-prefixed branches, end to end) and the
+  dual-workspace / dual-key sandbox ceremony. **⏳**
 - **M10 live two-forge merged-PR demo** and **M11/M12 full live model golden
   paths** on the operator's box: machinery proven hermetically + contract
-  batteries; full token-spending demos remain **⏳** when credentials allow.
+  batteries; live GitLab MRs are field-reported (Field evidence above),
+  but the two-forges-in-one-instance demo and the token-spending golden
+  paths remain **⏳**.
 - **Fresh-`/data` operator-drill re-run** after the post-v0.2 surface growth
-  (profiles, skills, Gitea Issues, per-PMO intake): **⏳** non-gating trailer.
+  (profiles, skills, Gitea Issues, per-PMO intake, default board, composer,
+  freshness, handoff): **⏳** non-gating trailer. Dual-team production and
+  the corpus run do **not** substitute for the wipe-and-reconfigure
+  stranger-operability ritual.
+- **Field-evidence detail pass**: the pictures above are shape-only pending
+  founder decisions on publishable detail (mission keys / MR numbers, exact
+  dual-Linear topology, quotable numbers) and the field-derived host-sizing
+  guidance for `13`/`18`. **⏳**
 
 ---
 
@@ -710,9 +796,16 @@ long-lived incomplete dialect API.
   `POST /secrets/clear` call `reload_connections` without `poll_rt.lock`, so
   a suspended poll cycle can still resume against a swapped adapter graph;
   config PUT and profile apply hold the lock since PR #104) ·
+  **`dispatch.py` vertical split** (`domain/orchestrator/dispatch.py` is the
+  ~1k-LOC gravity well left after the façade removal; split at public seams,
+  tests at the seams only) ·
   **conftest.py / event-loop test hygiene** (module-import loop ownership) ·
   **`${VAR:-default}`-guarded volume name in dev-run.yaml** (AUD-020 —
   verify Dagu expansion support first; see the #87 lesson).
+- **Local-backend operator recipe** — distill the field-exercised Qwen/vLLM +
+  Grok Build pairing (`08` §8, Field evidence above) into a reproducible
+  operator page: secret env, base URL, model string, known footguns. An
+  experimented pairing made repeatable — not a supported-matrix claim.
 - **Webhook ingestion** — PMO `watch()` / webhook `ChangeEvent` seam replacing
   polling (+ tunnel guide). Multi-PMO multiplies poll cost; strong candidate
   among deferred items, independent of any harness-platform work.

--- a/docs/17-positioning.md
+++ b/docs/17-positioning.md
@@ -3,12 +3,18 @@
 > **Audience:** anyone writing outward-facing words about this project — README,
 > website, pitch, launch post. The README is the applied version of this doc;
 > the full argument it compresses is [`19-thesis.md`](19-thesis.md).
-> **Status:** adopted at v0 close; motto and fit criteria revised 2026-07-18
-> (pre-v0.2) — §1, §1b. **Aligned with the product security contract**
+> **Status:** adopted at v0 close; last revised 2026-08-11 — §1, §1c, §6.
+> **Aligned with the product security contract**
 > in [`14-security.md`](14-security.md). Outward copy must not claim a stronger
-> posture than `14`. The product name is **provisional** (§6).
+> posture than `14`.
 
 ## 1. The core insight
+
+DevCake is a **meta-harness** — a CLI agent orchestrator. It does not replace
+Claude Code, Grok Build, or Codex; it **staffs** them. Those tools are model
+harnesses: one session between a model and its tools. DevCake is the outer
+envelope that turns board work into sequenced, isolated, accountable harness
+runs — swap the workers without changing the control plane.
 
 Most AI-developer products ask you to manage each task in a chat window, a
 special IDE, or someone else's work queue. DevCake keeps the **day-to-day
@@ -81,6 +87,29 @@ both lists recognizable within the first minute.
   ticket writers — ticket writers are inside the trust boundary (`14` §3).
 - You want pair programming in an editor. This is delegation, not
   companionship.
+
+### 1c. The clean room (what the envelope means)
+
+As machine workers improve, the scarce thing stops being capability and
+becomes **accountability** — specifying, checking, and accounting for work —
+and that is what the envelope supplies, domain-free. The clean-room analogy is
+precise, not decorative: fabs do not hope dust stays out; they build rooms
+that do not care which process runs inside. Contamination control, one-way
+pressure, QA-before-release, and batch records map one-to-one onto context
+contaminants, read-only valves, REVIEW, and receipts. **DevCake is the clean
+room for delegated deep work** — the meta-harness *is* the clean room; the
+inner harness is the process that runs inside it.
+
+| Clean-room concept | DevCake mechanism |
+|---|---|
+| Contamination control | Context hygiene: fresh containers, curated mounts, quoting quarantine, activity-mirror discipline (ADR-0014/0025) |
+| One-way pressure / valves | Read-only upstream context — credential scope plus instruction; the only kernel-RO mount is the provision-phase source mirror (ADR-0025) |
+| QA before release | REVIEW as an always-on pipeline stage, plus the operator/forge merge doctrine |
+| Batch records / genealogy | Transcripts, token reports, run records, feed posts, activity repos — the accountability trail (INV-5) |
+
+The analogy stops where `14` stops: a clean room for *work quality* is not a
+multi-tenant sandbox, and receipts do not make agents injection-proof
+(`14` §3).
 
 ## 2. The pitches
 
@@ -174,20 +203,8 @@ it is a multi-tenant secure sandbox (it is a powerful agent on **your** host —
 The long-form version of this argument — evidence status stated per claim,
 falsifiers included — is [`19-thesis.md`](19-thesis.md).
 
-## 6. The name (open decision)
+## 6. The name
 
-"DevCake" is provisional. Criteria for the real name: says *delegated work*
-or *board* at first hearing; two syllables preferred; survives being said
-aloud in a serious meeting; no collisions with known dev-tools.
-
-| Candidate | Why | Risk |
-|---|---|---|
-| **DevCake** (keep) | Warm, memorable, "piece of cake" = the promise; layers = the pipeline; 🍰 already ours | Reads playful; "Dev-" prefix is crowded |
-| **Boardhand** | A hand for your board — ranch-hand/deckhand worker DNA; motto-compatible ("hands for the board you already run") | Invented word; needs a beat to land |
-| **Nightcrew** | The work happens while you sleep; honest and evocative | Implies only-async; slightly ops-flavored |
-| **Punchlist** | Construction term: the list a contractor finishes and the owner inspects — exactly our loop | Existing small products use it |
-| **Ticketsmith** | Forges finished work from tickets; craft connotation | Three syllables; smith-naming is common |
-
-Recommendation: decide before anything public. Renaming touches the label
-namespace (`DEVCAKE-*`), repo, and docs — a one-day, find-and-replace-plus-
-migration job (label rename procedure already exists in ADR-0004).
+The product name is **DevCake**. "Piece of cake" is the promise; the layers
+are the pipeline; the 🍰 is ours. The name can smile — the sentences stay in
+work clothes (§4).

--- a/docs/19-thesis.md
+++ b/docs/19-thesis.md
@@ -140,6 +140,16 @@ together, and we think the combination — not any component — is the identity
 of the project. This is an argument against the field as of July 2026; it is
 dated, and it decays.
 
+The identity has a name. As machine workers improve, the scarce thing stops
+being capability and becomes **accountability** — specifying, checking, and
+accounting for work — and that is what the envelope supplies, domain-free.
+The clean-room analogy is precise, not decorative: fabs do not hope dust
+stays out; they build rooms that do not care which process runs inside.
+Contamination control, one-way pressure, QA-before-release, and batch records
+map one-to-one onto context contaminants, read-only valves, REVIEW, and
+receipts (`17` §1c holds the mapping). DevCake is the clean room for
+delegated deep work.
+
 ## 4. As an instrument *(conjecture, stated testably)*
 
 DevCake might matter to people who study these systems, for one structural


### PR DESCRIPTION
## What

The docs Tranche A1 from today's session plan — identity rulings landed as authoritative prose, and the living log caught up to the truth.

**Identity (founder rulings, 2026-08-10/11):**
- **Name settled**: provisional-name hedges removed everywhere; `17` §6 rewritten.
- **Meta-harness category**: DevCake staffs Claude Code / Grok Build / Codex rather than competing with them — glossary row in `00`, leads in README / `17` §1 / `08`. No code identifier renames.
- **Clean-room formulation** as normative meaning: `17` §1c (primary, with the four-correspondence table), echoed in `19` §3, short form in README. Explicitly bounded by `14` — not a sandbox, not injection-proof.
- **Status badge**: "technical preview" → **early production (dedicated host)**, with evidence class + the v1 gate in the same sentence.

**Honesty (docs/16 living log):**
- Versioning doctrine: pre-v1 = no backwards-compat obligation (wipe-over-migrate is legitimate); **v1 is gated on a pre-registered, receipted public evidence run**.
- Catch-up entry for PRs #88–#112 (the log had stopped at the audit campaign): includes the CI-outage caveat, #113's re-verification, and that the stack is **not yet redeployed** onto these merges.
- **Discovery routing: designed, not shipped** (`ELEVATED_MARKERS` deliberately empty; STEWARD's only duty is edge proposal) — clearly separated from shipped HANDOFF notes.
- New **Field evidence (operator-self-reported)** subsection: the three 2026-08 field pictures, shape-only, each pinned to the deploy that ran it (v0.3 `df08c9a` for multirepo + dual-Linear; v0.2.5 `d3361f2` for the Qwen/vLLM + Gitea Issues corpus run), with an explicit what-we-do-not-claim block. No credit to ADRs merged after those deploys.
- Still open re-scoped: M9's operational dual-Linear proof superseded by field use (colliding-id completion + dual-key ceremony remain); field-evidence detail pass recorded as pending founder decisions; `dispatch.py` split + local-backend recipe promoted into Deferred.

## Verification

Docs-only. Accuracy re-read done; grep proofs: zero `provisional` / `technical preview` hits outside historical ADRs; every field-evidence claim carries a deploy pin and evidence-class label; nothing outclaims `docs/14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)