### PR TITLE
refactor: cross-module underscore APIs promoted, moved, or folded (ADR-0034; F12)

### DIFF
--- a/app/devcake/domain/backend_health.py
+++ b/app/devcake/domain/backend_health.py
@@ -48,7 +48,7 @@ TERMINAL_STATES = ("finished", "failed", "timed_out", "orphaned")
 
 def _aware(ts):
     """Anchor timestamps come from several sources; a stray naive one must not
-    crash the detector (mirrors dispatch._aware)."""
+    crash the detector (mirrors run.aware)."""
     if ts is None:
         return datetime.min.replace(tzinfo=timezone.utc)
     return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)

--- a/app/devcake/domain/orchestrator/activity_payload.py
+++ b/app/devcake/domain/orchestrator/activity_payload.py
@@ -17,7 +17,7 @@ from datetime import datetime  # noqa: F401 — type context for Activity entrie
 from pathlib import Path
 
 from ..model import MissionRef
-from .feed import _is_devcake_comment
+from .feed import is_devcake_comment
 
 log = logging.getLogger("devcake.missions")
 
@@ -320,7 +320,7 @@ async def activity_payload(mgr, pmo_id: str, kind: str = "issue",
         body = e.body or ""
         # provenance is sentinel-based, never author-based (docs/03 §8a):
         # DevCake may post with the operator's own PMO credentials
-        provenance = "🤖 DevCake" if _is_devcake_comment(body) else "🧑 HUMAN"
+        provenance = "🤖 DevCake" if is_devcake_comment(body) else "🧑 HUMAN"
         lines.append(f"### {e.ts:%Y-%m-%d %H:%M} — {e.author} — {provenance} ({e.kind})")
         parent = by_id.get(e.parent_id) if e.parent_id else None
         if parent is not None:

--- a/app/devcake/domain/orchestrator/completion.py
+++ b/app/devcake/domain/orchestrator/completion.py
@@ -37,7 +37,7 @@ from ..model import (LABEL_EXECUTE, LABEL_MERGE, LABEL_REVIEW, Mission,
                      MissionRef)
 from ..run import Run
 from . import freshness, steps
-from .feed import _unquoted
+from .feed import unquoted
 from .markers import CONFLICT_MARKER, MAX_CONFLICT_RESOLVES
 
 log = logging.getLogger("devcake.missions")
@@ -138,7 +138,7 @@ async def conflict_attempts(mgr, pmo_id: str) -> int:
     human deleting directive comments deliberately resets it."""
     act = await mgr.pmo.get_activity(MissionRef(pmo_id, "issue"))
     hits = [int(mt.group(1)) for e in act.entries
-            for mt in CONFLICT_MARKER.finditer(_unquoted(e.body))]
+            for mt in CONFLICT_MARKER.finditer(unquoted(e.body))]
     return max(hits) if hits else 0
 
 

--- a/app/devcake/domain/orchestrator/deliver.py
+++ b/app/devcake/domain/orchestrator/deliver.py
@@ -56,14 +56,14 @@ async def deliver_internal_zip_for_mission(mgr, m, pr) -> None:
     future sweep candidates, so it fires once — but a crash between the swap
     and this call, or a redelivery, could re-enter. Guard durably against a
     double-attach by checking the feed for the deliverable's own filename
-    (review finding #9). Scans _unquoted bodies only (ADR-0014 D2): a quoted
+    (review finding #9). Scans unquoted bodies only (ADR-0014 D2): a quoted
     mention of the zip name must never suppress a real delivery."""
     if not _should_deliver_zip(mgr, m.repo):
         return
     marker = f"{m.key}-deliverable.zip"
     try:
         act = await mgr.pmo.get_activity(m.ref)
-        if any(marker in feed._unquoted(e.body) for e in act.entries):
+        if any(marker in feed.unquoted(e.body) for e in act.entries):
             return                               # already delivered
     except Exception:  # noqa: BLE001 — idempotency probe is advisory; failure logged and delivery proceeds (a double attach beats a lost deliverable)
         log.warning("deliverable idempotency check failed for %s — proceeding",

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -20,12 +20,12 @@ from ...config import DevType, assignment_for
 from .. import failure_taxonomy
 from ..model import (Activity, LABEL_FAILED, Mission, MissionRef, MissionType,
                      STAGE_LABELS, derive)
-from ..run import Run, utcnow
 from ..workspaces import WorkspaceUnavailable
 from . import markers
 from . import schedule
 from .activity_payload import push_activity_repo
-from .feed import _is_devcake_comment, _stage_of, _unquoted
+from ..run import Run, aware, utcnow
+from .feed import is_devcake_comment, stage_of, unquoted
 from .markers import STEP_MARKER
 
 log = logging.getLogger("devcake.missions")
@@ -357,7 +357,7 @@ async def dispatch(mgr, mission: Mission, mtype: MissionType,
     repo = mgr.forges.instance(repo_name)
     forge = mgr.forges.get(repo_name)
     if live.blocked_by:
-        open_blockers = await schedule._open_blockers(mgr, live, {}, {})  # all live
+        open_blockers = await schedule.open_blockers_live(mgr, live)
         if open_blockers:
             log.info("dispatch of %s aborted — blocked by %s",
                      live.key, ", ".join(open_blockers))
@@ -502,7 +502,7 @@ async def dispatch(mgr, mission: Mission, mtype: MissionType,
         run.spec_prompt = append_required_skills(
             prompt, dev_type.skills_required, run.spec_skills)
         run.branch = mission_branch(mgr.instance_name, mission.key)
-        run.stage_label_at_dispatch = _stage_of(live)
+        run.stage_label_at_dispatch = stage_of(live)
         run.mission_pmo_id = mission.pmo_id
         try:
             await mgr.runs.bootstrap.launch(
@@ -796,16 +796,10 @@ def _credential_spec(mgr, dev_type: DevType) -> tuple[dict[str, str], list[dict]
 def _derive_seq(activity) -> int:
     """docs/02 §8 — max step number among prior feed artifacts + 1 (max, not
     count: collision-proof when a human deletes a transcript comment). Scans
-    _unquoted bodies only (ADR-0014 D2): quoted marker mentions never count."""
+    unquoted bodies only (ADR-0014 D2): quoted marker mentions never count."""
     steps = [int(m.group(1)) for e in activity.entries
-             for m in STEP_MARKER.finditer(_unquoted(e.body))]
+             for m in STEP_MARKER.finditer(unquoted(e.body))]
     return (max(steps) + 1) if steps else 1
-
-
-def _aware(ts: datetime) -> datetime:
-    """Anchor timestamps come from three sources (audit log, run records,
-    PMO comments); a stray naive one must not crash the scheduler."""
-    return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
 
 
 def _last_giveup_at(pmo_id: str) -> datetime | None:
@@ -873,25 +867,25 @@ def attempt_number(mgr, pmo_id: str, mission_type: str,
                 if r.mission_pmo_id == pmo_id and mgr._run_is_ours(r)]
     history = [r for r in all_runs if r.mission_type == mission_type]
     anchors = [t for t in [_last_giveup_at(pmo_id),
-                           *(_aware(r.created_at) for r in all_runs
+                           *(aware(r.created_at) for r in all_runs
                              if r.state == "finished")] if t]
     if activity is not None:
         policy = mgr.config.attempt_reset
-        anchors += [_aware(e.ts) for e in activity.entries
+        anchors += [aware(e.ts) for e in activity.entries
                     if e.kind == "comment"
-                    and not _is_devcake_comment(e.body)
+                    and not is_devcake_comment(e.body)
                     and (policy == "any-comment"
                          # IRON RULE (markers.py, ADR-0014 D2): token scans
                          # run on the unquoted body — a human QUOTING a
                          # DevCake post that mentions the token is not the
                          # deliberate retry gesture (2026-08-12 audit F14)
-                         or RETRY_TOKEN in _unquoted(e.body or ""))]
+                         or RETRY_TOKEN in unquoted(e.body or ""))]
     since = max(anchors, default=None)
     return 1 + sum(
         1 for r in history
         if r.state in ("failed", "timed_out", "orphaned")
         and counts_toward_attempts(r)
-        and (since is None or _aware(r.created_at) > since)
+        and (since is None or aware(r.created_at) > since)
     )
 
 
@@ -902,22 +896,29 @@ def attempt_number(mgr, pmo_id: str, mission_type: str,
 _UNLIMITED_WARNED: set[tuple[str, str, int]] = set()
 
 
-def _mission_cost(mgr, pmo_id: str) -> float:
+def mission_cost(mgr, pmo_id: str, *,
+                 split_estimated: bool = False):
     """Cumulative effective cost of a mission's runs (ADR-0021 semantics —
     native harness cost when reported, else the finalize-stamped estimate).
-    Mirrors the REVIEW loop warning's arithmetic (review._reject_loop_warn)."""
+    THE one cost-rollup (ADR-0034 PR-3 — review's loop warning carried a
+    near-duplicate of this arithmetic): split_estimated=True additionally
+    returns the estimated share, named rather than blended away."""
     from .. import costing
     ci = mgr.config.cost_inputs
-    total = 0.0
+    total = est = 0.0
     for r in mgr.runs.store.all():
         if r.mission_pmo_id != pmo_id or not mgr._run_is_ours(r):
             continue
         tr = r.token_report or {}
-        eff = costing.effective_cost(
-            tr.get("cost_usd_native"), tr.get("cost_usd_estimated"), ci)
-        if eff is not None:
-            total += eff
-    return total
+        native = tr.get("cost_usd_native")
+        estimated = tr.get("cost_usd_estimated")
+        eff = costing.effective_cost(native, estimated, ci)
+        if eff is None:
+            continue
+        total += eff
+        if estimated is not None and (ci.override_native or native is None):
+            est += eff
+    return (total, est) if split_estimated else total
 
 
 async def _attempt_gate(mgr, mission: Mission, mtype: MissionType,
@@ -949,7 +950,7 @@ async def _unlimited_warn(mgr, mission: Mission, mtype: MissionType,
     if key in _UNLIMITED_WARNED:
         return
     _UNLIMITED_WARNED.add(key)
-    cost = _mission_cost(mgr, mission.pmo_id)
+    cost = mission_cost(mgr, mission.pmo_id)
     await mgr._feed(
         mission.pmo_id, mission.pmo_kind,
         f"⚠️ **Unlimited-attempts mode:** this mission's {mtype.value} step "

--- a/app/devcake/domain/orchestrator/feed.py
+++ b/app/devcake/domain/orchestrator/feed.py
@@ -81,7 +81,7 @@ async def _feed(mgr, pmo_id: str, kind: str, markdown: str, *,
             # preview from UNQUOTED lines only: flattening newlines would
             # otherwise land "> "-quarantined text mid-line, back in scan
             # scope (ADR-0014 D2)
-            preview = _unquoted(markdown) or markdown[:300]
+            preview = unquoted(markdown) or markdown[:300]
             markdown = (preview[:300].replace("\n", " ")
                         + f"… — full text attached: [{name}]({url})")
         except Exception:
@@ -91,8 +91,8 @@ async def _feed(mgr, pmo_id: str, kind: str, markdown: str, *,
         markdown.rstrip() + "\n\n" + COMMENT_SENTINEL)
 
 
-def _blockquote(text: str) -> str:
-    """Inverse of _unquoted: prefix EVERY line with '> ' (bare '>' for blank
+def blockquote(text: str) -> str:
+    """Inverse of unquoted: prefix EVERY line with '> ' (bare '>' for blank
     lines, so lazy-continuation can't leak) — the ADR-0014 D2 quarantine for
     model-authored text posted inline. Applied app-side at the finalize
     choke-point, never in the entrypoint: old images stay quarantined too."""
@@ -100,23 +100,23 @@ def _blockquote(text: str) -> str:
                      for line in (text or "").splitlines())
 
 
-def _unquoted(body: str | None) -> str:
+def unquoted(body: str | None) -> str:
     """Strip `>`-quoted lines: markers/sentinels inside a human's quote of
     a DevCake comment must never count as DevCake's own."""
     return "\n".join(line for line in (body or "").splitlines()
                      if not line.lstrip().startswith(">"))
 
 
-def _is_devcake_comment(body: str | None) -> bool:
+def is_devcake_comment(body: str | None) -> bool:
     """Provenance classification (docs/03 §8a): sentinel-signed ⇒ DevCake.
     `>`-quoted lines are ignored, so a human reply that ENDS by quoting a
     DevCake comment still classifies as human — misreading a human's
     instruction as DevCake's own record is the unsafe direction."""
     return bool(SENTINEL_RE.search(
-        _unquoted(body).rstrip()))
+        unquoted(body).rstrip()))
 
 
-def _stage_of(mission: Mission) -> str | None:
+def stage_of(mission: Mission) -> str | None:
     stage = mission.labels & STAGE_LABELS
     return next(iter(stage)) if stage else None
 

--- a/app/devcake/domain/orchestrator/finalize.py
+++ b/app/devcake/domain/orchestrator/finalize.py
@@ -12,7 +12,7 @@ from .. import backend_health, costing, failure_taxonomy
 from ..model import MissionRef
 from ..run import Run, utcnow
 from . import steps, transitions
-from .feed import _blockquote, _stage_of
+from .feed import blockquote, stage_of
 from .markers import FEED_INLINE_MAX, REPLY_MARKER
 
 log = logging.getLogger("devcake.missions")
@@ -348,7 +348,7 @@ async def restore_after_failure(mgr, run: Run) -> None:
         return  # only ONBOARD dispatches from backlog change the status
     try:
         live = await mgr.pmo.get(MissionRef(run.mission_pmo_id, run.pmo_kind))
-        if live.status == "in_progress" and _stage_of(live) is None:
+        if live.status == "in_progress" and stage_of(live) is None:
             await mgr.pmo.set_status(
                 MissionRef(run.mission_pmo_id, run.pmo_kind), "backlog")
             mgr._audit(run.mission_pmo_id, "set_status",
@@ -383,7 +383,7 @@ async def _post_transcript(mgr, run: Run, transcript: str,
         # step-marker header line stays unquoted for seq derivation
         log.exception("transcript upload failed — posting inline (quoted)")
         body = (f"🧾 DevCake transcript `{name}` (run `{run.run_id}`)\n\n"
-                + _blockquote(f"---\n\n{transcript}"))
+                + blockquote(f"---\n\n{transcript}"))
     if last_message and attached:
         # redact BEFORE truncate+quote: truncation must never split a secret
         # across the boundary, and quoting must never break a multi-line
@@ -394,7 +394,7 @@ async def _post_transcript(mgr, run: Run, transcript: str,
                             + "\n\n… (truncated — full text in the attachment)")
         # quoting quarantines the model text from every feed scan; the
         # opt-out is safe because the full text already rides the attachment
-        body += "\n\n" + _blockquote(last_message)
+        body += "\n\n" + blockquote(last_message)
         await mgr._feed(run.mission_pmo_id, "issue", body, externalize=False)
     else:
         # no attachment ⇒ the last message already rides inside the (quoted)
@@ -434,7 +434,7 @@ async def _post_reply(mgr, run: Run, last_message: str | None,
                   "on this issue)")
     await mgr._feed(
         run.mission_pmo_id, "issue",
-        f"{REPLY_MARKER}\n\n" + _blockquote(body),
+        f"{REPLY_MARKER}\n\n" + blockquote(body),
         externalize=False,
     )
 

--- a/app/devcake/domain/orchestrator/freshness.py
+++ b/app/devcake/domain/orchestrator/freshness.py
@@ -17,10 +17,10 @@ import logging
 from datetime import datetime
 
 from ..model import MissionRef
-from ..run import Run
 from . import steps
-from .dispatch import _aware, _mission_cost
-from .feed import _is_devcake_comment, _unquoted
+from ..run import Run, aware
+from .dispatch import mission_cost
+from .feed import is_devcake_comment, unquoted
 from .markers import (ELEVATED_MARKERS, FRESHNESS_MARKER,
                       MAX_FRESHNESS_REREVIEWS)
 
@@ -50,10 +50,10 @@ def _is_material(body: str | None) -> bool:
     CONSTRUCTION: that is the livelock guarantee. (Label/status events never
     arrive as entries at all — both adapters fetch comments only — so the
     non-empty-body test is defense-in-depth, not the operative exclusion.)"""
-    text = _unquoted(body).strip()
+    text = unquoted(body).strip()
     if not text:
         return False
-    if not _is_devcake_comment(body):
+    if not is_devcake_comment(body):
         return True
     return any(rx.search(text) for rx in ELEVATED_MARKERS)
 
@@ -80,12 +80,12 @@ def _entries_after_watermark(entries, run: Run) -> list:
     anchor = None
     if wm.get("ts"):
         try:
-            anchor = _aware(datetime.fromisoformat(wm["ts"]))
+            anchor = aware(datetime.fromisoformat(wm["ts"]))
         except ValueError:
             anchor = None
     if anchor is None:
-        anchor = _aware(run.created_at)
-    return [e for e in entries if _aware(e.ts) > anchor]
+        anchor = aware(run.created_at)
+    return [e for e in entries if aware(e.ts) > anchor]
 
 
 def _describe(entries: list) -> list[str]:
@@ -108,7 +108,7 @@ async def _unread_material(mgr, run: Run) -> tuple[list, int]:
     act = await mgr.pmo.get_activity(
         MissionRef(run.mission_pmo_id, "issue"), full=True)
     hits = [int(m.group(1)) for e in act.entries
-            for m in FRESHNESS_MARKER.finditer(_unquoted(e.body))]
+            for m in FRESHNESS_MARKER.finditer(unquoted(e.body))]
     count = max(hits) if hits else 0
     if act.truncated:
         return [_TRUNCATED], count
@@ -169,7 +169,7 @@ async def review_freshness_gate(mgr, run: Run) -> str:
                 f"re-review budget ({MAX_FRESHNESS_REREVIEWS}) is spent, so "
                 f"the standing approve verdict proceeds. Unevaluated: "
                 f"{names}{more}. Cumulative recorded mission cost: "
-                f"${_mission_cost(mgr, pmo_id):.2f}.")
+                f"${mission_cost(mgr, pmo_id):.2f}.")
             mgr._audit(pmo_id, "freshness_exhausted",
                        f"{len(found)} unread entries at close")
             mgr.anomalies[pmo_id] = (
@@ -211,7 +211,7 @@ async def disclose_unread_at_close(mgr, mission) -> None:
                    and r.state == "finished"]
         if not reviews:
             return
-        run = max(reviews, key=lambda r: _aware(r.created_at))
+        run = max(reviews, key=lambda r: aware(r.created_at))
         found, _ = await _unread_material(mgr, run)
         if not found:
             return

--- a/app/devcake/domain/orchestrator/markers.py
+++ b/app/devcake/domain/orchestrator/markers.py
@@ -28,7 +28,7 @@ LEGAL_OUTCOMES: dict[str, frozenset[str]] = {
 }
 
 # IRON RULE (ADR-0014 D2): every scan over feed bodies runs on
-# feed._unquoted(body) — `>`-quoted lines never count, for humans quoting
+# feed.unquoted(body) — `>`-quoted lines never count, for humans quoting
 # DevCake comments and for blockquoted model text alike. Quoting is the ONE
 # quarantine convention; a new feed scan that reads raw bodies is a bug.
 STEP_MARKER = re.compile(r"`(\d+)_(ONBOARD|PLAN|EXECUTE|REVIEW)\.md`")

--- a/app/devcake/domain/orchestrator/review.py
+++ b/app/devcake/domain/orchestrator/review.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import logging
 
 from ...security import redact
-from .. import costing
 from ..model import LABEL_EXECUTE, LABEL_MERGE, LABEL_REVIEW, MissionRef
 from ..run import Run
 from ...ports.forge import run_branch
-from . import completion, steps
+from . import completion, dispatch, steps
 from .freshness import review_freshness_gate
 from .markers import (HANDOFF_APPEND_MAX, HANDOFF_MARKER,
                       MERGE_HANDOFF_MARKER, MERGE_RETRY_MARKER)
@@ -328,21 +327,10 @@ async def finalize_review(mgr, run: Run, result: dict) -> None:
             # effective per run (ADR-0021): native harness cost when reported,
             # else the finalize-stamped estimate — grok spend no longer reads
             # as $0.00 here. The estimated share is named, not blended away.
-            ci = mgr.config.cost_inputs
-            cost = est = 0.0
-            for r in mgr.runs.store.all():
-                if r.mission_pmo_id != pmo_id or not mgr._run_is_ours(r):
-                    continue
-                tr = r.token_report or {}
-                native = tr.get("cost_usd_native")
-                estimated = tr.get("cost_usd_estimated")
-                eff = costing.effective_cost(native, estimated, ci)
-                if eff is None:
-                    continue
-                cost += eff
-                if estimated is not None and (ci.override_native
-                                              or native is None):
-                    est += eff
+            # ONE rollup (ADR-0034 PR-3): this used to inline a near-copy of
+            # dispatch.mission_cost's arithmetic.
+            cost, est = dispatch.mission_cost(mgr, pmo_id,
+                                              split_estimated=True)
             share = f" (of which ${est:.2f} estimated)" if est else ""
             warn = (f"⚠️ **Loop warning:** this mission has been through "
                     f"{rejections} REVIEW rejections. Cumulative recorded "

--- a/app/devcake/domain/orchestrator/schedule.py
+++ b/app/devcake/domain/orchestrator/schedule.py
@@ -133,6 +133,14 @@ async def schedule(mgr, missions: list[Mission],
     return dispatched
 
 
+async def open_blockers_live(mgr, m: Mission) -> list[str]:
+    """The all-live variant (ADR-0034 PR-3): dispatch's pre-launch re-read
+    resolves every blocker fresh — empty by_id (no snapshot index) and a
+    fresh memo (no cross-mission reuse). The two empty dicts USED to be
+    magic arguments hand-rolled at the call site."""
+    return await _open_blockers(mgr, m, {}, {})
+
+
 async def _open_blockers(mgr, m: Mission, by_id: dict[str, Mission],
                          memo: dict) -> list[str]:
     """Blockers of `m` that are still open (status not done/canceled), as

--- a/app/devcake/domain/orchestrator/sweeps.py
+++ b/app/devcake/domain/orchestrator/sweeps.py
@@ -10,7 +10,7 @@ from opentelemetry.trace import Status, StatusCode
 from ...ports.forge import legacy_branch, mission_branch
 from ..model import (LABEL_MERGE, LABEL_NEEDS_HUMAN, LABEL_TRACKING, Mission,
                      STAGE_LABELS)
-from ..run import utcnow
+from ..run import aware, utcnow
 from . import completion, dispatch, feed
 from .markers import MERGE_HANDOFF_MARKER, MERGE_RETRY_MARKER
 
@@ -162,8 +162,8 @@ async def _deferred_merge_retry(mgr, m: Mission, pr,
     act = await mgr.pmo.get_activity(m.ref)
     retry_ts = handoff_ts = None
     for e in act.entries:
-        body = feed._unquoted(e.body)
-        ts = dispatch._aware(e.ts)  # a naive PMO timestamp must not TypeError
+        body = feed.unquoted(e.body)
+        ts = aware(e.ts)  # a naive PMO timestamp must not TypeError
         if MERGE_RETRY_MARKER in body:
             retry_ts = max(retry_ts, ts) if retry_ts else ts
         if MERGE_HANDOFF_MARKER in body:

--- a/app/devcake/domain/orchestrator/transitions.py
+++ b/app/devcake/domain/orchestrator/transitions.py
@@ -64,7 +64,7 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
     expected_stages.update(
         stage for marker, stage in _SWAP_MARKER_STAGE.items()
         if marker in run.finalized_steps)
-    if feed._stage_of(live) not in expected_stages:
+    if feed.stage_of(live) not in expected_stages:
         async def _external():
             await mgr._feed(
                 pmo_id, run.pmo_kind,

--- a/app/devcake/domain/run.py
+++ b/app/devcake/domain/run.py
@@ -29,6 +29,14 @@ RunState = Literal[
 def utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
+def aware(ts: datetime) -> datetime:
+    """Timestamps arrive from three sources (audit log, run records, PMO
+    comments); a stray naive one must not crash a scheduler comparison.
+    Moved from dispatch._aware (ADR-0034 PR-3): a time utility, not
+    dispatch logic — it lives beside utcnow now."""
+    return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+
+
 
 def auth_digest(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()

--- a/app/tests/test_mission_actions.py
+++ b/app/tests/test_mission_actions.py
@@ -8,7 +8,7 @@ TestClient — tests call the module directly with per-file fakes, mirroring
 Rules under test:
 - INV-1 preserved: Linear is the source of truth (labels + comment).
 - Steering comments must NOT carry the DevCake sentinel — else they classify as
-  our own record (`_is_devcake_comment`) and the attempt-counter reset misses.
+  our own record (`is_devcake_comment`) and the attempt-counter reset misses.
 - 409 preconditions decided by the CACHED labels; the port swap raising
   RuntimeError is a 502, not a 409.
 - force_poll_now serialises against the shared poll lock and releases it even

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -676,8 +676,8 @@ def test_quoted_sentinel_still_classifies_human():
     quoted = ("please also add tests\n\n"
               "> ✋ **DevCake needs a human.** blah\n> `devcake:v1`")
     genuine = "> user asked:\n> do X\n\nDone.\n\n`devcake:v1`"
-    assert not feed._is_devcake_comment(quoted)
-    assert feed._is_devcake_comment(genuine)
+    assert not feed.is_devcake_comment(quoted)
+    assert feed.is_devcake_comment(genuine)
 
 
 def test_decomposition_wires_blocked_by_edges(tmp_path):
@@ -1211,7 +1211,7 @@ def test_finalize_posts_last_message_blockquoted(tmp_path):
     assert comment.count("`devcake:v1`") == 1
     assert "Details here." not in "\n".join(       # no unquoted model text
         l for l in lines if not l.lstrip().startswith(">"))
-    assert feed._is_devcake_comment(comment)   # provenance holds
+    assert feed.is_devcake_comment(comment)   # provenance holds
 
 
 def test_finalize_without_last_message_keeps_pointer_comment(tmp_path):
@@ -1258,8 +1258,8 @@ def test_finalize_last_message_markers_are_quarantined(tmp_path):
                           kind="comment", body=comment)
     assert dispatch._derive_seq(
         Activity(mission=m, entries=[entry])) == 2      # only the real step
-    from devcake.domain.orchestrator.feed import _unquoted
-    assert "T-1-deliverable.zip" not in _unquoted(comment)
+    from devcake.domain.orchestrator.feed import unquoted
+    assert "T-1-deliverable.zip" not in unquoted(comment)
 
 
 # ── docs/05 §4 attachment policy ─────────────────────────────────────────────
@@ -1304,10 +1304,10 @@ def test_feed_externalized_preview_strips_quoted_lines(tmp_path):
     # the 300-char preview of an externalized comment flattens newlines —
     # quoted content must be dropped from it, or "> " prefixes land mid-line
     # and markers leak back into scan scope
-    from devcake.domain.orchestrator.feed import _blockquote
+    from devcake.domain.orchestrator.feed import blockquote
     m = mission("in_progress", {"DEVCAKE"})
     mgr, fake, store = make_mgr(tmp_path, m)
-    body = "header line\n" + _blockquote("see `7_EXECUTE.md`\n" + "x" * 3000)
+    body = "header line\n" + blockquote("see `7_EXECUTE.md`\n" + "x" * 3000)
     run_coro(mgr._feed("p1", "issue", body))
     posted = fake.comments[-1]
     assert "full text attached:" in posted
@@ -2306,14 +2306,14 @@ def test_finalize_posts_the_answer_as_its_own_marked_comment(tmp_path):
     assert "> Root cause: the skip gate." in reply
     assert "> Fix in !2163." in reply
     # quarantine holds: every line of model text is quoted. Only our own
-    # provenance sentinel stays unquoted (feed._is_devcake_comment reads it),
+    # provenance sentinel stays unquoted (feed.is_devcake_comment reads it),
     # which is why a consumer relaying the answer must strip that line.
     body = [
         l for l in reply.splitlines()
         if l and not l.startswith(REPLY_MARKER) and "`devcake:v1`" not in l
     ]
     assert all(l.lstrip().startswith(">") or l == ">" for l in body), reply
-    assert feed._is_devcake_comment(reply)
+    assert feed.is_devcake_comment(reply)
 
 
 def test_the_reply_comment_redacts_before_it_truncates(tmp_path):


### PR DESCRIPTION
Phase 1 PR-3 of the 2026-08-12 audit intervention campaign.

- `feed.unquoted` / `is_devcake_comment` / `blockquote` / `stage_of` — public (they ARE the cross-module protocol; `unquoted` is the iron rule's face).
- `run.aware()` — moved from dispatch (time utility, not dispatch logic).
- `dispatch.mission_cost(split_estimated=…)` — promoted, and review's loop-warning inline near-duplicate (the third copy of the ADR-0021 arithmetic) folds onto it; warning copy byte-identical, pinned by existing tests.
- `schedule.open_blockers_live` — owns the `{}, {}` magic-dict semantics.
- The `mgr._*` seam deliberately untouched (ADR-0015-sanctioned; ADR-0034 out-of-scope list). No aliases.

Mechanical rename otherwise; the only behavioral edit is the cost fold, whose output string is unchanged. Suite: **1700 passed, 1 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)