### PR TITLE
fix(spa): instance-qualified refs, self-healing projection, stale-response guards

### DIFF
--- a/admin/spa/DESIGN.md
+++ b/admin/spa/DESIGN.md
@@ -251,6 +251,33 @@ semantically distinct:
 - **A11y minimums**: icon-only buttons get `aria-label`; menus get
   `aria-haspopup`/`aria-expanded` + `role="menu"`/`menuitem`; glyphs get
   `role="img"` + `aria-label`; decorative icons get `aria-hidden`.
+- **Optimistic overrides key on the (instance, pmo_id) ref, never the bare
+  id** (`lib/reqSeq.js`'s sibling concern): gitea_issues pmo_ids are per-repo
+  issue numbers, so #3 collides across boards — a bare-id key painted a Park
+  on one board onto the colliding id on another (2026-08-12 audit). Every
+  action/comment also sends `instance` so the server resolves the right board
+  (`mission_actions._find_row`). And an override self-heals after
+  `PROJECTION_MAX_POLLS` even if the server advanced to a state the projection
+  never predicted — an exact-label-match test alone would stick forever.
+- **Stale responses are dropped, not committed** (`lib/reqSeq.js`): loaders
+  that re-fire on changing deps (RunsPage's eight filters) or from many call
+  sites with no in-flight guard (ConfigDraftContext.reload) tag each request
+  with a monotonic token; a resolution that is not the latest is dropped. A
+  config rebase resolving out of order otherwise rolled the server baseline
+  backward, and since config does not poll the phantom dirt persisted.
+
+### Accepted single-operator scope (ledgered, NOT built — founder ruling
+2026-08-12)
+
+The control plane is single-operator by construction and stays that way for
+now: `PUT /config` is last-write-wins with an edits-win rebase, and there is
+no `If-Match`/version stamp on config or secret writes. With two admins, a
+second operator's change is overwritten with no conflict surface. This is a
+real liability the day there are two admins and the deliberate fix is
+end-to-end config versioning (backend version stamp → SPA `If-Match` → 409 +
+conflict UI) — out of scope for the audit-remediation campaign, which
+addressed only the single-operator correctness bugs above. Do not add
+optimistic multi-writer behavior without that versioning.
 
 ---
 

--- a/admin/spa/package.json
+++ b/admin/spa/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "check:ui": "node tests/run.mjs",
-    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs && node tests/config_draft.mjs && node tests/contracts.mjs"
+    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs && node tests/config_draft.mjs && node tests/contracts.mjs && node tests/req_seq.mjs"
   },
   "dependencies": {
     "@fontsource-variable/bricolage-grotesque": "^5.2.10",

--- a/admin/spa/src/components/MissionDrawer.jsx
+++ b/admin/spa/src/components/MissionDrawer.jsx
@@ -66,6 +66,7 @@ export default function MissionDrawer({ mission, multiPmo, syncing, rows, adopti
     try {
       await send("POST", `/missions/${encodeURIComponent(mission.pmo_id)}/comment`, {
         body,
+        instance: mission.instance,   // disambiguate a colliding pmo_id
       });
       setComment("");
       setFlash(

--- a/admin/spa/src/lib/ConfigDraftContext.jsx
+++ b/admin/spa/src/lib/ConfigDraftContext.jsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from "react";
 import { get } from "../api.js";
 import useConfigDraft from "./useConfigDraft.js";
+import { makeReqSeq } from "./reqSeq.js";
 
 // ONE unified draft over {cfg, devTypes, assignments}, shared by the
 // Configuration, Repositories and PMO pages (v0.1.1 B4 + 2026-08-02 nav
@@ -15,6 +16,7 @@ export function ConfigDraftProvider({ children }) {
   const [healthInfo, setHealthInfo] = useState(null);
   const [loadErr, setLoadErr] = useState("");
   const firstLoad = useRef(true);
+  const reloadSeq = useRef(makeReqSeq());
   // "new card" name tracking for PMO and repo cards lives HERE (audit D5
   // #12, extended): pages unmount on navigation, and a card added this
   // session must keep its editable-name status when the operator returns —
@@ -23,10 +25,16 @@ export function ConfigDraftProvider({ children }) {
   const repoNewNamesState = useState(() => new Set());
 
   const reload = async () => {
+    // stale-response guard: reload() fires from six places; two overlapping
+    // reloads resolving out of order used to rebase() the OLDER snapshot last
+    // — rolling the server baseline backward, and since config does not poll,
+    // the phantom dirt persisted until the next action (2026-08-12 audit)
+    const mine = reloadSeq.current.next();
     const [c, d, a, hs, h] = await Promise.all([
       get("/config"), get("/dev-types"), get("/assignments"),
       get("/harnesses"), get("/health").catch(() => null),
     ]);
+    if (!reloadSeq.current.isLatest(mine)) return;   // a newer reload won
     setHarnesses(hs);
     setHealthInfo(h);
     if (firstLoad.current) { dr.load(c, d, a); firstLoad.current = false; }

--- a/admin/spa/src/lib/reqSeq.js
+++ b/admin/spa/src/lib/reqSeq.js
@@ -1,0 +1,30 @@
+// Stale-response guard (2026-08-12 audit): several loaders re-fire on
+// changing deps (RunsPage's eight filter deps) or from many call sites with
+// no in-flight guard (ConfigDraftContext.reload). Without ordering, an
+// in-flight response for an OLD query resolving AFTER a newer one commits
+// wrong-query data — RunsPage self-corrects at the next 10s tick, but a
+// config rebase rolls the server baseline BACKWARD and the phantom dirt
+// persists (config does not poll). No AbortController rewrite needed: a
+// monotonic sequence per surface, and a resolution whose sequence is not
+// the latest is dropped.
+//
+// Usage:
+//   const seq = makeReqSeq();
+//   const load = async () => {
+//     const mine = seq.next();
+//     const data = await fetch(...);
+//     if (!seq.isLatest(mine)) return;   // a newer load already committed
+//     commit(data);
+//   };
+export function makeReqSeq() {
+  let latest = 0;
+  return {
+    next() {
+      latest += 1;
+      return latest;
+    },
+    isLatest(token) {
+      return token === latest;
+    },
+  };
+}

--- a/admin/spa/src/pages/MissionsPage.jsx
+++ b/admin/spa/src/pages/MissionsPage.jsx
@@ -16,6 +16,19 @@ import { bucketize, COLUMNS, unadoptedHiddenCount } from "../lib/board.js";
 // to expect a faster PMO round-trip than exists.
 const POLL_MS = 10_000;
 
+// Optimistic-override identity: gitea_issues pmo_ids are per-repo issue
+// numbers, so an override must be keyed by (instance, pmo_id), never the bare
+// id (2026-08-12 audit — a Park on one board bled onto a colliding id on
+// another). `instance` may be "" on a single-PMO deployment; that is fine —
+// there is exactly one board to collide on.
+const refKey = (instance, pmo_id) => `${instance || ""}::${pmo_id}`;
+
+// Self-heal bound: the scheduler can advance a mission to a THIRD state the
+// optimistic projection never predicted, and an exact-label-match test would
+// then keep overriding the real row FOREVER. Drop the override after this
+// many polls (~this×10s) regardless — the server row is authoritative.
+const PROJECTION_MAX_POLLS = 6;
+
 // Done is history, not work: the section previews the newest few and unfolds
 // on demand (bucketize itself already caps Done at its 30 newest).
 const DONE_PREVIEW = 10;
@@ -116,8 +129,11 @@ export default function MissionsPage() {
     dependency_cycles: [],
   });
   const [error, setError] = useState("");
-  // per-mission optimistic overrides (pmo_id → { labels, syncing:true }).
-  // Cleared once the next /missions poll confirms the change.
+  // per-mission optimistic overrides, keyed by the INSTANCE-QUALIFIED ref
+  // (2026-08-12 audit): gitea_issues pmo_ids are per-repo issue numbers, so a
+  // bare-pmo_id key painted a Park on gitea1's #3 onto linear1's #3 too. Each
+  // entry is { labels, syncing, polls } — `polls` bounds the self-heal so a
+  // projection can never stick forever if the server advances PAST it.
   const [pending, setPending] = useState({});
   const [openMission, setOpenMission] = useState(null);
   const [showAllDone, setShowAllDone] = useState(false);
@@ -139,7 +155,7 @@ export default function MissionsPage() {
       } catch { /* storage unavailable — the toggle still works this session */ }
       return next;
     });
-  const [confirmAction, setConfirmAction] = useState(null); // {pmo_id, action}
+  const [confirmAction, setConfirmAction] = useState(null); // {ref:{pmo_id,instance}, action}
   const [confirmBusy, setConfirmBusy] = useState(false);
   const [flash, setFlash] = useState("");
   const [pollBusy, setPollBusy] = useState(false);
@@ -191,11 +207,22 @@ export default function MissionsPage() {
       }
       setPending((prev) => {
         const next = {};
-        for (const [pmo_id, entry] of Object.entries(prev)) {
-          const row = missionsBody.missions.find((m) => m.pmo_id === pmo_id);
+        for (const [key, entry] of Object.entries(prev)) {
+          // match the SAME (instance, pmo_id) the override was minted for —
+          // never a colliding id on another board
+          const row = missionsBody.missions.find(
+            (m) => refKey(m.instance, m.pmo_id) === key,
+          );
           const serverLabels = row ? [...(row.labels || [])].sort().join(",") : null;
           const projected = [...(entry.labels || [])].sort().join(",");
-          if (serverLabels !== projected) next[pmo_id] = entry;
+          const polls = (entry.polls || 0) + 1;
+          // drop when the server confirms the projection OR after the
+          // self-heal bound — the scheduler may advance the mission to a
+          // THIRD state the projection never predicted, and a bare
+          // exact-match test would then override the real row forever
+          if (serverLabels !== projected && polls < PROJECTION_MAX_POLLS) {
+            next[key] = { ...entry, polls };
+          }
         }
         return next;
       });
@@ -209,7 +236,7 @@ export default function MissionsPage() {
 
   const rows = useMemo(() => {
     return (data.missions || []).map((row) => {
-      const p = pending[row.pmo_id];
+      const p = pending[refKey(row.instance, row.pmo_id)];
       if (!p) return row;
       return { ...row, labels: p.labels };
     });
@@ -246,14 +273,17 @@ export default function MissionsPage() {
     [filteredRows, data.adoption_mode]
   );
 
-  const doAction = async (pmo_id, action) => {
+  const doAction = async ({ pmo_id, instance }, action) => {
     try {
       const result = await send("POST", `/missions/${encodeURIComponent(pmo_id)}/actions`, {
         action,
+        instance,   // disambiguates a colliding pmo_id server-side
       });
       setPending((prev) => ({
         ...prev,
-        [pmo_id]: { labels: result.labels || [], syncing: true },
+        [refKey(instance, pmo_id)]: {
+          labels: result.labels || [], syncing: true, polls: 0,
+        },
       }));
       setFlash(`${action} sent — waiting for the next poll to confirm.`);
       setTimeout(() => setFlash(""), 4000);
@@ -262,11 +292,11 @@ export default function MissionsPage() {
     }
   };
 
-  const requestAction = (pmo_id, action) => {
+  const requestAction = (ref, action) => {
     if (CONFIRM_COPY[action]) {
-      setConfirmAction({ pmo_id, action });
+      setConfirmAction({ ref, action });
     } else {
-      doAction(pmo_id, action);
+      doAction(ref, action);
     }
   };
 
@@ -274,7 +304,7 @@ export default function MissionsPage() {
     if (!confirmAction) return;
     setConfirmBusy(true);
     try {
-      await doAction(confirmAction.pmo_id, confirmAction.action);
+      await doAction(confirmAction.ref, confirmAction.action);
       setConfirmAction(null);
     } finally {
       setConfirmBusy(false);
@@ -561,10 +591,10 @@ export default function MissionsPage() {
                     key={`${row.instance}:${row.pmo_id}`}
                     row={row}
                     multiPmo={multiPmo}
-                    syncing={!!pending[row.pmo_id]?.syncing}
+                    syncing={!!pending[refKey(row.instance, row.pmo_id)]?.syncing}
                     sectionReason={shared}
                     onOpen={() => setOpenMission(row)}
-                    onAction={(action) => requestAction(row.pmo_id, action)}
+                    onAction={(action) => requestAction({ pmo_id: row.pmo_id, instance: row.instance }, action)}
                   />
                 ))}
               </div>
@@ -580,13 +610,13 @@ export default function MissionsPage() {
           key={`${openMission.instance}:${openMission.pmo_id}`}
           mission={openMission}
           multiPmo={multiPmo}
-          syncing={!!pending[openMission.pmo_id]?.syncing}
+          syncing={!!pending[refKey(openMission.instance, openMission.pmo_id)]?.syncing}
           rows={rows}
           adoptionMode={data.adoption_mode}
           cycles={pollState.dependency_cycles}
           onOpenMission={(row) => setOpenMission(row)}
           onClose={() => setOpenMission(null)}
-          onAction={(action) => requestAction(openMission.pmo_id, action)}
+          onAction={(action) => requestAction({ pmo_id: openMission.pmo_id, instance: openMission.instance }, action)}
         />
       )}
       {confirmAction && (

--- a/admin/spa/src/pages/RunsPage.jsx
+++ b/admin/spa/src/pages/RunsPage.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight, ExternalLink, SquareTerminal } from "lucide-react";
 import { get, send } from "../api.js";
+import { makeReqSeq } from "../lib/reqSeq.js";
 import PageHeader from "../components/PageHeader.jsx";
 import { Card } from "../components/Card.jsx";
 import Button from "../components/Button.jsx";
@@ -55,6 +56,9 @@ export default function RunsPage() {
   // orders GROUPS by their aggregate (founder decision 2026-08-02)
   const [grouped, setGrouped] = useState(false);
 
+  // stale-response guard: eight filter deps re-fire load; an old query
+  // resolving after a newer one must not overwrite the fresh rows (2026-08-12)
+  const seq = useRef(makeReqSeq());
   const load = () => {
     const q = `/runs?limit=${PAGE}&offset=${offset}` +
       (query ? `&mission_key=${encodeURIComponent(query)}` : "") +
@@ -63,7 +67,10 @@ export default function RunsPage() {
       (toDate ? `&created_to=${toDate}` : "") +
       `&sort=${sortKey}&dir=${sortDir}` +
       (grouped ? "&group_by=mission" : "");
-    return get(q).then(setData).catch(() => {});
+    const mine = seq.current.next();
+    return get(q).then((d) => {
+      if (seq.current.isLatest(mine)) setData(d);   // drop out-of-order
+    }).catch(() => {});
   };
 
   usePoll(load, 10000, [offset, query, pmoRef, fromDate, toDate,

--- a/admin/spa/tests/req_seq.mjs
+++ b/admin/spa/tests/req_seq.mjs
@@ -1,0 +1,48 @@
+// Pure-node checks for the stale-response guard (2026-08-12 audit): an old
+// request resolving AFTER a newer one must be dropped, so a config rebase
+// never rolls the server baseline backward and a filtered runs query never
+// overwrites fresh rows with stale ones.
+import assert from "node:assert/strict";
+import { makeReqSeq } from "../src/lib/reqSeq.js";
+
+let failed = 0;
+const check = (name, fn) => {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.log(`  ✗ ${name}: ${e.message}`);
+  }
+};
+
+check("the latest token wins; an earlier one is stale", () => {
+  const seq = makeReqSeq();
+  const a = seq.next();
+  const b = seq.next();
+  assert.equal(seq.isLatest(b), true);
+  assert.equal(seq.isLatest(a), false, "the older request must be dropped");
+});
+
+check("out-of-order resolution: only the newest commit lands", () => {
+  const seq = makeReqSeq();
+  const committed = [];
+  // simulate two loads issued A then B, resolving B then A
+  const a = seq.next();
+  const b = seq.next();
+  if (seq.isLatest(b)) committed.push("B");   // resolves first
+  if (seq.isLatest(a)) committed.push("A");   // resolves second — stale
+  assert.deepEqual(committed, ["B"], "the stale A resolution must not commit");
+});
+
+check("a single in-flight request commits normally", () => {
+  const seq = makeReqSeq();
+  const t = seq.next();
+  assert.equal(seq.isLatest(t), true);
+});
+
+if (failed) {
+  console.error(`req_seq.mjs: ${failed} check(s) failed`);
+  process.exit(1);
+}
+console.log("req_seq.mjs: all checks passed");

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -313,10 +313,12 @@ TERMINAL_STATES = {"finished", "failed", "timed_out", "orphaned"}
 
 class _MissionActionBody(BaseModel):
     action: str
+    instance: str | None = None   # disambiguates colliding pmo_ids (F: SPA)
 
 
 class _SteeringBody(BaseModel):
     body: str
+    instance: str | None = None
 
 
 class _CreateAttachment(BaseModel):
@@ -355,7 +357,7 @@ async def mission_action(pmo_id: str, body: _MissionActionBody):
     s = svc()
     return await label_action(pmo_id, body.action,
                               missions_cache=s.poll_rt.missions_cache,
-                              managers=s.managers)
+                              managers=s.managers, instance=body.instance)
 
 
 @app.post("/api/v1/missions/{pmo_id}/comment")
@@ -366,7 +368,7 @@ async def mission_comment(pmo_id: str, body: _SteeringBody):
     s = svc()
     return await post_steering(pmo_id, body.body,
                                missions_cache=s.poll_rt.missions_cache,
-                               managers=s.managers)
+                               managers=s.managers, instance=body.instance)
 
 
 @app.post("/api/v1/poll/run")

--- a/app/devcake/api/mission_actions.py
+++ b/app/devcake/api/mission_actions.py
@@ -87,11 +87,31 @@ class _RunManager(Protocol):
 
 # ── helpers ─────────────────────────────────────────────────────────────────
 
-def _find_row(missions_cache: list[dict], pmo_id: str) -> dict:
-    for row in missions_cache:
-        if row.get("pmo_id") == pmo_id:
-            return row
-    raise HTTPException(status_code=404, detail="mission not found")
+def _find_row(missions_cache: list[dict], pmo_id: str,
+              instance: str | None = None) -> dict:
+    """Resolve one mission row. `pmo_id` alone matched the FIRST cache row
+    (mission_actions.py:90, 2026-08-12 audit) — but gitea_issues pmo_ids are
+    per-repo issue NUMBERS, so #3 collides across instances and the action
+    could land on the wrong board. When the caller qualifies with `instance`
+    (the SPA does whenever ≥2 PMOs are configured), match both; a bare id
+    that now resolves to >1 instance is a 409, not a silent wrong-board hit."""
+    if instance:
+        for row in missions_cache:
+            if row.get("pmo_id") == pmo_id and row.get("instance") == instance:
+                return row
+        raise HTTPException(
+            status_code=404,
+            detail=f"mission {pmo_id} not found on instance {instance!r}")
+    matches = [row for row in missions_cache if row.get("pmo_id") == pmo_id]
+    if not matches:
+        raise HTTPException(status_code=404, detail="mission not found")
+    if len({row.get("instance") for row in matches}) > 1:
+        raise HTTPException(
+            status_code=409,
+            detail=f"mission id {pmo_id} exists on multiple instances "
+                   f"({sorted({r.get('instance') for r in matches})}) — "
+                   f"retry with an explicit instance")
+    return matches[0]
 
 
 def _resolve_mgr(managers: dict[str, Any], instance_name: str) -> Any:
@@ -122,6 +142,7 @@ async def label_action(
     *,
     missions_cache: list[dict],
     managers: dict[str, Any],
+    instance: str | None = None,
 ) -> dict:
     """Apply the label swap for one UI action. Returns the projected label list."""
     spec = ACTION_SPECS.get(action)
@@ -131,7 +152,7 @@ async def label_action(
             detail=f"unknown action: {action!r}; "
                    f"expected one of {sorted(ACTION_SPECS)}")
 
-    row = _find_row(missions_cache, pmo_id)
+    row = _find_row(missions_cache, pmo_id, instance)
     mgr = _resolve_mgr(managers, row["instance"])
 
     labels = set(row.get("labels") or [])
@@ -174,12 +195,13 @@ async def post_steering(
     *,
     missions_cache: list[dict],
     managers: dict[str, Any],
+    instance: str | None = None,
 ) -> dict:
     """Post a human-authored feed comment (no sentinel) on behalf of the operator."""
     if not (body and body.strip()):
         raise HTTPException(status_code=422, detail="body must not be blank")
 
-    row = _find_row(missions_cache, pmo_id)
+    row = _find_row(missions_cache, pmo_id, instance)
     mgr = _resolve_mgr(managers, row["instance"])
 
     ref = MissionRef(pmo_id, row["kind"])

--- a/app/tests/test_mission_actions.py
+++ b/app/tests/test_mission_actions.py
@@ -447,3 +447,48 @@ def test_stop_all_isolates_a_failing_kill():
     assert out["ok"] is False
     assert out["errors"][0]["run_id"] == "r-2"
     assert "read-only" in out["errors"][0]["error"]
+
+
+# ── instance-qualified resolution (2026-08-12 audit: colliding pmo_ids) ──────
+
+
+def test_colliding_pmo_id_without_instance_is_a_409():
+    """gitea_issues pmo_ids are per-repo issue numbers: #3 exists on two
+    boards. A bare id used to hit the FIRST cache row (wrong board); it now
+    refuses so the SPA must qualify."""
+    cache = [_row(pmo_id="3", instance="gitea1", labels={"DEVCAKE", "DEVCAKE-FAILED"}),
+             _row(pmo_id="3", instance="gitea2", labels={"DEVCAKE", "DEVCAKE-FAILED"})]
+    managers = {"gitea1": FakeMgr(), "gitea2": FakeMgr()}
+    with pytest.raises(HTTPException) as exc:
+        run(ma.label_action("3", "retry", missions_cache=cache,
+                            managers=managers))
+    assert exc.value.status_code == 409
+    assert "multiple instances" in exc.value.detail
+    assert not managers["gitea1"].pmo.swaps and not managers["gitea2"].pmo.swaps
+
+
+def test_instance_qualifier_lands_on_the_right_board():
+    cache = [_row(pmo_id="3", instance="gitea1", labels={"DEVCAKE", "DEVCAKE-FAILED"}),
+             _row(pmo_id="3", instance="gitea2", labels={"DEVCAKE", "DEVCAKE-FAILED"})]
+    managers = {"gitea1": FakeMgr(), "gitea2": FakeMgr()}
+    run(ma.label_action("3", "retry", missions_cache=cache,
+                        managers=managers, instance="gitea2"))
+    assert not managers["gitea1"].pmo.swaps, "the other board is untouched"
+    assert len(managers["gitea2"].pmo.swaps) == 1
+
+
+def test_instance_qualifier_not_found_is_404():
+    cache = [_row(pmo_id="3", instance="gitea1", labels={"DEVCAKE"})]
+    with pytest.raises(HTTPException) as exc:
+        run(ma.label_action("3", "retry", missions_cache=cache,
+                            managers={"gitea1": FakeMgr()}, instance="ghost"))
+    assert exc.value.status_code == 404
+
+
+def test_bare_id_single_instance_still_works():
+    """The common single-PMO case: a bare id with exactly one match resolves
+    unchanged (no qualifier needed)."""
+    cache, managers = _fresh_env(row_labels={"DEVCAKE", "DEVCAKE-FAILED"})
+    result = run(ma.label_action("pmo-1", "retry", missions_cache=cache,
+                                 managers=managers))
+    assert "DEVCAKE-FAILED" not in result["labels"]


### PR DESCRIPTION
Phase 2 PR-11 of the 2026-08-12 audit intervention campaign — SPA concurrency, **minimal scope** per founder ruling (multi-admin If-Match ledgered, not built).

- **Ref disambiguation:** `_find_row` matched the first cache row for a bare `pmo_id`; gitea_issues ids collide across boards. Now `instance`-qualified (bare id → 409 on collision); SPA sends `instance` on every action/comment.
- **Projection keyed by `(instance, pmo_id)` + self-heal:** kills the cross-instance bleed *and* the stuck-forever projection (drops after `PROJECTION_MAX_POLLS`).
- **Stale-response guards** (`lib/reqSeq.js`): RunsPage + ConfigDraftContext drop out-of-order resolutions — no more config baseline rolling backward.
- **DESIGN.md:** the fixes as gotchas + the accepted single-operator scope ledgered (the If-Match fix named for the two-admin day).

Backend: colliding-id 409 / right-board / 404 / single-instance tests. SPA: reqSeq out-of-order drop, wired into `test:helpers`. Suite **1729 passed**; SPA helpers green; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)