### PR TITLE
fix: RETRY_TOKEN scan honors the unquoted-body iron rule (audit F14)

### DIFF
--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -912,7 +912,11 @@ def attempt_number(mgr, pmo_id: str, mission_type: str,
                     if e.kind == "comment"
                     and not _is_devcake_comment(e.body)
                     and (policy == "any-comment"
-                         or RETRY_TOKEN in (e.body or ""))]
+                         # IRON RULE (markers.py, ADR-0014 D2): token scans
+                         # run on the unquoted body — a human QUOTING a
+                         # DevCake post that mentions the token is not the
+                         # deliberate retry gesture (2026-08-12 audit F14)
+                         or RETRY_TOKEN in _unquoted(e.body or ""))]
     since = max(anchors, default=None)
     return 1 + sum(
         1 for r in history

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -463,6 +463,36 @@ def test_attempts_ignore_plain_comments_under_default_policy(tmp_path, monkeypat
     assert dispatch.attempt_number(mgr, "p1", "EXECUTE", activity) == 1
 
 
+def test_quoted_retry_token_does_not_reset_attempts(tmp_path, monkeypatch):
+    """IRON RULE (ADR-0014 D2, 2026-08-12 audit F14): a human QUOTING a post
+    that mentions DEVCAKE-RETRY — the reply-with-quote gesture every PMO UI
+    offers — is not the deliberate retry gesture. Only an unquoted token
+    resets the counter."""
+    from datetime import timedelta
+    import devcake.domain.orchestrator as orchestrator_mod
+
+    m = mission("in_progress", {"DEVCAKE"})
+    mgr, _fake, store = make_mgr(tmp_path, m)
+    monkeypatch.setattr(orchestrator_mod.markers, "AUDIT_PATH",
+                        tmp_path / "no-audit.jsonl")
+    assert mgr.config.attempt_reset == "label-ops"
+    t0 = datetime.now(timezone.utc)
+    _failed_execute_runs(store, t0)
+
+    quoting = ActivityEntry(
+        ts=t0 + timedelta(seconds=20), author="felix", kind="comment",
+        body="> when ready, comment DEVCAKE-RETRY to grant fresh attempts\n\n"
+             "not yet — still investigating")
+    activity = Activity(mission=m, entries=[quoting])
+    assert dispatch.attempt_number(mgr, "p1", "EXECUTE", activity) == 3
+
+    unquoted = ActivityEntry(
+        ts=t0 + timedelta(seconds=30), author="felix", kind="comment",
+        body="fixture fixed. DEVCAKE-RETRY")
+    activity = Activity(mission=m, entries=[quoting, unquoted])
+    assert dispatch.attempt_number(mgr, "p1", "EXECUTE", activity) == 1
+
+
 def test_attempts_reset_on_any_comment_when_opted_in(tmp_path, monkeypatch):
     """`attempt_reset: any-comment` restores the pre-0026 rule: a human
     comment is an intervention and grants fresh attempts. DevCake's own


### PR DESCRIPTION
Phase 0 PR-D of the 2026-08-12 audit intervention campaign.

`attempt_number` (dispatch.py) scanned for `DEVCAKE-RETRY` on the **raw** comment body, violating the markers.py iron rule (ADR-0014 D2: every feed scan runs on `feed._unquoted`). A human quoting a DevCake post that mentions the token — the standard reply-with-quote gesture — reset the attempt counter under `label-ops`, the exact accidental reset the literal-token design exists to prevent. Benign direction (extra attempts, never unsafe transitions), but a stated-invariant violation.

One-line fix + regression test: quoted token does **not** reset (pinned red-before: `1 failed, 1629 passed` on the old scan), unquoted token still does. Full suite green after: **1630 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)