### PR TITLE
ops: receipts-export script + pre-v1 host-refresh runbook

### DIFF
--- a/docs/tutorials/host-refresh.md
+++ b/docs/tutorials/host-refresh.md
@@ -1,0 +1,101 @@
+# Host refresh — the pre-v1 wipe-and-re-onboard ritual
+
+> **Audience:** the operator moving a live DevCake host onto a newer `main`.
+> **Doctrine:** below v1 the project carries no backwards-compat obligation
+> (`docs/16` versioning doctrine) — when persisted-state migrations are the
+> risk, wiping `/data` and re-onboarding is a legitimate, supported path.
+> This page is that path. Migrating in place remains possible; it is simply
+> not what this ritual does.
+
+The order matters: **receipts first** (they decay), **backups second**
+(they include secrets), **wipe third**, and the wipe touches **one volume
+only**.
+
+## Phase 0 — export receipts (they decay; do this first)
+
+Two clocks erase evidence on a live host: OpenObserve retention ages spans
+out, and any Clear-runs sweep deletes run records and `activity-*` repos.
+
+```bash
+python3 scripts/export_receipts.py --days 90
+```
+
+The pack (deploy identity, raw trace spans as JSONL, `/data` minus
+secrets) is private material — mission content, no credentials. Log
+streams are skipped but named in `MANIFEST.json`; add `--include-logs`
+if you want them. Repeat per host.
+
+## Phase 1 — full backups (password-export tier)
+
+1. **Settings bundle** — admin UI → Configuration → export the encrypted
+   settings bundle (ADR-0013). This is the re-onboard accelerator: config,
+   profiles, and secrets in one file.
+2. `scripts/backup_data.sh` — the `/data` volume, secrets included.
+3. `scripts/backup_gitea.sh` — the internal Gitea volume (repos, boards,
+   `activity-*`, sqlite DB).
+
+Both tarballs hold plaintext credentials: store them like a
+password-manager export.
+
+## Phase 2 — the wipe scope (one volume, not four)
+
+| Volume / path | Action | Why |
+|---|---|---|
+| `devcake_devcake_data` (`/data`) | **Wipe** | The only home of persisted app state — run store, config, `steward.yaml`, secrets. Wiping it is what makes the upgrade migration-free. |
+| `devcake_gitea_data` | **Keep** | Boards (Gitea Issues), internal repos, `activity-*` knowledge trail. No app state lives here; on a forge-issue host this volume *is* the board. |
+| OpenObserve volume | Optional | Exhaust, not knowledge (`docs/16` two-ledger doctrine). After Phase 0 it is fully disposable; keeping it costs only disk. |
+| `devcake_mirrors`, workspaces dir | Ignore | Disposable caches; the stack rebuilds them. |
+
+```bash
+docker compose down
+docker volume rm devcake_devcake_data
+```
+
+`.env` stays: stack bootstrap secrets (admin/Redis/Dagu/OO/Gitea
+passwords, `DOCKER_GID`) live there, not in `/data`.
+
+## Phase 3 — redeploy from the target commit
+
+The deploy ritual from `docs/13` (deploy ordering — the DAG bind-mount
+goes live at `git pull`, so dagu must stop first):
+
+```bash
+docker compose stop dagu    # belt-and-braces; up.sh re-asserts it
+git pull                    # or: git checkout <pinned commit>
+./up.sh --bake              # bakes images + compose up, tag-lockstep
+```
+
+Record the deployed commit (`git describe --tags --always`) — field
+evidence is only citable when pinned to the deploy that ran it.
+
+## Phase 4 — re-onboard
+
+1. Admin UI → import the **settings bundle** from Phase 1. Import applies
+   the current schema to older bundles (suite-covered); the fully-clean
+   alternative is hand-reconfiguring connections and secrets through the
+   admin UI from your records.
+2. Verify every connection: PMO and forge test buttons, `secrets-check`
+   presence ticks, per-instance health in `/health`.
+3. Review staffing and toggles against current defaults — seeds only
+   apply to fresh configs, so anything you re-imported keeps its old
+   values by design.
+
+## Phase 5 — first-poll smoke (before trusting it)
+
+- [ ] `/health` green; no unexpected warnings beyond your known posture.
+- [ ] Poll now → the boards' missions appear with correct provenance.
+- [ ] One trivial mission end-to-end (opt-in label on a sandbox ticket, or
+      the internal-forge path) reaches Done with transcript + token report
+      on the feed.
+- [ ] OO dashboard receives fresh spans (collector path alive).
+- [ ] Config UI serves the current knobs (a quick way to catch a stale
+      image: a feature merged on `main` that the UI does not show means
+      the bake or tag-lockstep failed).
+
+## Phase 6 — the observation window opens
+
+The refresh is when the field evaluation starts, not ends. For roughly a
+week, note: freshness re-review trips and exhaustions, incidents of
+lost upstream context, and cross-subtree "I wish that mission had known
+this" moments — the last class is exactly what ADR-0033's discovery
+routing exists to serve, and these observations tune its constants.

--- a/scripts/export_receipts.py
+++ b/scripts/export_receipts.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Export a host's receipts pack — the evidence trail — BEFORE it decays.
+
+Two clocks erase receipts on a live host: OpenObserve retention ages spans
+out, and Clear-runs sweeps run records and `activity-*` repos. This script
+captures, into one private directory:
+
+  1. deploy identity — git describe/HEAD, DEVCAKE_TAG, image digests,
+     `docker compose ps` (which code actually ran);
+  2. every TRACES stream in OpenObserve, exported raw as JSONL (the span
+     record IS the receipt: token reports, fault classes, durations —
+     aggregates stay derivable offline; docs/16 two-ledger doctrine: OO is
+     exhaust, so this export is a copy of derived data, never load-bearing);
+  3. a sanitized /data tarball — run records, state, audit log — with
+     `/data/secrets` EXCLUDED (unlike backup_data.sh, this pack is safe to
+     keep outside the password-manager tier; it still holds mission
+     content, so it stays private).
+
+Log streams (container logs) are NOT exported by default — they are bulky
+and rarely evidence — but they are NAMED in the manifest so the omission
+is visible (no silent caps). Pass --include-logs to export them too.
+
+This is NOT a backup. Full recovery needs scripts/backup_data.sh +
+scripts/backup_gitea.sh (both include secrets — password-export handling).
+
+Usage: scripts/export_receipts.py [--days N] [--out DIR] [--include-logs]
+Reads .env for OO_URL / OO_ORG / OO_ROOT_EMAIL / OO_ROOT_PASSWORD.
+Run from the repo root on the DevCake host. Fail-loud: any OO error body
+is printed verbatim and exits non-zero.
+"""
+
+import argparse
+import base64
+import datetime as dt
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+PAGE = 10_000
+MAX_PAGES = 500          # 5M spans per stream; loud, never silent (below)
+
+
+def env(name, default=None):
+    for line in open(".env"):
+        if line.startswith(f"{name}="):
+            return line.split("=", 1)[1].strip()
+    if default is not None:
+        return default
+    sys.exit(f"missing {name} in .env")
+
+
+def req(method, path, body=None):
+    r = urllib.request.Request(f"{OO}/api/{ORG}{path}", method=method,
+                               data=json.dumps(body).encode() if body else None,
+                               headers={"Authorization": f"Basic {AUTH}",
+                                        "Content-Type": "application/json"})
+    try:
+        return json.load(urllib.request.urlopen(r))
+    except urllib.error.HTTPError as e:
+        sys.exit(f"OO {method} {path} → {e.code}: {e.read().decode()[:600]}")
+    except urllib.error.URLError as e:
+        sys.exit(f"OO unreachable at {OO}: {e}")
+
+
+def sh(cmd):
+    """Best-effort host command for the manifest — records failure, never dies."""
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=60).stdout.strip()
+    except Exception as e:                                    # noqa: BLE001
+        return f"<unavailable: {e}>"
+
+
+def export_stream(name, stream_type, start_us, end_us, out_path):
+    """Page SELECT * into JSONL. Returns row count; loud on the page cap."""
+    rows = 0
+    with open(out_path, "w") as fh:
+        for page in range(MAX_PAGES):
+            body = {"query": {"sql": f'SELECT * FROM "{name}"',
+                              "start_time": start_us, "end_time": end_us,
+                              "from": page * PAGE, "size": PAGE}}
+            hits = req("POST", f"/_search?type={stream_type}", body).get("hits", [])
+            for h in hits:
+                fh.write(json.dumps(h, separators=(",", ":")) + "\n")
+            rows += len(hits)
+            if len(hits) < PAGE:
+                return rows, False
+    print(f"  ⚠ {name}: page cap hit at {rows} rows — window has MORE data; "
+          f"re-run with a shorter --days per slice", file=sys.stderr)
+    return rows, True
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--days", type=int, default=90)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--include-logs", action="store_true")
+    args = ap.parse_args()
+
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M")
+    out = pathlib.Path(args.out or os.path.join(
+        os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")),
+        "devcake", "receipts", f"receipts-{stamp}"))
+    out.mkdir(parents=True, exist_ok=True)
+    os.chmod(out, 0o700)
+
+    end_us = int(time.time() * 1_000_000)
+    start_us = end_us - args.days * 86_400 * 1_000_000
+
+    # 1 — deploy identity
+    manifest = {
+        "exported_at_utc": stamp,
+        "window_days": args.days,
+        "git_describe": sh(["git", "describe", "--tags", "--always"]),
+        "git_head": sh(["git", "rev-parse", "HEAD"]),
+        "devcake_tag": env("DEVCAKE_TAG", "latest"),
+        "images": sh(["docker", "images", "--digests",
+                      "--format", "{{.Repository}}:{{.Tag}} {{.Digest}}"]),
+        "compose_ps": sh(["docker", "compose", "ps"]),
+        "streams": {},
+        "skipped_log_streams": [],
+    }
+
+    # 2 — OO streams
+    listing = req("GET", "/streams")
+    streams = listing.get("list") or listing.get("data") or []
+    for s in streams:
+        name, stype = s.get("name"), s.get("stream_type", "traces")
+        if stype != "traces" and not args.include_logs:
+            manifest["skipped_log_streams"].append(f"{name} ({stype})")
+            continue
+        path = out / f"oo-{stype}-{name}.jsonl"
+        print(f"exporting {stype}/{name} …")
+        rows, capped = export_stream(name, stype, start_us, end_us, path)
+        manifest["streams"][f"{stype}/{name}"] = {"rows": rows, "capped": capped}
+        print(f"  {rows} rows → {path.name}")
+
+    # 3 — sanitized /data (secrets EXCLUDED; volume-tar per backup_data.sh,
+    # incl. its audit fixes: bind the DIRECTORY, basename via env, chown)
+    volume = os.environ.get("DEVCAKE_DATA_VOLUME", "devcake_devcake_data")
+    tar_base = "data-sans-secrets.tar.gz"
+    rc = subprocess.run(
+        ["docker", "run", "--rm",
+         "-e", f"OUT_BASE={tar_base}",
+         "-e", f"OWNER={os.getuid()}:{os.getgid()}",
+         "-v", f"{volume}:/src:ro", "-v", f"{out}:/out", "alpine",
+         "sh", "-c",
+         'umask 077 && tar czf "/out/$OUT_BASE" -C /src'
+         ' --exclude ./secrets . && chown "$OWNER" "/out/$OUT_BASE"'],
+    ).returncode
+    if rc != 0:
+        sys.exit(f"/data export failed (volume {volume}) — rc {rc}")
+
+    (out / "MANIFEST.json").write_text(json.dumps(manifest, indent=2))
+    print(f"\nreceipts pack: {out}")
+    if manifest["skipped_log_streams"]:
+        print(f"  log streams NOT exported (named in MANIFEST): "
+              f"{len(manifest['skipped_log_streams'])} — use --include-logs")
+    print("  private material (mission content) — store accordingly.")
+    print("  this is NOT a backup: run backup_data.sh + backup_gitea.sh for that.")
+
+
+if __name__ == "__main__":
+    os.chdir(pathlib.Path(__file__).resolve().parent.parent)
+    OO = env("OO_URL", "http://localhost:5080")
+    ORG = env("OO_ORG", "default")
+    AUTH = base64.b64encode(
+        f"{env('OO_ROOT_EMAIL')}:{env('OO_ROOT_PASSWORD')}".encode()).decode()
+    main()


### PR DESCRIPTION
## What

The two founder-side enablement deliverables aligned this session, ahead of the field-host work:

**`scripts/export_receipts.py`** — one command to capture a host's evidence trail before it decays (OO retention ages spans out; Clear-runs sweeps run records and activity repos):
- deploy identity: `git describe`/HEAD, `DEVCAKE_TAG`, image digests, `compose ps`;
- every **traces** stream exported raw as JSONL (paged; page-cap is loud, never silent; log streams are skipped but **named** in the manifest — `--include-logs` to take them too);
- `/data` tarball with **`/data/secrets` excluded** — private mission content, but not password-export tier (unlike `backup_data.sh`, which it explicitly does not replace).

Two-ledger compliant by construction: it exports a *copy* of exhaust + advisory state; nothing reads it back.

**`docs/tutorials/host-refresh.md`** — the pre-v1 wipe-and-re-onboard ritual, in execution order: receipts → password-tier backups (settings bundle / data / gitea) → wipe **`devcake_data` only** (the Gitea volume keeps boards and the activity knowledge trail; OO is disposable exhaust) → redeploy via the docs/13 stop-dagu ritual with the commit pinned → bundle re-import → first-poll smoke checklist → the observation window that tunes ADR-0033's constants.

## Verification

`py_compile` clean; script follows `provision_oo.py`'s .env/auth pattern and `backup_data.sh`'s audited volume-tar pattern (dir bind-mount, basename via env var, umask 077, chown). Docs-only otherwise. Live execution happens on the field hosts (founder-side, per the runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)