### PR TITLE
fix: ingress finalize offload — slow finalizes no longer starve heartbeats (F11/F12)

### DIFF
--- a/app/devcake/adapters/redis/messaging.py
+++ b/app/devcake/adapters/redis/messaging.py
@@ -7,6 +7,7 @@
 """
 
 import asyncio
+import contextlib
 import json
 import hashlib
 import logging
@@ -28,6 +29,10 @@ log = logging.getLogger("devcake.messaging")
 tracer = trace.get_tracer("devcake")
 
 INGRESS = "devcake:ingress"
+# concurrent run.artifacts finalizes (audit F11) — bounded so a burst of
+# completions cannot stampede the PMO/forge; heartbeats are not budgeted
+FINALIZE_CONCURRENCY = 4
+FINALIZE_KINDS = frozenset({"run.artifacts"})
 GROUP = "app"
 CONSUMER = "app-1"
 REPLY_TTL_SECONDS = 900          # secret material must not linger (docs/09 §5)
@@ -62,6 +67,17 @@ class Messaging:
     def __init__(self, url: str, password: str):
         self.redis = aioredis.from_url(url, password=password or None, decode_responses=True)
         self._chunks: dict[tuple[str, str, str], dict[str, Any]] = {}
+        # finalize offload (2026-08-12 audit F11): the ingress consumer was
+        # ONE serialized loop, so two slow finalizes against a lagging PMO
+        # starved heartbeat consumption past HEARTBEAT_GRACE and the
+        # watchdog killed HEALTHY runs. run.artifacts handling now rides
+        # per-run task chains (per-run ordering preserved) under a global
+        # concurrency bound; heartbeats/runspec traffic stays inline and
+        # always drains. Ack-after-handle is unchanged — a crash before a
+        # worker acks leaves the entry for redelivery (at-least-once).
+        self._finalize_tasks: dict[str, asyncio.Task] = {}   # run_id → chain tail
+        self._inflight_entries: set[str] = set()             # reclaim guard
+        self._finalize_sem = asyncio.Semaphore(FINALIZE_CONCURRENCY)
 
     async def setup(self) -> None:
         try:
@@ -117,8 +133,11 @@ class Messaging:
             "v": 1, "run_id": run_id, "kind": kind,
             "ts": datetime.now(timezone.utc).isoformat(), "payload": payload,
         }
-        await self.redis.xadd(stream, {"m": json.dumps(envelope)})
-        await self.redis.expire(stream, REPLY_TTL_SECONDS)
+        pipe = self.redis.pipeline(transaction=False)
+        pipe.xadd(stream, {"m": json.dumps(envelope)})
+        pipe.expire(stream, REPLY_TTL_SECONDS)   # one round-trip: the TTL is
+        # the docs/09 §5 secret-lingering guard — never separated from the add
+        await pipe.execute()
 
     async def delete_runspec_result(self, run_id: str) -> None:
         """XDEL runspec.result entries as soon as the Dev acknowledges (docs/09 §1a)."""
@@ -148,9 +167,16 @@ class Messaging:
             start, messages = resp[0], resp[1]
             for entry_id, fields in messages:
                 fields = {k: v for k, v in (fields or {}).items()} if isinstance(fields, dict)                     else dict(zip(fields[::2], fields[1::2]))
+                if entry_id in self._inflight_entries:
+                    # a worker is finalizing this entry RIGHT NOW — reclaim
+                    # must not hand it out again in-process (a >idle-window
+                    # finalize would otherwise run twice concurrently)
+                    continue
                 try:
-                    await self._handle_entry(entry_id, fields, handler, verify_auth)
-                    await self._maybe_poison(entry_id, fields)
+                    handled = await self._handle_entry(
+                        entry_id, fields, handler, verify_auth)
+                    if not handled:
+                        await self._maybe_poison(entry_id, fields)
                 except Exception:
                     log.exception("reclaim: failed handling %s", entry_id)
                     await self._maybe_poison(entry_id, fields)
@@ -188,8 +214,14 @@ class Messaging:
             for _stream, messages in entries or []:
                 for entry_id, fields in messages:
                     try:
-                        await self._handle_entry(entry_id, fields, handler, verify_auth)
-                        await self._maybe_poison(entry_id, fields)
+                        handled = await self._handle_entry(
+                            entry_id, fields, handler, verify_auth)
+                        if not handled:
+                            # a mid-group chunk entry stays unacked — the
+                            # poison check here is what eventually dead-
+                            # letters a PERMANENTLY incomplete group (its
+                            # redeliveries are no-progress "successes")
+                            await self._maybe_poison(entry_id, fields)
                     except Exception:
                         log.exception("ingress: failed handling %s", entry_id)
                         await self._maybe_poison(entry_id, fields)
@@ -228,7 +260,12 @@ class Messaging:
     async def _ack_delete(self, entry_ids: list[str]) -> None:
         if not entry_ids:
             return
-        pipe = self.redis.pipeline(transaction=False)
+        # ATOMIC (audit F12): XACK then XDEL in a MULTI/EXEC. A crash between
+        # the two used to leave an entry ACKED but PRESENT — which
+        # unresolved_run_ids (an xrange over present entries) then counted as
+        # "resumable", contradicting its own docstring invariant that handled
+        # entries leave the stream.
+        pipe = self.redis.pipeline(transaction=True)
         pipe.xack(INGRESS, GROUP, *entry_ids)
         pipe.xdel(INGRESS, *entry_ids)
         await pipe.execute()
@@ -361,7 +398,51 @@ class Messaging:
         assembly["parts"][chunk] = data
         assembly["last_progress"] = time.monotonic()   # accepted ⇒ real progress
 
-    async def _handle_entry(self, entry_id, fields, handler, verify_auth) -> None:
+    def _spawn_finalize(self, run_id, kind, payload, entry_ids, fields,
+                        handler, chunk_key=None, chunk_id=None) -> None:
+        """Chain a run.artifacts handling task after the run's previous one
+        (per-run ordering) under the global finalize bound. The WORKER owns
+        ack/complete-key/poison — exactly what the inline path did."""
+        prev = self._finalize_tasks.get(run_id)
+        self._inflight_entries.update(entry_ids)
+
+        async def _work():
+            if prev is not None and not prev.done():
+                with contextlib.suppress(Exception):
+                    await asyncio.shield(prev)
+            async with self._finalize_sem:
+                try:
+                    await handler(run_id, kind, payload)
+                    if chunk_id:
+                        await self.redis.set(
+                            chunk_complete_key(run_id, chunk_id), "1",
+                            ex=REPLY_TTL_SECONDS)
+                    await self._ack_delete(list(entry_ids))
+                    if chunk_key:
+                        self._chunks.pop(chunk_key, None)
+                except Exception:
+                    log.exception("ingress: finalize failed for %s", run_id)
+                    with contextlib.suppress(Exception):
+                        await self._maybe_poison(entry_ids[-1], fields)
+                finally:
+                    self._inflight_entries.difference_update(entry_ids)
+                    if self._finalize_tasks.get(run_id) is task:
+                        self._finalize_tasks.pop(run_id, None)
+
+        task = asyncio.create_task(_work())
+        self._finalize_tasks[run_id] = task
+
+    async def drain_finalizes(self) -> None:
+        """Await every in-flight finalize chain (tests + orderly paths)."""
+        while self._finalize_tasks:
+            tasks = list(self._finalize_tasks.values())
+            await asyncio.gather(*tasks, return_exceptions=True)
+            if all(t.done() for t in tasks) and not any(
+                    t2 for t2 in self._finalize_tasks.values()
+                    if t2 not in tasks):
+                break
+
+    async def _handle_entry(self, entry_id, fields, handler, verify_auth) -> bool:
         envelope = json.loads(fields.get("m", "{}"))
         run_id = envelope.get("run_id", "")
         kind = envelope.get("kind", "")
@@ -380,7 +461,7 @@ class Messaging:
                 log.warning("ingress: FORGED/unauthenticated message dropped "
                             "(run_id=%s kind=%s)", run_id, kind)
                 await self._ack_delete([entry_id])
-            return
+            return True
         if "chunk" in payload:  # reassemble chunked payloads (docs/09 §3)
             if kind != "run.artifacts":
                 raise ValueError("only run.artifacts may be chunked")
@@ -400,7 +481,7 @@ class Messaging:
             key = (run_id, kind, chunk_id)
             if await self.redis.exists(chunk_complete_key(run_id, chunk_id)):
                 await self._ack_delete([entry_id])
-                return
+                return True
             if key not in self._chunks and len(self._chunks) >= MAX_ACTIVE_CHUNK_GROUPS:
                 raise ValueError("too many active chunk groups")
             created = key not in self._chunks
@@ -419,7 +500,7 @@ class Messaging:
             if entry_id not in assembly["entry_ids"]:
                 assembly["entry_ids"].append(entry_id)
             if len(assembly["parts"]) < total:
-                return
+                return False   # unacked mid-group entry: poison check applies
             joined = "".join(assembly["parts"][i] for i in range(1, total + 1))
             if hashlib.sha256(joined.encode("utf-8")).hexdigest() != digest:
                 raise ValueError("assembled chunk sha256 mismatch")
@@ -427,12 +508,18 @@ class Messaging:
             if not isinstance(payload, dict):
                 raise ValueError("assembled payload must be an object")
             payload = self._scrub_envelope_auth(payload, auth)
-            await handler(run_id, kind, payload)
-            await self.redis.set(
-                chunk_complete_key(run_id, chunk_id), "1", ex=REPLY_TTL_SECONDS)
-            await self._ack_delete(list(assembly["entry_ids"]))
-            self._chunks.pop(key, None)
-            return
+            # chunked payloads are run.artifacts by construction (checked
+            # above) — the finalize rides the per-run chain (audit F11)
+            self._spawn_finalize(run_id, kind, payload,
+                                 list(assembly["entry_ids"]), fields, handler,
+                                 chunk_key=key, chunk_id=chunk_id)
+            return True
 
-        await handler(run_id, kind, self._scrub_envelope_auth(payload, auth))
+        payload = self._scrub_envelope_auth(payload, auth)
+        if kind in FINALIZE_KINDS:
+            self._spawn_finalize(run_id, kind, payload, [entry_id], fields,
+                                 handler)
+            return True
+        await handler(run_id, kind, payload)
         await self._ack_delete([entry_id])
+        return True

--- a/app/tests/test_messaging_live.py
+++ b/app/tests/test_messaging_live.py
@@ -117,6 +117,7 @@ def test_chunk_reassembly(msg):
                                "sha256": digest, "data": part}}
             await msg._handle_entry(f"0-{i}", {"m": json.dumps(env)}, handler,
                                     lambda r, a: True)
+        await msg.drain_finalizes()   # run.artifacts rides the F11 offload
         assert len(got) == 1 and got[0]["result"]["outcome"] == "hello"
         assert len(got[0]["data"]) == 900_000
     run(main())
@@ -226,6 +227,7 @@ def test_active_chunk_group_survives_poison_threshold(msg, monkeypatch):
         await msg.redis.xreadgroup("app", "app-1", {test_stream: ">"}, count=10)
         await msg._handle_entry(entry2, {"m": json.dumps(env2)}, handler,
                                 lambda r, a: True)
+        await msg.drain_finalizes()   # F11 offload owns handle+ack+pop
         assert len(got) == 1 and got[0]["result"]["outcome"] == "hello"
         assert (rid, "run.artifacts", chunk_id) not in msg._chunks
         await msg.redis.delete(test_stream)
@@ -321,6 +323,7 @@ def test_completing_chunk_admitted_at_global_cap(msg, monkeypatch):
         env2 = _chunk_env(rid, 2, 2, chunk_id, digest, blob[half:])
         await msg._handle_entry("0-4", {"m": json.dumps(env2)}, handler,
                                 lambda r, a: True)
+        await msg.drain_finalizes()   # F11 offload owns handle+ack+pop
         assert len(got) == 1 and got[0]["result"]["outcome"] == "drained"
         assert key not in msg._chunks
         assert _buffered_bytes(msg) < 1000            # its memory is released
@@ -436,6 +439,7 @@ def test_chunk_group_metadata_mismatch_rejected_cleanly(msg):
         await msg._handle_entry("0-4", {"m": json.dumps(
             _chunk_env(rid, 2, 2, chunk_id, digest, blob[half:]))},
             handler, lambda r, a: True)
+        await msg.drain_finalizes()   # F11 offload owns handle+ack+pop
         assert len(got) == 1 and got[0]["result"]["outcome"] == "gen-one"
         assert key not in msg._chunks
     run(main())
@@ -485,4 +489,67 @@ def test_run_user_password_registered_for_redaction(msg):
         assert pw not in redact(f"leak {pw} end")
         await msg.delete_run_user(rid)
         assert pw in redact(f"leak {pw} end")
+    run(main())
+
+
+def test_slow_finalize_does_not_starve_heartbeat_consumption(msg, monkeypatch):
+    """2026-08-12 audit F11: the ingress consumer was ONE serialized loop, so
+    a slow run.artifacts handler blocked heartbeat consumption for OTHER runs
+    past HEARTBEAT_GRACE and the watchdog killed healthy runs. Now finalize
+    handling rides a bounded per-run offload; a heartbeat delivered while a
+    finalize is mid-flight is handled without waiting on it."""
+    import devcake.adapters.redis.messaging as mm
+    test_stream = f"devcake:test:ingress:{uuid.uuid4().hex[:6]}"
+    monkeypatch.setattr(mm, "INGRESS", test_stream)
+
+    async def main():
+        order = []
+        release = asyncio.Event()
+
+        async def handler(run_id, kind, payload):
+            if kind == "run.artifacts":
+                await release.wait()           # a slow finalize, held open
+            order.append((kind, run_id))
+
+        # a run.artifacts entry (offloaded) then a heartbeat for another run
+        art = {"v": 1, "run_id": "SLOW", "auth": "pw", "kind": "run.artifacts",
+               "payload": {"result": {"outcome": "x"}}}
+        hb = {"v": 1, "run_id": "OTHER", "auth": "pw", "kind": "run.heartbeat",
+              "payload": {"phase": "working"}}
+        h1 = await msg._handle_entry("0-1", {"m": json.dumps(art)}, handler,
+                                     lambda r, a: True)
+        h2 = await msg._handle_entry("0-2", {"m": json.dumps(hb)}, handler,
+                                     lambda r, a: True)
+        assert h1 is True and h2 is True
+        # the heartbeat was handled INLINE despite the finalize still blocked
+        assert ("run.heartbeat", "OTHER") in order
+        assert ("run.artifacts", "SLOW") not in order
+        release.set()
+        await msg.drain_finalizes()
+        assert ("run.artifacts", "SLOW") in order
+
+    run(main())
+
+
+def test_per_run_finalize_ordering_preserved(msg):
+    """At-least-once + per-run ordering: two run.artifacts for the SAME run
+    handle in arrival order even though each rides the offload."""
+    async def main():
+        order = []
+        gate = asyncio.Event()
+
+        async def handler(run_id, kind, payload):
+            if payload["n"] == 1:
+                await gate.wait()              # first one is slow
+            order.append(payload["n"])
+
+        for n in (1, 2):
+            env = {"v": 1, "run_id": "R", "auth": "pw", "kind": "run.artifacts",
+                   "payload": {"n": n}}
+            await msg._handle_entry(f"0-{n}", {"m": json.dumps(env)}, handler,
+                                    lambda r, a: True)
+        gate.set()
+        await msg.drain_finalizes()
+        assert order == [1, 2], "same-run finalizes must stay ordered"
+
     run(main())


### PR DESCRIPTION
Phase 2 PR-9 of the 2026-08-12 audit intervention campaign.

The single serialized ingress consumer let slow `run.artifacts` finalizes starve heartbeat consumption for *other* runs → watchdog killed healthy runs past the 300s grace. Now `run.artifacts` rides a bounded per-run offload (`Semaphore(4)`, per-run chains preserve ordering); heartbeats/runspec stay inline and always drain. At-least-once and worker-owned ack/poison are unchanged; reclaim skips in-flight entries.

F12 ride-alongs: atomic `_ack_delete` (MULTI/EXEC), pipelined `reply()` XADD+EXPIRE (the secret-TTL guard), poison only on the unhandled path.

Live-Redis tests: the starvation regression (slow finalize + inline heartbeat for another run) and same-run ordering. Suite: **1714 passed, 1 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)