### PR TITLE
refactor: checkpoint step-key registry + layering ratchet (ADR-0034; F13)

### DIFF
--- a/app/devcake/domain/orchestrator/completion.py
+++ b/app/devcake/domain/orchestrator/completion.py
@@ -36,7 +36,7 @@ from ...ports.forge import mission_branch
 from ..model import (LABEL_EXECUTE, LABEL_MERGE, LABEL_REVIEW, Mission,
                      MissionRef)
 from ..run import Run
-from . import freshness
+from . import freshness, steps
 from .feed import _unquoted
 from .markers import CONFLICT_MARKER, MAX_CONFLICT_RESOLVES
 
@@ -108,7 +108,7 @@ async def complete_merged(mgr, cause: MergedCause, *, ref: MissionRef,
             mgr._audit(ref.pmo_id, spec.audit_action, pr_url)
 
         if run is not None:
-            await mgr._checkpoint(run, "review:done", _core)
+            await mgr._checkpoint(run, steps.REVIEW_DONE, _core)
         else:
             await _core()
         try:

--- a/app/devcake/domain/orchestrator/decomposition.py
+++ b/app/devcake/domain/orchestrator/decomposition.py
@@ -10,6 +10,7 @@ from ...security import redact
 from ..model import (LABEL_CREATED, LABEL_NEEDS_HUMAN, LABEL_OPTIN, LABEL_SKIP,
                      LABEL_TRACKING, MissionRef)
 from ..run import Run
+from . import steps
 from .markers import (COMMENT_SENTINEL, at_decomposition_limit,
                       decomposition_depth, decomposition_marker)
 
@@ -25,7 +26,8 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
     # under the limit of that moment — a config change mid-resume must finish
     # the wiring, not strand live children behind a SKIP park.
     limit = mgr.config.max_decomposition_depth
-    committed = any(s.startswith("decomp:child:") for s in run.finalized_steps)
+    committed = any(s.startswith(steps.DECOMP_CHILD_PREFIX)
+                    for s in run.finalized_steps)
     if not committed and at_decomposition_limit(live, limit):
         depth = decomposition_depth(live)
         async def _depth_limit():
@@ -42,7 +44,7 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
                 f"again. Parked with `DEVCAKE-SKIP` for a human to "
                 f"re-scope.")
             mgr._audit(pmo_id, "depth_limit_rejected", run.run_id)
-        await mgr._checkpoint(run, "decomp:depth_limit", _depth_limit)
+        await mgr._checkpoint(run, steps.DECOMP_DEPTH_LIMIT, _depth_limit)
         run.verdict = "handed off: decomposition depth limit"
         return
     # children of an unknown-depth parent (unlimited mode) record depth 2 —
@@ -126,7 +128,7 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
                     MissionRef(pmo_id, "project"),
                     redact(baton) + "\n\n" + COMMENT_SENTINEL)
             mgr._audit(pmo_id, "decomposition_conflict", detail)
-        await mgr._checkpoint(run, "decomp:conflict", _decomp_conflict)
+        await mgr._checkpoint(run, steps.DECOMP_CONFLICT, _decomp_conflict)
         run.verdict = "handed off: decomposition replay conflict"
         return
 
@@ -149,7 +151,7 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
 
     for i, d in enumerate(normalized, start=1):
         title = d["title"]
-        key_child = f"decomp:child:{i}"
+        key_child = steps.DECOMP_CHILD(i)
         if i in existing:
             child_id, key = existing[i], existing_keys[i]
         elif key_child in run.finalized_steps:
@@ -188,7 +190,7 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
         for j in d["blocked_by"]:
             blocker_id = child_ids.get(j)
             if blocker_id:
-                rel_key = f"decomp:rel:{j}->{i}"
+                rel_key = steps.DECOMP_REL(j, i)
                 async def _rel(blocker_id=blocker_id, child_id=child_id, j=j):
                     await mgr.pmo.create_relation(blocker_id, child_id)
                     mgr._audit(child_id, "relation_created",
@@ -247,11 +249,11 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
             for b in open_blockers:
                 async def _in(b=b, child_id=child_id):
                     await _inherit(b, child_id)
-                await mgr._checkpoint(run, f"decomp:inherit:in:{b}->{i}", _in)
+                await mgr._checkpoint(run, steps.DECOMP_INHERIT_IN(b, i), _in)
             for dep in dependents:
                 async def _out(child_id=child_id, dep=dep):
                     await _inherit(child_id, dep)
-                await mgr._checkpoint(run, f"decomp:inherit:out:{i}->{dep}",
+                await mgr._checkpoint(run, steps.DECOMP_INHERIT_OUT(i, dep),
                                        _out)
 
         # lineage note (ADR-0012 hygiene): best-effort BY DESIGN — the note
@@ -269,7 +271,7 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
                     MissionRef(pmo_id, "issue"), note)
             except Exception as e:  # noqa: BLE001 — lineage note is best-effort BY DESIGN (comment above); failure recorded in the audit, the cancel proceeds
                 mgr._audit(pmo_id, "lineage_note_failed", str(e)[:200])
-        await mgr._checkpoint(run, "decomp:parent_note", _parent_note)
+        await mgr._checkpoint(run, steps.DECOMP_PARENT_NOTE, _parent_note)
 
     links = ", ".join(created) or "(all already existed)"
     async def _tracking():
@@ -284,4 +286,4 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
                 f"{links}. This issue is canceled in their favor.")
             await mgr.pmo.cancel_mission(MissionRef(pmo_id, "issue"))
             mgr._audit(pmo_id, "decomposed_canceled", links)
-    await mgr._checkpoint(run, "decomp:tracking", _tracking)
+    await mgr._checkpoint(run, steps.DECOMP_TRACKING, _tracking)

--- a/app/devcake/domain/orchestrator/deliver.py
+++ b/app/devcake/domain/orchestrator/deliver.py
@@ -18,12 +18,12 @@ import logging
 import zipfile
 
 from ...ports.forge import PRFile, run_branch
-from . import feed
+from . import feed, steps
 from .markers import DELIVERABLE_MARKER
 
 log = logging.getLogger("devcake.deliver")
 
-_DELIVER_STEP = "deliver:zip"
+_DELIVER_STEP = steps.DELIVER_ZIP
 # leave headroom under the PMO attachment cap for the zip container overhead
 _SAFETY = 64 * 1024
 

--- a/app/devcake/domain/orchestrator/finalize.py
+++ b/app/devcake/domain/orchestrator/finalize.py
@@ -11,7 +11,7 @@ from ...security import redact, redact_value
 from .. import backend_health, costing, failure_taxonomy
 from ..model import MissionRef
 from ..run import Run, utcnow
-from . import transitions
+from . import steps, transitions
 from .feed import _blockquote, _stage_of
 from .markers import FEED_INLINE_MAX, REPLY_MARKER
 
@@ -99,13 +99,13 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
             span.set_attribute("devcake.continuations", run.continuations_used)
 
         # 1 — transcript (idempotent via finalized_steps)
-        if "transcript" not in run.finalized_steps:
+        if steps.TRANSCRIPT not in run.finalized_steps:
             if _pre_wipe(mgr, run):
                 log.info("abort finalize (transcript) pre-wipe %s", run.run_id)
                 return
             await _post_transcript(mgr, run, transcript,
                                         payload.get("last_message_md"))
-            run.finalized_steps.append("transcript")
+            run.finalized_steps.append(steps.TRANSCRIPT)
             mgr.runs.store.save(run)
 
         # 1b — the answer as its own marked comment (ADR-0014 D2 quarantine
@@ -113,7 +113,7 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
         # the answer without parsing our transcript header or opening the zip.
         # REVIEW/`reviewed` is suppressed (see _post_reply) so a trailing
         # "LGTM" cannot displace the EXECUTE answer as the newest REPLY.
-        await _checkpoint(mgr, run, "reply", lambda: _post_reply(
+        await _checkpoint(mgr, run, steps.REPLY, lambda: _post_reply(
             mgr, run, payload.get("last_message_md"), outcome,
         ))
 
@@ -123,7 +123,7 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
 
         run.token_report = redact_value(token_report)  # persisted cost source
         # 2 — token report (INV-5: always)
-        if "token_report" not in run.finalized_steps:
+        if steps.TOKEN_REPORT not in run.finalized_steps:
             await mgr._feed(pmo_id, run.pmo_kind,
                              _token_report_md(run, token_report,
                                               mgr.config.cost_inputs))
@@ -131,7 +131,7 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
                 log.info("abort finalize after token_report pre-wipe %s",
                          run.run_id)
                 return
-            run.finalized_steps.append("token_report")
+            run.finalized_steps.append(steps.TOKEN_REPORT)
             mgr.runs.store.save(run)
 
         # failure artifact (docs/07 §4 nonzero exits): evidence posted above,
@@ -163,7 +163,7 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
         # counted attempt (docs/15 §2), NOT an exception to propagate: the
         # run must fail cleanly so the mission reschedules next cycle
         # instead of stranding in `finalizing` until the watchdog timeout.
-        if "transition" not in run.finalized_steps:
+        if steps.TRANSITION not in run.finalized_steps:
             if _pre_wipe(mgr, run):
                 return
             try:
@@ -191,7 +191,7 @@ async def finalize(mgr, run: Run, payload: dict) -> None:
                 return
             if _pre_wipe(mgr, run):
                 return
-            run.finalized_steps.append("transition")
+            run.finalized_steps.append(steps.TRANSITION)
             mgr.runs.store.save(run)
 
         await mgr.messaging.delete_run_user(run.run_id)

--- a/app/devcake/domain/orchestrator/freshness.py
+++ b/app/devcake/domain/orchestrator/freshness.py
@@ -18,6 +18,7 @@ from datetime import datetime
 
 from ..model import MissionRef
 from ..run import Run
+from . import steps
 from .dispatch import _aware, _mission_cost
 from .feed import _is_devcake_comment, _unquoted
 from .markers import (ELEVATED_MARKERS, FRESHNESS_MARKER,
@@ -29,9 +30,10 @@ log = logging.getLogger("devcake.missions")
 # withholding the transition is coherent (merged or parked pre-upgrade) —
 # the gate must not run for the first time on a redelivery that already
 # merged the PR.
-_PAST_GATE_STEPS = ("review:done", "review:merge", "review:merge_failed",
-                    "review:merge_deferred", "review:conflict_routed",
-                    "review:awaiting_merge")
+# DERIVED from the step registry (ADR-0034): a step declares
+# past_freshness_gate at registration — the old hand-enumeration of
+# review.py's step names cannot drift anymore.
+_PAST_GATE_STEPS = steps.past_gate_steps()
 
 # Synthetic finding when the adapter's hard stop truncated the fetch: the
 # gitea_issues adapter pages ASCENDING and drops the NEWEST entries at its
@@ -133,14 +135,15 @@ async def review_freshness_gate(mgr, run: Run) -> str:
     duplicate. Returns 'pass' | 'tripped' | 'exhausted'; 'tripped' means the
     caller must return without transitioning ('exhausted' proceeds — the
     disclosure was posted here)."""
-    steps = run.finalized_steps
-    if "review:freshness_tripped" in steps:
+    done_steps = run.finalized_steps
+    if steps.REVIEW_FRESHNESS_TRIPPED in done_steps:
         # redelivery of a tripped finalize: stay tripped — re-running a
         # check that can fail open would close the mission directly under a
         # directive that just promised a re-review
         return "tripped"
-    if "review:freshness_ok" in steps or "review:freshness_exhausted" in steps \
-            or any(s in steps for s in _PAST_GATE_STEPS):
+    if steps.REVIEW_FRESHNESS_OK in done_steps \
+            or steps.REVIEW_FRESHNESS_EXHAUSTED in done_steps \
+            or any(s in done_steps for s in _PAST_GATE_STEPS):
         return "pass"
 
     try:
@@ -150,7 +153,7 @@ async def review_freshness_gate(mgr, run: Run) -> str:
                       run.mission_key)
         found, count = [], 0
     if not found:
-        steps.append("review:freshness_ok")
+        done_steps.append(steps.REVIEW_FRESHNESS_OK)
         mgr.runs.store.save(run)
         return "pass"
 
@@ -172,7 +175,7 @@ async def review_freshness_gate(mgr, run: Run) -> str:
             mgr.anomalies[pmo_id] = (
                 f"{run.mission_key}: closed with unevaluated feed activity "
                 f"(re-review budget spent)")  # transient — pruned once done
-        await mgr._checkpoint(run, "review:freshness_exhausted", _disclose)
+        await mgr._checkpoint(run, steps.REVIEW_FRESHNESS_EXHAUSTED, _disclose)
         return "exhausted"
 
     n = count + 1
@@ -183,11 +186,11 @@ async def review_freshness_gate(mgr, run: Run) -> str:
                    f"re-review {n}/{MAX_FRESHNESS_REREVIEWS}: "
                    f"{len(found)} unread entries")
     try:
-        await mgr._checkpoint(run, "review:freshness_directive", _directive)
+        await mgr._checkpoint(run, steps.REVIEW_FRESHNESS_DIRECTIVE, _directive)
     except Exception:  # noqa: BLE001 — a failed post must NOT fail open past found material (that would close on known-unread entries) and must not wedge finalize either: with no marker posted the count cannot inflate, and the next plain REVIEW's mirror carries the material anyway
         log.exception("freshness directive post failed for %s — the "
                       "re-review proceeds undirected", run.mission_key)
-    steps.append("review:freshness_tripped")
+    done_steps.append(steps.REVIEW_FRESHNESS_TRIPPED)
     run.verdict = (f"handed off: freshness re-review "
                    f"{n}/{MAX_FRESHNESS_REREVIEWS} dispatched")
     mgr.runs.store.save(run)

--- a/app/devcake/domain/orchestrator/markers.py
+++ b/app/devcake/domain/orchestrator/markers.py
@@ -6,8 +6,8 @@ import os
 import re
 from pathlib import Path
 
-from ..model import (LABEL_CREATED, LABEL_EXECUTE, LABEL_PLAN, LABEL_REVIEW,
-                     MissionType)
+from ..model import LABEL_CREATED, MissionType
+from . import steps
 
 # The full state machine is dispatchable, projects included (ADR-0006).
 DISPATCHABLE_TYPES = {MissionType.ONBOARD, MissionType.PLAN,
@@ -37,20 +37,10 @@ STEP_MARKER = re.compile(r"`(\d+)_(ONBOARD|PLAN|EXECUTE|REVIEW)\.md`")
 # removed). Consulted by the redelivery external-transition check in
 # _transition: a live stage matching a present marker's value is our own swap
 # resuming, anything else is an external change and halts the finalize.
-# Stage-label-swapping checkpoints MUST be registered here, or their
-# redeliveries will misread the swap as external (cosmetic skip, safe).
-_SWAP_MARKER_STAGE: dict[str, str | None] = {
-    "transition:planned:labels": LABEL_EXECUTE,
-    "transition:executed:labels": LABEL_REVIEW,
-    "transition:plan_needed_attach:labels": LABEL_EXECUTE,
-    "transition:plan_needed": LABEL_PLAN,
-    "review:reject:labels": LABEL_EXECUTE,
-    "review:conflict_routed": LABEL_EXECUTE,
-    "review:done": None,           # REVIEW removed, mission done
-    "review:merge_failed": None,   # REVIEW→MERGE; MERGE is not a stage label
-    "review:merge_deferred": None,
-    "review:awaiting_merge": None,  # REVIEW→MERGE (auto_merge off; audit A6)
-}
+# DERIVED from the step registry (ADR-0034) — a new stage-swapping checkpoint
+# declares its stage_after at registration in steps.py; the old hand-copy
+# ("MUST be registered here") cannot drift anymore.
+_SWAP_MARKER_STAGE: dict[str, str | None] = steps.swap_marker_stage()
 
 # docs/05 §4: feed comments longer than this are uploaded as .md attachments
 # and referenced from a short comment (POST-time only — the Dev-side mirror

--- a/app/devcake/domain/orchestrator/review.py
+++ b/app/devcake/domain/orchestrator/review.py
@@ -9,7 +9,7 @@ from .. import costing
 from ..model import LABEL_EXECUTE, LABEL_MERGE, LABEL_REVIEW, MissionRef
 from ..run import Run
 from ...ports.forge import run_branch
-from . import completion
+from . import completion, steps
 from .freshness import review_freshness_gate
 from .markers import (HANDOFF_APPEND_MAX, HANDOFF_MARKER,
                       MERGE_HANDOFF_MARKER, MERGE_RETRY_MARKER)
@@ -81,7 +81,7 @@ async def _append_handoff(mgr, run: Run, result: dict) -> None:
                 MissionRef(pmo_id, "issue"), note)
         except Exception as e:  # noqa: BLE001 — best-effort BY DESIGN (lineage-note precedent): the close proceeds, the failure is audited
             mgr._audit(pmo_id, "handoff_append_failed", str(e)[:200])
-    await mgr._checkpoint(run, "review:handoff", _note)
+    await mgr._checkpoint(run, steps.REVIEW_HANDOFF, _note)
 
 
 async def finalize_review(mgr, run: Run, result: dict) -> None:
@@ -122,7 +122,7 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                     pr.number,
                     "## DevCake REVIEW: APPROVED-BY-DEVCAKE ✅\n\n"
                     + report + footer)
-            await mgr._checkpoint(run, "review:pr_comment", _pr_comment)
+            await mgr._checkpoint(run, steps.REVIEW_PR_COMMENT, _pr_comment)
 
             async def _formal():
                 try:
@@ -130,25 +130,25 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                 except Exception:
                     log.exception("formal approval failed — falling back to marker")
                     return False
-            if "review:formal_approve" not in run.finalized_steps:
+            if steps.REVIEW_FORMAL_APPROVE not in run.finalized_steps:
                 formal = await _formal()
-                run.finalized_steps.append("review:formal_approve")
+                run.finalized_steps.append(steps.REVIEW_FORMAL_APPROVE)
                 if formal:
-                    run.finalized_steps.append("review:formal_approve_ok")
+                    run.finalized_steps.append(steps.REVIEW_FORMAL_APPROVE_OK)
                 mgr.runs.store.save(run)
             else:
                 # redelivery: only claim formal approval if it succeeded
-                formal = "review:formal_approve_ok" in run.finalized_steps
+                formal = steps.REVIEW_FORMAL_APPROVE_OK in run.finalized_steps
 
         if inst.auto_merge and pr:
-            if "review:done" not in run.finalized_steps \
-                    and "review:merge_failed" not in run.finalized_steps \
-                    and "review:merge_deferred" not in run.finalized_steps \
-                    and "review:conflict_routed" not in run.finalized_steps:
+            if steps.REVIEW_DONE not in run.finalized_steps \
+                    and steps.REVIEW_MERGE_FAILED not in run.finalized_steps \
+                    and steps.REVIEW_MERGE_DEFERRED not in run.finalized_steps \
+                    and steps.REVIEW_CONFLICT_ROUTED not in run.finalized_steps:
                 try:
                     async def _merge():
                         await forge.merge(pr.number)
-                    await mgr._checkpoint(run, "review:merge", _merge)
+                    await mgr._checkpoint(run, steps.REVIEW_MERGE, _merge)
                 except Exception as e:  # noqa: BLE001 — every MERGE failure, whatever its type, must enter the re-probe → conflict-route → merge-failed recovery ladder; escaping would strand the mission mid-REVIEW
                     merge_err = e
                     handled_below = True
@@ -156,7 +156,7 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                     # merge landed: complete via the chokepoint. Its failures
                     # PROPAGATE (F4) — the run stays finalizing and converges
                     # via redelivery (the four-way guard above doesn't block;
-                    # "review:merge" no-ops; "review:done" retries) or, past
+                    # steps.REVIEW_MERGE no-ops; steps.REVIEW_DONE retries) or, past
                     # the stalled-finalize deadline, the next REVIEW cycle's
                     # re-probe of an already-merged PR.
                     await completion.complete_merged(
@@ -183,8 +183,8 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                         # skips the merge checkpoint, then complete via the
                         # chokepoint — its failures PROPAGATE (run stays
                         # finalizing; redelivery/stalled-finalize converge)
-                        if "review:merge" not in run.finalized_steps:
-                            run.finalized_steps.append("review:merge")
+                        if steps.REVIEW_MERGE not in run.finalized_steps:
+                            run.finalized_steps.append(steps.REVIEW_MERGE)
                             mgr.runs.store.save(run)
                         await completion.complete_merged(
                             mgr, completion.MergedCause.REVIEW_AUTO_MERGE,
@@ -198,7 +198,7 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                     except Exception:
                         log.exception("mergeable check failed for %s", pr_url)
                     if completion.trusted_conflict(forge, mstate):
-                        if "review:conflict_routed" in run.finalized_steps:
+                        if steps.REVIEW_CONFLICT_ROUTED in run.finalized_steps:
                             return
                         try:
                             routed = await completion.route_conflict_to_execute(
@@ -209,11 +209,11 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                                           run.mission_key)
                             routed = False
                         if routed:
-                            run.finalized_steps.append("review:conflict_routed")
+                            run.finalized_steps.append(steps.REVIEW_CONFLICT_ROUTED)
                             mgr.runs.store.save(run)
                             return
-                    if "review:merge_failed" not in run.finalized_steps \
-                            and "review:merge_deferred" not in run.finalized_steps:
+                    if steps.REVIEW_MERGE_FAILED not in run.finalized_steps \
+                            and steps.REVIEW_MERGE_DEFERRED not in run.finalized_steps:
                         async def _fail_path():
                             await mgr.pmo.swap_labels(
                                 MissionRef(pmo_id, "issue"),
@@ -233,7 +233,7 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                                             str(merge_err)[:120])
                                 mgr._merge_window_closed.discard(pmo_id)
                                 run.finalized_steps.append(
-                                    "review:merge_deferred")
+                                    steps.REVIEW_MERGE_DEFERRED)
                             else:
                                 await mgr._feed(
                                     pmo_id, "issue",
@@ -245,12 +245,12 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                                             "review_approve_merge_failed",
                                             str(merge_err)[:120])
                                 run.finalized_steps.append(
-                                    "review:merge_failed")
+                                    steps.REVIEW_MERGE_FAILED)
                             mgr.runs.store.save(run)
                         await _fail_path()
         elif inst.auto_merge and inst.merge_retry_window_minutes > 0 \
-                and "review:merge_deferred" not in run.finalized_steps \
-                and "review:awaiting_merge" not in run.finalized_steps:
+                and steps.REVIEW_MERGE_DEFERRED not in run.finalized_steps \
+                and steps.REVIEW_AWAITING_MERGE not in run.finalized_steps:
             # AUD-006: auto_merge is ON but the PR wasn't visible at finalize
             # (forge list lag / branch-naming miss). Pure human-await copy
             # would strand app-driven merge FOREVER — the sweep silent-returns
@@ -270,10 +270,10 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                     f"{MERGE_RETRY_MARKER}")
                 mgr._audit(pmo_id, "review_approve_defer_missing_pr", pr_url)
                 mgr._merge_window_closed.discard(pmo_id)
-                run.finalized_steps.append("review:merge_deferred")
+                run.finalized_steps.append(steps.REVIEW_MERGE_DEFERRED)
                 mgr.runs.store.save(run)
             await _defer_missing_pr()
-        elif "review:awaiting_merge" not in run.finalized_steps:
+        elif steps.REVIEW_AWAITING_MERGE not in run.finalized_steps:
             async def _await_merge():
                 await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                            remove={LABEL_REVIEW}, add={LABEL_MERGE})
@@ -284,7 +284,7 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                     f"Awaiting human merge of {pr_url} — the merge sweep completes "
                     f"this mission once it merges." + footer)
                 mgr._audit(pmo_id, "review_approve_awaiting_merge", pr_url)
-            await mgr._checkpoint(run, "review:awaiting_merge", _await_merge)
+            await mgr._checkpoint(run, steps.REVIEW_AWAITING_MERGE, _await_merge)
     else:  # reject
         rejections = 1 + sum(
             1 for r in mgr.runs.store.all()
@@ -354,13 +354,13 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
                 await forge.post_pr_comment(pr.number, warn)
             mgr._audit(pmo_id, "loop_warning", f"{rejections} rejections")
 
-        await mgr._checkpoint(run, "review:reject:feed", _reject_feed)
-        await mgr._checkpoint(run, "review:reject:pr_comment",
+        await mgr._checkpoint(run, steps.REVIEW_REJECT_FEED, _reject_feed)
+        await mgr._checkpoint(run, steps.REVIEW_REJECT_PR_COMMENT,
                                _reject_pr_comment)
-        await mgr._checkpoint(run, "review:reject:labels", _reject_labels)
-        await mgr._checkpoint(run, "review:reject:loop_warn",
+        await mgr._checkpoint(run, steps.REVIEW_REJECT_LABELS, _reject_labels)
+        await mgr._checkpoint(run, steps.REVIEW_REJECT_LOOP_WARN,
                                _reject_loop_warn)
-        if "review:reject" not in run.finalized_steps:
-            run.finalized_steps.append("review:reject")
+        if steps.REVIEW_REJECT not in run.finalized_steps:
+            run.finalized_steps.append(steps.REVIEW_REJECT)
             mgr.runs.store.save(run)
 

--- a/app/devcake/domain/orchestrator/steps.py
+++ b/app/devcake/domain/orchestrator/steps.py
@@ -1,0 +1,201 @@
+"""Checkpoint step-key registry (ADR-0034; 2026-08-12 audit F13).
+
+``run.finalized_steps`` strings are the redelivery control flow — ~40 keys
+that used to live as scattered literals, with TWO hand-maintained side
+tables re-enumerating them (markers._SWAP_MARKER_STAGE, "MUST be registered
+here"; freshness._PAST_GATE_STEPS). This registry is the one authority: a
+step's key, whether it swaps the stage label (and to what), and whether its
+presence means the finalize is already past the freshness gate. The side
+tables are DERIVED views now — a new checkpoint author answers every
+question at registration and the tables cannot drift.
+
+Two hard rules:
+- **Byte compatibility is non-negotiable.** Constants carry today's exact
+  strings; record compatibility for in-flight finalizing runs at upgrade
+  time depends on it (test_steps_registry pins the load-bearing values).
+- **Every checkpoint key resolves to this module.** The AST guard in
+  test_structure_guards scans every ``_checkpoint`` / ``finalized_steps
+  .append`` call site under domain/: a bare literal or unresolvable name
+  fails with remediation. The guard is anti-accident, not anti-adversary.
+
+Leaf module: imports only ``..model`` labels — markers/freshness/every
+orchestrator module may import it without cycles.
+
+NOTE ``dynamic`` rows (families): instances are built ONLY by the
+constructor functions below (``DECOMP_CHILD(i)`` …) so the guard can
+recognize them; the row's ``key`` is the family PREFIX.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..model import LABEL_EXECUTE, LABEL_PLAN, LABEL_REVIEW
+
+# tri-state sentinel: "swaps the stage label to None (removed)" is a REAL
+# value in the swap table and must stay distinct from "not a swap at all"
+_NOT_A_SWAP = object()
+
+
+@dataclass(frozen=True)
+class Step:
+    key: str                          # exact key; for dynamic rows, the prefix
+    dynamic: bool = False
+    stage_after: object = _NOT_A_SWAP   # label str | None (removed) | sentinel
+    past_freshness_gate: bool = False
+
+
+# ── finalize.py ──────────────────────────────────────────────────────────────
+TRANSCRIPT = "transcript"
+REPLY = "reply"
+TOKEN_REPORT = "token_report"
+TRANSITION = "transition"
+
+# ── transitions.py ───────────────────────────────────────────────────────────
+TRANSITION_ILLEGAL = "transition:illegal"
+TRANSITION_PROJECT_PARK = "transition:project_park"
+TRANSITION_EXTERNAL = "transition:external"
+TRANSITION_PLANNED_UPLOAD = "transition:planned:upload"
+TRANSITION_PLANNED_FEED = "transition:planned:feed"
+TRANSITION_PLANNED_LABELS = "transition:planned:labels"
+TRANSITION_PLANNED = "transition:planned"
+TRANSITION_EXECUTED_LABELS = "transition:executed:labels"
+TRANSITION_EXECUTED_FEED = "transition:executed:feed"
+TRANSITION_EXECUTED = "transition:executed"
+TRANSITION_PLAN_NEEDED_ATTACH_UPLOAD = "transition:plan_needed_attach:upload"
+TRANSITION_PLAN_NEEDED_ATTACH_FEED = "transition:plan_needed_attach:feed"
+TRANSITION_PLAN_NEEDED_ATTACH_LABELS = "transition:plan_needed_attach:labels"
+TRANSITION_PLAN_NEEDED_ATTACH = "transition:plan_needed_attach"
+TRANSITION_PLAN_NEEDED = "transition:plan_needed"
+TRANSITION_HUMAN_NEEDED = "transition:human_needed"
+TRANSITION_UNKNOWN_PARK = "transition:unknown_park"
+
+# ── review.py / completion.py / freshness.py ────────────────────────────────
+REVIEW_HANDOFF = "review:handoff"
+REVIEW_PR_COMMENT = "review:pr_comment"
+REVIEW_FORMAL_APPROVE = "review:formal_approve"
+REVIEW_FORMAL_APPROVE_OK = "review:formal_approve_ok"
+REVIEW_MERGE = "review:merge"
+REVIEW_DONE = "review:done"
+REVIEW_CONFLICT_ROUTED = "review:conflict_routed"
+REVIEW_MERGE_DEFERRED = "review:merge_deferred"
+REVIEW_MERGE_FAILED = "review:merge_failed"
+REVIEW_AWAITING_MERGE = "review:awaiting_merge"
+REVIEW_REJECT_FEED = "review:reject:feed"
+REVIEW_REJECT_PR_COMMENT = "review:reject:pr_comment"
+REVIEW_REJECT_LABELS = "review:reject:labels"
+REVIEW_REJECT_LOOP_WARN = "review:reject:loop_warn"
+REVIEW_REJECT = "review:reject"
+REVIEW_FRESHNESS_EXHAUSTED = "review:freshness_exhausted"
+REVIEW_FRESHNESS_DIRECTIVE = "review:freshness_directive"
+REVIEW_FRESHNESS_OK = "review:freshness_ok"
+REVIEW_FRESHNESS_TRIPPED = "review:freshness_tripped"
+
+# ── decomposition.py ─────────────────────────────────────────────────────────
+DECOMP_DEPTH_LIMIT = "decomp:depth_limit"
+DECOMP_CONFLICT = "decomp:conflict"
+DECOMP_PARENT_NOTE = "decomp:parent_note"
+DECOMP_TRACKING = "decomp:tracking"
+DECOMP_CHILD_PREFIX = "decomp:child:"
+
+
+def DECOMP_CHILD(i: int) -> str:
+    return f"{DECOMP_CHILD_PREFIX}{i}"
+
+
+def DECOMP_REL(j: int, i: int) -> str:
+    return f"decomp:rel:{j}->{i}"
+
+
+def DECOMP_INHERIT_IN(b: str, i: int) -> str:
+    return f"decomp:inherit:in:{b}->{i}"
+
+
+def DECOMP_INHERIT_OUT(i: int, dep: str) -> str:
+    return f"decomp:inherit:out:{i}->{dep}"
+
+
+# ── deliver.py / domain/runs.py ──────────────────────────────────────────────
+DELIVER_ZIP = "deliver:zip"
+ACL_USER_DELETED = "acl_user_deleted"
+REPLY_STREAM_DELETED = "reply_stream_deleted"
+
+
+REGISTRY: tuple[Step, ...] = (
+    Step(TRANSCRIPT),
+    Step(REPLY),
+    Step(TOKEN_REPORT),
+    Step(TRANSITION),
+    Step(TRANSITION_ILLEGAL),
+    Step(TRANSITION_PROJECT_PARK),
+    Step(TRANSITION_EXTERNAL),
+    Step(TRANSITION_PLANNED_UPLOAD),
+    Step(TRANSITION_PLANNED_FEED),
+    Step(TRANSITION_PLANNED_LABELS, stage_after=LABEL_EXECUTE),
+    Step(TRANSITION_PLANNED),
+    Step(TRANSITION_EXECUTED_LABELS, stage_after=LABEL_REVIEW),
+    Step(TRANSITION_EXECUTED_FEED),
+    Step(TRANSITION_EXECUTED),
+    Step(TRANSITION_PLAN_NEEDED_ATTACH_UPLOAD),
+    Step(TRANSITION_PLAN_NEEDED_ATTACH_FEED),
+    Step(TRANSITION_PLAN_NEEDED_ATTACH_LABELS, stage_after=LABEL_EXECUTE),
+    Step(TRANSITION_PLAN_NEEDED_ATTACH),
+    Step(TRANSITION_PLAN_NEEDED, stage_after=LABEL_PLAN),
+    Step(TRANSITION_HUMAN_NEEDED),
+    Step(TRANSITION_UNKNOWN_PARK),
+    Step(REVIEW_HANDOFF),
+    Step(REVIEW_PR_COMMENT),
+    Step(REVIEW_FORMAL_APPROVE),
+    Step(REVIEW_FORMAL_APPROVE_OK),
+    Step(REVIEW_MERGE, past_freshness_gate=True),
+    # stage_after=None (a REAL swap-table value): REVIEW removed, mission done
+    Step(REVIEW_DONE, stage_after=None, past_freshness_gate=True),
+    Step(REVIEW_CONFLICT_ROUTED, stage_after=LABEL_EXECUTE,
+         past_freshness_gate=True),
+    # REVIEW→MERGE; MERGE is not a stage label, so the swap table sees None
+    Step(REVIEW_MERGE_DEFERRED, stage_after=None, past_freshness_gate=True),
+    Step(REVIEW_MERGE_FAILED, stage_after=None, past_freshness_gate=True),
+    Step(REVIEW_AWAITING_MERGE, stage_after=None, past_freshness_gate=True),
+    Step(REVIEW_REJECT_FEED),
+    Step(REVIEW_REJECT_PR_COMMENT),
+    Step(REVIEW_REJECT_LABELS, stage_after=LABEL_EXECUTE),
+    Step(REVIEW_REJECT_LOOP_WARN),
+    Step(REVIEW_REJECT),
+    Step(REVIEW_FRESHNESS_EXHAUSTED),
+    Step(REVIEW_FRESHNESS_DIRECTIVE),
+    Step(REVIEW_FRESHNESS_OK),
+    Step(REVIEW_FRESHNESS_TRIPPED),
+    Step(DECOMP_DEPTH_LIMIT),
+    Step(DECOMP_CONFLICT),
+    Step(DECOMP_PARENT_NOTE),
+    Step(DECOMP_TRACKING),
+    Step(DECOMP_CHILD_PREFIX, dynamic=True),
+    Step("decomp:rel:", dynamic=True),
+    Step("decomp:inherit:in:", dynamic=True),
+    Step("decomp:inherit:out:", dynamic=True),
+    Step(DELIVER_ZIP),
+    Step(ACL_USER_DELETED),
+    Step(REPLY_STREAM_DELETED),
+)
+
+EXACT_KEYS: frozenset[str] = frozenset(
+    s.key for s in REGISTRY if not s.dynamic)
+
+# names of the family constructor functions — the AST guard accepts
+# `steps.<FAMILY>(…)` call expressions as registered keys
+FAMILY_CONSTRUCTORS: frozenset[str] = frozenset(
+    {"DECOMP_CHILD", "DECOMP_REL", "DECOMP_INHERIT_IN", "DECOMP_INHERIT_OUT"})
+
+
+def swap_marker_stage() -> dict[str, str | None]:
+    """Derived view: stage label each checkpointed swap leaves behind
+    (None = stage label removed). Consumed by markers._SWAP_MARKER_STAGE —
+    the old hand-copy with its "MUST be registered here" comment is gone."""
+    return {s.key: s.stage_after for s in REGISTRY
+            if s.stage_after is not _NOT_A_SWAP}
+
+
+def past_gate_steps() -> tuple[str, ...]:
+    """Derived view: steps whose presence means the finalize is already past
+    the freshness gate (consumed by freshness._PAST_GATE_STEPS)."""
+    return tuple(s.key for s in REGISTRY if s.past_freshness_gate)

--- a/app/devcake/domain/orchestrator/transitions.py
+++ b/app/devcake/domain/orchestrator/transitions.py
@@ -8,7 +8,7 @@ from ...security import redact
 from ..model import (LABEL_EXECUTE, LABEL_NEEDS_HUMAN, LABEL_PLAN, LABEL_REVIEW,
                      LABEL_SKIP, MissionRef)
 from ..run import Run
-from . import decomposition, feed, review
+from . import decomposition, feed, review, steps
 from .markers import COMMENT_SENTINEL, LEGAL_OUTCOMES, _SWAP_MARKER_STAGE
 
 log = logging.getLogger("devcake.missions")
@@ -31,7 +31,7 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
                 f"human to inspect.")
             mgr._audit(pmo_id, "illegal_outcome",
                         f"{outcome or '(empty)'} from {run.mission_type}")
-        await mgr._checkpoint(run, "transition:illegal", _illegal)
+        await mgr._checkpoint(run, steps.TRANSITION_ILLEGAL, _illegal)
         run.verdict = redact(
             f"rejected: outcome {outcome or '(empty)'} is illegal "
             f"for {run.mission_type} — parked with DEVCAKE-SKIP")
@@ -44,7 +44,7 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
             await mgr.pmo.swap_labels(MissionRef(pmo_id, "project"),
                                        remove=set(), add={LABEL_SKIP})
             mgr._audit(pmo_id, "project_bad_outcome_parked", outcome)
-        await mgr._checkpoint(run, "transition:project_park", _proj_park)
+        await mgr._checkpoint(run, steps.TRANSITION_PROJECT_PARK, _proj_park)
         run.verdict = redact(
             f"rejected: project returned {outcome} (only decomposed "
             f"is legal) — parked with DEVCAKE-SKIP")
@@ -72,7 +72,7 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
                 f"this mission's state was changed externally while it ran. The output is "
                 f"posted above; **no status or label changes were applied**.")
             mgr._audit(pmo_id, "external_transition", run.run_id)
-        await mgr._checkpoint(run, "transition:external", _external)
+        await mgr._checkpoint(run, steps.TRANSITION_EXTERNAL, _external)
         run.verdict = ("skipped: mission state changed externally while the "
                        "run was in flight — no transition applied")
         log.warning("EXTERNAL_TRANSITION on %s — no labels applied", run.run_id)
@@ -102,11 +102,11 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
                                        remove={LABEL_PLAN}, add={LABEL_EXECUTE})
             mgr._audit(pmo_id, "label_swap", f"{LABEL_PLAN}→{LABEL_EXECUTE}")
 
-        await mgr._checkpoint(run, "transition:planned:upload", _plan_upload)
-        await mgr._checkpoint(run, "transition:planned:feed", _plan_feed)
-        await mgr._checkpoint(run, "transition:planned:labels", _plan_labels)
-        if "transition:planned" not in run.finalized_steps:
-            run.finalized_steps.append("transition:planned")
+        await mgr._checkpoint(run, steps.TRANSITION_PLANNED_UPLOAD, _plan_upload)
+        await mgr._checkpoint(run, steps.TRANSITION_PLANNED_FEED, _plan_feed)
+        await mgr._checkpoint(run, steps.TRANSITION_PLANNED_LABELS, _plan_labels)
+        if steps.TRANSITION_PLANNED not in run.finalized_steps:
+            run.finalized_steps.append(steps.TRANSITION_PLANNED)
             mgr.runs.store.save(run)
     elif outcome == "executed":
         async def _executed_labels():
@@ -122,10 +122,10 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
                 f"🔀 DevCake opened/updated the {noun}: "
                 f"{result.get('pr_url', '(no url reported)')} — awaiting REVIEW.")
 
-        await mgr._checkpoint(run, "transition:executed:labels", _executed_labels)
-        await mgr._checkpoint(run, "transition:executed:feed", _executed_feed)
-        if "transition:executed" not in run.finalized_steps:
-            run.finalized_steps.append("transition:executed")
+        await mgr._checkpoint(run, steps.TRANSITION_EXECUTED_LABELS, _executed_labels)
+        await mgr._checkpoint(run, steps.TRANSITION_EXECUTED_FEED, _executed_feed)
+        if steps.TRANSITION_EXECUTED not in run.finalized_steps:
+            run.finalized_steps.append(steps.TRANSITION_EXECUTED)
             mgr.runs.store.save(run)
     elif outcome == "reviewed":
         await review.finalize_review(mgr, run, result)
@@ -153,21 +153,21 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
                                        remove=set(), add={LABEL_EXECUTE})
             mgr._audit(pmo_id, "label_add", LABEL_EXECUTE)
 
-        await mgr._checkpoint(run, "transition:plan_needed_attach:upload",
+        await mgr._checkpoint(run, steps.TRANSITION_PLAN_NEEDED_ATTACH_UPLOAD,
                                _plan_attach_upload)
-        await mgr._checkpoint(run, "transition:plan_needed_attach:feed",
+        await mgr._checkpoint(run, steps.TRANSITION_PLAN_NEEDED_ATTACH_FEED,
                                _plan_attach_feed)
-        await mgr._checkpoint(run, "transition:plan_needed_attach:labels",
+        await mgr._checkpoint(run, steps.TRANSITION_PLAN_NEEDED_ATTACH_LABELS,
                                _plan_attach_labels)
-        if "transition:plan_needed_attach" not in run.finalized_steps:
-            run.finalized_steps.append("transition:plan_needed_attach")
+        if steps.TRANSITION_PLAN_NEEDED_ATTACH not in run.finalized_steps:
+            run.finalized_steps.append(steps.TRANSITION_PLAN_NEEDED_ATTACH)
             mgr.runs.store.save(run)
     elif outcome == "plan_needed":
         async def _plan_needed():
             await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),
                                        remove=set(), add={LABEL_PLAN})
             mgr._audit(pmo_id, "label_add", LABEL_PLAN)
-        await mgr._checkpoint(run, "transition:plan_needed", _plan_needed)
+        await mgr._checkpoint(run, steps.TRANSITION_PLAN_NEEDED, _plan_needed)
     elif outcome == "human_needed":
         # deliberate hand-off (docs/03 §4a, ADR-0007): the run finished
         # cleanly, so it never counts toward max_attempts; the stage label
@@ -205,7 +205,7 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
                                 run.mission_key, exc_info=True)
             mgr._audit(pmo_id, "devcake_needs_human",
                         f"#{nth}: " + (result.get("summary") or "")[:110])
-        await mgr._checkpoint(run, "transition:human_needed", _human)
+        await mgr._checkpoint(run, steps.TRANSITION_HUMAN_NEEDED, _human)
         run.verdict = f"handed off: needs human on {run.mission_type}"
         mgr.needs_human[pmo_id] = (
             f"{run.mission_key}: needs human on {run.mission_type}"
@@ -220,7 +220,7 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
                 f"`DEVCAKE-SKIP` for a human to inspect.")
             mgr._audit(pmo_id, "label_add",
                         f"{LABEL_SKIP} (unknown outcome {outcome})")
-        await mgr._checkpoint(run, "transition:unknown_park", _unknown)
+        await mgr._checkpoint(run, steps.TRANSITION_UNKNOWN_PARK, _unknown)
         run.verdict = redact(
             f"rejected: unknown outcome {outcome} — parked with DEVCAKE-SKIP")
 

--- a/app/devcake/domain/runs.py
+++ b/app/devcake/domain/runs.py
@@ -383,14 +383,17 @@ class RunManager:
             span.set_attribute("devcake.outcome", str((run.result or {}).get("outcome")))
             # Mission runs post transcripts/token reports in MissionManager
             # .finalize (INV-5); this path serves runs with no PMO host.
-            for step in ("acl_user_deleted", "reply_stream_deleted"):
-                if step not in run.finalized_steps:
-                    if step == "acl_user_deleted":
-                        await self.messaging.delete_run_user(run.run_id)
-                    else:
-                        await self.messaging.delete_reply_stream(run.run_id)
-                    run.finalized_steps.append(step)
-                    self.store.save(run)
+            # lazy: importing orchestrator.steps at module top would cycle
+            # (runs -> orchestrator/__init__ -> manager -> runs)
+            from .orchestrator import steps
+            if steps.ACL_USER_DELETED not in run.finalized_steps:
+                await self.messaging.delete_run_user(run.run_id)
+                run.finalized_steps.append(steps.ACL_USER_DELETED)
+                self.store.save(run)
+            if steps.REPLY_STREAM_DELETED not in run.finalized_steps:
+                await self.messaging.delete_reply_stream(run.run_id)
+                run.finalized_steps.append(steps.REPLY_STREAM_DELETED)
+                self.store.save(run)
             run.state, run.ended_at = "finished", utcnow()
             self.store.save(run)
             log.info("finalized %s → finished", run.run_id)

--- a/app/tests/test_steps_registry.py
+++ b/app/tests/test_steps_registry.py
@@ -1,0 +1,85 @@
+"""steps.py registry (ADR-0034; audit F13): byte-value canaries (record
+compatibility for in-flight finalizing runs is non-negotiable), derived-view
+snapshots against the exact pre-registry literal tables, and the guard's own
+self-test (test the test)."""
+
+from devcake.domain.orchestrator import steps
+from devcake.domain.orchestrator.freshness import _PAST_GATE_STEPS
+from devcake.domain.orchestrator.markers import _SWAP_MARKER_STAGE
+
+from test_structure_guards import scan_step_key_sites
+
+
+def test_swap_marker_stage_matches_the_pre_registry_literal_table():
+    """Byte-exact snapshot of the table markers.py carried by hand before
+    the registry — the derived view must reproduce it verbatim."""
+    assert _SWAP_MARKER_STAGE == {
+        "transition:planned:labels": "DEVCAKE-EXECUTE",
+        "transition:executed:labels": "DEVCAKE-REVIEW",
+        "transition:plan_needed_attach:labels": "DEVCAKE-EXECUTE",
+        "transition:plan_needed": "DEVCAKE-PLAN",
+        "review:reject:labels": "DEVCAKE-EXECUTE",
+        "review:conflict_routed": "DEVCAKE-EXECUTE",
+        "review:done": None,
+        "review:merge_failed": None,
+        "review:merge_deferred": None,
+        "review:awaiting_merge": None,
+    }
+
+
+def test_past_gate_steps_matches_the_pre_registry_literal_tuple():
+    assert set(_PAST_GATE_STEPS) == {
+        "review:done", "review:merge", "review:merge_failed",
+        "review:merge_deferred", "review:conflict_routed",
+        "review:awaiting_merge",
+    }
+
+
+def test_constant_byte_values_are_frozen():
+    """Record compatibility: a renamed CONSTANT is a refactor; a changed
+    VALUE strands every in-flight finalizing run at upgrade time."""
+    assert steps.REVIEW_DONE == "review:done"
+    assert steps.REVIEW_MERGE == "review:merge"
+    assert steps.DELIVER_ZIP == "deliver:zip"
+    assert steps.TRANSCRIPT == "transcript"
+    assert steps.REPLY == "reply"
+    assert steps.TOKEN_REPORT == "token_report"
+    assert steps.TRANSITION == "transition"
+    assert steps.TRANSITION_HUMAN_NEEDED == "transition:human_needed"
+    assert steps.ACL_USER_DELETED == "acl_user_deleted"
+    assert steps.DECOMP_CHILD(3) == "decomp:child:3"
+    assert steps.DECOMP_REL(2, 5) == "decomp:rel:2->5"
+    assert steps.DECOMP_INHERIT_IN("b1", 4) == "decomp:inherit:in:b1->4"
+    assert steps.DECOMP_INHERIT_OUT(4, "d9") == "decomp:inherit:out:4->d9"
+
+
+def test_registry_has_no_duplicate_keys():
+    keys = [s.key for s in steps.REGISTRY]
+    assert len(keys) == len(set(keys))
+
+
+def test_the_guard_catches_unregistered_keys():
+    """Test the test: the AST guard must flag bare literals, unknown
+    constants, and unresolvable names — and pass every registered shape."""
+    bad = (
+        "async def f(mgr, run):\n"
+        "    await mgr._checkpoint(run, 'review:brand_new_step', fn)\n"
+        "    run.finalized_steps.append('another:literal')\n"
+        "    key = mystery()\n"
+        "    await mgr._checkpoint(run, key, fn)\n"
+    )
+    offenders = scan_step_key_sites(bad, steps)
+    assert len(offenders) == 3, offenders
+
+    good = (
+        "from . import steps\n"
+        "async def f(mgr, run, i, j):\n"
+        "    await mgr._checkpoint(run, steps.REVIEW_DONE, fn)\n"
+        "    await mgr._checkpoint(run, 'review:merge', fn)\n"
+        "    rel = steps.DECOMP_REL(j, i)\n"
+        "    await mgr._checkpoint(run, rel, fn)\n"
+        "    run.finalized_steps.append(steps.DECOMP_CHILD(i))\n"
+        "async def _checkpoint(mgr, run, key, fn):\n"
+        "    run.finalized_steps.append(key)   # the mechanism is exempt\n"
+    )
+    assert scan_step_key_sites(good, steps) == []

--- a/app/tests/test_structure_guards.py
+++ b/app/tests/test_structure_guards.py
@@ -185,3 +185,148 @@ def test_main_module_level_is_wiring_only():
     assert not offenders, (
         "api/main.py module scope grew non-wiring calls — move them into "
         "build_services() / lifespan (ADR-0028): " + "; ".join(offenders))
+
+
+# ── ADR-0034: checkpoint step keys resolve to the registry ───────────────────
+
+DOMAIN = Path(__file__).parents[1] / "devcake" / "domain"
+
+# The two sanctioned domain→adapters seams (2026-08-12 audit, docs audit §3):
+# git is the single subprocess seam (ADR-0024 §"single subprocess seam");
+# adapters.http's pool cleanup rides the hot-reload path (F16 — documented
+# by this allowlist entry and the module's own comment).
+DOMAIN_ADAPTER_IMPORT_ALLOWLIST = {
+    ("repo_mirror.py", "adapters.git"),
+    ("forge_runtime.py", "adapters.http"),
+}
+
+
+def _steps_module():
+    from devcake.domain.orchestrator import steps
+    return steps
+
+
+def _step_key_expr_ok(node, local_assigns, steps) -> bool:
+    """A registered key expression: a literal in EXACT_KEYS, `steps.<CONST>`
+    naming a registered constant, a family constructor call, or a local Name
+    assigned from one of those."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value in steps.EXACT_KEYS
+    if (isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)
+            and node.value.id == "steps"):
+        val = getattr(steps, node.attr, None)
+        return isinstance(val, str) and val in steps.EXACT_KEYS
+    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "steps"):
+        return node.func.attr in steps.FAMILY_CONSTRUCTORS
+    if isinstance(node, ast.Name):
+        assigned = local_assigns.get(node.id)
+        return assigned is not None and _step_key_expr_ok(assigned, {}, steps)
+    return False
+
+
+def scan_step_key_sites(source: str, steps) -> list[str]:
+    """Offending `_checkpoint(...)` / `finalized_steps.append(...)` key
+    expressions — anything that does not resolve to the registry. Anti-
+    accident, not anti-adversary: it resolves literals, `steps.*` constants,
+    family constructor calls, and simple local assignments of those; it does
+    not chase arbitrary dataflow. The checkpoint MECHANISM itself
+    (finalize._checkpoint's own `append(key)`) is exempt by name."""
+    tree = ast.parse(source)
+    local_assigns: dict[str, ast.AST] = {}
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)):
+            local_assigns[node.targets[0].id] = node.value
+    # drop the mechanism's own body from the scan
+    mechanism = {id(n) for fn in ast.walk(tree)
+                 if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+                 and fn.name == "_checkpoint"
+                 for n in ast.walk(fn)}
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or id(node) in mechanism:
+            continue
+        f = node.func
+        key = None
+        if isinstance(f, ast.Attribute) and f.attr == "_checkpoint":
+            # mgr._checkpoint(run, key, fn) → args[1];
+            # finalize._checkpoint(mgr, run, key, fn) → args[2]
+            if len(node.args) >= 3:
+                key = node.args[1] if len(node.args) == 3 else node.args[2]
+        elif (isinstance(f, ast.Attribute) and f.attr == "append"
+                and isinstance(f.value, ast.Attribute)
+                and f.value.attr == "finalized_steps"):
+            key = node.args[0] if node.args else None
+        if key is not None and not _step_key_expr_ok(key, local_assigns, steps):
+            offenders.append(f"line {node.lineno}: {ast.unparse(key)}")
+    return offenders
+
+
+def test_every_checkpoint_key_resolves_to_the_registry():
+    """ADR-0034 / audit F13: `run.finalized_steps` strings are the
+    redelivery control flow — every producer site must use a registered
+    constant or family constructor from orchestrator/steps.py, never a bare
+    literal the two derived tables (swap-marker stage, past-gate) can't see.
+    Remediation: register the key in steps.py (declaring stage_after /
+    past_freshness_gate) or use its family constructor."""
+    steps = _steps_module()
+    offenders = []
+    for p in sorted(DOMAIN.rglob("*.py")):
+        if p.name == "steps.py" or "__pycache__" in p.parts:
+            continue
+        offenders += [f"{p.relative_to(DOMAIN)}: {o}"
+                      for o in scan_step_key_sites(p.read_text(), steps)]
+    assert not offenders, (
+        "unregistered checkpoint keys (register in orchestrator/steps.py or "
+        "use its family constructor): " + "; ".join(offenders))
+
+
+def test_every_registry_key_is_used():
+    """Reverse ratchet: the registry accumulates no dead rows — every exact
+    key's constant and every family constructor is referenced somewhere in
+    domain/ (as `steps.<NAME>`)."""
+    steps = _steps_module()
+    used: set[str] = set()
+    for p in sorted(DOMAIN.rglob("*.py")):
+        if p.name == "steps.py" or "__pycache__" in p.parts:
+            continue
+        for node in ast.walk(ast.parse(p.read_text())):
+            if (isinstance(node, ast.Attribute)
+                    and isinstance(node.value, ast.Name)
+                    and node.value.id == "steps"):
+                used.add(node.attr)
+    const_by_key = {getattr(steps, name): name for name in dir(steps)
+                    if isinstance(getattr(steps, name), str)
+                    and not name.startswith("_")}
+    dead = sorted(const_by_key[s.key] for s in steps.REGISTRY
+                  if not s.dynamic and const_by_key.get(s.key) not in used)
+    dead += sorted(f for f in steps.FAMILY_CONSTRUCTORS if f not in used)
+    assert not dead, f"registry rows with no producer in domain/: {dead}"
+
+
+def test_domain_never_imports_adapters():
+    """The layering rule (docs/01: domain depends on port Protocols, never
+    adapter packages), previously enforced by prose and review culture only
+    (2026-08-12 docs audit). Two sanctioned seams are allowlisted above;
+    a third needs its own documented ruling, not a quiet import."""
+    offenders = []
+    for p in sorted(DOMAIN.rglob("*.py")):
+        if "__pycache__" in p.parts:
+            continue
+        for node in ast.walk(ast.parse(p.read_text())):
+            mods = []
+            if isinstance(node, ast.ImportFrom) and node.module:
+                if "adapters" in node.module.split("."):
+                    mods.append(node.module)
+            elif isinstance(node, ast.Import):
+                mods += [a.name for a in node.names
+                         if "adapters" in a.name.split(".")]
+            for m in mods:
+                short = m[m.index("adapters"):]
+                if (p.name, short) not in DOMAIN_ADAPTER_IMPORT_ALLOWLIST:
+                    offenders.append(f"{p.relative_to(DOMAIN)}: imports {m}")
+    assert not offenders, (
+        "domain must not import adapter packages (ADR-0034 layering ratchet; "
+        "sanctioned seams live in the allowlist): " + "; ".join(offenders))


### PR DESCRIPTION
Phase 1 PR-2 of the 2026-08-12 audit intervention campaign.

## Registry
`orchestrator/steps.py` owns every `finalized_steps` key: exact-key constants (today's bytes, canary-frozen), family constructors (`DECOMP_CHILD(i)` …), and per-row attributes. `markers._SWAP_MARKER_STAGE` and `freshness._PAST_GATE_STEPS` become **derived views**, snapshot-pinned byte-exact against the literal tables they replace. A new checkpoint author now declares stage/gate semantics at registration — the two side registries structurally cannot drift.

Bonus finding: the migration flushed out **two keys the audit inventory missed** (`review:freshness_ok`/`_tripped`, appended through a local alias named `steps` — which also shadowed the new module import; local renamed). Exactly the class of invisibility the registry exists to end.

## Guards (the ADR-0034 enforcement arm)
- **Key guard:** AST scan over `domain/**` — every `_checkpoint`/`finalized_steps.append` key must resolve to the registry (constants, constructors, simple local assigns). Mechanism exempt by name; anti-accident by declared scope; self-tested both directions.
- **Reverse ratchet:** no dead registry rows.
- **Layering ratchet:** `domain/` never imports adapter packages — the docs-audit gap closed, with the two sanctioned seams (`repo_mirror→adapters.git` ADR-0024, `forge_runtime→adapters.http` F16) allowlisted and thereby documented.

Deliberate non-migrations: `payload.get("token_report")` and the `"transcript"` audit action share bytes with step keys but belong to different vocabularies (Dev protocol / audit) — left as literals.

Suite: **1692 passed, 1 skipped**; ruff clean. Byte values frozen — no pre-v1 wipe spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)