### PR TITLE
test: close the audit's load-bearing coverage gaps

### DIFF
--- a/app/tests/test_boot_smoke.py
+++ b/app/tests/test_boot_smoke.py
@@ -1,0 +1,93 @@
+"""Boot-path coverage the lifespan test deliberately skips (2026-08-12 audit
+test-gap). The full lifespan is I/O-bound (Redis, OO, Gitea) and belongs to
+the live R9 drill, but two boot behaviors are unit-testable and were
+uncovered: the background-task death reporter (an error path whose failure
+is SILENCE) and the SEC-3 boot-refusal wiring."""
+
+import ast
+import asyncio
+import logging
+from pathlib import Path
+
+from devcake.api.services import _log_task_death
+
+MAIN = Path(__file__).resolve().parents[1] / "devcake" / "api" / "main.py"
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_log_task_death_reports_a_crashed_background_task(caplog):
+    """poll/watchdog tasks get add_done_callback(_log_task_death); a task that
+    dies with an exception must be LOUD — a silent death is exactly how the
+    2026-08 poll-loop deaths went unnoticed."""
+    async def boom():
+        raise RuntimeError("poll loop crashed")
+
+    async def scenario():
+        t = asyncio.create_task(boom(), name="poll:linear")
+        t.add_done_callback(_log_task_death)
+        try:
+            await t
+        except RuntimeError:
+            pass
+        await asyncio.sleep(0)   # let the done-callback run
+
+    with caplog.at_level(logging.ERROR):
+        _run(scenario())
+    assert any("background task poll:linear DIED" in r.message
+               for r in caplog.records)
+
+
+def test_log_task_death_is_silent_on_clean_and_cancelled(caplog):
+    async def clean():
+        return 1
+
+    async def scenario():
+        ok = asyncio.create_task(clean(), name="ok")
+        ok.add_done_callback(_log_task_death)
+        await ok
+        cancelled = asyncio.create_task(asyncio.sleep(10), name="cx")
+        cancelled.add_done_callback(_log_task_death)
+        cancelled.cancel()
+        try:
+            await cancelled
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0)
+
+    with caplog.at_level(logging.ERROR):
+        _run(scenario())
+    assert not any("DIED" in r.message for r in caplog.records)
+
+
+def test_boot_refuses_on_invalid_cross_store_semantics():
+    """SEC-3 boot-refusal wiring: the lifespan calls validate_config_semantics
+    after template seeding and converts a BundleError into a boot RuntimeError
+    with remediation — so a hand-edited config referencing a deleted custom
+    Dev Type refuses at startup, not at dispatch. Source-guarded (the full
+    lifespan needs live Redis/OO); the semantics function itself is behavior-
+    tested in test_config_schema/test_settings_bundle."""
+    tree = ast.parse(MAIN.read_text())
+    lifespan = next(n for n in ast.walk(tree)
+                    if isinstance(n, ast.AsyncFunctionDef)
+                    and n.name == "lifespan")
+    calls_validate = any(
+        isinstance(n, ast.Call) and (
+            (isinstance(n.func, ast.Name) and n.func.id == "validate_config_semantics")
+            or (isinstance(n.func, ast.Attribute)
+                and n.func.attr == "validate_config_semantics"))
+        for n in ast.walk(lifespan))
+    assert calls_validate, (
+        "lifespan must validate cross-store semantics at boot (SEC-3) — "
+        "a config referencing a deleted Dev Type must refuse at startup")
+    # and the BundleError → boot RuntimeError conversion is present
+    handlers = [n for n in ast.walk(lifespan)
+                if isinstance(n, ast.ExceptHandler)
+                and n.type is not None
+                and ast.unparse(n.type) == "BundleError"]
+    assert any(
+        any(isinstance(s, ast.Raise) for s in ast.walk(h)) for h in handlers), (
+        "a boot BundleError must re-raise as a loud RuntimeError, not be "
+        "swallowed")

--- a/app/tests/test_clear_bodies.py
+++ b/app/tests/test_clear_bodies.py
@@ -1,0 +1,159 @@
+"""The clear_* subsystem bodies EXECUTED (2026-08-12 audit test-gap): the
+ordering tests in test_clear.py monkeypatch clear_redis/clear_dagu/
+clear_openobserve away, so the dangerous code — clear_redis's `ACL DELUSER
+dev-*` (the very logic behind the incident quoted in test_clear.py's header)
+— was never run by any test. Here each body runs for real: clear_redis on
+the live compose redis, clear_dagu/clear_openobserve via MockTransport."""
+
+import asyncio
+
+import httpx
+
+from devcake.api import clear as clear_mod
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ── clear_dagu (real body, MockTransport) ────────────────────────────────────
+
+
+def test_clear_dagu_stops_then_deletes_every_run(monkeypatch):
+    from devcake.adapters.dagu import DaguExecutor
+    from devcake.adapters.dagu.executor import DAG_NAME
+
+    state = {"runs": ["r-1", "r-2", "r-3"], "stopped": False, "deleted": []}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        if req.method == "POST" and path.endswith(f"/dags/{DAG_NAME}/stop-all"):
+            state["stopped"] = True
+            return httpx.Response(200, json={"errors": []})
+        if req.method == "GET" and path.endswith(f"/dag-runs/{DAG_NAME}"):
+            return httpx.Response(200, json={
+                "dagRuns": [{"dagRunId": r} for r in state["runs"]],
+                "nextCursor": None})
+        if req.method == "DELETE" and "/dag-runs/" in path:
+            rid = path.rsplit("/", 1)[-1]
+            state["deleted"].append(rid)
+            return httpx.Response(204)
+        return httpx.Response(404)
+
+    ex = DaguExecutor(base_url="http://dagu:8080",
+                      transport=httpx.MockTransport(handler))
+    out = run(clear_mod.clear_dagu(ex))   # real ~1.5s settle sleep (harmless)
+    assert state["stopped"] is True, "must stop in-flight Devs BEFORE deleting"
+    assert sorted(state["deleted"]) == ["r-1", "r-2", "r-3"]
+    assert out == {"stop_errors": [], "listed": 3, "deleted": 3, "failed": []}
+
+
+def test_clear_dagu_second_pass_retries_still_settling_runs(monkeypatch):
+    from devcake.adapters.dagu import DaguExecutor
+    from devcake.adapters.dagu.executor import DAG_NAME
+
+    attempts = {"r-slow": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        if req.method == "POST":
+            return httpx.Response(200, json={"errors": []})
+        if req.method == "GET" and path.endswith(f"/dag-runs/{DAG_NAME}"):
+            return httpx.Response(200, json={
+                "dagRuns": [{"dagRunId": "r-slow"}], "nextCursor": None})
+        if req.method == "DELETE":
+            attempts["r-slow"] += 1
+            # 400 (still running) on the first pass, 204 on the retry
+            return httpx.Response(204 if attempts["r-slow"] > 1 else 400,
+                                  text="still running")
+        return httpx.Response(404)
+
+    ex = DaguExecutor(base_url="http://dagu:8080",
+                      transport=httpx.MockTransport(handler))
+    out = run(clear_mod.clear_dagu(ex))
+    assert attempts["r-slow"] == 2 and out["deleted"] == 1 and out["failed"] == []
+
+
+# ── clear_openobserve (real body, MockTransport) ─────────────────────────────
+
+
+def test_clear_openobserve_deletes_data_streams_spares_metadata(monkeypatch):
+    monkeypatch.setattr(clear_mod, "OO_URL", "http://oo:5080")
+    monkeypatch.setattr(clear_mod, "_oo_auth_header", lambda: "Basic x")
+    deleted = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "GET" and req.url.path.endswith("/streams"):
+            return httpx.Response(200, json={"list": [
+                {"name": "traces", "stream_type": "traces"},
+                {"name": "app_logs", "stream_type": "logs"},
+                {"name": "_index", "stream_type": "metadata"},
+            ]})
+        if req.method == "DELETE":
+            deleted.append(req.url.path.rsplit("/", 1)[-1] + ":"
+                           + req.url.params.get("type", ""))
+            return httpx.Response(200)
+        return httpx.Response(404)
+
+    real_client = httpx.AsyncClient
+
+    def _client(*a, **k):
+        k["transport"] = httpx.MockTransport(handler)
+        return real_client(*a, **k)
+
+    monkeypatch.setattr(clear_mod.httpx, "AsyncClient", _client)
+    out = run(clear_mod.clear_openobserve())
+    assert sorted(out["deleted"]) == ["app_logs:logs", "traces:traces"]
+    assert "_index:metadata" not in deleted, "metadata streams must be spared"
+    assert out["errors"] == []
+
+
+# ── clear_redis (real body, LIVE compose redis) ──────────────────────────────
+
+
+def test_clear_redis_revokes_dev_acl_users_and_drains(monkeypatch):
+    """The incident logic itself: `ACL DELUSER dev-*` + reply-stream drain +
+    ingress trim, run against the live redis. (test_clear.py pins the ORDER
+    that keeps this from racing the SIGTERM grace; this pins the BODY.)"""
+    import os
+    import uuid
+
+    from devcake.adapters.redis import INGRESS, Messaging
+
+    url = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+    pw = os.environ.get("REDIS_PASSWORD", "")
+    msg = Messaging(url, pw)
+    tag = uuid.uuid4().hex[:6]
+    reply_key = f"devcake:reply:test-{tag}"
+    user = f"dev-test-{tag}"
+
+    async def main():
+        r = msg.redis
+        await r.xadd(reply_key, {"m": "secret-bearing reply"})
+        await r.xadd(INGRESS, {"m": "backlog"})
+        await r.execute_command("ACL", "SETUSER", user, "on", ">pw", "+ping")
+        msg._chunks[("x", "y", "z")] = {"parts": {}}
+
+        out = await clear_mod.clear_redis(msg)
+
+        assert await r.exists(reply_key) == 0, "reply stream (secrets) drained"
+        assert await r.xlen(INGRESS) == 0, "ingress trimmed"
+        users = await r.execute_command("ACL", "USERS")
+        names = [u.decode() if isinstance(u, (bytes, bytearray)) else str(u)
+                 for u in users]
+        assert user not in names, "leftover per-run ACL user revoked"
+        assert msg._chunks == {}, "in-process chunk reassembly cleared"
+        assert out["acl_users_deleted"] >= 1 and out["ingress_trimmed"] is True
+
+    try:
+        run(main())
+    finally:
+        # never leave the test user behind if an assert tripped mid-body
+        run(_best_effort_deluser(msg, user))
+
+
+async def _best_effort_deluser(msg, user):
+    try:
+        await msg.redis.execute_command("ACL", "DELUSER", user)
+    except Exception:  # noqa: BLE001 — teardown only
+        pass

--- a/app/tests/test_cycle_lock_wiring.py
+++ b/app/tests/test_cycle_lock_wiring.py
@@ -1,0 +1,63 @@
+"""The secret/config mutation ROUTES must thread cycle_lock (2026-08-12 audit
+test-gap): test_secret_reload_lock proves the SERVICE blocks when handed a
+held lock, but nothing guarded that the routes actually PASS s.poll_rt.lock —
+deleting `cycle_lock=...` from a route (the L-1 regression class) left every
+test green. This is the auth-surface guard's shape (test_api_surface) applied
+to the lock wiring: an AST scan over main.py's route bodies."""
+
+import ast
+from pathlib import Path
+
+MAIN = Path(__file__).resolve().parents[1] / "devcake" / "api" / "main.py"
+
+# Routes whose handler MUST forward the poll-cycle lock into its service call
+# (config/secret world-swaps — a mid-cycle mutation swaps the adapter graph
+# under a suspended poll segment; ADR-0015 L-1/L-2). Keyed by the service
+# function the route forwards to.
+LOCK_REQUIRED_CALLS = {
+    "apply_config_patch",
+    "put_secret",
+    "delete_secret",
+    "clear_secrets",
+}
+
+
+def _service_calls(tree):
+    """Every Call whose func is `<module>.<name>` or a bare `<name>`, yielded
+    as (name, node) — the route bodies forward to service functions this way."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        f = node.func
+        if isinstance(f, ast.Attribute):
+            yield f.attr, node
+        elif isinstance(f, ast.Name):
+            yield f.id, node
+
+
+def test_mutation_routes_thread_the_poll_cycle_lock():
+    tree = ast.parse(MAIN.read_text())
+    seen = {name: False for name in LOCK_REQUIRED_CALLS}
+    offenders = []
+    for name, call in _service_calls(tree):
+        if name not in LOCK_REQUIRED_CALLS:
+            continue
+        seen[name] = True
+        has_lock = any(kw.arg == "cycle_lock" for kw in call.keywords)
+        # the value must be the real poll lock, not None/a placeholder
+        lock_kw = next((kw for kw in call.keywords if kw.arg == "cycle_lock"),
+                       None)
+        good = has_lock and lock_kw is not None and (
+            isinstance(lock_kw.value, ast.Attribute)
+            and lock_kw.value.attr == "lock")
+        if not good:
+            offenders.append(name)
+    missing = [n for n, hit in seen.items() if not hit]
+    assert not missing, (
+        f"expected these lock-required routes in main.py but did not find "
+        f"their service calls (renamed? move the name into this guard): "
+        f"{missing}")
+    assert not offenders, (
+        f"these mutation routes do not forward cycle_lock=<poll_rt.lock> — "
+        f"a mid-cycle secret/config write would swap the adapter graph under "
+        f"a suspended poll segment (L-1/L-2): {offenders}")

--- a/app/tests/test_dispatch_chokepoint.py
+++ b/app/tests/test_dispatch_chokepoint.py
@@ -105,7 +105,30 @@ def test_prod_wires_a_real_workspace_store():
     MUST inject the real WorkspaceStore, or every dispatch would run onto an
     unmanaged workspace with no pre-create, cleanup, or fail-closed gate.
     Guard the wiring so dropping it fails CI rather than silently degrading.
-    ADR-0028: the composition root lives in api/services.py now."""
+    ADR-0028: the composition root lives in api/services.py now.
+
+    AST, not substring (2026-08-12 audit test-gap): `"WorkspaceStore(" in src`
+    is ALSO satisfied by `NullWorkspaceStore(` — the exact silent-no-op
+    regression the guard exists to catch — and by `workspaces=workspaces`
+    even if the object bound there is null. This checks a real call to the
+    class whose name is EXACTLY WorkspaceStore, passed as workspaces=."""
+    tree = ast.parse((ROOT / "api" / "services.py").read_text())
+    real_ctor = any(
+        isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        and n.func.id == "WorkspaceStore"
+        for n in ast.walk(tree))
+    assert real_ctor, (
+        "prod must construct a REAL WorkspaceStore (exact name) — "
+        "NullWorkspaceStore does not satisfy the AUD-016 guard")
+    wired = any(
+        isinstance(n, ast.Call)
+        and any(kw.arg == "workspaces"
+                and isinstance(kw.value, ast.Name)
+                and kw.value.id == "workspaces"
+                for kw in n.keywords)
+        for n in ast.walk(tree))
+    assert wired, "RunManager must be wired workspaces=<the real store>"
+    # the legacy substring assertions kept as a cheap belt-and-braces
     src = (ROOT / "api" / "services.py").read_text()
     assert "WorkspaceStore(" in src, "prod must construct a real WorkspaceStore"
     assert "workspaces=workspaces" in src, \

--- a/app/tests/test_grace_cycle.py
+++ b/app/tests/test_grace_cycle.py
@@ -1,0 +1,77 @@
+"""The grace-cycle skip END-TO-END (2026-08-12 audit test-gap): after DevCake
+writes to a mission's PMO feed, the NEXT poll cycle must not re-dispatch that
+mission on the feedback loop it just created (docs/04 §2). The wiring is
+feed._audit → mgr._grace_next → poll.rotate_grace → schedule skips _grace.
+The only prior touch of _grace_next poked a SimpleNamespace attribute; here
+the real chain runs, so deleting the schedule skip (or the rotate) turns the
+suite red."""
+
+import asyncio
+
+from devcake.domain.orchestrator import schedule
+from devcake.domain.run import Run
+
+from test_transitions import make_mgr, mission
+
+
+def run_coro(c):
+    return asyncio.new_event_loop().run_until_complete(c)
+
+
+def _backlog_mgr(tmp_path, monkeypatch):
+    """A schedulable backlog mission on a resolved repo, real _audit wired to
+    an isolated audit log (make_mgr's noop_audit would bypass _grace_next)."""
+    import devcake.domain.orchestrator as orchestrator_mod
+
+    m = mission("backlog", {"DEVCAKE"})
+    mgr, fake, store = make_mgr(tmp_path, m)
+    # ONBOARD (backlog derives to it) must staff the ONE dev type make_mgr
+    # provides, or the assignment gate — not grace — is what skips
+    from devcake.config import Assignment
+    mgr.config.assignments = {mt: Assignment(dev_type="senior-dev")
+                              for mt in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW")}
+    # restore the REAL _audit (make_mgr no-ops it) so it feeds _grace_next,
+    # and point its append at a tmp file
+    monkeypatch.setattr(orchestrator_mod.markers, "AUDIT_PATH",
+                        tmp_path / "events.jsonl")
+    del mgr._audit          # drop the noop override → the class method returns
+    dispatched = []
+
+    async def fake_dispatch(mission_, mtype, dev_type):
+        dispatched.append(mission_.pmo_id)
+        return None
+
+    mgr.dispatch = fake_dispatch
+    # a resolved repo so the per-mission repo gate doesn't pre-empt the test
+    m.repo = "main"
+    return mgr, fake, m, dispatched
+
+
+def test_own_write_defers_dispatch_one_cycle(tmp_path, monkeypatch):
+    mgr, fake, m, dispatched = _backlog_mgr(tmp_path, monkeypatch)
+
+    # cycle 1: a normal audit (as any feed write does) marks the mission for
+    # the grace skip, THEN the cycle ends and grace rotates
+    mgr._audit(m.pmo_id, "label_swap", "DEVCAKE→DEVCAKE-PLAN")
+    assert m.pmo_id in mgr._grace_next
+    mgr.rotate_grace()                       # poll.py does this per segment
+    assert m.pmo_id in mgr._grace
+
+    # cycle 2: schedule must SKIP the mission we just wrote to — deleting the
+    # `if m.pmo_id in mgr._grace: continue` line makes this dispatch (red)
+    run_coro(schedule.schedule(mgr, [m], gate={}))
+    assert dispatched == [], "a mission written to last cycle must not dispatch"
+
+    # cycle 3: grace has rotated empty, so it dispatches normally now
+    mgr.rotate_grace()
+    run_coro(schedule.schedule(mgr, [m], gate={}))
+    assert dispatched == [m.pmo_id], "the skip is ONE cycle, not permanent"
+
+
+def test_grace_is_not_triggered_without_a_write(tmp_path, monkeypatch):
+    """The skip must be precise: a mission we did NOT write to dispatches on
+    the very first cycle."""
+    mgr, fake, m, dispatched = _backlog_mgr(tmp_path, monkeypatch)
+    mgr.rotate_grace()                        # empty rotate, no prior audit
+    run_coro(schedule.schedule(mgr, [m], gate={}))
+    assert dispatched == [m.pmo_id]


### PR DESCRIPTION
Phase 2 PR-13 of the 2026-08-12 audit intervention campaign — the test-suite audit's named holes.

- **Grace-cycle skip e2e** — the feedback-loop guard, previously untested end-to-end; deleting the schedule skip now turns red.
- **clear_redis/clear_dagu/clear_openobserve bodies executed** — the ordering tests monkeypatched them away, so the `ACL DELUSER dev-*` incident logic never ran. Live-redis for clear_redis, MockTransport for the other two.
- **AUD-016 substring → AST** — `"WorkspaceStore(" in src` matched `NullWorkspaceStore(`, the exact regression it guards; now an AST call to the exact class name (verified to reject the null shape).
- **Route-level cycle_lock wiring** — the L-1 lock was proven only at the service layer; an AST guard now pins that the mutation routes forward `s.poll_rt.lock`.
- **Boot path** — `_log_task_death` loud-on-crash / silent-on-clean (the silent-death class), and the SEC-3 boot-refusal wiring source-guarded.

Suite: **1732 passed, 1 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)