### PR TITLE
refactor: mission completion goes through ONE chokepoint (ADR-0034; F1/F4/AUD-010)

### DIFF
--- a/app/devcake/domain/orchestrator/completion.py
+++ b/app/devcake/domain/orchestrator/completion.py
@@ -1,0 +1,179 @@
+"""Mission completion on merge — THE chokepoint (ADR-0034).
+
+"Mission completes on merge" used to be implemented at four sites
+(review._done, review._done_merged, the merge sweep's merged branch, the
+deferred-retry tail) and the AUD-010 conflict-trust rule at two — and
+AUD-010's own history records the copies splitting doctrine once (the sweep
+routed Gitea conflicts to EXECUTE while finalize handed them off).
+Everything that differs per path lives in the _CAUSES table below; nobody
+composes completion copy, labels, or ordering anywhere else. Feed strings
+are today's exact bytes — copy changes are a decision, never a refactor
+side effect (deliver's feed-probe idempotency greps the deliverable name
+out of these threads, and operators grep them too).
+
+Checkpoint semantics are preserved, NOT unified: the REVIEW-finalize path
+checkpoints the core as the existing byte-stable key ``review:done`` so
+in-flight finalizing runs at upgrade time resume through it; the sweep
+paths execute directly — their idempotency is the label swap removing the
+mission from the sweep's selection predicate, plus the zip's own durable
+feed-probe guard. Unifying the two regimes would change PMO read costs and
+failure economics for no defect closed (ADR-0034 out-of-scope list).
+
+Leaf module by design: imports only model/run/freshness/feed/markers/ports
+so both review and sweeps import downward (sweeps already imports review —
+a chokepoint living in either would cycle).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+
+from opentelemetry import trace
+
+from ...ports.forge import mission_branch
+from ..model import (LABEL_EXECUTE, LABEL_MERGE, LABEL_REVIEW, Mission,
+                     MissionRef)
+from ..run import Run
+from . import freshness
+from .feed import _unquoted
+from .markers import CONFLICT_MARKER, MAX_CONFLICT_RESOLVES
+
+log = logging.getLogger("devcake.missions")
+tracer = trace.get_tracer("devcake")
+
+
+class MergedCause(StrEnum):
+    REVIEW_AUTO_MERGE = "review_auto_merge"        # finalize: our merge landed, or found merged on the re-probe
+    SWEEP_EXTERNAL_MERGE = "sweep_external_merge"  # merge sweep: PR turned up merged (human / CI)
+    DEFERRED_RETRY_MERGE = "deferred_retry_merge"  # windowed retry: our merge landed
+
+
+@dataclass(frozen=True)
+class _Cause:
+    remove_label: str
+    feed: str                 # .format(pr_url=…) — byte-exact legacy copy
+    audit_action: str
+    disclose_before: bool     # ADR-0031 D1 disclose-only pre-step
+
+
+_CAUSES: dict[MergedCause, _Cause] = {
+    MergedCause.REVIEW_AUTO_MERGE: _Cause(
+        remove_label=LABEL_REVIEW,
+        feed="✅ REVIEW approved; PR merged ({pr_url}). Mission done.",
+        audit_action="review_approve_merged",
+        disclose_before=False),
+    MergedCause.SWEEP_EXTERNAL_MERGE: _Cause(
+        remove_label=LABEL_MERGE,
+        feed="✅ PR {pr_url} merged — mission done (merge sweep).",
+        audit_action="merge_sweep_done",
+        disclose_before=False),
+    MergedCause.DEFERRED_RETRY_MERGE: _Cause(
+        remove_label=LABEL_MERGE,
+        feed="✅ Merged after deferred retry ({pr_url}). Mission done.",
+        # ADR-0031 D1 (deferred-merge row): DISCLOSE-ONLY — the finalize-time
+        # gate passed minutes-to-hours ago; material landing since still
+        # closes (the merge was operator-sanctioned) but never silently
+        audit_action="merge_retry_succeeded",
+        disclose_before=True),
+}
+
+
+async def complete_merged(mgr, cause: MergedCause, *, ref: MissionRef,
+                          mission_key: str, pr, pr_url: str,
+                          run: Run | None = None,
+                          mission: Mission | None = None) -> None:
+    """Complete a mission whose PR is merged. Fixed order for every cause:
+    disclose pre-step (table-driven) → core (swap → status → feed → audit;
+    checkpointed as ``review:done`` when a Run is in flight, direct on sweep
+    paths) → deliverable zip (best-effort — packaging must NEVER un-Done the
+    mission, deliver.py doctrine). ``pr`` is forwarded verbatim to the zip
+    path (a PR on the run path, a PR/PRState on the sweep paths)."""
+    assert run is not None or mission is not None, (
+        "complete_merged needs a Run (finalize path) or a Mission (sweep path)")
+    spec = _CAUSES[cause]
+    with tracer.start_as_current_span("mission.complete") as span:
+        span.set_attribute("devcake.mission.key", mission_key)
+        span.set_attribute("devcake.cause", str(cause))
+        if spec.disclose_before and mission is not None:
+            await freshness.disclose_unread_at_close(mgr, mission)
+
+        async def _core():
+            await mgr.pmo.swap_labels(ref, remove={spec.remove_label},
+                                      add=set())
+            await mgr.pmo.set_status(ref, "done")
+            await mgr._feed(ref.pmo_id, ref.kind,
+                            spec.feed.format(pr_url=pr_url))
+            mgr._audit(ref.pmo_id, spec.audit_action, pr_url)
+
+        if run is not None:
+            await mgr._checkpoint(run, "review:done", _core)
+        else:
+            await _core()
+        try:
+            if run is not None:
+                await mgr.deliver_internal_zip(run, pr)
+            else:
+                await mgr.deliver_internal_zip_for_mission(mission, pr)
+        except Exception:  # noqa: BLE001 — packaging never un-Dones: zip failure degrades loudly in the log, the mission stays done
+            log.exception("deliverable zip failed for %s — mission stays done",
+                          mission_key)
+
+
+# ── AUD-010 conflict doctrine (trust + routing + budget), one copy ───────────
+
+def trusted_conflict(forge, verdict) -> bool:
+    """A ``False`` mergeable verdict is a real conflict ONLY on a genuine
+    tri-state forge (GitHub/GitLab); Gitea's boolean ``False`` can be "not
+    computed yet" (AUD-010 / M11), so a failed merge there hands off to a
+    human rather than routing EXECUTE rework."""
+    caps = getattr(forge, "capabilities", None)
+    return verdict is False and (caps is None or caps.mergeable_tristate)
+
+
+async def conflict_attempts(mgr, pmo_id: str) -> int:
+    """Prior auto-resolve attempts, derived from feed markers — the PMO is
+    the source of truth (docs/03), so the count survives restarts and a
+    human deleting directive comments deliberately resets it."""
+    act = await mgr.pmo.get_activity(MissionRef(pmo_id, "issue"))
+    hits = [int(mt.group(1)) for e in act.entries
+            for mt in CONFLICT_MARKER.finditer(_unquoted(e.body))]
+    return max(hits) if hits else 0
+
+
+async def route_conflict_to_execute(mgr, pmo_id: str, key: str, pr_url: str,
+                                    from_label: str, inst) -> bool:
+    """docs/03 §4.1 — on an auto-resolvable merge failure (conflict or
+    stale branch), route the mission back to EXECUTE with a resolve
+    directive, max MAX_CONFLICT_RESOLVES attempts per mission. Returns
+    True when routed; any failure or decline returns False so the caller's
+    human fallback (DEVCAKE-MERGE) is never blocked. ``inst`` is the
+    mission's RepoInstance (per-repo doctrine, ADR-0020)."""
+    if not inst.auto_resolve_merge_conflicts:
+        return False
+    try:
+        n = await conflict_attempts(mgr, pmo_id)
+        if n >= MAX_CONFLICT_RESOLVES:
+            mgr._audit(pmo_id, "conflict_resolve_exhausted", pr_url)
+            return False
+        # directive FIRST, then swap (mirrors the reject path): if the
+        # post fails the mission stays put and the marker count never
+        # undercounts. The EXECUTE playbook tells the Dev a 🧩 resolve
+        # directive overrides its normal implement-the-mission job (🧩 is
+        # reserved for this directive — 🔀 already means "PR opened").
+        await mgr._feed(
+            pmo_id, "issue",
+            f"🧩 Auto-merge hit a merge conflict on {pr_url} (auto-resolve "
+            f"attempt {n + 1}/{MAX_CONFLICT_RESOLVES}) — back to EXECUTE. "
+            f"Next Dev: sync `{mission_branch(mgr.instance_name, key)}` with the default branch, "
+            f"resolve the conflicts, and push; the PR then returns to "
+            f"REVIEW. `devcake:conflict-resolve:{n + 1}`")
+        await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
+                                   remove={from_label}, add={LABEL_EXECUTE})
+        mgr._audit(pmo_id, "conflict_resolve_dispatched",
+                    f"attempt {n + 1} ({pr_url})")
+        return True
+    except Exception:
+        log.exception("conflict auto-resolve routing failed for %s", key)
+        return False

--- a/app/devcake/domain/orchestrator/review.py
+++ b/app/devcake/domain/orchestrator/review.py
@@ -8,12 +8,11 @@ from ...security import redact
 from .. import costing
 from ..model import LABEL_EXECUTE, LABEL_MERGE, LABEL_REVIEW, MissionRef
 from ..run import Run
-from ...ports.forge import mission_branch, run_branch
-from .feed import _unquoted
+from ...ports.forge import run_branch
+from . import completion
 from .freshness import review_freshness_gate
-from .markers import (CONFLICT_MARKER, HANDOFF_APPEND_MAX, HANDOFF_MARKER,
-                      MAX_CONFLICT_RESOLVES, MERGE_HANDOFF_MARKER,
-                      MERGE_RETRY_MARKER)
+from .markers import (HANDOFF_APPEND_MAX, HANDOFF_MARKER,
+                      MERGE_HANDOFF_MARKER, MERGE_RETRY_MARKER)
 
 log = logging.getLogger("devcake.missions")
 
@@ -55,54 +54,6 @@ async def _flag_out_of_pipeline_merge(mgr, run: Run) -> None:
     except Exception:  # noqa: BLE001 — anomaly probe is best-effort; failure logged (debug), the review flow is unaffected
         log.debug("out-of-pipeline merge check failed for %s",
                   run.mission_key, exc_info=True)
-
-
-async def _conflict_attempts(mgr, pmo_id: str) -> int:
-    """Prior auto-resolve attempts, derived from feed markers — the PMO is
-    the source of truth (docs/03), so the count survives restarts and a
-    human deleting directive comments deliberately resets it."""
-    act = await mgr.pmo.get_activity(MissionRef(pmo_id, "issue"))
-    hits = [int(mt.group(1)) for e in act.entries
-            for mt in CONFLICT_MARKER.finditer(_unquoted(e.body))]
-    return max(hits) if hits else 0
-
-
-async def _maybe_route_conflict_to_execute(mgr, pmo_id: str, key: str,
-                                           pr_url: str,
-                                           from_label: str, inst) -> bool:
-    """docs/03 §4.1 — on an auto-resolvable merge failure (conflict or
-    stale branch), route the mission back to EXECUTE with a resolve
-    directive, max MAX_CONFLICT_RESOLVES attempts per mission. Returns
-    True when routed; any failure or decline returns False so the caller's
-    human fallback (DEVCAKE-MERGE) is never blocked. ``inst`` is the
-    mission's RepoInstance (per-repo doctrine, ADR-0020)."""
-    if not inst.auto_resolve_merge_conflicts:
-        return False
-    try:
-        n = await _conflict_attempts(mgr, pmo_id)
-        if n >= MAX_CONFLICT_RESOLVES:
-            mgr._audit(pmo_id, "conflict_resolve_exhausted", pr_url)
-            return False
-        # directive FIRST, then swap (mirrors the reject path): if the
-        # post fails the mission stays put and the marker count never
-        # undercounts. The EXECUTE playbook tells the Dev a 🧩 resolve
-        # directive overrides its normal implement-the-mission job (🧩 is
-        # reserved for this directive — 🔀 already means "PR opened").
-        await mgr._feed(
-            pmo_id, "issue",
-            f"🧩 Auto-merge hit a merge conflict on {pr_url} (auto-resolve "
-            f"attempt {n + 1}/{MAX_CONFLICT_RESOLVES}) — back to EXECUTE. "
-            f"Next Dev: sync `{mission_branch(mgr.instance_name, key)}` with the default branch, "
-            f"resolve the conflicts, and push; the PR then returns to "
-            f"REVIEW. `devcake:conflict-resolve:{n + 1}`")
-        await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
-                                   remove={from_label}, add={LABEL_EXECUTE})
-        mgr._audit(pmo_id, "conflict_resolve_dispatched",
-                    f"attempt {n + 1} ({pr_url})")
-        return True
-    except Exception:
-        log.exception("conflict auto-resolve routing failed for %s", key)
-        return False
 
 
 async def _append_handoff(mgr, run: Run, result: dict) -> None:
@@ -198,65 +149,59 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                     async def _merge():
                         await forge.merge(pr.number)
                     await mgr._checkpoint(run, "review:merge", _merge)
-                    async def _done():
-                        await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
-                                             remove={LABEL_REVIEW}, add=set())
-                        await mgr.pmo.set_status(MissionRef(pmo_id, "issue"), "done")
-                        await mgr._feed(
-                            pmo_id, "issue",
-                            f"✅ REVIEW approved; PR merged ({pr_url}). "
-                            f"Mission done.")
-                        mgr._audit(pmo_id, "review_approve_merged", pr_url)
-                    await mgr._checkpoint(run, "review:done", _done)
-                    await mgr.deliver_internal_zip(run, pr)
-                except Exception as e:  # noqa: BLE001 — every merge failure, whatever its type, must enter the re-probe → conflict-route → merge-failed recovery ladder; escaping would strand the mission mid-REVIEW
-                    # Capture for nested async defs (static F821 + safe if
-                    # await order changes later); not a known production 500.
+                except Exception as e:  # noqa: BLE001 — every MERGE failure, whatever its type, must enter the re-probe → conflict-route → merge-failed recovery ladder; escaping would strand the mission mid-REVIEW
                     merge_err = e
+                    handled_below = True
+                else:
+                    # merge landed: complete via the chokepoint. Its failures
+                    # PROPAGATE (F4) — the run stays finalizing and converges
+                    # via redelivery (the four-way guard above doesn't block;
+                    # "review:merge" no-ops; "review:done" retries) or, past
+                    # the stalled-finalize deadline, the next REVIEW cycle's
+                    # re-probe of an already-merged PR.
+                    await completion.complete_merged(
+                        mgr, completion.MergedCause.REVIEW_AUTO_MERGE,
+                        ref=MissionRef(pmo_id, "issue"),
+                        mission_key=run.mission_key,
+                        pr=pr, pr_url=pr_url, run=run)
+                    handled_below = False
+                if handled_below:
                     # Already-merged treated as success by forge.merge; if we
-                    # still fail, re-probe before posting merge-failed (ISSUES #6).
+                    # still fail, re-probe before posting merge-failed
+                    # (ISSUES #6). The try covers ONLY the probe (2026-08-12
+                    # audit F4): the old scope also swallowed completion's
+                    # PMO transients, misattributed them to the probe, and
+                    # posted "auto-merge failed" on an already-merged PR.
+                    merged = False
                     try:
-                        state = await forge.pr_state(pr.number)
-                        if state.merged:
-                            async def _done_merged():
-                                if "review:merge" not in run.finalized_steps:
-                                    run.finalized_steps.append("review:merge")
-                                    mgr.runs.store.save(run)
-                                await mgr.pmo.swap_labels(
-                                    MissionRef(pmo_id, "issue"),
-                                    remove={LABEL_REVIEW}, add=set())
-                                await mgr.pmo.set_status(
-                                    MissionRef(pmo_id, "issue"), "done")
-                                await mgr._feed(
-                                    pmo_id, "issue",
-                                    f"✅ REVIEW approved; PR merged ({pr_url}). "
-                                    f"Mission done.")
-                                mgr._audit(pmo_id, "review_approve_merged", pr_url)
-                            await mgr._checkpoint(run, "review:done", _done_merged)
-                            await mgr.deliver_internal_zip(run, pr)
-                            return
+                        merged = (await forge.pr_state(pr.number)).merged
                     except Exception:
                         log.exception("pr_state probe after merge fail for %s",
                                       pr_url)
+                    if merged:
+                        # absorb the found-merged stamp so a redelivery
+                        # skips the merge checkpoint, then complete via the
+                        # chokepoint — its failures PROPAGATE (run stays
+                        # finalizing; redelivery/stalled-finalize converge)
+                        if "review:merge" not in run.finalized_steps:
+                            run.finalized_steps.append("review:merge")
+                            mgr.runs.store.save(run)
+                        await completion.complete_merged(
+                            mgr, completion.MergedCause.REVIEW_AUTO_MERGE,
+                            ref=MissionRef(pmo_id, "issue"),
+                            mission_key=run.mission_key,
+                            pr=pr, pr_url=pr_url, run=run)
+                        return
                     mstate = None
                     try:
                         mstate = await forge.mergeable(pr.number)
                     except Exception:
                         log.exception("mergeable check failed for %s", pr_url)
-                    # capability branch (M11): a `False` verdict is trustworthy
-                    # as a real conflict only when the forge exposes a genuine
-                    # mergeable tri-state (GitHub/GitLab). On a boolean-only
-                    # forge (Gitea) it can be a transient not-computed-yet, so
-                    # don't route to EXECUTE rework on the verdict alone — the
-                    # merge already failed above; hand off to a human instead
-                    caps = getattr(forge, "capabilities", None)
-                    trust_conflict = mstate is False and (
-                        caps is None or caps.mergeable_tristate)
-                    if trust_conflict:
+                    if completion.trusted_conflict(forge, mstate):
                         if "review:conflict_routed" in run.finalized_steps:
                             return
                         try:
-                            routed = await _maybe_route_conflict_to_execute(
+                            routed = await completion.route_conflict_to_execute(
                                 mgr, pmo_id, run.mission_key, pr_url,
                                 LABEL_REVIEW, inst)
                         except Exception:

--- a/app/devcake/domain/orchestrator/sweeps.py
+++ b/app/devcake/domain/orchestrator/sweeps.py
@@ -11,7 +11,7 @@ from ...ports.forge import legacy_branch, mission_branch
 from ..model import (LABEL_MERGE, LABEL_NEEDS_HUMAN, LABEL_TRACKING, Mission,
                      STAGE_LABELS)
 from ..run import utcnow
-from . import dispatch, feed, freshness, review
+from . import completion, dispatch, feed
 from .markers import MERGE_HANDOFF_MARKER, MERGE_RETRY_MARKER
 
 log = logging.getLogger("devcake.missions")
@@ -108,15 +108,16 @@ async def merge_sweep(mgr, m: Mission) -> None:
             span.set_attribute("devcake.mission.key", m.key)
             span.set_attribute("devcake.outcome",
                                "merged" if state.merged else "closed")
-            await mgr.pmo.swap_labels(m.ref, remove={LABEL_MERGE}, add=set())
             if state.merged:
-                await mgr.pmo.set_status(m.ref, "done")
-                await mgr._feed(
-                    m.pmo_id, "issue",
-                    f"✅ PR {state.url} merged — mission done (merge sweep).")
-                mgr._audit(m.pmo_id, "merge_sweep_done", state.url)
-                await mgr.deliver_internal_zip_for_mission(m, state)
+                await completion.complete_merged(
+                    mgr, completion.MergedCause.SWEEP_EXTERNAL_MERGE,
+                    ref=m.ref, mission_key=m.key,
+                    pr=state, pr_url=state.url, mission=m)
             else:
+                # a CLOSED-unmerged PR is a cancellation, not a completion —
+                # deliberately outside the chokepoint (ADR-0034 scope note)
+                await mgr.pmo.swap_labels(m.ref, remove={LABEL_MERGE},
+                                          add=set())
                 await mgr.pmo.cancel_mission(m.ref)
                 await mgr._feed(
                     m.pmo_id, "issue",
@@ -225,12 +226,9 @@ async def _deferred_merge_retry(mgr, m: Mission, pr,
             # rework — IDENTICAL doctrine to finalize (review.py capability
             # branch). Without this, the sweep routed Gitea conflicts to
             # EXECUTE while finalize handed them off — a doctrine split.
-            caps = getattr(forge, "capabilities", None)
-            trust_conflict = verdict is False and (
-                caps is None or caps.mergeable_tristate)
-            if trust_conflict:
+            if completion.trusted_conflict(forge, verdict):
                 span.set_attribute("devcake.outcome", "conflict")
-                if not await review._maybe_route_conflict_to_execute(
+                if not await completion.route_conflict_to_execute(
                         mgr, m.pmo_id, m.key, pr_url, LABEL_MERGE, inst):
                     span.set_attribute("devcake.outcome", "conflict_handoff")
                     await mgr._feed(
@@ -250,17 +248,11 @@ async def _deferred_merge_retry(mgr, m: Mission, pr,
                           exc_info=True)
             return
         span.set_attribute("devcake.outcome", "merged")
-        # ADR-0031 D1 (deferred-merge row): DISCLOSE-ONLY — the finalize-time
-        # gate passed minutes-to-hours ago; material landing since still
-        # closes (the merge was operator-sanctioned) but never silently
-        await freshness.disclose_unread_at_close(mgr, m)
-        await mgr.pmo.swap_labels(m.ref, remove={LABEL_MERGE}, add=set())
-        await mgr.pmo.set_status(m.ref, "done")
-        await mgr._feed(
-            m.pmo_id, "issue",
-            f"✅ Merged after deferred retry ({pr_url}). Mission done.")
-        mgr._audit(m.pmo_id, "merge_retry_succeeded", pr_url)
-        await mgr.deliver_internal_zip_for_mission(m, pr)
+        # disclose-only freshness pre-step rides the cause table
+        # (DEFERRED_RETRY_MERGE → disclose_before=True)
+        await completion.complete_merged(
+            mgr, completion.MergedCause.DEFERRED_RETRY_MERGE,
+            ref=m.ref, mission_key=m.key, pr=pr, pr_url=pr_url, mission=m)
 
 
 async def tracking_sweep(mgr, m: Mission) -> None:

--- a/app/tests/test_completion.py
+++ b/app/tests/test_completion.py
@@ -1,0 +1,230 @@
+"""completion.py — THE merged-mission chokepoint (ADR-0034; audit F1/F4).
+
+Pins: the three-cause table (labels, byte-exact feed copy, disclosure flag),
+run-path checkpoint idempotency, the F4 regression (a PMO failure inside
+completion must PROPAGATE, never fall into the merge-failure ladder and post
+"auto-merge failed" on an already-merged PR), the AUD-010 trust matrix, and
+the source ratchet that keeps the doctrine from forking again."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from devcake.domain.model import MissionRef
+from devcake.domain.orchestrator import completion, review
+from devcake.domain.orchestrator.markers import COMMENT_SENTINEL
+from devcake.domain.run import Run
+from devcake.ports.forge import ForgeError, PullRequest
+
+from test_transitions import FakeForge, FakePMO, make_mgr, mission, run_coro
+
+
+def _review_run():
+    return Run(run_id="T-1-1-REVIEW-CCCCCC", mission_key="T-1",
+               mission_pmo_id="p1", mission_type="REVIEW",
+               dev_type="senior-dev", seq=1,
+               stage_label_at_dispatch="DEVCAKE-REVIEW")
+
+
+CASES = [
+    (completion.MergedCause.REVIEW_AUTO_MERGE, "DEVCAKE-REVIEW",
+     "✅ REVIEW approved; PR merged (https://forge/pr/8). Mission done.",
+     False),
+    (completion.MergedCause.SWEEP_EXTERNAL_MERGE, "DEVCAKE-MERGE",
+     "✅ PR https://forge/pr/8 merged — mission done (merge sweep).",
+     False),
+    (completion.MergedCause.DEFERRED_RETRY_MERGE, "DEVCAKE-MERGE",
+     "✅ Merged after deferred retry (https://forge/pr/8). Mission done.",
+     True),
+]
+
+
+@pytest.mark.parametrize("cause,label,copy,discloses", CASES)
+def test_cause_table_labels_copy_and_disclosure(tmp_path, monkeypatch,
+                                                cause, label, copy, discloses):
+    m = mission("in_progress", {"DEVCAKE", label})
+    mgr, fake, store = make_mgr(tmp_path, m)
+    pr = PullRequest(number=8, url="https://forge/pr/8", state="open",
+                     merged=True)
+    disclosed = []
+
+    async def fake_disclose(mgr_, mission_):
+        disclosed.append(mission_.pmo_id)
+
+    monkeypatch.setattr(completion.freshness, "disclose_unread_at_close",
+                        fake_disclose)
+    zipped = []
+
+    async def fake_zip(*a):
+        zipped.append(a)
+
+    monkeypatch.setattr(mgr, "deliver_internal_zip", fake_zip)
+    monkeypatch.setattr(mgr, "deliver_internal_zip_for_mission", fake_zip)
+
+    run = _review_run() if cause is completion.MergedCause.REVIEW_AUTO_MERGE \
+        else None
+    if run:
+        store.save(run)
+    run_coro(completion.complete_merged(
+        mgr, cause, ref=MissionRef("p1", "issue"), mission_key="T-1",
+        pr=pr, pr_url="https://forge/pr/8",
+        run=run, mission=None if run else m))
+
+    assert label not in m.labels, "the stage/park label must come off"
+    assert m.status == "done"
+    # byte-exact legacy copy + the _feed chokepoint's provenance sentinel
+    assert fake.comments == [f"{copy}\n\n{COMMENT_SENTINEL}"]
+    assert len(zipped) == 1
+    assert disclosed == (["p1"] if discloses else [])
+    if run:
+        assert "review:done" in run.finalized_steps
+
+
+def test_run_path_redelivery_skips_core_but_retries_zip(tmp_path, monkeypatch):
+    m = mission("in_progress", {"DEVCAKE", "DEVCAKE-REVIEW"})
+    mgr, fake, store = make_mgr(tmp_path, m)
+    pr = PullRequest(number=8, url="https://forge/pr/8", state="open")
+    zipped = []
+
+    async def fake_zip(*a):
+        zipped.append(a)
+
+    monkeypatch.setattr(mgr, "deliver_internal_zip", fake_zip)
+    run = _review_run()
+    store.save(run)
+    for _ in range(2):   # redelivery after a crash between core and ack
+        run_coro(completion.complete_merged(
+            mgr, completion.MergedCause.REVIEW_AUTO_MERGE,
+            ref=MissionRef("p1", "issue"), mission_key="T-1",
+            pr=pr, pr_url="https://forge/pr/8", run=run))
+    assert len(fake.comments) == 1, "checkpointed core must not re-post"
+    assert len(zipped) == 2, "zip has its own idempotency (deliver:zip)"
+
+
+def test_zip_failure_never_undoes_done(tmp_path, monkeypatch):
+    m = mission("in_progress", {"DEVCAKE", "DEVCAKE-MERGE"})
+    mgr, fake, store = make_mgr(tmp_path, m)
+
+    async def boom_zip(*a):
+        raise RuntimeError("attachment upload 500")
+
+    monkeypatch.setattr(mgr, "deliver_internal_zip_for_mission", boom_zip)
+    run_coro(completion.complete_merged(
+        mgr, completion.MergedCause.SWEEP_EXTERNAL_MERGE,
+        ref=MissionRef("p1", "issue"), mission_key="T-1",
+        pr=SimpleNamespace(url="https://forge/pr/8"),
+        pr_url="https://forge/pr/8", mission=m))
+    assert m.status == "done", "packaging must never un-Done the mission"
+
+
+def test_requires_run_or_mission():
+    with pytest.raises(AssertionError):
+        run_coro(completion.complete_merged(
+            None, completion.MergedCause.SWEEP_EXTERNAL_MERGE,
+            ref=MissionRef("p1", "issue"), mission_key="T-1",
+            pr=None, pr_url="u"))
+
+
+# ── F4: completion failures propagate, never masquerade as merge failures ───
+
+
+class _MergedOnProbeForge(FakeForge):
+    """merge() raises; the re-probe finds the PR already merged."""
+
+    async def pr_state(self, pr_number):
+        return PullRequest(number=pr_number, url="https://forge/pr/8",
+                           state="closed", merged=True)
+
+
+class _FlakyStatusPMO(FakePMO):
+    def __init__(self, mission, fail_times=1):
+        super().__init__(mission)
+        self._status_fails = fail_times
+
+    async def set_status(self, ref, status):
+        if self._status_fails > 0:
+            self._status_fails -= 1
+            raise RuntimeError("PMO 502 mid-completion")
+        await super().set_status(ref, status)
+
+
+def test_pmo_failure_inside_completion_propagates_not_merge_failed(tmp_path):
+    """2026-08-12 audit F4 regression, pinned red-before: the old except
+    scope swallowed a set_status transient inside the found-merged done
+    path, logged it as a probe failure, fell into the failure ladder, and
+    posted "auto-merge failed" + REVIEW→MERGE on an ALREADY-MERGED PR."""
+    m = mission("in_progress", {"DEVCAKE", "DEVCAKE-REVIEW"})
+    forge = _MergedOnProbeForge(
+        merge_exc=ForgeError("PUT merge → 405", status=405))
+    from fakes import make_mission_manager
+    from devcake.config import AppConfig, DevType
+    from test_transitions import NullMessaging
+    fake = _FlakyStatusPMO(m)
+    mgr = make_mission_manager(
+        tmp_path, pmo=fake, forge=forge, config=AppConfig(),
+        dev_types={"senior-dev": DevType(name="senior-dev",
+                                         harness_template="claude-code")},
+        messaging=NullMessaging(), noop_audit=True)
+    mgr.forges.instance("main").auto_merge = True
+    run = _review_run()
+    mgr.runs.store.save(run)
+
+    with pytest.raises(RuntimeError, match="PMO 502"):
+        run_coro(review.finalize_review(
+            mgr, run, {"verdict": "approve", "report_md": "ok"}))
+    assert not any("auto-merge failed" in c for c in fake.comments), (
+        "a completion failure must never post the merge-failure copy")
+    assert "DEVCAKE-MERGE" not in m.labels
+    assert "review:done" not in run.finalized_steps
+    # the found-merged stamp was absorbed so redelivery skips the merge
+    assert "review:merge" in run.finalized_steps
+
+    # convergence: the redelivery re-enters finalize and completes cleanly
+    run_coro(review.finalize_review(
+        mgr, run, {"verdict": "approve", "report_md": "ok"}))
+    assert m.status == "done"
+    assert sum("Mission done." in c for c in fake.comments) == 1
+    assert "review:done" in run.finalized_steps
+
+
+# ── AUD-010 trust matrix ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("verdict,tristate,expected", [
+    (False, True, True),     # GitHub/GitLab False = real conflict
+    (False, False, False),   # Gitea boolean False = maybe not-computed-yet
+    (False, None, True),     # missing caps → legacy default: trust
+    (True, True, False),
+    (None, True, False),
+    (None, False, False),
+])
+def test_trusted_conflict_matrix(verdict, tristate, expected):
+    forge = SimpleNamespace() if tristate is None else SimpleNamespace(
+        capabilities=SimpleNamespace(mergeable_tristate=tristate))
+    assert completion.trusted_conflict(forge, verdict) is expected
+
+
+# ── the ratchet: completion doctrine cannot fork again ───────────────────────
+
+
+def test_completion_doctrine_lives_only_in_completion_py():
+    """Source ratchet (ADR-0034): the AUD-010 capability test and the
+    completion feed copy exist in exactly one module. A re-inlined copy in
+    review.py or sweeps.py — the shape of the original doctrine split —
+    turns this red."""
+    import devcake.domain.orchestrator as pkg
+    root = Path(pkg.__file__).parent
+    offenders = []
+    for p in sorted(root.glob("*.py")):
+        if p.name == "completion.py":
+            continue
+        src = p.read_text()
+        for needle in ("mergeable_tristate", "Mission done.",
+                       "merge_sweep_done", "review_approve_merged",
+                       "merge_retry_succeeded"):
+            if needle in src:
+                offenders.append(f"{p.name}: {needle}")
+    assert not offenders, (
+        f"completion doctrine must live only in completion.py — route these "
+        f"through the chokepoint: {offenders}")


### PR DESCRIPTION
Phase 1 PR-1 of the 2026-08-12 audit intervention campaign — the founder's core complaint made structural. Implements the completion chokepoint per ADR-0034 (#123).

## What moves where
- **New leaf module `orchestrator/completion.py`** (cycle-free: review and sweeps import downward): `complete_merged` + `_CAUSES` table (three causes; per-cause label/copy/audit/disclose), `trusted_conflict`, `route_conflict_to_execute`, `conflict_attempts`.
- **review.py** −~120 lines: `_done`/`_done_merged`/`_maybe_route_conflict_to_execute`/`_conflict_attempts` deleted; sweeps' merged branch and deferred tail call the chokepoint.
- **Checkpoint keys byte-stable** (`review:done`, `review:merge`, `deliver:zip`) — in-flight finalizing runs resume across the upgrade; the pre-v1 wipe is NOT spent.
- Feed copy is today's exact bytes (deliver's feed-probe idempotency and operator grep depend on it) — pinned by test.

## The F4 fix (intentional semantics change)
The re-probe `try` now covers only `forge.pr_state`. Old behavior: a PMO transient inside the found-merged done path was swallowed, logged as a probe failure, and the ladder posted **"auto-merge failed" + REVIEW→MERGE on an already-merged PR** (wrong message, sweep self-heal later). New behavior: completion failures propagate — run stays `finalizing`, converges via redelivery (traced: four-way guard passes → `review:merge` no-ops → `review:done` retries) with the stalled-finalize killer + next REVIEW cycle's re-probe as backstops. The regression test pins the exact old failure shape (flaky `set_status` → no merge-failure post, one "Mission done." after redelivery). Red-before note: on the old code this test cannot even collect (`completion.py` didn't exist); the behavioral half — "auto-merge failed" posted on a merged PR — is precisely what the old except scope did.

## Ratchet
`test_completion_doctrine_lives_only_in_completion_py`: `mergeable_tristate` + all three completion copy/audit strings exist in exactly one module — the shape of the original AUD-010 doctrine split turns red.

Every pre-existing review/sweep behavioral test passes **unchanged** (byte-exact copy held through the chokepoint). Suite: **1670 passed, 1 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)