### PR TITLE
ops: one bring-up derivation, suite tag lockstep, hello bus pinned mirror (OPS-M3/L3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
             -e REDIS_URL=redis://redis:6379/0 \
             -e REDIS_PASSWORD=ci-redis-pass \
             -v "${{ github.workspace }}/images/common:/srv/images/common:ro" \
+            -v "${{ github.workspace }}/images/hello:/srv/images/hello:ro" \
             -v "${{ github.workspace }}/dagu/dags:/srv/dagu-dags:ro" \
             -v "${{ github.workspace }}/app/Dockerfile:/srv/app.Dockerfile:ro" \
             -v "${{ github.workspace }}/docs:/srv/docs:ro" \

--- a/app/tests/test_hello_bus_contract.py
+++ b/app/tests/test_hello_bus_contract.py
@@ -1,0 +1,74 @@
+"""hello_dev.py ↔ devcake_dev/adapters/bus.py pinned-mirror contract
+(ADR-0034). The hello image is deliberately a standalone one-file CI fixture
+(no devcake_dev package), so its chunking/shrinking logic is a COPY of the
+bus's — and it had already drifted (SHRINKABLE_FIELDS lost last_message_md;
+2026-08-12 audit OPS-L3). Both files have import-time env reads and Redis
+connections, so the shared pieces are AST-extracted and exec'd instead of
+imported."""
+
+import ast
+import json
+from pathlib import Path
+
+HELLO = Path("/srv/images/hello/hello_dev.py")
+BUS = Path("/srv/images/common/devcake_dev/adapters/bus.py")
+
+_CONSTS = ("MAX_ARTIFACT_BYTES", "SHRINKABLE_FIELDS", "TRUNCATE_FLOOR",
+           "CHUNK_LIMIT", "CHUNK_SIZE")
+
+
+def _extract(path: Path) -> dict:
+    assert path.exists(), (
+        f"mount missing — the pytest runner must bind {path.parent} "
+        f"(images/hello + images/common → /srv/images/…)"
+    )
+    tree = ast.parse(path.read_text())
+    keep = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and all(
+                isinstance(t, ast.Name) and t.id in _CONSTS
+                for t in node.targets):
+            keep.append(node)
+        elif (isinstance(node, ast.Assign)
+                and isinstance(node.targets[0], ast.Tuple)
+                and all(isinstance(e, ast.Name) and e.id in _CONSTS
+                        for e in node.targets[0].elts)):
+            keep.append(node)                # CHUNK_LIMIT, CHUNK_SIZE = …, …
+        elif isinstance(node, ast.FunctionDef) and node.name == "_fit_payload":
+            keep.append(node)
+    ns: dict = {"json": json}
+    exec(compile(ast.Module(body=keep, type_ignores=[]),  # noqa: S102 — repo-controlled source, constants + one pure function
+                 str(path), "exec"), ns)
+    return ns
+
+
+def test_constants_match_field_by_field():
+    hello, bus = _extract(HELLO), _extract(BUS)
+    for name in _CONSTS:
+        assert name in hello, f"hello_dev.py lost {name}"
+        assert name in bus, f"bus.py lost {name}"
+        assert hello[name] == bus[name], (
+            f"{name} drifted: hello_dev.py={hello[name]!r} "
+            f"bus.py={bus[name]!r} — update the pinned mirror"
+        )
+
+
+def test_fit_payload_behavior_parity():
+    """Same oversized payload → byte-identical shrink on both sides (the
+    constants could match while the algorithm drifted)."""
+    hello, bus = _extract(HELLO), _extract(BUS)
+    big = {
+        "result": {"outcome": "executed"},
+        "exit_code": 0,
+        "token_report": {"total": 1},
+        "transcript_md": "t" * (60 * 1024 * 1024),
+        "plan_md": "p" * 20_000,
+        "last_message_md": "m" * 20_000,
+    }
+    out_h = hello["_fit_payload"](dict(big))
+    out_b = bus["_fit_payload"](dict(big))
+    assert out_h == out_b
+    # the invariants both sides promise: never shrink the verdict fields
+    for f in ("result", "exit_code", "token_report"):
+        assert out_h[f] == big[f]
+    assert len(json.dumps(out_h).encode()) <= hello["MAX_ARTIFACT_BYTES"]

--- a/images/hello/hello_dev.py
+++ b/images/hello/hello_dev.py
@@ -49,8 +49,13 @@ def send(kind: str, payload: dict) -> None:
             time.sleep(0.25 * (2 ** attempt))
 
 
+# PINNED MIRROR of devcake_dev/adapters/bus.py (ADR-0034): the hello image
+# stays a standalone one-file CI fixture on purpose, so these constants and
+# _fit_payload are a copy — tests/test_hello_bus_contract.py compares both
+# sides field-by-field and turns red on drift (this copy HAD drifted:
+# last_message_md was missing from SHRINKABLE_FIELDS).
 MAX_ARTIFACT_BYTES = 50 * 1024 * 1024 - 256 * 1024  # headroom under ingress caps
-SHRINKABLE_FIELDS = ("transcript_md", "plan_md")     # never result/exit_code/token_report
+SHRINKABLE_FIELDS = ("transcript_md", "plan_md", "last_message_md")
 TRUNCATE_FLOOR = 10_000
 
 

--- a/scripts/ci_compose_for_dispatch.sh
+++ b/scripts/ci_compose_for_dispatch.sh
@@ -18,13 +18,19 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# ONE derivation, shared with up.sh (ADR-0034: the two bring-up paths used
+# to derive independently — a standing drift surface). CI policy stays here:
+# permissive fallbacks (gid 0, cwd workspaces) instead of up.sh's hard fails.
+# shellcheck source=lib/stack_env.sh
+source "$(dirname "$0")/lib/stack_env.sh"
+
 TAG="${DEVCAKE_TAG:-latest}"
-DOCKER_GID="${DOCKER_GID:-$(stat -c %g /var/run/docker.sock 2>/dev/null || echo 0)}"
+DOCKER_GID="${DOCKER_GID:-$(devcake_docker_gid || echo 0)}"
 # ADR-0025: per-run workspace base — host-absolute (DAG bind sources resolve
 # on the daemon host). 0777 on purpose: the GHA runner user is uid 1001 but
 # the app container (which mkdirs run subdirs here) is uid 1000; CI runners
 # are ephemeral, so the prod 0700 posture does not apply.
-DEVCAKE_WS_HOST="${DEVCAKE_WS_HOST:-$(pwd)/workspaces}"
+DEVCAKE_WS_HOST="${DEVCAKE_WS_HOST:-$(devcake_ws_host .env "$(pwd)")}"
 
 # On GHA always write synthetic .env. Locally: only if CI_COMPOSE_WRITE_ENV=1
 # (never clobber a developer's real .env by default).

--- a/scripts/ci_suite.sh
+++ b/scripts/ci_suite.sh
@@ -13,18 +13,39 @@ cd "$(dirname "$0")/.."
 if [[ -f .env ]]; then
   while IFS= read -r line; do
     export "${line?}"
-  done < <(grep -E '^(REDIS_PASSWORD|ADMIN_USER|ADMIN_PASSWORD)=' .env)
+  done < <(grep -E '^(REDIS_PASSWORD|ADMIN_USER|ADMIN_PASSWORD|DEVCAKE_TAG)=' .env)
 fi
 
 : "${REDIS_PASSWORD:?REDIS_PASSWORD must be set (compose .env)}"
 : "${ADMIN_USER:?ADMIN_USER must be set (compose .env)}"
 : "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set (compose .env)}"
 
+# AUD-004 applied to the SUITE (2026-08-12 audit OPS-M3): on a pinned
+# install the suite used to bake app-test:latest from the working tree while
+# the dispatch battery graded the LIVE, pinned stack — green then proved a
+# MIX of two code versions. DEVCAKE_TAG now rides from .env into the bake
+# and every docker run below (tag lockstep, like up.sh); and when the live
+# app container is not running the freshly-baked image, the run is loudly
+# labeled so a mixed-version green can never read as tree evidence.
+mixed_version_banner() {
+  local live_id local_id
+  live_id="$(docker inspect -f '{{.Image}}' devcake-app-1 2>/dev/null || true)"
+  local_id="$(docker image inspect -f '{{.Id}}' "devcake/app:${DEVCAKE_TAG:-latest}" 2>/dev/null || true)"
+  if [[ -n "$live_id" && -n "$local_id" && "$live_id" != "$local_id" ]]; then
+    echo "⚠️  MIXED-VERSION RUN: the live app container is NOT running the"
+    echo "    local devcake/app:${DEVCAKE_TAG:-latest} image (stack predates"
+    echo "    the last bake). Unit lanes grade the TREE; the dispatch and"
+    echo "    contract batteries grade the LIVE STACK. Redeploy (./up.sh)"
+    echo "    before reading this green as evidence for the tree."
+  fi
+}
+
 echo "── digest-pin gate (ISSUES #29)"
 python3 scripts/check_image_pins.py
 
-echo "── bake app-test (prod image has no pytest)"
+echo "── bake app-test (prod image has no pytest; DEVCAKE_TAG=${DEVCAKE_TAG:-latest} lockstep)"
 docker buildx bake -f docker-bake.hcl app-test
+mixed_version_banner
 
 echo "── ruff (syntax / undefined names / blanket-except policy, docs/15 §7)"
 docker run --rm -e RUFF_CACHE_DIR=/tmp/ruff-cache -w /srv \
@@ -40,6 +61,7 @@ docker run --rm \
   -e "REDIS_URL=redis://redis:6379/0" \
   -e "REDIS_PASSWORD=${REDIS_PASSWORD}" \
   -v "$(pwd)/images/common:/srv/images/common:ro" \
+  -v "$(pwd)/images/hello:/srv/images/hello:ro" \
   -v "$(pwd)/dagu/dags:/srv/dagu-dags:ro" \
   -v "$(pwd)/app/Dockerfile:/srv/app.Dockerfile:ro" \
   -v "$(pwd)/docs:/srv/docs:ro" \
@@ -58,4 +80,5 @@ docker compose exec -T app python - < scripts/contract_tests_pmo.py
 
 # Full Dagu → hello container → Redis → finalize (also wired into GHA ci.yml)
 ./scripts/ci_dispatch_hello.sh
+mixed_version_banner
 echo "── CI suite green"

--- a/scripts/lib/stack_env.sh
+++ b/scripts/lib/stack_env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Shared stack-env derivation (ADR-0034: one path per singular process).
+# up.sh and ci_compose_for_dispatch.sh both need DOCKER_GID and
+# DEVCAKE_WS_HOST; each used to derive them independently — a standing
+# drift surface between the deploy ritual and the CI bring-up (2026-08-12
+# audit). Sourced, not executed: POLICY stays with the caller (up.sh fails
+# hard, CI falls back to permissive defaults) — only the DERIVATION is one.
+
+# gid of the docker socket, validated numeric; empty output + rc 1 when the
+# socket is missing/unreadable — the CALLER decides whether that is fatal.
+devcake_docker_gid() {
+  local sock="${1:-/var/run/docker.sock}" gid=""
+  [[ -e "$sock" ]] || return 1
+  if gid=$(stat -c '%g' "$sock" 2>/dev/null); then
+    :
+  elif gid=$(stat -f '%g' "$sock" 2>/dev/null); then
+    : # BSD/macOS
+  else
+    return 1
+  fi
+  [[ "$gid" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$gid"
+}
+
+# DEVCAKE_WS_HOST resolution order (ADR-0025: bind sources resolve on the
+# daemon host, so the value must be host-absolute): existing .env value wins
+# (operator relocation), else <repo>/workspaces. Prints the value; the
+# CALLER validates absoluteness with its own error copy.
+devcake_ws_host() {
+  local env_file="${1:-.env}" repo_root="${2:-$(pwd)}" ws=""
+  ws="$(grep -E '^DEVCAKE_WS_HOST=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+  if [[ -z "$ws" ]]; then
+    ws="${repo_root}/workspaces"
+  fi
+  printf '%s\n' "$ws"
+}

--- a/scripts/pytest_app.sh
+++ b/scripts/pytest_app.sh
@@ -64,6 +64,7 @@ docker run --rm \
   "${NET_ARGS[@]}" \
   "${ENV_ARGS[@]}" \
   -v "$(pwd)/images/common:/srv/images/common:ro" \
+  -v "$(pwd)/images/hello:/srv/images/hello:ro" \
   -v "$(pwd)/dagu/dags:/srv/dagu-dags:ro" \
   -v "$(pwd)/app/Dockerfile:/srv/app.Dockerfile:ro" \
   -v "$(pwd)/docs:/srv/docs:ro" \

--- a/up.sh
+++ b/up.sh
@@ -54,22 +54,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# ONE derivation, shared with the CI bring-up (ADR-0034; policy stays here)
+# shellcheck source=scripts/lib/stack_env.sh
+source "$(dirname "$0")/scripts/lib/stack_env.sh"
+
 discover_docker_gid() {
-  if [[ ! -e "$SOCK" ]]; then
-    echo "error: $SOCK not found — is the Docker daemon running?" >&2
-    exit 1
-  fi
   local gid=""
-  if gid=$(stat -c '%g' "$SOCK" 2>/dev/null); then
-    :
-  elif gid=$(stat -f '%g' "$SOCK" 2>/dev/null); then
-    : # BSD/macOS
-  else
-    echo "error: cannot read group id of $SOCK" >&2
-    exit 1
-  fi
-  if [[ ! "$gid" =~ ^[0-9]+$ ]]; then
-    echo "error: unexpected DOCKER_GID from $SOCK: ${gid@Q}" >&2
+  if ! gid="$(devcake_docker_gid "$SOCK")"; then
+    echo "error: cannot derive DOCKER_GID from $SOCK — is the Docker daemon running?" >&2
     exit 1
   fi
   printf '%s\n' "$gid"
@@ -114,10 +106,7 @@ echo "── DOCKER_GID=${GID}  (from ${SOCK})"
 # bind sources resolve on the daemon host. Existing .env value wins (operator
 # relocation); default is ./workspaces in this checkout. 0700: the tree holds
 # repo source, activity transcripts and agent output (docs/14 §1).
-WS_HOST="$(grep -E '^DEVCAKE_WS_HOST=' .env 2>/dev/null | head -1 | cut -d= -f2- || true)"
-if [[ -z "$WS_HOST" ]]; then
-  WS_HOST="$(pwd)/workspaces"
-fi
+WS_HOST="$(devcake_ws_host .env "$(pwd)")"
 if [[ "$WS_HOST" != /* ]]; then
   echo "error: DEVCAKE_WS_HOST must be an absolute host path, got: ${WS_HOST@Q}" >&2
   exit 1


### PR DESCRIPTION
Phase 1 PR-7 of the 2026-08-12 audit intervention campaign (ADR-0034: CI bring-up ×2 and bus chunking ×2 rows of the inventory).

- **One env derivation** (`scripts/lib/stack_env.sh`) sourced by `up.sh` and `ci_compose_for_dispatch.sh`; derivation is shared, policy (hard-fail vs CI fallback) stays per caller. `up.sh --dry-run` verified.
- **Suite tag lockstep (OPS-M3):** `ci_suite.sh` loads `DEVCAKE_TAG` from `.env` for the bake + every app-test run, and prints a loud mixed-version banner whenever the live app container isn't running the local `devcake/app:${TAG}` image — a mixed-version green can no longer masquerade as tree evidence.
- **Pinned mirror for the hello fixture (OPS-L3):** drift fixed (`last_message_md` restored to `SHRINKABLE_FIELDS`) and a contract test AST-extracts both sides to compare constants + `_fit_payload` behavior. `images/hello` mounted into all three pytest lanes with the hard-fail mount assert.

Suite: **1694 passed, 1 skipped**; pin gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)