### PR TITLE
fix(spa): config draft converges after saving an added instance card

### DIFF
--- a/admin/spa/package.json
+++ b/admin/spa/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "check:ui": "node tests/run.mjs",
-    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs"
+    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs && node tests/config_draft.mjs"
   },
   "dependencies": {
     "@fontsource-variable/bricolage-grotesque": "^5.2.10",

--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -15,6 +15,7 @@ import { ADOPTION_COPY } from "../lib/configLabels.js";
 import { useSharedDraft } from "../lib/ConfigDraftContext.jsx";
 import { getRegistry, loadRegistry } from "../lib/registry.js";
 import { nextFreeName, useNewNames } from "../lib/instanceNames.js";
+import { newPmoCard } from "../lib/cards.js";
 
 export default function PmoSection({ newNamesState, health = {}, healthError = false,
                                      onHealthChange }) {
@@ -388,10 +389,7 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
           newPmoNames.track(name);
           setExpandedPmos((prev) => new Set(prev).add(cfg.pmos.length));
           const defaultSystem = (registry.pmo_systems || [])[0]?.id || "linear";
-          setField("cfg.pmos", [...cfg.pmos,
-            { name, system: defaultSystem,
-              team_key: "", api_base: null, repos: [],
-              reference_repos: [] }]);
+          setField("cfg.pmos", [...cfg.pmos, newPmoCard(name, defaultSystem)]);
         }}>
           + Add PMO instance
         </Button>

--- a/admin/spa/src/lib/cards.js
+++ b/admin/spa/src/lib/cards.js
@@ -1,0 +1,29 @@
+// Draft scaffolds for new instance cards. Every server-model field is
+// present with its server default: a saved card must deep-equal its
+// refetched server row, because two seams depend on that convergence —
+// useNewNames' name-lock rule, and the rebase's clean-diff-after-save
+// contract (a partial scaffold re-applied over the fresh snapshot strips
+// the server's fields and leaves permanent phantom dirt).
+
+export const newPmoCard = (name, system) => ({
+  name,
+  system,
+  team_key: "",
+  api_base: null,
+  repos: [],
+  reference_repos: [],
+  intake_paused: false,
+  assignments: {},
+  managed: false,
+});
+
+export const newRepoCard = (name) => ({
+  name,
+  forge: "github",
+  url: "",
+  api_base: null,
+  default_branch: "main",
+  auto_merge: false,
+  auto_resolve_merge_conflicts: true,
+  merge_retry_window_minutes: 30,
+});

--- a/admin/spa/src/lib/configLabels.js
+++ b/admin/spa/src/lib/configLabels.js
@@ -18,7 +18,11 @@ export const ADOPTION_COPY =
   "label DEVCAKE.";
 
 const onOff = (v) => (v ? "on" : "off");
-const orEmpty = (v) => (v === null || v === undefined || v === "" ? "(empty)" : String(v));
+// objects/arrays reaching a generic formatter render as JSON — a diff row
+// must never show [object Object]
+const orEmpty = (v) =>
+  v === null || v === undefined || v === "" ? "(empty)"
+    : typeof v === "object" ? JSON.stringify(v) : String(v);
 const lines = (v) => ((v || []).length ? (v || []).join("\n") : "(none)");
 // rate-card rows diff atomically (the Cost Inputs modal PUTs the whole
 // list) — render them as readable per-1M lines, never [object Object]
@@ -144,11 +148,14 @@ export function metaFor(path) {
       label: `Repo #${+m[1] + 1} · ${f.label}`,
     };
   }
-  m = path.match(/^cfg\.pmos\.(\d+)\.(name|system|team_key|api_base)$/);
+  m = path.match(/^cfg\.pmos\.(\d+)\.(name|system|team_key|api_base|intake_paused|managed)$/);
   if (m) {
     const FIELDS = { name: "Instance name", system: "System",
-                     team_key: "Team key", api_base: "API base" };
-    return { group: "PMO", multiline: false, format: orEmpty,
+                     team_key: "Team key", api_base: "API base",
+                     intake_paused: "Intake paused",
+                     managed: "Managed (default board)" };
+    const bool = m[2] === "intake_paused" || m[2] === "managed";
+    return { group: "PMO", multiline: false, format: bool ? onOff : orEmpty,
              label: `PMO #${+m[1] + 1} · ${FIELDS[m[2]]}` };
   }
   m = path.match(/^cfg\.active_prompt_templates\.([^.]+)$/);
@@ -183,6 +190,15 @@ export function metaFor(path) {
              format: (v) => (v == null ? "(inherit global)"
                              : `${v.dev_type || "(unassigned)"}` +
                                (v.extra_cli_args ? ` · ${v.extra_cli_args}` : "")) };
+  }
+  m = path.match(/^cfg\.pmos\.(\d+)\.assignments$/);
+  if (m) {
+    return { group: "Mission Types", multiline: false,
+             label: `Stage overrides (PMO #${+m[1] + 1})`,
+             format: (v) => {
+               const keys = Object.keys(v || {});
+               return keys.length ? keys.join(", ") : "(none)";
+             } };
   }
   m = path.match(/^devTypes\.([^.]+)\.(.+)$/);
   if (m && DEV_TYPE_FIELDS[m[2]]) {

--- a/admin/spa/src/lib/objectPath.js
+++ b/admin/spa/src/lib/objectPath.js
@@ -51,3 +51,30 @@ export function containerExists(tree, path) {
   const parent = path.split(".").slice(0, -1).join(".");
   return parent === "" || getIn(tree, parent) != null;
 }
+
+// Same name sequence = an atomic instance-list edit (add/remove diffs as one
+// whole-list row) whose shape change has LANDED on the server: the fresh
+// list's enriched cards are canonical, and re-applying the draft's partial
+// scaffold wholesale would strip server-side fields — leaving a diff that
+// can never converge (permanent "Unsaved changes" + phantom value→(empty)
+// rows after every save of an added card).
+const sameNameShape = (a, b) =>
+  Array.isArray(a) && Array.isArray(b) && a.length === b.length &&
+  a.every(isPlainObject) && b.every(isPlainObject) &&
+  a.every((el, i) => el.name === b[i].name);
+
+// Re-apply user edits onto a fresh server snapshot — edits win, EXCEPT when
+// the fresh tree already subsumes the edit: the value landed verbatim, or
+// the instance-list shape matches by name (see above). Edits under a
+// deleted container are silently dropped, as before.
+export function applyEditsOnto(fresh, edits) {
+  let next = fresh;
+  for (const e of edits) {
+    if (!containerExists(fresh, e.path)) continue;
+    const cur = getIn(fresh, e.path);
+    if (JSON.stringify(cur) === JSON.stringify(e.new)) continue;
+    if (sameNameShape(cur, e.new)) continue;
+    next = setIn(next, e.path, e.new);
+  }
+  return next;
+}

--- a/admin/spa/src/lib/useConfigDraft.js
+++ b/admin/spa/src/lib/useConfigDraft.js
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { diffLeaves, setIn, containerExists } from "./objectPath.js";
+import { diffLeaves, setIn, applyEditsOnto } from "./objectPath.js";
 import { INSTANCE_NAME_RE, INSTANCE_NAME_RULE } from "./instanceNames.js";
 
 // Paths that never dirty the draft: server-owned state that immediate
@@ -57,9 +57,10 @@ export default function useConfigDraft() {
     let next = fresh;
     if (prevServer && prevDraft) {
       const edits = diffLeaves(prevServer, prevDraft).filter((e) => !ignored(e.path));
-      for (const e of edits) {
-        if (containerExists(fresh, e.path)) next = setIn(next, e.path, e.new);
-      }
+      // edits win — except where fresh already subsumes them (verbatim value,
+      // or a landed instance-list shape change: the server's enriched cards
+      // are canonical, never the draft's partial scaffold)
+      next = applyEditsOnto(fresh, edits);
     }
     setServer(fresh);
     setDraft(next);

--- a/admin/spa/src/pages/ReposPage.jsx
+++ b/admin/spa/src/pages/ReposPage.jsx
@@ -16,6 +16,7 @@ import { AUTO_MERGE_COPY } from "../lib/configLabels.js";
 import { getRegistry, loadRegistry } from "../lib/registry.js";
 import { useSharedDraft } from "../lib/ConfigDraftContext.jsx";
 import { nextFreeName, useNewNames } from "../lib/instanceNames.js";
+import { newRepoCard } from "../lib/cards.js";
 
 // Repositories page (v0.1.1 B4, founder request): the repository cards +
 // merge policy lifted out of Configuration, plus the internal-forge
@@ -546,11 +547,7 @@ export default function ReposPage({ onHealthChange }) {
           const name = nextFreeName("repo", cfg.repos, dr.server.cfg.repos);
           newNames.track(name);
           setExpandedRepos((prev) => new Set(prev).add(cfg.repos.length));
-          setField("cfg.repos", [...cfg.repos,
-            { name, forge: "github", url: "",
-              api_base: null, default_branch: "main",
-              auto_merge: false, auto_resolve_merge_conflicts: true,
-              merge_retry_window_minutes: 30 }]);
+          setField("cfg.repos", [...cfg.repos, newRepoCard(name)]);
         }}>
           + Add repository
         </Button>

--- a/admin/spa/tests/config_draft.mjs
+++ b/admin/spa/tests/config_draft.mjs
@@ -1,0 +1,109 @@
+// Pure-node checks for the config-draft diff/rebase seam (no browser) —
+// pins the 2026-08-12 phantom-diff bug closed: adding a PMO card, saving,
+// and refetching must converge to a CLEAN draft (no [object Object] rows,
+// no permanent "Unsaved changes" bar).
+import assert from "node:assert/strict";
+import { diffLeaves, applyEditsOnto, getIn } from "../src/lib/objectPath.js";
+import { metaFor, describeDiff } from "../src/lib/configLabels.js";
+import { newPmoCard, newRepoCard } from "../src/lib/cards.js";
+
+let failed = 0;
+const check = (name, fn) => {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.log(`  ✗ ${name}: ${e.message}`);
+  }
+};
+
+// Server-shaped cards (config GET returns every model field).
+const BOARD = {
+  name: "board", system: "gitea_issues", team_key: "devcake-pmo/missions",
+  api_base: "http://gitea:3000", repos: [], reference_repos: [],
+  intake_paused: false, assignments: {}, managed: true,
+};
+const snap = (pmos, extra = {}) =>
+  ({ cfg: { pmos, poll_interval_seconds: 30, ...extra }, devTypes: {}, assignments: {} });
+
+// The add→save→refetch cycle, as the hook drives it.
+const scaffold = newPmoCard("linearb", "linear");
+const prevServer = snap([BOARD]);
+const prevDraft = snap([BOARD, scaffold]);
+// what the server returns after the save: the scaffold, enriched/canonical
+const LINEARB_SAVED = { ...scaffold, api_base: null, team_key: "TEAM" };
+const freshAfterSave = snap([BOARD, LINEARB_SAVED]);
+
+check("add card: unequal-length instance lists diff as ONE atomic row", () => {
+  const edits = diffLeaves(prevServer, prevDraft);
+  assert.equal(edits.length, 1);
+  assert.equal(edits[0].path, "cfg.pmos");
+});
+
+check("post-save rebase converges: clean diff, no phantom rows", () => {
+  const edits = diffLeaves(prevServer, prevDraft);
+  const next = applyEditsOnto(freshAfterSave, edits);
+  assert.deepEqual(diffLeaves(freshAfterSave, next), []);
+});
+
+check("post-save rebase: the server's canonical card wins over the scaffold", () => {
+  const edits = diffLeaves(prevServer, prevDraft);
+  const next = applyEditsOnto(freshAfterSave, edits);
+  assert.equal(getIn(next, "cfg.pmos.1.team_key"), "TEAM");
+});
+
+check("failed save: the addition stays dirty (edits win)", () => {
+  const edits = diffLeaves(prevServer, prevDraft);
+  const next = applyEditsOnto(prevServer, edits);   // fresh == old server
+  const diff = diffLeaves(prevServer, next);
+  assert.equal(diff.length, 1);
+  assert.equal(diff[0].path, "cfg.pmos");
+});
+
+check("plain leaf edits still re-apply onto a fresh snapshot", () => {
+  const edited = snap([BOARD], { poll_interval_seconds: 45 });
+  const edits = diffLeaves(prevServer, edited);
+  const fresh = snap([BOARD]);                       // server still at 30
+  const next = applyEditsOnto(fresh, edits);
+  assert.equal(getIn(next, "cfg.poll_interval_seconds"), 45);
+});
+
+check("rename inside a same-length list still wins over fresh", () => {
+  const renamed = snap([{ ...BOARD, name: "renamed" }]);
+  const edits = diffLeaves(prevServer, renamed);
+  const next = applyEditsOnto(prevServer, edits);
+  assert.equal(getIn(next, "cfg.pmos.0.name"), "renamed");
+});
+
+check("scaffolds carry every server-model field (pmo: 9, repo: 8)", () => {
+  assert.deepEqual(Object.keys(newPmoCard("x", "linear")).sort(),
+    ["api_base", "assignments", "intake_paused", "managed", "name",
+     "reference_repos", "repos", "system", "team_key"]);
+  assert.deepEqual(Object.keys(newRepoCard("x")).sort(),
+    ["api_base", "auto_merge", "auto_resolve_merge_conflicts",
+     "default_branch", "forge", "merge_retry_window_minutes", "name", "url"]);
+});
+
+check("pmo card fields have real labels, not raw paths", () => {
+  assert.match(metaFor("cfg.pmos.1.intake_paused").label, /Intake paused/);
+  assert.match(metaFor("cfg.pmos.1.managed").label, /Managed/);
+  assert.notEqual(metaFor("cfg.pmos.1.assignments").group, "Other");
+});
+
+check("no diff row ever renders [object Object]", () => {
+  const rows = describeDiff([
+    { path: "cfg.pmos.1.assignments", old: {}, new: undefined },
+    { path: "cfg.some.unknown", old: { a: 1 }, new: undefined },
+  ]);
+  for (const r of rows) {
+    assert.ok(!`${r.oldText}${r.newText}`.includes("[object Object]"),
+      `${r.path}: ${r.oldText} → ${r.newText}`);
+  }
+});
+
+if (failed) {
+  console.error(`config_draft: ${failed} check(s) failed`);
+  process.exit(1);
+}
+console.log("config_draft: all checks passed");


### PR DESCRIPTION
## Symptom (founder-reported, live on the fresh stack)

Add a PMO instance → Save → the dirty bar never clears; the Review dialog shows three phantom "changes" under OTHER: `cfg.pmos.1.assignments` ~~[object Object]~~ → (empty), `intake_paused` ~~false~~ → (empty), `managed` ~~false~~ → (empty).

## Root cause

Instance lists deliberately diff **atomically** on add/remove (one whole-list row — the readable name-set rendering). But `rebase()` re-applied that atomic edit verbatim onto the fresh post-save snapshot, clobbering the server's enriched card with the client's **partial scaffold** (6 of 9 model fields). Lists now equal length → per-field recursion → phantom `value → (empty)` rows for exactly the fields the scaffold lacked; the draft can never converge, breaking the save-flow contract ("saved edits match the fresh server and vanish from the diff") and `useNewNames`' deep-equal name-lock rule.

## Fix (three layers)

1. **`objectPath.applyEditsOnto`** — edits win, except where fresh already subsumes them: verbatim value, or an instance list matching by **name sequence** (the shape change landed; server cards are canonical). Failed saves keep the addition dirty; renames and plain leaf edits still win.
2. **`lib/cards.js`** — add-card scaffolds now carry every server-model field (PMO 9, repo 8; asserted against the literal key sets), so pre-save diffs are honest and saved cards deep-equal their refetched rows.
3. **`configLabels`** — `intake_paused` / `managed` / bare `assignments` get real labels + formats; the generic formatter JSON-renders objects so no diff row can ever show `[object Object]`.

## Verification

Red→green: `tests/config_draft.mjs` (9 checks — atomic add row, post-save convergence, server-canonical wins, failed-save stays dirty, leaf edits and renames win, scaffold completeness, labels, no `[object Object]`) wired into `test:helpers` (runs in CI's hermetic admin helpers step). Full helpers suite + production build green. Live verification on the freshly wiped stack follows merge (rebake admin, retry the founder's exact flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)