### PR TITLE
fix(discovery): gate only mirror-eligible family repos (zero-repo wedge)

### DIFF
--- a/app/devcake/domain/steward_service.py
+++ b/app/devcake/domain/steward_service.py
@@ -179,8 +179,16 @@ class StewardService:
                     mgr._discoveries_pending.discard(s.pmo_id)
             if not pending:
                 return
+            # mirror-ELIGIBLE names only (the needed_for precedent): the
+            # family's work repos legitimately include INTERNAL per-mission
+            # repos — valid clone extras (direct, mission-scoped creds) but
+            # never mirrored (ADR-0024 §5 security ruling). Passing one to
+            # ensure_fresh would 401 the unauthenticated mirror fetch and
+            # wedge the gate mirror_stale forever on zero-repo boards
+            # (found by the graduation-smoke prep, 2026-08-13).
             fam_repos = [e["repo_ref"] for e in family_graph.family_work_repos(
-                mgr, fam, exclude=frozenset({repo}))]
+                mgr, fam, exclude=frozenset({repo}))
+                if mgr.repo_cache.eligible(e["repo_ref"])]
             mirror_ok, mirror_why = await mgr.repo_cache.ensure_fresh(
                 [repo] + fam_repos)
             if not mirror_ok:

--- a/app/tests/test_discovery_trigger.py
+++ b/app/tests/test_discovery_trigger.py
@@ -228,9 +228,18 @@ def test_gate_filters_mirror_ineligible_family_repos(tmp_path, monkeypatch):
     forever on zero-repo boards (graduation-smoke prep find, 2026-08-13)."""
     from devcake.domain.orchestrator import family_graph
     pmo, mgr, svc, calls, missions = _svc_setup(tmp_path)
+    missions[1].blocked_by = ["src"]          # sibling JOINS src's family
     missions[1].repo = "intmission1"          # the sibling's internal repo
     monkeypatch.setattr(family_graph, "blocker_read_credential",
                         lambda mgr_, name: ("internal", object()))
+    # Positive control (audit find: the first cut of this test never linked
+    # the missions into one family, so the asserts passed on the UNFIXED
+    # code). The family wiring must genuinely surface intmission1 — only
+    # then does the eligible() filter carry the assertions below.
+    fam = family_graph.family_of(missions[0], missions)
+    assert "intmission1" in [
+        e["repo_ref"] for e in family_graph.family_work_repos(
+            mgr, fam, exclude=frozenset({"home"}))]
     asked: list[list[str]] = []
 
     class Cache:

--- a/app/tests/test_discovery_trigger.py
+++ b/app/tests/test_discovery_trigger.py
@@ -218,3 +218,32 @@ def test_harvest_notify_seam_is_best_effort(tmp_path):
     store.save(r2)
     n = run_coro(discovery.harvest(mgr2, r2, {"discoveries": [entry]}))
     assert n == 1                                  # close never wedged
+
+
+def test_gate_filters_mirror_ineligible_family_repos(tmp_path, monkeypatch):
+    """The family's work repos legitimately include INTERNAL per-mission
+    repos — valid clone extras, never mirrored (ADR-0024 §5). The gate must
+    pass only mirror-ELIGIBLE names to ensure_fresh: an internal name would
+    401 the unauthenticated mirror fetch and wedge the lane mirror_stale
+    forever on zero-repo boards (graduation-smoke prep find, 2026-08-13)."""
+    from devcake.domain.orchestrator import family_graph
+    pmo, mgr, svc, calls, missions = _svc_setup(tmp_path)
+    missions[1].repo = "intmission1"          # the sibling's internal repo
+    monkeypatch.setattr(family_graph, "blocker_read_credential",
+                        lambda mgr_, name: ("internal", object()))
+    asked: list[list[str]] = []
+
+    class Cache:
+        def eligible(self, name):
+            return name == "home"             # only the steward's card
+        async def ensure_fresh(self, names):
+            asked.append(sorted(names))
+            assert "intmission1" not in names, \
+                "internal repo reached the mirror gate"
+            return True, {}
+
+    mgr.repo_cache = Cache()
+    mgr._discoveries_pending.add("src")
+    run_coro(svc.maybe_dispatch_discovery(missions))
+    assert len(calls) == 1        # dispatched despite the internal sibling
+    assert asked and all("intmission1" not in a for a in asked)


### PR DESCRIPTION
Found while preparing the ADR-0033 graduation smoke on the managed zero-repo board — before it wedged live.

`family_work_repos` legitimately includes **internal per-mission repos** (valid direct-clone extras with mission-scoped credentials), but `maybe_dispatch_discovery` passed them straight into `repo_cache.ensure_fresh`. Internal repos are mirror-**ineligible** by ADR-0024 §5 (security ruling: they stay direct-clone), so the unauthenticated mirror fetch would 401 and wedge the discovery lane `mirror_stale` **forever** on any family of internal missions — i.e., on every zero-repo/default-board deployment.

The mission-dispatch gate never had this bug (its `needed_for` applies the eligibility filter); this call site missed it. Fix mirrors the precedent: filter through `repo_cache.eligible()` at the gate. The clone set (`Run.blocker_work`) deliberately keeps the internal entries — `_launch_steward` already eligibility-filters its `mirror_repos` snapshot separately.

Regression test: an internal-repo sibling (blocker-cred–mountable) never reaches `ensure_fresh` while the dispatch proceeds.

Suite 1838 passed, 1 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)