### PR TITLE
ops: backups verified, restores non-destructive, ops images pinned (OPS-H1/M1)

### DIFF
--- a/app/tests/test_backup_cli.py
+++ b/app/tests/test_backup_cli.py
@@ -1,9 +1,44 @@
 import os
-from pathlib import Path
+import re
 import subprocess
+import tarfile
+from pathlib import Path
 
 
 BACKUP_SCRIPT = Path("/srv/repo-scripts/backup_data.sh")
+RESTORE_SCRIPT = Path("/srv/repo-scripts/restore_data.sh")
+PAYLOADS = Path("/srv/repo-scripts/lib")
+PINNED = re.compile(r"@sha256:[0-9a-f]{64}\b")
+
+
+def _payload(name: str) -> Path:
+    p = PAYLOADS / name
+    assert p.exists(), (
+        "mount missing — the pytest runner must bind scripts → /srv/repo-scripts"
+    )
+    return p
+
+
+def _run_backup_payload(src: Path, out_dir: Path, kind: str,
+                        out_base: str = "t.tar.gz", extra_env=None):
+    env = {**os.environ, "SRC": str(src), "OUT_DIR": str(out_dir),
+           "OUT_BASE": out_base, "KIND": kind,
+           "OWNER": f"{os.getuid()}:{os.getgid()}", **(extra_env or {})}
+    return subprocess.run(["sh", str(_payload("backup_payload.sh"))],
+                          capture_output=True, text=True, env=env)
+
+
+def _run_restore_payload(dst: Path, in_dir: Path, kind: str,
+                         tarfile_name: str = "t.tar.gz"):
+    env = {**os.environ, "DST": str(dst), "IN_DIR": str(in_dir),
+           "TARFILE": tarfile_name, "KIND": kind}
+    return subprocess.run(["sh", str(_payload("restore_payload.sh"))],
+                          capture_output=True, text=True, env=env)
+
+
+def _tree(root: Path) -> dict[str, str]:
+    return {str(p.relative_to(root)): p.read_text()
+            for p in root.rglob("*") if p.is_file()}
 
 
 def test_data_backup_defaults_outside_the_checkout(tmp_path):
@@ -38,3 +73,144 @@ def test_data_backup_defaults_outside_the_checkout(tmp_path):
     expected_dir = operator_home / ".local/share/devcake/backups"
     assert f"wrote {expected_dir}/devcake-data-" in result.stdout
     assert expected_dir.stat().st_mode & 0o777 == 0o700
+
+
+# --- restore drill: the container payloads run for real against tmp dirs ---
+# (2026-08-12 audit OPS-H1: restores wiped the volume before validating the
+# tarball, and no backup was ever verified — these drills pin the fixed
+# ordering with real tar archives, no docker needed.)
+
+
+def test_backup_restore_round_trip(tmp_path):
+    src, out, dst = tmp_path / "src", tmp_path / "out", tmp_path / "dst"
+    (src / "sub").mkdir(parents=True)
+    out.mkdir(), dst.mkdir()
+    (src / "a.txt").write_text("hello")
+    (src / "sub" / "b.txt").write_text("world")
+    (src / ".hidden").write_text("dot")
+    (dst / "stale.txt").write_text("previous volume contents")
+
+    r = _run_backup_payload(src, out, "data")
+    assert r.returncode == 0, r.stderr
+    with tarfile.open(out / "t.tar.gz") as tf:
+        assert tf.getnames()[0] == "DEVCAKE_BACKUP_KIND"
+
+    r = _run_restore_payload(dst, out, "data")
+    assert r.returncode == 0, r.stderr
+    assert _tree(dst) == {"a.txt": "hello", "sub/b.txt": "world",
+                          ".hidden": "dot"}
+    assert not list(dst.glob(".pre-restore-*")), "aside must be cleaned up"
+
+
+def test_restore_refuses_corrupt_tarball_without_touching_dst(tmp_path):
+    src, out, dst = tmp_path / "src", tmp_path / "out", tmp_path / "dst"
+    src.mkdir(), out.mkdir(), dst.mkdir()
+    (src / "a.txt").write_text("x")
+    (dst / "precious.txt").write_text("only copy")
+    assert _run_backup_payload(src, out, "data").returncode == 0
+    whole = (out / "t.tar.gz").read_bytes()
+    (out / "t.tar.gz").write_bytes(whole[: len(whole) // 2])
+
+    r = _run_restore_payload(dst, out, "data")
+    assert r.returncode != 0
+    assert _tree(dst) == {"precious.txt": "only copy"}, (
+        "a corrupt tarball must not mutate the volume at all"
+    )
+    assert not list(dst.glob(".pre-restore-*"))
+
+
+def test_restore_refuses_wrong_kind_without_touching_dst(tmp_path):
+    src, out, dst = tmp_path / "src", tmp_path / "out", tmp_path / "dst"
+    src.mkdir(), out.mkdir(), dst.mkdir()
+    (src / "repo.git").write_text("gitea stuff")
+    (dst / "data-thing.json").write_text("app data")
+    assert _run_backup_payload(src, out, "gitea").returncode == 0
+
+    r = _run_restore_payload(dst, out, "data")
+    assert r.returncode == 2
+    assert "kind is 'gitea', expected 'data'" in r.stderr
+    assert _tree(dst) == {"data-thing.json": "app data"}
+    assert not list(dst.glob(".pre-restore-*"))
+
+
+def test_restore_accepts_legacy_markerless_backup_with_warning(tmp_path):
+    out, dst = tmp_path / "out", tmp_path / "dst"
+    out.mkdir(), dst.mkdir()
+    legacy_src = tmp_path / "legacy"
+    legacy_src.mkdir()
+    (legacy_src / "old.txt").write_text("pre-marker era")
+    with tarfile.open(out / "t.tar.gz", "w:gz") as tf:
+        tf.add(legacy_src / "old.txt", arcname="./old.txt")
+
+    r = _run_restore_payload(dst, out, "data")
+    assert r.returncode == 0, r.stderr
+    assert "legacy backup" in r.stderr and "unverified" in r.stderr
+    assert _tree(dst) == {"old.txt": "pre-marker era"}
+
+
+def test_backup_verifies_the_archive_it_wrote(tmp_path):
+    """A tar wrapper corrupts its own czf output — the payload's verify
+    pass (full tzf walk of what was just written) must be what fails, so a
+    truncated backup dies on backup day, not on restore day."""
+    src, out = tmp_path / "src", tmp_path / "out"
+    src.mkdir(), out.mkdir()
+    (src / "a.txt").write_text("x" * 4096)
+    fake_bin = tmp_path / "tarbin"
+    fake_bin.mkdir()
+    wrapper = fake_bin / "tar"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        'command -p tar "$@"\n'
+        "rc=$?\n"
+        'if [ "$1" = czf ]; then truncate -s 40 "$2"; fi\n'
+        "exit $rc\n"
+    )
+    wrapper.chmod(0o700)
+    r = _run_backup_payload(
+        src, out, "data",
+        extra_env={"PATH": f"{fake_bin}:{os.environ['PATH']}"})
+    assert r.returncode != 0, "verify pass must catch the truncated archive"
+
+
+# --- host-side contract: the scripts drive docker with the pinned image ---
+
+
+def _fake_docker(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log = tmp_path / "docker-args.log"
+    fake = fake_bin / "docker"
+    fake.write_text(
+        "#!/bin/sh\n"
+        f'if [ "$1" = run ]; then echo "$@" >> {log}; fi\n'
+        "exit 0\n"
+    )
+    fake.chmod(0o700)
+    return fake_bin, log
+
+
+def test_backup_script_uses_pinned_image_and_payload(tmp_path):
+    fake_bin, log = _fake_docker(tmp_path)
+    env = {**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}",
+           "DEVCAKE_BACKUP_DIR": str(tmp_path / "backups")}
+    r = subprocess.run([str(BACKUP_SCRIPT)], check=True, capture_output=True,
+                       text=True, env=env)
+    args = log.read_text()
+    assert PINNED.search(args), "backup container image must be digest-pinned"
+    assert "backup_payload.sh" in args
+    assert "KIND=data" in args
+    assert "(verified readable)" in r.stdout
+
+
+def test_restore_script_uses_pinned_image_and_payload(tmp_path):
+    fake_bin, log = _fake_docker(tmp_path)
+    tarball = tmp_path / "devcake-data-x.tar.gz"
+    tarball.write_bytes(b"irrelevant - docker is faked")
+    env = {**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"}
+    subprocess.run([str(RESTORE_SCRIPT), str(tarball)], check=True,
+                   capture_output=True, text=True, env=env)
+    args = log.read_text()
+    assert PINNED.search(args), "restore container image must be digest-pinned"
+    assert "restore_payload.sh" in args
+    assert "KIND=data" in args
+    assert "find /dst" not in args, "delete-first restore must stay dead"

--- a/app/tests/test_image_pins_gate.py
+++ b/app/tests/test_image_pins_gate.py
@@ -1,0 +1,113 @@
+"""The docker-run scanner in check_image_pins.py (2026-08-12 audit OPS-M1)
+must catch unpinned images in ops scripts and pass the legitimate shapes the
+repo actually uses — variable defaults, array splices, multi-line payloads,
+python subprocess lists. Test the gate, not just the gated."""
+
+import importlib.util
+from pathlib import Path
+
+GATE = Path("/srv/repo-scripts/check_image_pins.py")
+
+DIGEST = "a" * 64
+
+
+def _load(tmp_path):
+    assert GATE.exists(), (
+        "mount missing — the pytest runner must bind scripts → /srv/repo-scripts"
+    )
+    spec = importlib.util.spec_from_file_location("pins_gate", GATE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.ROOT = tmp_path  # rel-path anchor for offender messages
+    return mod
+
+
+def _sh(mod, tmp_path, body: str) -> list[str]:
+    f = tmp_path / "case.sh"
+    f.write_text("#!/bin/sh\n" + body)
+    offenders: list[str] = []
+    mod.check_shell_script(f, offenders)
+    return offenders
+
+
+def _py(mod, tmp_path, body: str) -> list[str]:
+    f = tmp_path / "case.py"
+    f.write_text(body)
+    offenders: list[str] = []
+    mod.check_python_script(f, offenders)
+    return offenders
+
+
+def test_unpinned_shell_image_is_an_offender(tmp_path):
+    mod = _load(tmp_path)
+    off = _sh(mod, tmp_path,
+              'docker run --rm -v "$V":/x alpine sh -c "true"\n')
+    assert off and "alpine" in off[0]
+
+
+def test_pinned_variable_default_passes(tmp_path):
+    mod = _load(tmp_path)
+    off = _sh(mod, tmp_path,
+              f'IMG="${{OVERRIDE:-alpine:3.22@sha256:{DIGEST}}}"\n'
+              'docker run --rm "$IMG" true\n')
+    assert not off, off
+
+
+def test_variable_without_in_file_default_is_an_offender(tmp_path):
+    mod = _load(tmp_path)
+    off = _sh(mod, tmp_path, 'docker run --rm "$MYSTERY" true\n')
+    assert off and "MYSTERY" in off[0]
+
+
+def test_devcake_local_image_with_splice_and_entrypoint_passes(tmp_path):
+    mod = _load(tmp_path)
+    off = _sh(mod, tmp_path,
+              'docker run --rm "${ARGS[@]}" --entrypoint sh '
+              'devcake/foo:latest -c "x"\n')
+    assert not off, off
+
+
+def test_multiline_run_with_unterminated_payload_resolves_variable(tmp_path):
+    mod = _load(tmp_path)
+    off = _sh(mod, tmp_path,
+              'OUT="$(docker run --rm "${N[@]}" \\\n'
+              '  -e A="$B" \\\n'
+              "  --entrypoint bash \"$IMAGE\" -c '\n"
+              "set -eu\n"
+              "true\n"
+              "')\"\n"
+              'IMAGE="${X:-devcake/dev:latest}"\n')
+    assert not off, off
+
+
+def test_comment_lines_are_ignored(tmp_path):
+    mod = _load(tmp_path)
+    off = _sh(mod, tmp_path, "# e.g. docker run --rm alpine sh\ntrue\n")
+    assert not off, off
+
+
+def test_python_unpinned_list_is_an_offender(tmp_path):
+    mod = _load(tmp_path)
+    off = _py(mod, tmp_path,
+              'import subprocess\n'
+              'subprocess.run(["docker", "run", "--rm",\n'
+              '                "-v", f"{v}:/x", "alpine", "sh"])\n')
+    assert off and "alpine" in off[0]
+
+
+def test_python_module_constant_pin_passes(tmp_path):
+    mod = _load(tmp_path)
+    off = _py(mod, tmp_path,
+              f'IMG = ("alpine:3.22@sha256:" "{DIGEST}")\n'
+              'import subprocess\n'
+              'subprocess.run(["docker", "run", "--rm",\n'
+              '                "-v", f"{v}:/x", IMG, "sh"])\n')
+    assert not off, off
+
+
+def test_python_fstring_image_is_an_offender(tmp_path):
+    mod = _load(tmp_path)
+    off = _py(mod, tmp_path,
+              'import subprocess\n'
+              'subprocess.run(["docker", "run", f"{img}", "sh"])\n')
+    assert off and "not a resolvable literal" in off[0]

--- a/scripts/backup_data.sh
+++ b/scripts/backup_data.sh
@@ -18,6 +18,11 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# Digest-pinned (ISSUES #29 rider, 2026-08-12 audit OPS-M1): this container
+# runs as root with RW on the secrets-bearing output dir — the one place a
+# floating :latest was least acceptable. check_image_pins.py enforces.
+ALPINE_IMAGE="${DEVCAKE_ALPINE_IMAGE:-alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce}"
+
 VOLUME="${DEVCAKE_DATA_VOLUME:-devcake_devcake_data}"
 if [[ $# -gt 0 ]]; then
   OUT="$1"
@@ -42,12 +47,13 @@ if docker ps --format '{{.Names}}' | grep -q devcake-app; then
 fi
 
 # tar as root (container default) so 0600/0700 secret files under
-# /data/secrets are readable regardless of the operator's host uid; basename
-# rides an ENV VAR (never shell-interpolated — re-audit #5); umask 077 keeps
-# the tarball non-world-readable; the chown hands it to the invoker (audit
-# D5 #19).
+# /data/secrets are readable regardless of the operator's host uid. The
+# payload (scripts/lib/backup_payload.sh — shared with the pytest restore
+# drill) owns umask/marker/verify/chown; basename rides an ENV VAR (never
+# shell-interpolated — re-audit #5).
 docker run --rm \
-  -e OUT_BASE="$OUT_BASE" -e OWNER="$(id -u):$(id -g)" \
-  -v "$VOLUME":/src:ro -v "$OUT_DIR":/out alpine \
-  sh -c 'umask 077 && tar czf "/out/$OUT_BASE" -C /src . && chown "$OWNER" "/out/$OUT_BASE"'
-echo "wrote $OUT_DIR/$OUT_BASE — contains EVERY operator secret in plaintext; store like a password export"
+  -e OUT_BASE="$OUT_BASE" -e OWNER="$(id -u):$(id -g)" -e KIND=data \
+  -v "$VOLUME":/src:ro -v "$OUT_DIR":/out \
+  -v "$(pwd)/scripts/lib":/lib:ro \
+  "$ALPINE_IMAGE" sh /lib/backup_payload.sh
+echo "wrote $OUT_DIR/$OUT_BASE (verified readable) — contains EVERY operator secret in plaintext; store like a password export"

--- a/scripts/backup_gitea.sh
+++ b/scripts/backup_gitea.sh
@@ -13,6 +13,10 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# Digest-pinned (ISSUES #29 rider, 2026-08-12 audit OPS-M1): this container
+# runs as root with RW on the output dir — check_image_pins.py enforces.
+ALPINE_IMAGE="${DEVCAKE_ALPINE_IMAGE:-alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce}"
+
 VOLUME="${GITEA_VOLUME:-devcake_gitea_data}"
 OUT="${1:-devcake-gitea-$(date -u +%Y%m%d-%H%M).tar.gz}"
 
@@ -35,12 +39,12 @@ fi
 # tar runs as ROOT (the container default) so it can read gitea's rootless
 # 0700 data dirs (git/, custom/, jwt/private.pem — owned by the in-container
 # uid 1000, unreadable to a host operator whose uid != 1000; re-audit #4).
-# The basename rides an ENV VAR, never interpolated into the shell string, so
-# a filename with quotes/spaces is safe (re-audit #5). umask 077 keeps the
-# tarball non-world-readable, and a trailing chown hands it to the invoking
-# operator instead of leaving it root-owned (audit D5 #19).
+# The payload (scripts/lib/backup_payload.sh — shared with the pytest restore
+# drill) owns umask/marker/verify/chown; the basename rides an ENV VAR, never
+# interpolated into the shell string (re-audit #5).
 docker run --rm \
-  -e OUT_BASE="$OUT_BASE" -e OWNER="$(id -u):$(id -g)" \
-  -v "$VOLUME":/src:ro -v "$OUT_DIR":/out alpine \
-  sh -c 'umask 077 && tar czf "/out/$OUT_BASE" -C /src . && chown "$OWNER" "/out/$OUT_BASE"'
-echo "wrote $OUT_DIR/$OUT_BASE — contains repo content AND Gitea's credential DB; store like a password export"
+  -e OUT_BASE="$OUT_BASE" -e OWNER="$(id -u):$(id -g)" -e KIND=gitea \
+  -v "$VOLUME":/src:ro -v "$OUT_DIR":/out \
+  -v "$(pwd)/scripts/lib":/lib:ro \
+  "$ALPINE_IMAGE" sh /lib/backup_payload.sh
+echo "wrote $OUT_DIR/$OUT_BASE (verified readable) — contains repo content AND Gitea's credential DB; store like a password export"

--- a/scripts/check_image_pins.py
+++ b/scripts/check_image_pins.py
@@ -6,9 +6,14 @@ and stage references are exempt; every devcake/* compose service must declare
 `pull_policy: never` (otherwise a typo'd tag would pull from the public —
 squattable — Docker Hub `devcake` namespace). Exit non-zero listing offenders.
 
-Files are DISCOVERED (rglob Dockerfile*, glob docker-compose*.yml), not
-hardcoded — a new Dockerfile or a docker-compose.override.yml (which compose
-auto-loads) is scanned the moment it exists (audit A14).
+Files are DISCOVERED (rglob Dockerfile*, glob docker-compose*.yml, glob
+scripts/*.sh + scripts/*.py), not hardcoded — a new Dockerfile or a
+docker-compose.override.yml (which compose auto-loads) is scanned the moment
+it exists (audit A14). `docker run` invocations in ops scripts are covered
+too (2026-08-12 audit OPS-M1: the backup/restore containers — root, RW on
+secrets-bearing volumes — ran floating `alpine`, structurally invisible to
+this gate): the image token must be pinned, a devcake/* local image, or a
+variable whose in-file default resolves to one.
 
 Bump procedure: docker buildx imagetools inspect <image:tag> → paste the
 manifest-list digest.
@@ -20,7 +25,9 @@ This checker covers image refs only; the exception lives here so it is
 auditable.
 """
 
+import ast
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -39,6 +46,11 @@ def _dockerfiles() -> list[Path]:
 def _compose_files() -> list[Path]:
     return sorted(ROOT.glob("docker-compose*.yml")) + sorted(
         ROOT.glob("docker-compose*.yaml"))
+
+
+def _script_files() -> tuple[list[Path], list[Path]]:
+    scripts = ROOT / "scripts"
+    return (sorted(scripts.glob("*.sh")), sorted(scripts.glob("*.py")))
 
 
 def _strip_platform(tokens: list[str]) -> list[str]:
@@ -148,12 +160,180 @@ def _service_block_has(lines: list[str], image_idx: int, indent: int,
     return False
 
 
+# --- `docker run` in ops scripts (2026-08-12 audit OPS-M1) -----------------
+
+# docker-run flags that consume the NEXT token as their value — the walk must
+# skip both, or a flag value would be mistaken for the image ref.
+_RUN_FLAGS_WITH_VALUE = {
+    "-e", "--env", "--env-file", "-v", "--volume", "--mount", "-w",
+    "--workdir", "-u", "--user", "--name", "--network", "--network-alias",
+    "--entrypoint", "--platform", "-p", "--publish", "--expose", "-l",
+    "--label", "--hostname", "--tmpfs", "--add-host", "--cap-add",
+    "--cap-drop", "--device", "--gpus", "--restart", "--memory", "-m",
+    "--cpus", "--pids-limit", "--security-opt", "--log-driver", "--log-opt",
+    "--stop-timeout", "--pull", "--health-cmd", "--health-interval",
+}
+
+_ARRAY_SPLICE = re.compile(r"\$\{\w+\[@\]\}")
+_VAR_TOKEN = re.compile(r"\$\{?(\w+)\}?$")
+
+_UNRESOLVED = ""  # sentinel: an image token exists but is not a literal
+
+
+def _walk_run_args(tokens: list) -> str | None:
+    """First non-flag token after `run` is the image ref. Entries are str
+    for literal tokens, None for opaque ones (python f-strings). Returns the
+    token, _UNRESOLVED for an opaque image position, None if none found."""
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok is None:
+            return _UNRESOLVED
+        tok = tok.strip("\"'")
+        if _ARRAY_SPLICE.fullmatch(tok):
+            i += 1                       # bash array splice: args, not image
+            continue
+        if tok in _RUN_FLAGS_WITH_VALUE:
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1                       # standalone flag or --flag=value
+            continue
+        return tok
+    return None
+
+
+def _shell_logical_lines(text: str) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    buf: list[str] = []
+    start = 1
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        if not buf:
+            start = lineno
+        line = raw.rstrip()
+        if line.endswith("\\"):
+            buf.append(line[:-1])
+            continue
+        buf.append(line)
+        out.append((start, " ".join(buf)))
+        buf = []
+    if buf:
+        out.append((start, " ".join(buf)))
+    return out
+
+
+def _resolve_shell_default(name: str, text: str) -> str | None:
+    """Resolve NAME=VALUE to a literal, unwrapping ${VAR:-default} layers —
+    `IMG="${OVERRIDE:-alpine@sha256:…}"` pins via its in-file default."""
+    m = re.search(rf"^\s*{re.escape(name)}=(\S+)", text, re.MULTILINE)
+    if not m:
+        return None
+    val = m.group(1).strip().strip("\"'")
+    while True:
+        inner = re.fullmatch(r"\$\{\w+:-(.*)\}", val)
+        if not inner:
+            return val
+        val = inner.group(1)
+
+
+def _check_script_image(rel, lineno: int, img, text: str,
+                        offenders: list[str]) -> None:
+    if img is None:
+        offenders.append(
+            f"{rel}:{lineno}: `docker run` with no locatable image token — "
+            f"restructure so the gate can verify the pin")
+        return
+    if img is not _UNRESOLVED:
+        var = _VAR_TOKEN.fullmatch(img)
+        if var:
+            resolved = _resolve_shell_default(var.group(1), text)
+            if resolved is None:
+                offenders.append(
+                    f"{rel}:{lineno}: image ${var.group(1)} has no in-file "
+                    f"literal default to verify — give it a pinned default")
+                return
+            img = resolved
+    if img is _UNRESOLVED:
+        offenders.append(
+            f"{rel}:{lineno}: image ref is not a resolvable literal — "
+            f"pin it via a module/script constant")
+        return
+    if img.startswith(LOCAL_PREFIX) or PINNED.search(img):
+        return
+    offenders.append(f"{rel}:{lineno}: docker run {img}")
+
+
+def check_shell_script(path: Path, offenders: list[str]) -> None:
+    rel = path.relative_to(ROOT)
+    text = path.read_text()
+    for lineno, line in _shell_logical_lines(text):
+        if "docker run" not in line or line.lstrip().startswith("#"):
+            continue
+        try:
+            tokens = shlex.split(line, posix=True)
+        except ValueError:
+            # unterminated quote — a `docker run … sh -c '…multi-line…'`
+            # whose payload opens on this logical line; naive split still
+            # exposes the flag/image tokens, quotes stripped in the walk
+            tokens = line.split()
+        idx = next((i for i in range(len(tokens) - 1)
+                    if tokens[i].strip("\"'").split("(")[-1] == "docker"
+                    and tokens[i + 1] == "run"), None)
+        if idx is None:
+            continue
+        img = _walk_run_args(tokens[idx + 2:])
+        _check_script_image(rel, lineno, img, text, offenders)
+
+
+def check_python_script(path: Path, offenders: list[str]) -> None:
+    """Scan list literals shaped ["docker", "run", …] — the subprocess
+    idiom. Module-level str constants resolve (export_receipts.ALPINE_IMAGE);
+    anything non-literal in image position is an offender, fail-closed."""
+    rel = path.relative_to(ROOT)
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError:
+        return
+    consts: dict[str, str] = {}
+    for node in tree.body:
+        if (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)):
+            try:
+                val = ast.literal_eval(node.value)
+            except (ValueError, SyntaxError):
+                continue
+            if isinstance(val, str):
+                consts[node.targets[0].id] = val
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.List) and len(node.elts) >= 3):
+            continue
+        head = [e.value for e in node.elts[:2]
+                if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+        if head != ["docker", "run"]:
+            continue
+        tokens: list = []
+        for e in node.elts[2:]:
+            if isinstance(e, ast.Constant) and isinstance(e.value, str):
+                tokens.append(e.value)
+            elif isinstance(e, ast.Name) and e.id in consts:
+                tokens.append(consts[e.id])
+            else:
+                tokens.append(None)
+        img = _walk_run_args(tokens)
+        _check_script_image(rel, node.lineno, img, "", offenders)
+
+
 def main() -> int:
     offenders: list[str] = []
     for df in _dockerfiles():
         check_dockerfile(df, offenders)
     for cf in _compose_files():
         check_compose(cf, offenders)
+    sh_files, py_files = _script_files()
+    for f in sh_files:
+        check_shell_script(f, offenders)
+    for f in py_files:
+        check_python_script(f, offenders)
     if offenders:
         print("UNPINNED image references (ISSUES #29 — pin tag@sha256:…):")
         for o in offenders:

--- a/scripts/export_receipts.py
+++ b/scripts/export_receipts.py
@@ -44,6 +44,11 @@ import urllib.request
 PAGE = 10_000
 MAX_PAGES = 500          # 5M spans per stream; loud, never silent (below)
 
+# Digest-pinned (ISSUES #29 rider, 2026-08-12 audit OPS-M1): runs as root
+# with RW on the output dir — check_image_pins.py enforces the pin.
+ALPINE_IMAGE = ("alpine:3.22@sha256:"
+                "14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce")
+
 
 def env(name, default=None):
     for line in open(".env"):
@@ -148,7 +153,7 @@ def main():
         ["docker", "run", "--rm",
          "-e", f"OUT_BASE={tar_base}",
          "-e", f"OWNER={os.getuid()}:{os.getgid()}",
-         "-v", f"{volume}:/src:ro", "-v", f"{out}:/out", "alpine",
+         "-v", f"{volume}:/src:ro", "-v", f"{out}:/out", ALPINE_IMAGE,
          "sh", "-c",
          'umask 077 && tar czf "/out/$OUT_BASE" -C /src'
          ' --exclude ./secrets . && chown "$OWNER" "/out/$OUT_BASE"'],

--- a/scripts/lib/backup_payload.sh
+++ b/scripts/lib/backup_payload.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Container-side payload for backup_data.sh / backup_gitea.sh — POSIX sh
+# (busybox in the alpine container; any sh in the pytest restore drill, which
+# overrides SRC/OUT_DIR to run it against tmp dirs without docker).
+#
+# Ordering is the safety property (2026-08-12 audit OPS-H1): the tarball is
+# structurally VERIFIED (full tzf walk) in the same run that wrote it, so a
+# truncated/corrupt archive fails on backup day, not on restore day. A
+# DEVCAKE_BACKUP_KIND marker (first archive member) records what volume kind
+# the tarball holds; restore_payload.sh refuses a mismatched kind.
+#
+# Env: OUT_BASE  tarball basename (rides env, never shell-interpolated —
+#                re-audit #5)
+#      OWNER    uid:gid to hand the tarball to (audit D5 #19)
+#      KIND     "data" | "gitea" — written into the marker
+#      SRC      source dir (default /src), OUT_DIR output dir (default /out)
+set -eu
+SRC="${SRC:-/src}"
+OUT_DIR="${OUT_DIR:-/out}"
+umask 077
+
+KIND_DIR="$(mktemp -d)"
+printf '%s\n' "$KIND" > "$KIND_DIR/DEVCAKE_BACKUP_KIND"
+
+tar czf "$OUT_DIR/$OUT_BASE" -C "$KIND_DIR" DEVCAKE_BACKUP_KIND -C "$SRC" .
+
+# verify: walk the ENTIRE archive — a backup that cannot be listed today
+# could not have been restored tomorrow (write-only-backup audit finding)
+tar tzf "$OUT_DIR/$OUT_BASE" > /dev/null
+
+chown "$OWNER" "$OUT_DIR/$OUT_BASE"

--- a/scripts/lib/restore_payload.sh
+++ b/scripts/lib/restore_payload.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Container-side payload for restore_data.sh / restore_gitea.sh — POSIX sh
+# (busybox in the alpine container; any sh in the pytest restore drill, which
+# overrides DST/IN_DIR to run it against tmp dirs without docker).
+#
+# Ordering is the safety property (2026-08-12 audit OPS-H1 — the old payload
+# was `find /dst -delete && tar xzf`, so a corrupt tarball destroyed the only
+# copy):
+#   1. validate the ENTIRE archive structure before touching $DST
+#   2. verify the DEVCAKE_BACKUP_KIND marker matches (a gitea tarball must
+#      never be extracted into the data volume); markerless legacy backups
+#      warn and proceed — they predate the marker and stay restorable
+#   3. move the current contents ASIDE (rename within the volume — no copy),
+#      never delete them up front
+#   4. extract; only after a clean extract is the move-aside removed
+# On any failure the previous contents survive inside the volume under the
+# printed .pre-restore-* path.
+#
+# Env: TARFILE  tarball basename (rides env, never shell-interpolated)
+#      KIND     expected kind: "data" | "gitea"
+#      DST      target dir (default /dst), IN_DIR tarball dir (default /in)
+set -eu
+DST="${DST:-/dst}"
+IN_DIR="${IN_DIR:-/in}"
+TAR="$IN_DIR/$TARFILE"
+
+# 1 — full structural preflight: list every member before any mutation
+tar tzf "$TAR" > /dev/null
+
+# 2 — kind check (marker is the first member, so both commands are cheap)
+if tar tzf "$TAR" | grep -qx 'DEVCAKE_BACKUP_KIND'; then
+  found="$(tar xzf "$TAR" -O DEVCAKE_BACKUP_KIND)"
+  if [ "$found" != "$KIND" ]; then
+    echo "refusing: tarball kind is '$found', expected '$KIND' — wrong backup for this volume" >&2
+    exit 2
+  fi
+else
+  echo "WARNING: no DEVCAKE_BACKUP_KIND marker (legacy backup) — kind unverified" >&2
+fi
+
+# 3 — move aside, never delete-first; leftover .pre-restore-* dirs from an
+# earlier failed attempt stay where they are instead of nesting
+ASIDE="$DST/.pre-restore-$(date -u +%Y%m%d-%H%M%S)"
+mkdir "$ASIDE"
+trap 'echo "RESTORE FAILED — previous contents preserved at $ASIDE (inside the volume); discard the partial extract and re-run" >&2' EXIT
+find "$DST" -mindepth 1 -maxdepth 1 ! -name '.pre-restore-*' -exec mv {} "$ASIDE/" \;
+
+# 4 — extract, drop the marker from the restored tree, then discard the aside
+tar xzf "$TAR" -C "$DST"
+rm -f "$DST/DEVCAKE_BACKUP_KIND"
+rm -rf "$ASIDE"
+trap - EXIT

--- a/scripts/restore_data.sh
+++ b/scripts/restore_data.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Restore the app's /data volume from a backup_data.sh tarball. REFUSES while
-# the app service is running, and REPLACES the volume's current contents.
+# the app service is running, and REPLACES the volume's current contents —
+# but never destructively: the payload validates the whole archive and its
+# kind marker first, moves the current contents aside, and deletes the aside
+# only after a clean extract (2026-08-12 audit OPS-H1; on failure the
+# previous contents survive at the printed .pre-restore-* path).
 #
 # After restore: run files reflect the backup's moment — the app's boot
 # reconciliation (docs/04 §6) orphans anything whose container no longer
@@ -9,6 +13,9 @@
 # Usage: docker compose stop app && scripts/restore_data.sh <backup.tar.gz>
 set -euo pipefail
 cd "$(dirname "$0")/.."
+
+# Digest-pinned (ISSUES #29 rider, OPS-M1): root + RW on the data volume.
+ALPINE_IMAGE="${DEVCAKE_ALPINE_IMAGE:-alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce}"
 
 VOLUME="${DEVCAKE_DATA_VOLUME:-devcake_devcake_data}"
 TARBALL="${1:?usage: restore_data.sh <devcake-data-*.tar.gz>}"
@@ -22,8 +29,11 @@ docker volume inspect "$VOLUME" >/dev/null
 
 TARDIR="$(cd "$(dirname "$TARBALL")" && pwd)"
 TARFILE="$(basename "$TARBALL")"
-# Basename via ENV VAR, never shell-interpolated (re-audit #5 pattern).
-docker run --rm -e TARFILE="$TARFILE" \
-  -v "$VOLUME":/dst -v "$TARDIR":/in:ro alpine \
-  sh -c 'find /dst -mindepth 1 -delete && tar xzf "/in/$TARFILE" -C /dst'
-echo "restored $VOLUME from $TARBALL — docker compose up -d to restart the stack"
+# Basename via ENV VAR, never shell-interpolated (re-audit #5 pattern). The
+# payload (scripts/lib/restore_payload.sh — shared with the pytest restore
+# drill) owns preflight/kind-check/move-aside/extract ordering.
+docker run --rm -e TARFILE="$TARFILE" -e KIND=data \
+  -v "$VOLUME":/dst -v "$TARDIR":/in:ro \
+  -v "$(pwd)/scripts/lib":/lib:ro \
+  "$ALPINE_IMAGE" sh /lib/restore_payload.sh
+echo "restored $VOLUME from $TARBALL (verified before extract) — docker compose up -d to restart the stack"

--- a/scripts/restore_gitea.sh
+++ b/scripts/restore_gitea.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 # Restore the internal Gitea volume from a backup_gitea.sh tarball
 # (ADR-0013 decision 5). REFUSES while the gitea service is running, and
-# REPLACES the volume's current contents.
+# REPLACES the volume's current contents — but never destructively: the
+# payload validates the whole archive and its kind marker first, moves the
+# current contents aside, and deletes the aside only after a clean extract
+# (2026-08-12 audit OPS-H1; on failure the previous contents survive at the
+# printed .pre-restore-* path).
 #
 # Usage: docker compose stop gitea && scripts/restore_gitea.sh <backup.tar.gz>
 set -euo pipefail
 cd "$(dirname "$0")/.."
+
+# Digest-pinned (ISSUES #29 rider, OPS-M1): root + RW on the gitea volume.
+ALPINE_IMAGE="${DEVCAKE_ALPINE_IMAGE:-alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce}"
 
 VOLUME="${GITEA_VOLUME:-devcake_gitea_data}"
 TARBALL="${1:?usage: restore_gitea.sh <devcake-gitea-*.tar.gz>}"
@@ -19,10 +26,11 @@ docker volume inspect "$VOLUME" >/dev/null
 
 TARDIR="$(cd "$(dirname "$TARBALL")" && pwd)"
 TARFILE="$(basename "$TARBALL")"
-# Basename rides an ENV VAR, never interpolated into the shell string — the
-# same hardening backup_gitea.sh got in re-audit #5; the restore twin had
-# kept the interpolation (2026-08 evaluation).
-docker run --rm -e TARFILE="$TARFILE" \
-  -v "$VOLUME":/dst -v "$TARDIR":/in:ro alpine \
-  sh -c 'find /dst -mindepth 1 -delete && tar xzf "/in/$TARFILE" -C /dst'
-echo "restored $VOLUME from $TARBALL — docker compose up -d to restart the stack"
+# Basename rides an ENV VAR, never interpolated into the shell string (re-
+# audit #5). The payload (scripts/lib/restore_payload.sh — shared with the
+# pytest restore drill) owns preflight/kind-check/move-aside/extract ordering.
+docker run --rm -e TARFILE="$TARFILE" -e KIND=gitea \
+  -v "$VOLUME":/dst -v "$TARDIR":/in:ro \
+  -v "$(pwd)/scripts/lib":/lib:ro \
+  "$ALPINE_IMAGE" sh /lib/restore_payload.sh
+echo "restored $VOLUME from $TARBALL (verified before extract) — docker compose up -d to restart the stack"


### PR DESCRIPTION
Phase 0 PR-A of the 2026-08-12 audit intervention campaign (plan: seven-reviewer skeptical audit at ccc6da9).

## Findings addressed
- **OPS-H1 (high):** `restore_data.sh`/`restore_gitea.sh` wiped the volume *before* validating the tarball; backups were never verified after writing — write-only until the day they're needed.
- **OPS-M1 (med):** the most privileged containers in the system (root, RW on secrets volumes) ran floating `alpine:latest`, and the pin gate only scanned Dockerfiles/compose.

## Changes
- Shared container-side payloads (`scripts/lib/`) own the safety ordering: backup = write + kind marker + **full tzf verify in the same run**; restore = **preflight → kind check → move-aside → extract → cleanup**. On any restore failure the previous contents survive inside the volume at a printed `.pre-restore-*` path. Markerless legacy backups warn and remain restorable.
- All five ops `docker run` sites pinned to `alpine:3.22@sha256:1435…` (env-overridable).
- `check_image_pins.py` now scans `scripts/*.sh|*.py` docker-run image tokens: resolves `${VAR:-default}` chains and module constants, skips `"${ARR[@]}"` splices, fail-closed on unresolvable refs.

## Tests
- Behavioral restore drills run the *real payloads* against tmp dirs (no docker): round-trip, corrupt tarball leaves dst byte-identical, wrong-kind refuses (rc 2), legacy warns, and a tar-wrapper test proves the *verify* step catches a truncated write.
- Fake-docker argv contracts pin the host-side invariants (pinned image, payload path, `KIND=`, and `find /dst` staying dead).
- Gate self-tests cover offender and clean shapes both directions.

Full suite: **1645 passed, 1 skipped** (pytest_app.sh, rebaked image). `check_image_pins.py` green on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)