### PR TITLE
fix(gitea_issues): label pagination, fail-loud project refs, open-only dep enrichment (F8/F1/F9)

### DIFF
--- a/app/devcake/adapters/gitea_issues/adapter.py
+++ b/app/devcake/adapters/gitea_issues/adapter.py
@@ -33,6 +33,8 @@ MAX_COMMENT_PAGES_FULL = 100
 COMMENTS_PAGE = 50
 ISSUES_PAGE = 50
 MAX_ISSUE_PAGES = 40  # 2000 issues fail-loud
+LABELS_PAGE = 50
+MAX_LABEL_PAGES = 10  # 500 labels fail-loud — see _fetch_all_labels
 
 # Attachment host patterns for markdown link recovery
 _NAMED_ASSET_RE = re.compile(
@@ -199,6 +201,16 @@ class GiteaIssuesAdapter:
                 f"(need owner/repo)")
         return f"/repos/{self._owner}/{self._repo}{suffix}"
 
+    def _require_issue(self, ref: MissionRef) -> None:
+        """projects_supported=False: a project-kind ref reaching this adapter
+        is a caller bug. Raise (permanent family) — never fabricate a Mission
+        or silently no-op a write, which would report success while swapping
+        no labels and setting no status (2026-08-12 audit F1)."""
+        if ref.kind != "issue":
+            raise RuntimeError(
+                "gitea_issues: projects are not supported "
+                f"(got kind={ref.kind!r})")
+
     # ── normalization ───────────────────────────────────────────────────────
 
     def _mission(self, issue: dict) -> Mission:
@@ -292,7 +304,15 @@ class GiteaIssuesAdapter:
         out: list[Mission] = []
         for raw in await self._list_issues(state="all"):
             m = self._mission(raw)
-            out.append(await self._enrich_blocked_by(m))
+            # blocked_by enrichment costs one GET per issue per poll cycle —
+            # spend it on OPEN issues only: the scheduler's gate reads a
+            # BLOCKER's status off its own list row, never a closed issue's
+            # blocked_by, and set_status deletes dependencies on close. The
+            # old unconditional enrichment grew monotonically with history
+            # (2026-08-12 audit F9).
+            if m.status not in ("done", "canceled"):
+                m = await self._enrich_blocked_by(m)
+            out.append(m)
         return out
 
     def _apply_team(self, team_ref: str) -> None:
@@ -303,24 +323,17 @@ class GiteaIssuesAdapter:
             self._label_ids.clear()
 
     async def get(self, ref: MissionRef) -> Mission:
-        if ref.kind != "issue":
-            raise RuntimeError(
-                "gitea_issues: projects are not supported "
-                f"(got kind={ref.kind!r})")
+        self._require_issue(ref)
         raw = await self._req(
             "GET", self._repo_path(f"/issues/{ref.pmo_id}"))
         return await self._enrich_blocked_by(self._mission(raw))
 
     async def get_activity(self, ref: MissionRef,
                            full: bool = False) -> Activity:
-        if ref.kind != "issue":
-            m = Mission(
-                pmo_id=ref.pmo_id, pmo_kind="project", key=f"PRJ-{ref.pmo_id}",
-                title="", description="", status="backlog", priority="medium",
-                labels=set(), updated_at=datetime.now(timezone.utc), url="",
-                instance=self._instance)
-            return Activity(mission=m, entries=[], mission_attachments=[],
-                            truncated=False)
+        # The port's "shallow project ref never raises" clause is scoped to
+        # projects_supported vendors — here a project ref is a caller bug,
+        # and the old fabricated Mission answer made misroutes invisible.
+        self._require_issue(ref)
         mission = await self.get(ref)
         max_pages = MAX_COMMENT_PAGES_FULL if full else MAX_COMMENT_PAGES
         entries: list[ActivityEntry] = []
@@ -403,15 +416,13 @@ class GiteaIssuesAdapter:
     # ── writes ──────────────────────────────────────────────────────────────
 
     async def post_feed(self, ref: MissionRef, markdown: str) -> None:
-        if ref.kind != "issue":
-            return
+        self._require_issue(ref)
         await self._req(
             "POST", self._repo_path(f"/issues/{ref.pmo_id}/comments"),
             json={"body": markdown})
 
     async def set_status(self, ref: MissionRef, status: NormalizedStatus) -> None:
-        if ref.kind != "issue":
-            return
+        self._require_issue(ref)
         if status in ("done", "canceled"):
             state = "closed"
             # Gitea 412s close when the issue still has open blockers
@@ -451,8 +462,7 @@ class GiteaIssuesAdapter:
             _ = result
 
     async def cancel_mission(self, ref: MissionRef) -> None:
-        if ref.kind != "issue":
-            return
+        self._require_issue(ref)
         cur = await self._req(
             "GET", self._repo_path(f"/issues/{ref.pmo_id}"))
         if (cur.get("state") == "closed"
@@ -462,8 +472,7 @@ class GiteaIssuesAdapter:
 
     async def swap_labels(self, ref: MissionRef, remove: set[str],
                           add: set[str]) -> None:
-        if ref.kind != "issue":
-            return
+        self._require_issue(ref)
         await self._ensure_label_cache()
         cur = await self._req(
             "GET", self._repo_path(f"/issues/{ref.pmo_id}"))
@@ -475,8 +484,13 @@ class GiteaIssuesAdapter:
             if lid is None:
                 await self.ensure_labels(self._team_ref, {name})
                 lid = self._label_ids.get(name.upper())
-            if lid is not None:
-                ids.append(lid)
+            if lid is None:
+                # NEVER PUT a set assembled from unresolved names: the PUT
+                # replaces the issue's FULL label set, so dropping the id
+                # here silently erases the label from the issue (2026-08-12
+                # audit F8 — Linear's write path refuses the same way).
+                raise RuntimeError(f"label {name} missing — ensure_labels not run?")
+            ids.append(lid)
         # PUT replaces the full set (live-verified 1.24.7)
         await self._req(
             "PUT", self._repo_path(f"/issues/{ref.pmo_id}/labels"),
@@ -519,13 +533,42 @@ class GiteaIssuesAdapter:
         if isinstance(result, dict) and result.get("_duplicate"):
             return  # idempotent
 
+    async def _fetch_all_labels(self) -> list[dict]:
+        """Every label on the repo, paginated with a fail-loud ceiling.
+
+        swap_labels PUT-replaces the issue's FULL label set, so any rewrite
+        computed from a truncated registry read silently erases labels past
+        the page boundary from the vendor system (2026-08-12 audit F8 — the
+        ISSUES #7 destruction class; this is the REST twin of Linear's
+        `_refuse_truncated_rewrite`). Raise at the ceiling, never truncate:
+        every consumer of this read feeds a full-set rewrite, a create
+        decision, or an ensure that would mint an uppercase duplicate."""
+        labels: list[dict] = []
+        page = 1
+        while page <= MAX_LABEL_PAGES:
+            batch = await self._req("GET", self._repo_path("/labels"),
+                                    params={"page": page,
+                                            "limit": LABELS_PAGE})
+            if not batch:
+                break
+            labels.extend(batch)
+            if len(batch) < LABELS_PAGE:
+                break
+            page += 1
+        else:
+            raise RuntimeError(
+                f"gitea_issues: more than {MAX_LABEL_PAGES * LABELS_PAGE} "
+                f"labels on {self._owner}/{self._repo} — refusing (a label "
+                f"past the ceiling would be silently erased by the next "
+                f"full-set label rewrite)")
+        return labels
+
     async def ensure_labels(self, team_ref: str, names: set[str]) -> None:
         self._apply_team(team_ref)
         await self._enable_issue_dependencies()
-        existing = await self._req("GET", self._repo_path("/labels"),
-                                   params={"limit": 50})
+        existing = await self._fetch_all_labels()
         by_upper = {(lb.get("name") or "").upper(): lb
-                    for lb in (existing or [])}
+                    for lb in existing}
         for name in names:
             u = name.upper()
             if u in by_upper:
@@ -541,9 +584,7 @@ class GiteaIssuesAdapter:
     async def _ensure_label_cache(self) -> None:
         if self._label_ids:
             return
-        existing = await self._req("GET", self._repo_path("/labels"),
-                                   params={"limit": 50})
-        for lb in existing or []:
+        for lb in await self._fetch_all_labels():
             n = (lb.get("name") or "").upper()
             if n:
                 self._label_ids[n] = int(lb["id"])
@@ -562,8 +603,7 @@ class GiteaIssuesAdapter:
             log.warning("gitea_issues enable dependencies: %s", e)
 
     async def append_description(self, ref: MissionRef, text: str) -> None:
-        if ref.kind != "issue":
-            return
+        self._require_issue(ref)
         cur = await self._req(
             "GET", self._repo_path(f"/issues/{ref.pmo_id}"))
         body = (cur.get("body") or "") + text
@@ -670,11 +710,9 @@ class GiteaIssuesAdapter:
                 return PMOHealth(ok=False, detail="api_base is empty")
             await self.ensure_labels(team_ref, ALL_LABELS)
             await self._ensure_label_cache()
-            present = sum(1 for n in ALL_LABELS if n.upper() in self._label_ids)
             # count only managed intersection on the repo
-            raw_labels = await self._req("GET", self._repo_path("/labels"),
-                                         params={"limit": 50})
-            remote = {(lb.get("name") or "").upper() for lb in (raw_labels or [])}
+            raw_labels = await self._fetch_all_labels()
+            remote = {(lb.get("name") or "").upper() for lb in raw_labels}
             present = len(remote & {n.upper() for n in ALL_LABELS})
             return PMOHealth(
                 ok=True,

--- a/app/devcake/ports/pmo.py
+++ b/app/devcake/ports/pmo.py
@@ -49,7 +49,13 @@ class PMOPort(Protocol):
     - `get_activity` SHALLOW on a ref without an issue-style comment feed
       (Linear projects) returns the mission with `entries=[]` — never raises.
       The shallow project path has no production caller (marker scans are
-      issue-only) and must stay cheap.
+      issue-only) and must stay cheap. That never-raises clause is scoped to
+      `projects_supported` vendors: on a vendor WITHOUT project support, a
+      project-kind ref is a caller bug and every method — reads and writes —
+      MUST raise (permanent family), never fabricate a Mission or silently
+      no-op the write (2026-08-12 audit F1: a swallowed project write
+      reports success while swapping no labels, so the misroute re-derives
+      forever with zero signal).
     - `get_activity(full=True)` (ADR-0014 D3, the activity-folder builder's
       mode) walks the ENTIRE feed history, carries reply structure
       (`entry_id`/`parent_id`) and mission-level attachments (description

--- a/app/tests/test_gitea_issues_contract.py
+++ b/app/tests/test_gitea_issues_contract.py
@@ -80,10 +80,15 @@ class Router:
         if method == "PATCH" and path == "/api/v1/repos/o/r":
             return httpx.Response(200, json={"name": "r"})
 
-        # labels collection
+        # labels collection (pagination-aware: the adapter must walk pages —
+        # a one-page read feeding the full-set PUT is the audit-F8 bug)
         if path == "/api/v1/repos/o/r/labels":
             if method == "GET":
-                return httpx.Response(200, json=list(self.labels.values()))
+                page = int(req.url.params.get("page", 1))
+                limit = int(req.url.params.get("limit", 50))
+                items = list(self.labels.values())
+                return httpx.Response(
+                    200, json=items[(page - 1) * limit: page * limit])
             if method == "POST":
                 name = (body.get("name") or "").upper()
                 self.next_label += 1
@@ -463,10 +468,97 @@ def test_download_asset_allows_same_host_redirect():
     assert body == b"payload-bytes"
 
 
-def test_get_activity_full_project_ref_stays_empty():
-    # projects_supported=False: the non-issue branch answers without any
-    # HTTP and the project-fidelity fields stay defaulted
-    pmo = GiteaIssuesAdapter("http://gitea:3000", "tok", "o/r")
-    act = run(pmo.get_activity(MissionRef("9", "project"), full=True))
-    assert act.entries == [] and act.documents == []
-    assert act.mission_attachments == [] and act.truncated is False
+@pytest.mark.parametrize("op", [
+    lambda pmo: pmo.get_activity(MissionRef("9", "project"), full=True),
+    lambda pmo: pmo.get_activity(MissionRef("9", "project")),
+    lambda pmo: pmo.post_feed(MissionRef("9", "project"), "hi"),
+    lambda pmo: pmo.set_status(MissionRef("9", "project"), "done"),
+    lambda pmo: pmo.swap_labels(MissionRef("9", "project"), set(), {"X"}),
+    lambda pmo: pmo.cancel_mission(MissionRef("9", "project")),
+    lambda pmo: pmo.append_description(MissionRef("9", "project"), "x"),
+])
+def test_project_ref_operations_raise_never_fabricate_or_noop(op):
+    """projects_supported=False: a project ref is a caller bug (2026-08-12
+    audit F1). The old adapter fabricated a Mission for get_activity and
+    silently no-opped every write — success reported, no labels swapped, the
+    misroute invisible forever. All seven now raise the permanent family."""
+    router = Router()
+    pmo = make_pmo(router)
+    with pytest.raises(RuntimeError, match="projects are not supported"):
+        run(op(pmo))
+    assert not any(c.startswith(("POST", "PATCH", "PUT", "DELETE"))
+                   for c in router.calls), "no write may reach the vendor"
+
+
+# --- label-registry data safety (2026-08-12 audit F8) -----------------------
+
+
+def test_swap_labels_reads_all_label_pages_and_preserves_overflow():
+    """The destruction case: a human-applied label whose registry entry sits
+    past page 1. The full-set PUT rewrite must still carry it — the old
+    one-page read dropped its id and erased it from the issue."""
+    router = Router()
+    for i in range(118):                       # +DEVCAKE = 120 labels, 3 pages
+        router.labels[f"L{i:03d}"] = {"id": 2000 + i, "name": f"L{i:03d}",
+                                      "color": "ffffff"}
+    router.labels["HUMANPICK"] = {"id": 9999, "name": "HUMANPICK",
+                                  "color": "ffffff"}
+    router.issues[1]["labels"] = [{"id": 1, "name": "DEVCAKE"},
+                                  {"id": 9999, "name": "HUMANPICK"}]
+    pmo = make_pmo(router)
+    run(pmo.swap_labels(MissionRef("1", "issue"),
+                        remove=set(), add={"DEVCAKE-PLAN"}))
+    names = {lb["name"] for lb in router.issues[1]["labels"]}
+    assert "HUMANPICK" in names, "overflow label must survive the rewrite"
+    assert "DEVCAKE" in names and "DEVCAKE-PLAN" in names
+
+
+def test_label_ceiling_refuses_loudly_with_zero_writes():
+    router = Router()
+    for i in range(520):
+        router.labels[f"M{i:04d}"] = {"id": 3000 + i, "name": f"M{i:04d}",
+                                      "color": "ffffff"}
+    pmo = make_pmo(router)
+    with pytest.raises(RuntimeError, match="more than 500 labels"):
+        run(pmo.swap_labels(MissionRef("1", "issue"),
+                            remove=set(), add={"DEVCAKE-PLAN"}))
+    assert not any(c.startswith("PUT") for c in router.calls)
+
+
+def test_swap_labels_never_puts_a_set_with_unresolved_names(monkeypatch):
+    """An issue carrying a label absent from the registry (deleted from the
+    repo while still attached): if the ensure retry cannot resolve it, the
+    swap must raise — the old code PUT the partial set and erased it."""
+    router = Router()
+    router.issues[1]["labels"] = [{"id": 77, "name": "GHOST"}]
+    pmo = make_pmo(router)
+
+    async def ensure_noop(team_ref, names):
+        return None
+
+    monkeypatch.setattr(pmo, "ensure_labels", ensure_noop)
+    with pytest.raises(RuntimeError, match="label GHOST missing"):
+        run(pmo.swap_labels(MissionRef("1", "issue"),
+                            remove=set(), add=set()))
+    assert not any(c.startswith("PUT") for c in router.calls)
+
+
+# --- dependency-enrichment cost (2026-08-12 audit F9) ------------------------
+
+
+def test_list_all_skips_dependency_fetch_for_closed_issues():
+    """blocked_by enrichment is one GET per issue per poll cycle; closed
+    issues never need it (the gate reads a blocker's status off its own list
+    row, and set_status clears dependencies on close) — history must not
+    grow the poll's request count."""
+    router = Router()
+    router.issues[3] = _issue(3, state="closed")
+    router.comments[3] = []
+    router.deps[3] = []
+    pmo = make_pmo(router)
+    missions = run(pmo.list_all("o/r"))
+    assert {m.pmo_id for m in missions} == {"1", "2", "3"}
+    dep_gets = [c for c in router.calls
+                if c.startswith("GET") and "/dependencies" in c]
+    assert any("/issues/1/" in c for c in dep_gets)
+    assert not any("/issues/3/" in c for c in dep_gets)


### PR DESCRIPTION
Phase 0 PR-B of the 2026-08-12 audit intervention campaign.

## The pattern this closes
The audit's sharpest cross-cutting finding: *first implementations are rigorous, second implementations copy the shape but not the guards.* Linear refuses truncated label rewrites loudly; the gitea_issues twin PUT the full set from a one-page read — **silent destruction of human-applied labels in the vendor system past 50 repo labels**. Same adapter satisfied the port by lying on project refs (silent no-op writes, fabricated `get_activity` Mission).

## Changes
- `_fetch_all_labels()`: paginated registry read, fail-loud at 500 labels; all three consumers (ensure/cache/probe) switch to it. `swap_labels` raises instead of PUTting a set with unresolved names (Linear's exact message).
- `_require_issue()`: all seven project-ref paths raise `RuntimeError` (the permanent family per `ports/pmo.py:13-15` — deliberately **no new exception type**). Port docstring scopes the never-raises clause to `projects_supported` vendors. Downstream traced: API → 502; poll → per-mission skip / `poll_degraded`; finalize → redelivery → dead-letter → stalled-finalize kill → bounded park. Not a crash loop.
- `list_all` enriches `blocked_by` for **open issues only** — the poll cycle's dependency-GET count stops growing with closed history.

## Notes
- >500-label repos now refuse loudly (release-note); Done-card `blocked_by` display on gitea boards goes empty (cosmetic — the data was never consulted).
- The `(pmo_id, updated_at)` enrichment cache from the design is deliberately deferred, gated on a live probe that dependency edits bump `updated_at` (a stale `blocked_by` under-blocks the gate — ADR-0012 failure class).

Suite: **1639 passed, 1 skipped** (rebaked); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)