### PR TITLE
refactor: ONE repo-sourcing rule + ONE blocker-credential rule (ADR-0034; F11)

### DIFF
--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -97,18 +97,13 @@ MAX_BLOCKER_WORK_EXTRAS = 8
 
 
 def _blocker_mount_ok(mgr, name: str) -> bool:
-    """Mirror of `_extra_repos_for`'s blocker branch: True when a read
-    credential exists for `name` right now. A dispatch-time snapshot only —
-    a clear between dispatch and runspec still omits silently at runspec
-    (non-fatal); this check keeps the PROMPT from listing a mount that is
-    already known to be gone (cleared internal repo, removed instance)."""
-    if mgr.internal_forge is not None:
-        creds = mgr.internal_forge.mission_credentials(name)
-        if creds is not None and creds.token_read:
-            return True
-    inst = mgr.forges.instance(name)
-    return (inst is not None and mgr.forges.get(name) is not None
-            and bool(inst.token_ro or inst.token))
+    """True when a read credential exists for `name` right now — THE shared
+    rule (repo_sourcing.blocker_read_credential, ADR-0034; this used to be
+    a hand-mirror of `_extra_repos_for`'s blocker branch). This check keeps
+    the PROMPT from listing a mount that is already known to be gone
+    (cleared internal repo, removed instance)."""
+    from ..repo_sourcing import blocker_read_credential
+    return blocker_read_credential(mgr, name) is not None
 
 
 async def resolve_blocker_work(
@@ -711,25 +706,36 @@ def _mirrored(mgr, run: Run, name: str) -> bool:
 def _extra_repos_for(mgr, run: Run) -> list[dict]:
     """Read-only sibling clones for a run, built at request time (nothing
     secret at rest); read tokens preferred, write fallback (same rule as
-    the primary token). Three sources:
-    - the routing set's OTHER repos: ONBOARD only (multi-repo triage)
-    - the instance's REFERENCE repos: EVERY mission stage
-    - done blockers' work repos snapshotted on run.blocker_work (pipeline
-      continuity — internal uses mission token_read; configured uses RO)
+    the primary token). Sourcing comes from THE shared rule
+    (repo_sourcing.sourced_repo_names, ADR-0034) — the same list the mirror
+    gate freshens, so the two structurally cannot disagree; this function
+    only enriches each name with its clone credential/mirror.
 
     Tokens that resolve empty are omitted (a clone with no credential is
     never useful and would only burn a non-fatal failure note).
     """
-    wanted: list[str] = []
-    if run.mission_type == "ONBOARD":
-        wanted += list(mgr.instance.repos or [])
-    if run.mission_type in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW"):
-        wanted += list(mgr.instance.reference_repos or [])
-    extras, seen = [], {run.repo_ref}
-    for name in wanted:
-        if name in seen:
-            continue
-        seen.add(name)
+    from ..repo_sourcing import blocker_read_credential, sourced_repo_names
+    blocker_names = {(bw.get("repo_ref") or "")
+                     for bw in run.blocker_work or []}
+    extras = []
+    for name in sourced_repo_names(
+            work_repo=run.repo_ref, mission_type=run.mission_type,
+            instance=mgr.instance, blocker_entries=run.blocker_work):
+        if name == run.repo_ref:
+            continue                     # the primary clone rides separately
+        if name in blocker_names:
+            cred = blocker_read_credential(mgr, name)
+            if cred is not None and cred[0] == "internal":
+                # internal mission work repo: token_read from stored
+                # credentials. Gitea ignores userinfo in the clone URL
+                # (descriptor clone_user is "devcake"); askpass carries
+                # token_read.
+                creds = cred[1]
+                extras.append({
+                    "name": name, "url": creds.clone_url,
+                    "clone_user": creds.username or "devcake",
+                    "token": creds.token_read})
+                continue
         inst_x = mgr.forges.instance(name)
         forge_x = mgr.forges.get(name)
         if inst_x is None or forge_x is None:
@@ -749,43 +755,6 @@ def _extra_repos_for(mgr, run: Run) -> list[dict]:
         extras.append({"name": name, "url": inst_x.url,
                        "clone_user": forge_x.descriptor.clone_user,
                        "token": token})
-    if run.mission_type in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW"):
-        for bw in run.blocker_work or []:
-            name = bw.get("repo_ref") or ""
-            if not name or name in seen:
-                continue
-            # internal mission work repo: token_read from stored credentials
-            if mgr.internal_forge is not None:
-                creds = mgr.internal_forge.mission_credentials(name)
-                if creds is not None and creds.token_read:
-                    # Gitea ignores userinfo in the clone URL (descriptor
-                    # clone_user is "devcake"); askpass carries token_read.
-                    extras.append({
-                        "name": name, "url": creds.clone_url,
-                        "clone_user": creds.username or "devcake",
-                        "token": creds.token_read})
-                    seen.add(name)
-                    continue
-            inst_x = mgr.forges.instance(name)
-            forge_x = mgr.forges.get(name)
-            if inst_x is None or forge_x is None:
-                continue     # cleared / vanished — non-fatal omit
-            if _mirrored(mgr, run, name):
-                # ADR-0024: configured blocker-work repos ride the mirror
-                # like every other configured card (same rationale as above)
-                extras.append({"name": name, "url": inst_x.url,
-                               "clone_user": forge_x.descriptor.clone_user,
-                               "mirror_path": str(
-                                   mgr.repo_cache.mirror_path(name))})
-                seen.add(name)
-                continue
-            token = inst_x.token_ro or inst_x.token
-            if not token:
-                continue
-            extras.append({"name": name, "url": inst_x.url,
-                           "clone_user": forge_x.descriptor.clone_user,
-                           "token": token})
-            seen.add(name)
     return extras
 
 

--- a/app/devcake/domain/repo_mirror.py
+++ b/app/devcake/domain/repo_mirror.py
@@ -107,20 +107,15 @@ class RepoCache:
     def needed_for(self, *, work_repo: str, mission_type: str, instance,
                    blocker_entries: list[dict]) -> list[str]:
         """The mirror-eligible repo set one run must have fresh (docs/07 §5a).
-        Mirrors _extra_repos_for's sourcing exactly, so the gate and the
-        runspec can never disagree about which repos ride the mirror."""
-        wanted: list[str] = [work_repo]
-        if mission_type == "ONBOARD":
-            wanted += list(instance.repos or [])
-        if mission_type in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW"):
-            wanted += list(instance.reference_repos or [])
-            wanted += [bw.get("repo_ref") or "" for bw in blocker_entries or []]
-        out, seen = [], set()
-        for name in wanted:
-            if name and name not in seen and self.eligible(name):
-                seen.add(name)
-                out.append(name)
-        return out
+        Sourcing comes from THE shared rule (repo_sourcing.sourced_repo_names,
+        ADR-0034) — the gate and the runspec structurally cannot disagree
+        about which repos ride the mirror; this method only applies the
+        mirror-eligibility filter."""
+        from .repo_sourcing import sourced_repo_names
+        return [name for name in sourced_repo_names(
+                    work_repo=work_repo, mission_type=mission_type,
+                    instance=instance, blocker_entries=blocker_entries)
+                if self.eligible(name)]
 
     # ── the gate primitive ───────────────────────────────────────────────────
 

--- a/app/devcake/domain/repo_sourcing.py
+++ b/app/devcake/domain/repo_sourcing.py
@@ -1,0 +1,59 @@
+"""The ONE repo-sourcing rule (ADR-0034 chokepoint; 2026-08-12 audit F11).
+
+Which repo NAMES a run draws in — the primary work repo, ONBOARD's routing
+set, every stage's reference repos, and done-blockers' work repos — used to
+be written twice (`RepoCache.needed_for` and dispatch's `_extra_repos_for`)
+and kept aligned by a "mirrors X's sourcing exactly" comment; the blocker
+read-credential rule was written twice more (`_blocker_mount_ok` and the
+`_extra_repos_for` blocker branch). Drift meant the mirror gate blocking on
+repos the runspec never mounts, or mounting repos the gate never freshened
+(a dead `file://` clone). Both rules now live here; consumers apply their
+own per-name FILTERS (mirror eligibility, token enrichment) but never their
+own sourcing.
+"""
+
+from __future__ import annotations
+
+# stages whose runs receive reference repos + done-blockers' work repos
+STAGES_WITH_EXTRAS = ("ONBOARD", "PLAN", "EXECUTE", "REVIEW")
+
+
+def sourced_repo_names(*, work_repo: str, mission_type: str, instance,
+                       blocker_entries: list[dict] | None) -> list[str]:
+    """Ordered, deduped repo names this run draws from (docs/07 §5a):
+    primary first, then (ONBOARD only) the instance's routing set, then
+    reference repos, then blocker work repos. May include ineligible or
+    uncredentialed names — filtering is the caller's job, sourcing is not."""
+    wanted: list[str] = [work_repo]
+    if mission_type == "ONBOARD":
+        wanted += list(instance.repos or [])
+    if mission_type in STAGES_WITH_EXTRAS:
+        wanted += list(instance.reference_repos or [])
+        wanted += [bw.get("repo_ref") or "" for bw in blocker_entries or []]
+    out: list[str] = []
+    seen: set[str] = set()
+    for name in wanted:
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+def blocker_read_credential(mgr, name: str):
+    """The ONE blocker-work read-credential rule: internal mission
+    credentials first (token_read), else the configured card's read token
+    (token_ro, write fallback — the primary-token rule). Returns
+    ``("internal", creds)`` / ``("configured", inst, forge, token)`` /
+    ``None`` (not mountable now — cleared internal repo, removed instance,
+    or no token). A dispatch-time snapshot only: a clear between dispatch
+    and runspec still omits silently at runspec (non-fatal)."""
+    if mgr.internal_forge is not None:
+        creds = mgr.internal_forge.mission_credentials(name)
+        if creds is not None and creds.token_read:
+            return ("internal", creds)
+    inst = mgr.forges.instance(name)
+    forge = mgr.forges.get(name)
+    if (inst is not None and forge is not None
+            and (inst.token_ro or inst.token)):
+        return ("configured", inst, forge, inst.token_ro or inst.token)
+    return None

--- a/app/tests/test_repo_sourcing.py
+++ b/app/tests/test_repo_sourcing.py
@@ -1,0 +1,100 @@
+"""repo_sourcing — THE repo-sourcing + blocker-credential rules (ADR-0034;
+audit F11). The mirror gate and the runspec extras builder consume one
+sourcing list; the ratchet keeps either from growing its own copy back."""
+
+import inspect
+
+from types import SimpleNamespace
+
+import pytest
+
+from devcake.domain.repo_sourcing import (blocker_read_credential,
+                                          sourced_repo_names)
+
+
+def _inst(repos=(), refs=()):
+    return SimpleNamespace(repos=list(repos), reference_repos=list(refs))
+
+
+@pytest.mark.parametrize("mission_type,work,expected", [
+    # ONBOARD: routing set + references + blockers, primary first, deduped
+    ("ONBOARD", "alpha", ["alpha", "beta", "pub", "int-1", "gone"]),
+    # non-ONBOARD stages: references + blockers only
+    ("PLAN", "alpha", ["alpha", "pub", "beta", "int-1", "gone"]),
+    ("EXECUTE", "beta", ["beta", "pub", "int-1", "gone"]),
+    ("REVIEW", "beta", ["beta", "pub", "int-1", "gone"]),
+    # STEWARD and friends: primary only
+    ("STEWARD", "alpha", ["alpha"]),
+])
+def test_sourcing_table(mission_type, work, expected):
+    blockers = [{"repo_ref": "beta"}, {"repo_ref": "int-1"},
+                {"repo_ref": "gone"}, {"repo_ref": ""}]
+    got = sourced_repo_names(
+        work_repo=work, mission_type=mission_type,
+        instance=_inst(repos=["alpha", "beta"], refs=["pub"]),
+        blocker_entries=blockers)
+    assert got == expected
+
+
+def test_gate_set_is_the_filtered_sourcing_set(tmp_path):
+    """The audit's drift scenario made structurally impossible: the mirror
+    gate's repo set IS the shared sourcing list under the eligibility
+    filter — not a parallel computation."""
+    from test_repo_mirror import PUB, R1, R2, make_cache
+    cache, _, _ = make_cache(tmp_path, [R1, R2, PUB], internal=["int-1"])
+    inst = SimpleNamespace(name="linear", repos=["alpha", "beta"],
+                           reference_repos=["pub"])
+    blockers = [{"repo_ref": "beta"}, {"repo_ref": "int-1"},
+                {"repo_ref": "gone"}]
+    for mt in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW", "STEWARD"):
+        sourced = sourced_repo_names(work_repo="alpha", mission_type=mt,
+                                     instance=inst, blocker_entries=blockers)
+        assert cache.needed_for(work_repo="alpha", mission_type=mt,
+                                instance=inst, blocker_entries=blockers) \
+            == [n for n in sourced if cache.eligible(n)]
+
+
+def test_blocker_read_credential_rule():
+    internal_creds = SimpleNamespace(token_read="tr", clone_url="u",
+                                     username="devcake")
+
+    def mgr(internal=None, inst=None, forge=None):
+        return SimpleNamespace(
+            internal_forge=None if internal is None else SimpleNamespace(
+                mission_credentials=lambda name: internal),
+            forges=SimpleNamespace(instance=lambda n: inst,
+                                   get=lambda n: forge))
+
+    # internal creds win
+    kind, creds = blocker_read_credential(
+        mgr(internal=internal_creds), "linear-DEV-1")
+    assert kind == "internal" and creds.token_read == "tr"
+    # configured card: token_ro preferred, write fallback
+    card = SimpleNamespace(token_ro="", token="wtok", url="u")
+    kind, _i, _f, token = blocker_read_credential(
+        mgr(inst=card, forge=object()), "beta")
+    assert kind == "configured" and token == "wtok"
+    card_ro = SimpleNamespace(token_ro="rtok", token="wtok", url="u")
+    assert blocker_read_credential(
+        mgr(inst=card_ro, forge=object()), "beta")[3] == "rtok"
+    # nothing mountable: no internal creds, no card / no token
+    assert blocker_read_credential(mgr(), "gone") is None
+    tokenless = SimpleNamespace(token_ro="", token="", url="u")
+    assert blocker_read_credential(
+        mgr(inst=tokenless, forge=object()), "beta") is None
+
+
+def test_sourcing_lives_only_in_repo_sourcing():
+    """Ratchet (ADR-0034): neither consumer may grow its own sourcing back —
+    both must call the chokepoint and neither may touch the sourcing fields
+    (instance.repos / reference_repos / blocker repo_ref extraction)."""
+    from devcake.domain.orchestrator import dispatch
+    from devcake.domain.repo_mirror import RepoCache
+    for fn in (RepoCache.needed_for, dispatch._extra_repos_for):
+        src = inspect.getsource(fn)
+        assert "sourced_repo_names" in src, (
+            f"{fn.__qualname__} must source through the chokepoint")
+        assert "reference_repos" not in src, (
+            f"{fn.__qualname__} re-implements sourcing")
+    assert "blocker_read_credential" in inspect.getsource(
+        dispatch._blocker_mount_ok)


### PR DESCRIPTION
Phase 1 PR-4 of the 2026-08-12 audit intervention campaign (ADR-0034 chokepoints).

Extracts the twice-written mission-type→repo-set sourcing and the twice-written blocker read-credential rule into `domain/repo_sourcing.py`. The `at_decomposition_limit` precedent, applied to the audit's F11: the gate and the runspec now consume ONE list and structurally cannot disagree about which repos ride the mirror.

- `RepoCache.needed_for` = `filter(eligible, sourced_repo_names(...))` — the "mirrors _extra_repos_for's sourcing exactly" comment is dead.
- `_extra_repos_for` iterates the same sourced list and only enriches (mirror path / token / internal creds).
- `_blocker_mount_ok` = `blocker_read_credential(...) is not None`.

Behavior-preserving (existing `test_repo_mirror` + `test_blocker_work` suites pass unchanged); new tests pin the sourcing table, the gate-set==filtered-sourcing equivalence over all five mission types, the credential matrix, and an `inspect.getsource` ratchet against either consumer re-growing its own copy.

Suite: **1678 passed, 1 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)