### PR TITLE
fix: run-store lost-update fence + single-process contract ledger (F8/F9)

### DIFF
--- a/app/devcake/adapters/files/run_store.py
+++ b/app/devcake/adapters/files/run_store.py
@@ -55,7 +55,27 @@ class RunStore:
                 run.run_id, gen, self.wipe_generation,
             )
             return
-        self._write_text(self.root / f"{run.run_id}.json", run.model_dump_json(indent=2))
+        path = self.root / f"{run.run_id}.json"
+        # lost-update fence (audit F8): the single-process contract says
+        # "mutate-then-save promptly" on ONE object per run — but get()
+        # (fresh parse) and all() (shared cache) can hand two writers two
+        # different objects, and a save from the stale one silently discards
+        # the other's fields. Last-writer-wins is PRESERVED (refusing could
+        # wedge a finalize on a benign race); the collision is now LOUD.
+        if path.exists():
+            try:
+                disk_rev = json.loads(path.read_text()).get("rev", 0)
+            except Exception:  # noqa: BLE001 — unreadable record: the quarantine path owns that failure mode, the fence stays quiet
+                disk_rev = None
+            if disk_rev is not None and disk_rev != run.rev:
+                log.error(
+                    "lost-update fence tripped for %s: on-disk rev=%s, this "
+                    "object holds rev=%s — two writers held different Run "
+                    "objects (single-process contract, docs/10 §6); "
+                    "last-writer-wins preserved, fields from the other "
+                    "writer may be gone", run.run_id, disk_rev, run.rev)
+        run.rev += 1
+        self._write_text(path, run.model_dump_json(indent=2))
 
     @staticmethod
     def _sensitive_env_name(name: str) -> bool:

--- a/app/devcake/domain/run.py
+++ b/app/devcake/domain/run.py
@@ -44,6 +44,12 @@ def auth_digest(value: str) -> str:
 
 class Run(BaseModel):
     schema_version: int = 2
+    # lost-update fence (2026-08-12 audit F8): bumped by RunStore.save() on
+    # every write. Two writers holding DIFFERENT objects for the same run
+    # (a fresh get() vs a shared all()-cache object) used to last-writer-
+    # wins SILENTLY; the fence makes the collision loud. Additive — legacy
+    # records parse as rev 0.
+    rev: int = 0
     run_id: str
     mission_key: str
     mission_pmo_id: str = ""

--- a/app/tests/test_run_store_cache.py
+++ b/app/tests/test_run_store_cache.py
@@ -64,3 +64,63 @@ def test_corrupt_files_stay_skipped_on_every_call(tmp_path):
     (tmp_path / "runs" / "junk.json").write_text("{not json")
     assert [r.run_id for r in store.all()] == [_run(1).run_id]
     assert [r.run_id for r in store.all()] == [_run(1).run_id]
+
+
+# ── the lost-update fence (2026-08-12 audit F8) ──────────────────────────────
+
+
+def test_lost_update_fence_trips_loudly_but_preserves_last_writer(
+        tmp_path, caplog):
+    """get() and all() can hand two writers two different objects for the
+    same run; the stale writer's save used to discard the other's fields
+    SILENTLY. Semantics preserved (last writer wins), collision now loud."""
+    import logging
+
+    store = RunStore(tmp_path)
+    r = _run("fence1")
+    store.save(r)                       # rev 0 → 1
+
+    a = store.get(r.run_id)             # two INDEPENDENT objects
+    b = store.get(r.run_id)
+    a.verdict = "from writer A"
+    store.save(a)                       # rev 1 → 2, clean
+    b.verdict = "from writer B"
+    with caplog.at_level(logging.ERROR):
+        store.save(b)                   # stale rev 1 vs disk 2 → fence
+    assert any("lost-update fence tripped" in rec.message
+               for rec in caplog.records)
+    assert store.get(r.run_id).verdict == "from writer B"  # last writer wins
+
+
+def test_same_object_resaves_never_trip_the_fence(tmp_path, caplog):
+    """The sanctioned pattern — mutate-then-save the SAME object repeatedly
+    (checkpoints, heartbeats) — must stay silent."""
+    import logging
+
+    store = RunStore(tmp_path)
+    r = _run("fence2")
+    with caplog.at_level(logging.ERROR):
+        for i in range(5):
+            r.verdict = f"step {i}"
+            store.save(r)
+    assert not any("lost-update fence" in rec.message
+                   for rec in caplog.records)
+    assert store.get(r.run_id).rev == 5
+
+
+def test_legacy_record_without_rev_parses_and_fences_forward(tmp_path):
+    import json
+
+    store = RunStore(tmp_path)
+    r = _run("legacy1")
+    store.save(r)
+    # simulate a pre-rev record on disk
+    p = tmp_path / f"{r.run_id}.json"
+    raw = json.loads(p.read_text())
+    raw.pop("rev")
+    p.write_text(json.dumps(raw))
+    got = store.get(r.run_id)
+    assert got.rev == 0
+    got.verdict = "migrated forward"
+    store.save(got)
+    assert store.get(r.run_id).rev == 1

--- a/app/tests/test_token_report_shape.py
+++ b/app/tests/test_token_report_shape.py
@@ -140,6 +140,9 @@ def test_unavailable_is_explicit_not_silent():
 # everything else must stay scalar-typed. Widening either list is a deliberate,
 # reviewed diff — that is the point.
 RUN_SCALAR_COLUMNS = {
+    # rev: the lost-update fence counter (2026-08-12 audit F8) — deliberate
+    # widening per this guard's own instruction; INTEGER DEFAULT 0 in DDL
+    "rev",
     "schema_version", "run_id", "mission_key", "mission_pmo_id", "pmo_kind",
     "pmo_ref", "repo_ref", "mission_type", "dev_type", "seq",
     "attempt_of_step", "stage_label_at_dispatch", "branch", "spec_prompt",

--- a/docs/10-persistence.md
+++ b/docs/10-persistence.md
@@ -172,3 +172,20 @@ Direct file edits are tolerated but take effect on the next app start, when `loa
 | `/data/config/profiles` + `/data/secrets/profiles` | Saved profile snapshots are gone; **live settings are untouched** (profiles are fire-and-forget snapshots, ADR-0013). |
 | the `/mirrors` volume (`docker volume rm devcake_mirrors`, stack stopped) | Nothing durable lost — the mirror is a mandatory but DISPOSABLE cache (ADR-0024): the next dispatch's fail-closed freshness gate re-clones every needed repo (one full re-fetch per repo of cost). Deleting it while the stack runs instead trips the volume error → dispatch refuses with a visible reason until `verify_writable` clears. |
 | the `$DEVCAKE_WS_HOST` tree | Per-run scratch only (ADR-0025). In-flight runs' containers lose their bind and fail (counted per docs/15); terminal residue is exactly what the periodic sweep reclaims anyway. Never part of the backup set. |
+
+## 6. The single-process contract (normative; 2026-08-12 audit F8/F9)
+
+Three load-bearing invariants rest on the app being ONE process with ONE
+event loop. They were previously documented only at their definition sites;
+this section is the ledger, and each carries its tripwire:
+
+| Invariant | Where it lives | What breaks multi-process | Tripwire |
+| --- | --- | --- | --- |
+| Run records: one mutating object per run, "mutate-then-save promptly". `all()` returns SHARED cached objects; `get()` re-parses. | `adapters/files/run_store.py` parse cache | Two writers holding different objects last-writer-wins each other's fields | `Run.rev` lost-update fence in `save()` — collisions log loudly (`lost-update fence tripped`); writes still land |
+| Give-up cursor: byte-offset incremental reader over `events.jsonl`, lock-free because the writer is synchronous in the same loop | `orchestrator/markers.py` `_GIVEUP_STATE` | A second writer interleaves records mid-read; attempt counting miscounts | none mechanical — the fence above catches the downstream symptom; a second process is out of contract |
+| `unlimited`-mode warning dedup: process-local set, at most one repeat per restart | `orchestrator/dispatch.py` `_UNLIMITED_WARNED` | Duplicate loop warnings per cycle (loud direction — annoying, safe) | none needed |
+
+Deployment rule this implies: exactly one app container per `/data` volume
+(`docker-compose.yml` runs a single `app` service; uvicorn has no
+`--workers`). Running a second app process against the same volume is out
+of contract — the fence makes the corruption visible, not safe.


### PR DESCRIPTION
Phase 2 PR-10 of the 2026-08-12 audit intervention campaign.

The convention ("mutate-then-save promptly", one object per run) becomes detectable: `Run.rev` + a save-time fence turn silent lost-updates into loud `log.error` collisions while preserving last-writer-wins (no wedge risk). docs/10 §6 ledgers all three single-process invariants with their tripwires and the deployment rule. ADR-0029's DDL pin widened deliberately, per the guard's own message.

Suite: **1715 passed, 1 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)