### PR TITLE
fix: /health probes are read-only, cached, and concurrent (audit F3)

### DIFF
--- a/app/devcake/adapters/gitea_issues/adapter.py
+++ b/app/devcake/adapters/gitea_issues/adapter.py
@@ -689,9 +689,11 @@ class GiteaIssuesAdapter:
                                      f"need owner/repo")
             if not self._api:
                 return PMOHealth(ok=False, detail="api_base is empty")
-            await self.ensure_labels(team_ref, ALL_LABELS)
-            await self._ensure_label_cache()
-            # count only managed intersection on the repo
+            # READ-ONLY (PMOHealth contract; 2026-08-12 audit F3): the
+            # old probe ran ensure_labels — a repo-settings PATCH + label
+            # POSTs fired at the SPA's 10 s /health cadence, forever. The
+            # healing now rides the poll cycle's per-config-generation
+            # once-latch (poll.poll_instance); the probe only reads.
             raw_labels = await self._fetch_all_labels()
             remote = {(lb.get("name") or "").upper() for lb in raw_labels}
             present = len(remote & {n.upper() for n in ALL_LABELS})

--- a/app/devcake/api/connections_service.py
+++ b/app/devcake/api/connections_service.py
@@ -20,7 +20,7 @@ from ..harness import HARNESSES
 from ..ports.forge import ForgeError, mission_branch
 from ..ports.pmo import PMOTransient
 from ..security import redact
-from .health import reset_protection_cache
+from .health import reset_health_caches
 
 log = logging.getLogger("devcake.connections")
 
@@ -78,7 +78,7 @@ async def put_secret(scope: str, instance: str, field: str, body: dict, *,
         secrets_store.write_connection_secret(scope, instance, field, value)
         if scope == "repo":
             forge_runtime.breakers.pop(instance, None)
-            reset_protection_cache()
+            reset_health_caches()
         # adapters capture credentials by VALUE at construction — a rotated
         # secret takes effect only through a rebuild, same as a config PUT
         reload()
@@ -93,7 +93,7 @@ async def delete_secret(scope: str, instance: str, field: str, *,
         secrets_store.delete_connection_field(scope, instance, field)
         if scope == "repo":
             forge_runtime.breakers.pop(instance, None)
-            reset_protection_cache()
+            reset_health_caches()
         reload()
     return {"present": False}
 
@@ -252,7 +252,7 @@ async def clear_secrets(body: dict, *, forge_runtime, reload, config,
             shared_breakers.pop(dev_type, None)
 
         if repo_touched:
-            reset_protection_cache()
+            reset_health_caches()
         if connections:
             # connection secrets are captured at adapter construction
             reload()

--- a/app/devcake/api/health.py
+++ b/app/devcake/api/health.py
@@ -39,10 +39,21 @@ async def _check_redis() -> bool:
 # by the SPA, the forge API needs at most one look every few minutes
 _protection_cache: dict = {"ts": 0.0, "value": {}}
 
+# per-instance PMO probe cache (2026-08-12 audit F3): same rationale — the
+# vendor needs at most one look a minute, not one per SPA poll. Keyed by
+# (instance, team_key) so a team repoint reprobes immediately.
+_PMO_PROBE_TTL = 60
+_PMO_PROBE_TIMEOUT = 5   # one sick PMO must not stall /health (audit F3)
+_pmo_probe_cache: dict = {}
 
-def reset_protection_cache() -> None:
-    """Config reload hook: repos may have changed — reprobe on next /health."""
+
+def reset_health_caches() -> None:
+    """THE config-reload hook (one reset path, ADR-0034): connections or
+    repos may have changed — every cached probe reprobes on the next
+    /health. The admin 'Test' endpoint stays live and uncached."""
     _protection_cache["ts"] = 0.0
+    _pmo_probe_cache.clear()
+
 
 
 async def _branch_protection(forge_runtime) -> dict:
@@ -138,24 +149,37 @@ async def build_health_payload(*, config, dev_types, managers, stewards,
     )
     # per-instance PMO health (schema v3): unconfigured instances show grey
     # (ok: None), never red; the scalar `pmo` aggregate keeps the SPA's
-    # health dot working (true = every configured instance probes ok)
-    pmo_instances: dict[str, dict] = {}
-    for inst in config.pmos:
+    # health dot working (true = every configured instance probes ok).
+    # Cached (60 s TTL) + CONCURRENT with a per-probe timeout (audit F3):
+    # the old sequential uncached loop let one sick PMO stall /health ~30 s
+    # while the SPA's 10 s cadence piled up overlapping requests.
+    async def _probe_one(inst) -> tuple[str, dict]:
         if not inst.configured:
-            pmo_instances[inst.name] = {
+            return inst.name, {
                 "ok": None, "configured": False, "team": "",
                 "intake_paused": bool(inst.intake_paused),
             }
-            continue
-        mgr = managers.get(inst.name)
-        try:
-            ok = bool(mgr) and (await mgr.pmo.health_probe(inst.team_key)).ok
-        except Exception:  # noqa: BLE001 — probe contract: any failure → ok:False for this instance; /health must never 500
-            ok = False
-        pmo_instances[inst.name] = {
+        key = (inst.name, inst.team_key)
+        cached = _pmo_probe_cache.get(key)
+        now = time.monotonic()
+        if cached is not None and now - cached["ts"] < _PMO_PROBE_TTL:
+            ok = cached["ok"]
+        else:
+            mgr = managers.get(inst.name)
+            try:
+                async with asyncio.timeout(_PMO_PROBE_TIMEOUT):
+                    ok = bool(mgr) and (
+                        await mgr.pmo.health_probe(inst.team_key)).ok
+            except Exception:  # noqa: BLE001 — probe contract: any failure (incl. the 5s timeout) → ok:False; /health must never 500
+                ok = False
+            _pmo_probe_cache[key] = {"ts": now, "ok": ok}
+        return inst.name, {
             "ok": ok, "configured": True, "team": inst.team_key,
             "intake_paused": bool(inst.intake_paused),
         }
+
+    pmo_instances: dict[str, dict] = dict(
+        await asyncio.gather(*(_probe_one(i) for i in config.pmos)))
     configured_ok = [v["ok"] for v in pmo_instances.values() if v["configured"]]
     prefixed = len(managers) > 1   # advisory text carries the instance when N>1
 

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -207,6 +207,7 @@ async def lifespan(app: FastAPI):
     for mgr in list(s.managers.values()):
         try:
             await mgr.pmo.ensure_labels(mgr.instance.team_key, ALL_LABELS)   # step 2
+            mgr.labels_ready = True        # the poll's F3 once-latch is fed
             log.info("labels ensured in team %s (instance %s)",
                      mgr.instance.team_key, mgr.instance_name)
         except Exception:

--- a/app/devcake/api/poll.py
+++ b/app/devcake/api/poll.py
@@ -20,7 +20,7 @@ from opentelemetry.trace import Status, StatusCode
 
 from ..adapters.files.owner_store import OwnerStore
 from ..domain import backend_health
-from ..domain.model import derive
+from ..domain.model import ALL_LABELS, derive
 from ..domain.orchestrator import MissionManager
 from ..ports.pmo import PMOTransient
 
@@ -141,6 +141,17 @@ class PollRuntime:
         gate + sweeps + schedule + cache rows. Returns (seen, candidates,
         dispatched, fetched_ids). Raises PMOTransient for the caller's
         per-instance skip."""
+        if not mgr.labels_ready:
+            # per-config-generation once-latch (audit F3): heal the managed
+            # labels here — not in the read-only /health probe. Failure is
+            # logged and retried next cycle; reads below tolerate missing
+            # labels (boot already ensures once, main.py lifespan).
+            try:
+                await mgr.pmo.ensure_labels(mgr.instance.team_key, ALL_LABELS)
+                mgr.labels_ready = True
+            except Exception:  # noqa: BLE001 — label healing must never take the segment down; the poll's reads work without it
+                log.exception("label ensure failed for %s — retrying next "
+                              "cycle", mgr.instance_name)
         fetched = await mgr.pmo.list_all(mgr.instance.team_key)
         fetched_ids = {m.pmo_id for m in fetched}
         missions = _claim_missions(mgr, fetched, self.mission_owner)

--- a/app/devcake/api/services.py
+++ b/app/devcake/api/services.py
@@ -46,7 +46,7 @@ from ..domain.repo_mirror import RepoCache
 from ..domain.workspaces import WorkspaceStore
 from ..domain.runs import RunManager
 from ..domain.skills import SkillService
-from .health import reset_protection_cache
+from .health import reset_health_caches
 from .poll import PollRuntime
 
 log = logging.getLogger("devcake")
@@ -100,6 +100,7 @@ class Services:
             if name in self.managers:
                 mgr = self.managers[name]
                 mgr.pmo, mgr.forges, mgr.config = p, self.forge_runtime, self.config
+                mgr.labels_ready = False   # repoint may change team_key (F3 latch)
                 mgr.instance, mgr.instance_name = inst, name
                 mgr.internal_forge = self.internal_forge
                 mgr.skills = self.skill_service
@@ -133,7 +134,7 @@ class Services:
         team_key would run unlabeled until restart."""
         self.forge_runtime.rebuild(self.config.repos, make_forge)
         self.build_managers()
-        reset_protection_cache()           # repos may have changed — reprobe
+        reset_health_caches()              # connections/repos may have changed — reprobe
         # the adapter set feeds secret_env_vars (descriptor env lists), so the
         # redaction scan cache must rebuild with it (2026-08 F17)
         security.invalidate_secret_scan()

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -55,6 +55,10 @@ class MissionManager:
                  blocker_locator=None, repo_cache=None):
         self.config = config
         self.dev_types = dev_types
+        # per-config-generation once-latch (audit F3): the poll cycle
+        # ensures the managed labels ONCE after each boot/repoint —
+        # the /health probe is read-only now and heals nothing
+        self.labels_ready = False
         self.pmo = pmo
         # the SHARED per-repo forge runtime (M10, docs/16 F3): repos belong
         # to the deployment, not to a PMO instance — one runtime, injected

--- a/app/devcake/ports/pmo.py
+++ b/app/devcake/ports/pmo.py
@@ -17,7 +17,11 @@ class PMOTransient(Exception):
 
 class PMOHealth(BaseModel):
     """Neutral connection-probe result (docs/05): replaces the old private
-    reach-ins into vendor JSON from /health and the admin test endpoint."""
+    reach-ins into vendor JSON from /health and the admin test endpoint.
+    Probes MUST NOT write (2026-08-12 audit F3): /health rides the SPA's
+    10 s poll, so a probe that heals labels or PATCHes repo settings is a
+    write path at poll cadence — healing belongs to the poll cycle's
+    once-latch, never here."""
     ok: bool
     workspace: str = ""                 # resolved team/workspace reference
     managed_labels_present: int = 0     # of DevCake's managed set, found remotely

--- a/app/tests/test_gitea_issues_contract.py
+++ b/app/tests/test_gitea_issues_contract.py
@@ -276,6 +276,9 @@ def test_create_mission_returns_key_and_id():
 
 
 def test_health_probe_counts_managed_labels_only():
+    """READ-ONLY since audit F3: the probe REPORTS the managed-label deficit
+    honestly (healing rides the poll once-latch) and a custom label never
+    inflates the count."""
     r = Router()
     r.labels["CUSTOM-EXTRA"] = {"id": 99, "name": "CUSTOM-EXTRA", "color": "fff"}
     pmo = make_pmo(r)
@@ -283,8 +286,13 @@ def test_health_probe_counts_managed_labels_only():
     assert h.ok
     assert h.workspace == "o/r"
     assert h.managed_labels_expected == len(ALL_LABELS)
-    # ensure created all managed; CUSTOM-EXTRA must not inflate present beyond managed ∩ remote
+    assert h.managed_labels_present == 1      # only DEVCAKE seeded; no healing
+    # a healed repo (the poll latch ran ensure_labels) reports the full set
+    run(pmo.ensure_labels("o/r", ALL_LABELS))
+    r.calls.clear()
+    h = run(pmo.health_probe("o/r"))
     assert h.managed_labels_present == len(ALL_LABELS)
+    assert not any(c.startswith(("POST", "PATCH")) for c in r.calls)
 
 
 def test_capabilities_issue_only():
@@ -562,3 +570,17 @@ def test_list_all_skips_dependency_fetch_for_closed_issues():
                 if c.startswith("GET") and "/dependencies" in c]
     assert any("/issues/1/" in c for c in dep_gets)
     assert not any("/issues/3/" in c for c in dep_gets)
+
+
+def test_health_probe_is_strictly_read_only():
+    """PMOHealth contract (2026-08-12 audit F3): the probe rides the SPA's
+    10 s /health poll — the old one ran ensure_labels (repo-settings PATCH +
+    label POSTs) per call, forever. Reads only now; healing lives on the
+    poll cycle's once-latch."""
+    router = Router()
+    pmo = make_pmo(router)
+    health = run(pmo.health_probe("o/r"))
+    assert health.ok is True
+    writes = [c for c in router.calls
+              if c.startswith(("POST", "PATCH", "PUT", "DELETE"))]
+    assert not writes, f"probe must not write: {writes}"

--- a/app/tests/test_health_payload.py
+++ b/app/tests/test_health_payload.py
@@ -37,7 +37,7 @@ def _payload(fr, monkeypatch, repo_cache=None, workspaces=None):
     monkeypatch.setattr(health_mod, "_check_redis", _true)
     monkeypatch.setattr(health_mod, "_check_http", _true)
     monkeypatch.setattr(health_mod, "_oo_ingest_check", _ingest)
-    health_mod.reset_protection_cache()
+    health_mod.reset_health_caches()
     return run_coro(health_mod.build_health_payload(
         config=AppConfig(), dev_types={}, managers={}, stewards={},
         forge_runtime=fr, shared_breakers={},
@@ -90,7 +90,7 @@ def test_unused_repo_names_and_payload_block(monkeypatch):
     monkeypatch.setattr(health_mod, "_check_redis", _true)
     monkeypatch.setattr(health_mod, "_check_http", _true)
     monkeypatch.setattr(health_mod, "_oo_ingest_check", _ingest)
-    health_mod.reset_protection_cache()
+    health_mod.reset_health_caches()
     payload = run_coro(health_mod.build_health_payload(
         config=cfg, dev_types={}, managers={}, stewards={},
         forge_runtime=_forge_runtime(), shared_breakers={},
@@ -123,10 +123,10 @@ def test_branch_protection_probes_concurrently(monkeypatch):
     inst = SimpleNamespace(reference_only=False, default_branch="main")
     fr = SimpleNamespace(forges={f"r{i}": _Forge() for i in range(3)},
                          instance=lambda name: inst)
-    health_mod.reset_protection_cache()
+    health_mod.reset_health_caches()
     out = run_coro(asyncio.wait_for(health_mod._branch_protection(fr), timeout=5))
     assert out == {f"r{i}": {"rendezvous": True} for i in range(3)}
-    health_mod.reset_protection_cache()   # don't leak the fake into others
+    health_mod.reset_health_caches()   # don't leak the fake into others
 
 
 def test_repo_mirror_block_shape(monkeypatch):
@@ -181,3 +181,91 @@ def test_workspaces_block_shape(monkeypatch):
     assert got["disk"] == {"total_bytes": 100, "free_bytes": 9}
     bare = _payload(fr, monkeypatch)["workspaces"]
     assert bare == {"volume_error": None, "leaked": 0, "disk": None}
+
+
+# ── PMO probe cache + concurrency (2026-08-12 audit F3) ──────────────────────
+
+
+def _pmo_world(probe, tmp_path, monkeypatch, name="linear", team="ENG"):
+    """A config with one CONFIGURED instance (stored api_key — `configured`
+    reads the secret store) whose manager probe is `probe`."""
+    from devcake import secrets as secrets_store
+    from devcake.config import PMOInstance
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    secrets_store.write_connection_secret("pmo", name, "api_key", "k-test")
+    cfg = AppConfig(pmos=[PMOInstance(name=name, team_key=team)])
+    mgr = SimpleNamespace(pmo=SimpleNamespace(health_probe=probe),
+                          anomalies={}, blocked_reasons={}, needs_human={},
+                          merge_handoffs={}, cycles=[])
+    return cfg, {name: mgr}
+
+
+def _pmo_payload(cfg, managers, monkeypatch, *, reset=True):
+    async def _true(*a, **k):
+        return True
+
+    async def _ingest():
+        return {"ok": True, "detail": ""}
+
+    monkeypatch.setattr(health_mod, "_check_redis", _true)
+    monkeypatch.setattr(health_mod, "_check_http", _true)
+    monkeypatch.setattr(health_mod, "_oo_ingest_check", _ingest)
+    if reset:
+        health_mod.reset_health_caches()
+    return run_coro(health_mod.build_health_payload(
+        config=cfg, dev_types={}, managers=managers, stewards={},
+        forge_runtime=_forge_runtime(), shared_breakers={},
+        store=SimpleNamespace(active=lambda: []),
+        internal_forge=None,
+        poll_rt=SimpleNamespace(last_poll_at=None, poll_degraded={})))
+
+
+def test_pmo_probe_is_cached_between_health_calls(tmp_path, monkeypatch):
+    """The SPA polls /health every 10 s; the vendor needs one look a minute.
+    (The gitea probe used to WRITE per call — F3; caching bounds even the
+    read cost.)"""
+    calls = []
+
+    async def probe(team):
+        calls.append(team)
+        return SimpleNamespace(ok=True)
+
+    cfg, managers = _pmo_world(probe, tmp_path, monkeypatch)
+    assert _pmo_payload(cfg, managers, monkeypatch)["pmo"] is True
+    assert _pmo_payload(cfg, managers, monkeypatch,
+                        reset=False)["pmo"] is True
+    assert len(calls) == 1, "second /health inside the TTL must not reprobe"
+    health_mod.reset_health_caches()
+    _pmo_payload(cfg, managers, monkeypatch, reset=False)
+    assert len(calls) == 2, "reset_health_caches must force a reprobe"
+
+
+def test_one_hanging_pmo_cannot_stall_health(tmp_path, monkeypatch):
+    """Per-probe 5 s timeout + concurrent gather: a sick PMO reports
+    ok:False; /health returns without waiting out a 30 s client timeout."""
+    from devcake.config import PMOInstance
+
+    async def hang(team):
+        await asyncio.sleep(3600)
+
+    async def fine(team):
+        return SimpleNamespace(ok=True)
+
+    from devcake import secrets as secrets_store
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    secrets_store.write_connection_secret("pmo", "sick", "api_key", "k1")
+    secrets_store.write_connection_secret("pmo", "fine", "api_key", "k2")
+    cfg = AppConfig(pmos=[PMOInstance(name="sick", team_key="A"),
+                          PMOInstance(name="fine", team_key="B")])
+    def _mgr(probe):
+        return SimpleNamespace(pmo=SimpleNamespace(health_probe=probe),
+                               anomalies={}, blocked_reasons={},
+                               needs_human={}, merge_handoffs={},
+                               cycles=[])
+
+    managers = {"sick": _mgr(hang), "fine": _mgr(fine)}
+    monkeypatch.setattr(health_mod, "_PMO_PROBE_TIMEOUT", 0.05)
+    payload = _pmo_payload(cfg, managers, monkeypatch)
+    assert payload["pmo_instances"]["sick"]["ok"] is False, (
+        "the timeout must convert a hang into ok:False")
+    assert payload["pmo_instances"]["fine"]["ok"] is True

--- a/app/tests/test_secrets_store.py
+++ b/app/tests/test_secrets_store.py
@@ -430,7 +430,7 @@ def test_secrets_clear_repo_pops_forge_breaker_and_reloads(monkeypatch, tmp_path
     # clear_secrets binds reload/forge_runtime at the route — call the service
     # with fakes so we can assert the side effects without full composition.
     from devcake.api import connections_service as cs
-    monkeypatch.setattr(cs, "reset_protection_cache",
+    monkeypatch.setattr(cs, "reset_health_caches",
                         lambda: resets.append(True))
 
     out = run_coro(cs.clear_secrets(


### PR DESCRIPTION
Phase 2 PR-8 of the 2026-08-12 audit intervention campaign.

`/health` was a write path at SPA poll cadence (gitea probe ran `ensure_labels` incl. a repo-settings PATCH per call) and serial/uncached (one sick PMO stalled it ~30s). Now: read-only probe with the contract stated on `PMOHealth`; healing on a per-config-generation once-latch in the poll cycle (boot feeds it; repoint resets it); 60s per-instance probe cache + concurrent gather with a 5s per-probe timeout; `reset_health_caches` is the ONE reset path (no alias).

SPA note: health dots lag ≤60s after a credential fix; the "Test" button stays live/uncached — and no longer creates labels as a side effect.

Suite: **1715 passed, 1 skipped**; ruff clean. Depends on PR-B's `_fetch_all_labels` (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)