### PR TITLE
fix: secret writes serialize against an in-flight poll cycle (L-1/L-2)

### DIFF
--- a/app/devcake/api/connections_service.py
+++ b/app/devcake/api/connections_service.py
@@ -6,8 +6,10 @@ thin forwards that pass the composition root's singletons at call time
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
+from contextlib import nullcontext
 
 from fastapi import HTTPException
 
@@ -51,8 +53,19 @@ def _require_harness_var(var: str) -> None:
         raise HTTPException(422, "harness var must match ^[A-Z][A-Z0-9_]{0,63}$")
 
 
+def _cycle(lock: asyncio.Lock | None):
+    """Serialize the write + adapter-graph swap against an in-flight poll
+    cycle — the config-PUT precedent (PR #104). The poll loop holds
+    `poll_rt.lock` for a whole cycle but suspends at awaits; without this,
+    a secret write mid-cycle swaps the graph (or deletes the credential)
+    underneath the suspended cycle. None (tests, scripts) = no
+    serialization, mirroring `apply_config_patch`."""
+    return lock if lock is not None else nullcontext()
+
+
 async def put_secret(scope: str, instance: str, field: str, body: dict, *,
-                     forge_runtime, reload):
+                     forge_runtime, reload,
+                     cycle_lock: asyncio.Lock | None = None):
     """Store a connection secret VALUE (never echoed). scope ∈ pmo|repo;
     instance is the config instance name; field ∈ api_key|token|token_ro|
     reviewer_token. Writing a repo/pmo secret clears any latched breaker."""
@@ -60,24 +73,27 @@ async def put_secret(scope: str, instance: str, field: str, body: dict, *,
     value = body.get("value")
     if not isinstance(value, str) or not value:
         raise HTTPException(422, "value must be a non-empty string")
-    secrets_store.write_connection_secret(scope, instance, field, value)
-    if scope == "repo":
-        forge_runtime.breakers.pop(instance, None)
-        reset_protection_cache()
-    # adapters capture credentials by VALUE at construction — a rotated
-    # secret takes effect only through a rebuild, same as a config PUT
-    reload()
+    async with _cycle(cycle_lock):
+        secrets_store.write_connection_secret(scope, instance, field, value)
+        if scope == "repo":
+            forge_runtime.breakers.pop(instance, None)
+            reset_protection_cache()
+        # adapters capture credentials by VALUE at construction — a rotated
+        # secret takes effect only through a rebuild, same as a config PUT
+        reload()
     return secrets_store.connection_status(scope, instance, field)
 
 
 async def delete_secret(scope: str, instance: str, field: str, *,
-                        forge_runtime, reload):
+                        forge_runtime, reload,
+                        cycle_lock: asyncio.Lock | None = None):
     _require_secret_ref(scope, instance, field)
-    secrets_store.delete_connection_field(scope, instance, field)
-    if scope == "repo":
-        forge_runtime.breakers.pop(instance, None)
-        reset_protection_cache()
-    reload()
+    async with _cycle(cycle_lock):
+        secrets_store.delete_connection_field(scope, instance, field)
+        if scope == "repo":
+            forge_runtime.breakers.pop(instance, None)
+            reset_protection_cache()
+        reload()
     return {"present": False}
 
 
@@ -129,7 +145,8 @@ async def secrets_inventory():
 
 
 async def clear_secrets(body: dict, *, forge_runtime, reload, config,
-                        shared_breakers, dev_types):
+                        shared_breakers, dev_types,
+                        cycle_lock: asyncio.Lock | None = None):
     """Delete the operator-selected subset of stored secrets.
 
     Body:
@@ -139,9 +156,10 @@ async def clear_secrets(body: dict, *, forge_runtime, reload, config,
       pause_intake: bool  (optional; default false when omitted)
 
     Order is load-bearing: validate → optional master intake pause (fail
-    aborts with no deletes) → deletes → breakers/reload → audit. Pausing
-    first means a residual poll race can only fire before keys are gone,
-    not after (no poll lock in this path).
+    aborts with no deletes) → deletes → breakers/reload → audit. The
+    pause-through-reload transaction runs under the poll-cycle lock
+    (`_cycle`): a cycle observes either the pre-clear world or the
+    post-reload one, never a half-swapped adapter graph over deleted keys.
 
     SPA always sends pause_intake explicitly; API-safe default when omitted
     is false so scripts do not freeze intake by accident.
@@ -202,40 +220,41 @@ async def clear_secrets(body: dict, *, forge_runtime, reload, config,
             raise HTTPException(422, str(e)) from e
         credential_files.append((dev_type, filename))
 
-    # ── pause first (if requested) — no deletes yet ─────────────────────────
-    if pause_intake:
-        config.intake_paused = True
-        save_config(config)
+    async with _cycle(cycle_lock):
+        # ── pause first (if requested) — no deletes yet ─────────────────────
+        if pause_intake:
+            config.intake_paused = True
+            save_config(config)
 
-    deleted_h: list[str] = []
-    for var in harness_vars:
-        secrets_store.delete_harness_secret(var)
-        deleted_h.append(var)
-        for dt_name, dt in dev_types.items():
-            if var in HARNESSES[dt.harness_template].credential_env:
-                shared_breakers.pop(dt_name, None)
+        deleted_h: list[str] = []
+        for var in harness_vars:
+            secrets_store.delete_harness_secret(var)
+            deleted_h.append(var)
+            for dt_name, dt in dev_types.items():
+                if var in HARNESSES[dt.harness_template].credential_env:
+                    shared_breakers.pop(dt_name, None)
 
-    deleted_c: list[dict] = []
-    repo_touched = False
-    for scope, instance, field in connections:
-        secrets_store.delete_connection_field(scope, instance, field)
-        deleted_c.append({"scope": scope, "instance": instance,
-                          "field": field})
-        if scope == "repo":
-            forge_runtime.breakers.pop(instance, None)
-            repo_touched = True
+        deleted_c: list[dict] = []
+        repo_touched = False
+        for scope, instance, field in connections:
+            secrets_store.delete_connection_field(scope, instance, field)
+            deleted_c.append({"scope": scope, "instance": instance,
+                              "field": field})
+            if scope == "repo":
+                forge_runtime.breakers.pop(instance, None)
+                repo_touched = True
 
-    deleted_f: list[dict] = []
-    for dev_type, filename in credential_files:
-        secrets_store.delete_credential_file(dev_type, filename)
-        deleted_f.append({"dev_type": dev_type, "filename": filename})
-        shared_breakers.pop(dev_type, None)
+        deleted_f: list[dict] = []
+        for dev_type, filename in credential_files:
+            secrets_store.delete_credential_file(dev_type, filename)
+            deleted_f.append({"dev_type": dev_type, "filename": filename})
+            shared_breakers.pop(dev_type, None)
 
-    if repo_touched:
-        reset_protection_cache()
-    if connections:
-        # connection secrets are captured at adapter construction
-        reload()
+        if repo_touched:
+            reset_protection_cache()
+        if connections:
+            # connection secrets are captured at adapter construction
+            reload()
 
     audit_event(
         "secrets_cleared",

--- a/app/devcake/api/default_board.py
+++ b/app/devcake/api/default_board.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import nullcontext
 
 from ..config import MANAGED_BOARD_NAME, PMOInstance, save_config
 
@@ -28,37 +29,49 @@ async def ensure_default_board(s) -> None:
         return
     async with _lock:
         info = await s.internal_forge.ensure_pmo_board()
-        # adopt-don't-crash: an operator who manually configured this exact
-        # board pre-feature would collide with the duplicate-target validator
-        # — their instance IS the board; skip injection and say so
-        for inst in s.config.pmos:
-            if (not inst.managed and inst.system == "gitea_issues"
-                    and inst.team_key == info["team_key"]
-                    and (inst.api_base or "").rstrip("/") == info["api_base"]):
-                log.info("default board: operator instance %r already targets "
-                         "%s — adopting it, no managed row injected",
-                         inst.name, info["team_key"])
+        # L-2 (2026-08): the config mutation + reload below must not race a
+        # suspended poll cycle — same contract as config PUT and the secret
+        # endpoints. Lock ordering is always _lock → poll_rt.lock and never
+        # inverted: reload_connections is sync and only SPAWNS the re-ensure
+        # (services.py create_task), so no cycle-lock holder ever awaits this
+        # function inline. Fakes without poll_rt run lock-free, like a
+        # missing cycle_lock elsewhere. Held across the network call above?
+        # No — acquired after it, so a poll waits only on local work.
+        poll_rt = getattr(s, "poll_rt", None)
+        async with (poll_rt.lock if poll_rt is not None else nullcontext()):
+            # adopt-don't-crash: an operator who manually configured this
+            # exact board pre-feature would collide with the duplicate-target
+            # validator — their instance IS the board; skip injection and say
+            # so
+            for inst in s.config.pmos:
+                if (not inst.managed and inst.system == "gitea_issues"
+                        and inst.team_key == info["team_key"]
+                        and (inst.api_base or "").rstrip("/") == info["api_base"]):
+                    log.info("default board: operator instance %r already "
+                             "targets %s — adopting it, no managed row "
+                             "injected", inst.name, info["team_key"])
+                    return
+            desired = {"name": MANAGED_BOARD_NAME, "system": "gitea_issues",
+                       "team_key": info["team_key"],
+                       "api_base": info["api_base"], "managed": True}
+            row = next((p for p in s.config.pmos
+                        if p.managed and p.name == MANAGED_BOARD_NAME), None)
+            if row is not None and all(getattr(row, k) == v
+                                       for k, v in desired.items()):
+                if info["minted"]:
+                    # the running adapter cached the dead PAT at construction
+                    # — rebuild so the fresh one takes (managers reconciled
+                    # in place)
+                    s.reload_connections()
                 return
-        desired = {"name": MANAGED_BOARD_NAME, "system": "gitea_issues",
-                   "team_key": info["team_key"], "api_base": info["api_base"],
-                   "managed": True}
-        row = next((p for p in s.config.pmos
-                    if p.managed and p.name == MANAGED_BOARD_NAME), None)
-        if row is not None and all(getattr(row, k) == v
-                                   for k, v in desired.items()):
-            if info["minted"]:
-                # the running adapter cached the dead PAT at construction —
-                # rebuild so the fresh one takes (managers reconciled in place)
-                s.reload_connections()
-            return
-        if row is None:
-            s.config.pmos = [*s.config.pmos, PMOInstance(**desired)]
-            log.info("default board: managed instance %r registered (%s)",
-                     MANAGED_BOARD_NAME, info["team_key"])
-        else:
-            for k, v in desired.items():
-                setattr(row, k, v)
-            log.info("default board: managed instance %r repaired (%s)",
-                     MANAGED_BOARD_NAME, info["team_key"])
-        save_config(s.config)
-        s.reload_connections()
+            if row is None:
+                s.config.pmos = [*s.config.pmos, PMOInstance(**desired)]
+                log.info("default board: managed instance %r registered (%s)",
+                         MANAGED_BOARD_NAME, info["team_key"])
+            else:
+                for k, v in desired.items():
+                    setattr(row, k, v)
+                log.info("default board: managed instance %r repaired (%s)",
+                         MANAGED_BOARD_NAME, info["team_key"])
+            save_config(s.config)
+            s.reload_connections()

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -655,7 +655,8 @@ async def put_secret(scope: str, instance: str, field: str, body: dict):
     s = svc()
     return await connections_service.put_secret(
         scope, instance, field, body,
-        forge_runtime=s.forge_runtime, reload=s.reload_connections)
+        forge_runtime=s.forge_runtime, reload=s.reload_connections,
+        cycle_lock=s.poll_rt.lock)
 
 
 @app.delete("/api/v1/secrets/{scope}/{instance}/{field}")
@@ -663,7 +664,8 @@ async def delete_secret(scope: str, instance: str, field: str):
     s = svc()
     return await connections_service.delete_secret(
         scope, instance, field,
-        forge_runtime=s.forge_runtime, reload=s.reload_connections)
+        forge_runtime=s.forge_runtime, reload=s.reload_connections,
+        cycle_lock=s.poll_rt.lock)
 
 
 @app.put("/api/v1/harness-secrets/{var}")
@@ -696,7 +698,7 @@ async def clear_secrets(body: dict):
     return await connections_service.clear_secrets(
         body, forge_runtime=s.forge_runtime, reload=s.reload_connections,
         config=s.config, shared_breakers=s.shared_breakers,
-        dev_types=s.dev_types)
+        dev_types=s.dev_types, cycle_lock=s.poll_rt.lock)
 
 
 @app.get("/api/v1/connections/registry")

--- a/app/tests/test_secret_reload_lock.py
+++ b/app/tests/test_secret_reload_lock.py
@@ -1,0 +1,127 @@
+"""L-1/L-2 (2026-08 evaluation): secret writes serialize against an
+in-flight poll cycle, the config-PUT precedent (PR #104).
+
+`reload_connections` swaps the adapter graph. The poll loop holds
+`poll_rt.lock` for a whole cycle but suspends at awaits — a secret
+PUT/DELETE/clear landing mid-cycle must not swap the graph (or delete the
+credential) underneath the suspended cycle: it waits for the lock, so a
+cycle observes either the pre-write world or the post-reload world, never
+a half-swapped one. Same contract for the default board's opportunistic
+repair, which reloads from a background task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from devcake.api import connections_service
+from devcake.config import AppConfig, MANAGED_BOARD_NAME
+
+
+def run_coro(c):
+    return asyncio.new_event_loop().run_until_complete(c)
+
+
+def _blocked_then_released(make_task, *, mutated, reloads):
+    """Acquire the cycle lock, start the op, assert NOTHING happened while
+    the cycle owns the lock, release, assert the op completed."""
+    async def scenario():
+        lock = asyncio.Lock()
+        await lock.acquire()
+        task = asyncio.create_task(make_task(lock))
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert not task.done(), "op must wait for the in-flight poll cycle"
+        assert mutated == [] and reloads == [], \
+            "no store mutation and no reload while the cycle owns its lock"
+        lock.release()
+        return await task
+    return run_coro(scenario())
+
+
+def test_put_secret_waits_for_in_flight_poll_cycle(monkeypatch):
+    mutated, reloads = [], []
+    monkeypatch.setattr(connections_service.secrets_store,
+                        "write_connection_secret",
+                        lambda *a: mutated.append(a))
+    monkeypatch.setattr(connections_service.secrets_store,
+                        "connection_status",
+                        lambda *a: {"present": True})
+    out = _blocked_then_released(
+        lambda lock: connections_service.put_secret(
+            "pmo", "board", "api_key", {"value": "k"},
+            forge_runtime=None, reload=lambda: reloads.append(1),
+            cycle_lock=lock),
+        mutated=mutated, reloads=reloads)
+    assert out == {"present": True}
+    assert len(mutated) == 1 and reloads == [1]
+
+
+def test_delete_secret_waits_for_in_flight_poll_cycle(monkeypatch):
+    mutated, reloads = [], []
+    monkeypatch.setattr(connections_service.secrets_store,
+                        "delete_connection_field",
+                        lambda *a: mutated.append(a))
+    out = _blocked_then_released(
+        lambda lock: connections_service.delete_secret(
+            "pmo", "board", "api_key",
+            forge_runtime=None, reload=lambda: reloads.append(1),
+            cycle_lock=lock),
+        mutated=mutated, reloads=reloads)
+    assert out == {"present": False}
+    assert len(mutated) == 1 and reloads == [1]
+
+
+def test_clear_secrets_waits_for_in_flight_poll_cycle(monkeypatch):
+    mutated, reloads = [], []
+    monkeypatch.setattr(connections_service.secrets_store,
+                        "delete_connection_field",
+                        lambda *a: mutated.append(a))
+    monkeypatch.setattr("devcake.settings_bundle.audit_event",
+                        lambda *a, **k: None)
+    cfg = SimpleNamespace(intake_paused=False)
+    out = _blocked_then_released(
+        lambda lock: connections_service.clear_secrets(
+            {"connections": [{"scope": "pmo", "instance": "board",
+                              "field": "api_key"}]},
+            forge_runtime=None, reload=lambda: reloads.append(1),
+            config=cfg, shared_breakers={}, dev_types={}, cycle_lock=lock),
+        mutated=mutated, reloads=reloads)
+    assert out["ok"] is True
+    assert len(mutated) == 1 and reloads == [1]
+
+
+def test_default_board_repair_waits_for_in_flight_poll_cycle(tmp_path,
+                                                             monkeypatch):
+    """L-2: the opportunistic board repair mutates config + reloads from a
+    background task — same serialization contract when `s.poll_rt` exists
+    (test fakes without one keep running lock-free)."""
+    from devcake.api.default_board import ensure_default_board
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    reloads = []
+    forge = SimpleNamespace(ensure_pmo_board=None)
+
+    async def ensure_pmo_board():
+        return {"team_key": "devcake-pmo/missions",
+                "api_base": "http://gitea:3000",
+                "minted": False, "adopted": True}
+    forge.ensure_pmo_board = ensure_pmo_board
+
+    async def scenario():
+        lock = asyncio.Lock()
+        await lock.acquire()
+        s = SimpleNamespace(
+            config=AppConfig(pmos=[]), internal_forge=forge,
+            reload_connections=lambda: reloads.append(1),
+            poll_rt=SimpleNamespace(lock=lock))
+        task = asyncio.create_task(ensure_default_board(s))
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert not task.done(), "board repair must wait for the poll cycle"
+        assert s.config.pmos == [] and reloads == []
+        lock.release()
+        await task
+        assert [p.name for p in s.config.pmos] == [MANAGED_BOARD_NAME]
+        assert reloads == [1]
+    run_coro(scenario())

--- a/app/tests/test_secrets_store.py
+++ b/app/tests/test_secrets_store.py
@@ -83,7 +83,10 @@ def _main(monkeypatch, tmp_path):
     monkeypatch.setattr(app_main, "services", make_services(
         config=AppConfig(), dev_types={}, shared_breakers={},
         forge_runtime=SimpleNamespace(breakers={}),
-        reload_connections=lambda: None))
+        reload_connections=lambda: None,
+        # the secret routes serialize their write+reload against the poll
+        # cycle (L-1) — wire the lock they now take
+        poll_rt=SimpleNamespace(lock=asyncio.Lock())))
     return app_main
 
 


### PR DESCRIPTION
## Why

`reload_connections()` tears down and rebuilds the PMO/forge adapter graph. The poll loop holds `poll_rt.lock` for an entire cycle but suspends at awaits — and the secrets endpoints called reload **bare**, so a secret PUT/DELETE/clear landing mid-cycle could swap the graph (or delete the credential) underneath the suspended cycle. This is the last surviving instance of a bug class already fixed twice: clear-runs (poll lock + dispatch lock) and config PUT / profile apply (PR #104). `clear_secrets` even documented the gap: *"no poll lock in this path."* Tracked as the cycle-lock item in docs/16 Deferred; approved this session as the PR-1 ride-along.

## What

- **L-1**: `put_secret` / `delete_secret` / `clear_secrets` gain `cycle_lock` (None = bare — the `apply_config_patch` convention); the write→breaker→reload transaction runs under it; `main.py` forwards pass `s.poll_rt.lock`. `clear_secrets`' docstring now states the real ordering guarantee instead of the old caveat.
- **L-2** (audit finding): the default board's opportunistic repair mutates `config.pmos` and reloads **from a background task** — same contract now, via a getattr-guarded lock so fakes without `poll_rt` run lock-free. Deadlock analysis in-code: ordering is always `_lock → poll_rt.lock`; `reload_connections` is sync and only *spawns* the re-ensure (`create_task`), so no cycle-lock holder ever awaits it inline; boot's ensure runs before the poll task exists.
- **L-3**: `test_secret_reload_lock.py` — four blocked-then-released tests proving **no mutation and no reload** happen while a cycle owns its lock, and that release completes the op. `test_secrets_store` wires the `poll_rt` slot its routes now touch (the fail-loud fixture guard caught every affected test by name).

## Verification

Red first (4 failed / 1625 passed), then green: **1629 passed, ruff clean**. Stack redeploy from main follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)