### PR TITLE
fix: entrypoint resilience — first heartbeat, finalize retries, capture truncation (OPS-M5/L2/M4)

### DIFF
--- a/app/tests/test_bus_resilience.py
+++ b/app/tests/test_bus_resilience.py
@@ -1,0 +1,103 @@
+"""bus.py send/heartbeat resilience (2026-08-12 audit OPS-M5): the FIRST
+heartbeat was outside any try (a boot-window Redis blip killed the thread
+permanently, and heartbeat grace then killed a healthy run), and the
+finalize send used the narrow retry budget. bus.py has import-time env reads
++ a Redis connection, so the functions are AST-extracted and exec'd against
+a fake client instead of imported (the test_hello_bus_contract pattern)."""
+
+import ast
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+BUS = Path("/srv/images/common/devcake_dev/adapters/bus.py")
+
+
+class _FlakyRedis:
+    """RedisError for the first `fail_n` xadds, then succeeds."""
+
+    class RedisError(Exception):
+        pass
+
+    def __init__(self, fail_n):
+        self.fail_n = fail_n
+        self.adds = 0
+
+    def xadd(self, *a, **k):
+        self.adds += 1
+        if self.adds <= self.fail_n:
+            raise self.RedisError("connection refused")
+
+
+def _load_bus(fake, monkeypatch):
+    assert BUS.exists(), (
+        "mount missing — bind images/common → /srv/images/common"
+    )
+    monkeypatch.setenv("DEVCAKE_RUN_ID", "R-bus-1")
+    monkeypatch.setenv("REDIS_URL", "redis://x")
+    monkeypatch.setenv("REDIS_USER", "u")
+    monkeypatch.setenv("REDIS_PASSWORD", "p")
+    tree = ast.parse(BUS.read_text())
+    keep = []
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in (
+                "send", "heartbeat_loop", "send_artifacts", "_fit_payload"):
+            keep.append(node)
+        elif isinstance(node, ast.Assign):
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if any(n.isupper() for n in names):
+                keep.append(node)
+    ns = {"os": __import__("os"), "json": __import__("json"),
+          "time": time, "threading": threading, "redis": fake,
+          "hashlib": __import__("hashlib"), "uuid": __import__("uuid"),
+          "datetime": __import__("datetime").datetime,
+          "timezone": __import__("datetime").timezone,
+          "RUN_ID": "R-bus-1", "INGRESS": "ingress", "r": fake,
+          "sys": __import__("sys")}
+    exec(compile(ast.Module(body=keep, type_ignores=[]),  # noqa: S102 — repo-controlled bus.py functions
+                 str(BUS), "exec"), ns)
+    return ns
+
+
+def test_send_default_budget_gives_up_after_its_attempts(monkeypatch):
+    fake = _FlakyRedis(fail_n=99)
+    bus = _load_bus(fake, monkeypatch)
+    with pytest.raises(fake.RedisError):
+        bus["send"]("run.heartbeat", {}, )
+    assert fake.adds == bus["SEND_ATTEMPTS"]
+
+
+def test_send_recovers_within_the_resilient_budget(monkeypatch):
+    # a blip that clears after more than the default budget but within the
+    # resilient one — the finalize/first-heartbeat path must ride it out
+    fail_n = 4
+    fake = _FlakyRedis(fail_n=fail_n)
+    bus = _load_bus(fake, monkeypatch)
+    monkeypatch.setattr(bus["time"], "sleep", lambda *_: None)  # no real waits
+    assert bus["SEND_ATTEMPTS"] <= fail_n < bus["SEND_ATTEMPTS_RESILIENT"]
+    bus["send"]("run.artifacts", {"ok": True},
+                attempts=bus["SEND_ATTEMPTS_RESILIENT"])
+    assert fake.adds == fail_n + 1
+
+
+def test_first_heartbeat_blip_does_not_kill_the_thread(monkeypatch):
+    """The regression: a boot-window blip on the FIRST beat used to raise out
+    of heartbeat_loop and the thread died silently. It must survive and go on
+    to send the working beats."""
+    fail_n = 3   # first beat blips, then recovers
+    fake = _FlakyRedis(fail_n=fail_n)
+    bus = _load_bus(fake, monkeypatch)
+    monkeypatch.setattr(bus["time"], "sleep", lambda *_: None)
+    stop = threading.Event()
+
+    class _OneShot:
+        def wait(self, _):
+            fired = stop.is_set()
+            stop.set()
+            return fired          # False once (send a working beat), then True
+
+    bus["heartbeat_loop"](_OneShot())
+    # the starting beat blipped 3x then landed, and one working beat followed
+    assert fake.adds >= fail_n + 1

--- a/app/tests/test_entrypoint_render.py
+++ b/app/tests/test_entrypoint_render.py
@@ -281,7 +281,7 @@ def test_logrelay_batches_truncates_and_caps(monkeypatch):
     sent = []
     # LogRelay calls bus.send (not the entrypoint façade name).
     monkeypatch.setattr("devcake_dev.adapters.bus.send",
-                        lambda kind, payload: sent.append((kind, payload)))
+                        lambda kind, payload, **_k: sent.append((kind, payload)))
     relay = ep.LogRelay()
     relay.add("a" * 5000)                     # truncated to LINE_LIMIT
     relay.add("multi\nline")                  # split into two entries
@@ -303,7 +303,7 @@ def test_logrelay_batches_truncates_and_caps(monkeypatch):
 
 
 def test_logrelay_swallows_send_failures(monkeypatch):
-    def boom(kind, payload):
+    def boom(kind, payload, **_k):
         raise RuntimeError("redis down")
     monkeypatch.setattr("devcake_dev.adapters.bus.send", boom)
     relay = ep.LogRelay()
@@ -513,7 +513,7 @@ def test_send_artifacts_chunks_carry_id_and_digest(monkeypatch):
     import hashlib
     sent = []
     monkeypatch.setattr("devcake_dev.adapters.bus.send",
-                        lambda kind, payload: sent.append((kind, payload)))
+                        lambda kind, payload, **_k: sent.append((kind, payload)))
     ep.send_artifacts({"result": {"outcome": "hello"},
                        "transcript_md": "y" * 900_000})
     assert len(sent) > 1

--- a/images/common/dev_entrypoint.py
+++ b/images/common/dev_entrypoint.py
@@ -561,6 +561,18 @@ def harness_main() -> None:
             for t in pumps:
                 t.join(timeout=10)
             progress.join(timeout=10)
+            # OPS-L2: a pump still draining after the 10s join means the
+            # joined output below is TRUNCATED — the very stdout the fault
+            # predicates classify on. Say so loudly instead of silently
+            # judging a partial capture.
+            if any(t.is_alive() for t in pumps):
+                relay.add("[devcake] WARNING: output capture truncated — a "
+                          "pump thread did not drain within 10s; the fault "
+                          "classification below reads a PARTIAL transcript",
+                          visible_output=False)
+                print(f"[devcake] output capture truncated for {RUN_ID} "
+                      f"attempt {attempt} — pump still draining after join",
+                      file=sys.stderr)
         joined_out = "".join(out_lines)
         joined_err = "".join(err_lines)
         n_bytes, n_lines = len(joined_out), len(out_lines)

--- a/images/common/devcake_dev/adapters/bus.py
+++ b/images/common/devcake_dev/adapters/bus.py
@@ -30,18 +30,27 @@ SHRINKABLE_FIELDS = ("transcript_md", "plan_md", "last_message_md")
 TRUNCATE_FLOOR = 10_000
 
 
-def send(kind: str, payload: dict) -> None:
+# attempts × backoff. The default (~1.75s) covers a momentary blip; the
+# BOOT and FINALIZE sends widen it (2026-08-12 audit OPS-M5): an operator
+# `compose restart redis` at container start used to kill the first
+# heartbeat, and a blip at run end turned a cleanly classified failure into
+# an unclassified crash-with-traceback. ~15s of retry rides both windows out.
+SEND_ATTEMPTS = 4
+SEND_ATTEMPTS_RESILIENT = 8
+
+
+def send(kind: str, payload: dict, *, attempts: int = SEND_ATTEMPTS) -> None:
     envelope = {"v": 1, "run_id": RUN_ID, "auth": os.environ["REDIS_PASSWORD"],
                 "kind": kind, "ts": datetime.now(timezone.utc).isoformat(),
                 "payload": payload}
-    for attempt in range(4):
+    for attempt in range(attempts):
         try:
             r.xadd(INGRESS, {"m": json.dumps(envelope)})
             return
         except redis.RedisError:
-            if attempt == 3:
+            if attempt == attempts - 1:
                 raise
-            time.sleep(0.25 * (2 ** attempt))
+            time.sleep(min(4.0, 0.25 * (2 ** attempt)))
 
 
 def _fit_payload(payload: dict) -> dict:
@@ -65,10 +74,13 @@ def _fit_payload(payload: dict) -> dict:
 
 
 def send_artifacts(payload: dict) -> None:
+    # FINALIZE send (OPS-M5): the artifacts are the run's whole verdict — a
+    # transient Redis blip here must not lose them to an unclassified crash,
+    # so ride the wider retry budget.
     payload = _fit_payload(payload)
     blob = json.dumps(payload)
     if len(blob) <= CHUNK_LIMIT:
-        send("run.artifacts", payload)
+        send("run.artifacts", payload, attempts=SEND_ATTEMPTS_RESILIENT)
         return
     parts = [blob[i:i + CHUNK_SIZE] for i in range(0, len(blob), CHUNK_SIZE)]
     if len(parts) > 128 or len(blob.encode("utf-8")) > 50 * 1024 * 1024:
@@ -78,7 +90,7 @@ def send_artifacts(payload: dict) -> None:
     for i, part in enumerate(parts, start=1):
         send("run.artifacts", {"chunk": i, "of": len(parts),
                                "chunk_id": chunk_id, "sha256": digest,
-                               "data": part})
+                               "data": part}, attempts=SEND_ATTEMPTS_RESILIENT)
 
 
 def request_reply(kind: str, want: str, timeout: int = 90,
@@ -103,7 +115,15 @@ def request_reply(kind: str, want: str, timeout: int = 90,
 
 
 def heartbeat_loop(stop: threading.Event) -> None:
-    send("run.heartbeat", {"phase": "starting"})
+    # The FIRST beat was outside the try (OPS-M5): a boot-window Redis blip
+    # raised out of it, the thread died PERMANENTLY, and a perfectly healthy
+    # multi-hour run was later killed by heartbeat grace. Guard it like the
+    # loop body, with the wider boot-window budget.
+    try:
+        send("run.heartbeat", {"phase": "starting"},
+             attempts=SEND_ATTEMPTS_RESILIENT)
+    except Exception:
+        pass
     while not stop.wait(30):
         try:
             send("run.heartbeat", {"phase": "working"})

--- a/images/common/devcake_dev/domain/fault.py
+++ b/images/common/devcake_dev/domain/fault.py
@@ -51,6 +51,18 @@ HARNESS_AUTH_MARKERS = tuple(_re.compile(r"\b" + p + r"\b") for p in (
 # when the fault predicate has already explained a failure, only unambiguous
 # credential evidence may override it. Bare "authentication"/"unauthorized" are
 # excluded: OpenAI-compatible gateways emit them for ordinary rejections.
+#
+# CAPTURE RITUAL (2026-08-12 audit OPS-M4 — these markers are version-coupled
+# to CLI stderr wording; exit 12 vs the exit-10 burned-attempt cascade turns
+# on one phrase). Whenever a harness CLI pin is bumped (images/Dockerfile
+# CLAUDE_CODE_VERSION / CODEX_VERSION, or the unpinned grok floats), RE-RUN
+# the in-image capture so a wording change is caught as a fixture-verdict
+# mismatch, not discovered as a revoked-credential cascade in production:
+#   docker run --rm -v "$PWD:/srv" -w /srv devcake/dev-<harness>:<tag> \
+#       python scripts/harness_capture/in_container.py --auth-revoked
+# then commit the new capture under app/tests/fixtures/harness_streams/ — the
+# parity test (test_harness_captures) fails if the CURRENT predicate disagrees
+# with the recorded verdict. See scripts/harness_capture/in_container.py.
 DISTINCTIVE_AUTH_MARKERS = tuple(_re.compile(r"\b" + p + r"\b") for p in (
     "not signed in", r"grok login",
 ))


### PR DESCRIPTION
Phase 2 PR-12 of the 2026-08-12 audit intervention campaign.

- **First heartbeat guarded + wider budget (M5):** a boot-window Redis blip used to kill the heartbeat thread permanently → healthy run killed by grace. Now wrapped, with an 8-attempt (~15s) budget the finalize `send_artifacts` shares.
- **Truncation is loud (L2):** a pump not drained within the 10s join warns instead of silently handing the fault predicates a partial transcript.
- **Capture ritual documented (M4):** exit-12 auth markers are CLI-version-coupled; the mandatory in-image re-capture on every pin bump is now written next to the markers, with the command. Drift surfaces as a fixture-verdict mismatch.

Tests: AST-extract `bus.py` against a flaky fake redis (hello-mirror pattern) — budget exhaustion, resilient-budget recovery, first-heartbeat survival.

**Deferred honestly** (ledgered in PR-14): the SIGTERM artifact-flush (sits in the verified kill path — needs a live kill-drill) and the /health exit-10 auth-fingerprint warning (soft signal, deliberate backend change). Both are improvements, neither is safe to bolt on unverified here.

Suite: **1723 passed, 1 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)