### PR TITLE
feat(pmo): GitLab Issues adapter

### DIFF
--- a/admin/spa/src/components/NewMissionDialog.jsx
+++ b/admin/spa/src/components/NewMissionDialog.jsx
@@ -122,6 +122,11 @@ export default function NewMissionDialog({ adoptionMode, onClose, onCreated }) {
             </Select>
           </Field>
         )}
+        {sysMeta?.operator_note ? (
+          <p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/60 dark:text-amber-300">
+            {sysMeta.operator_note}
+          </p>
+        ) : null}
         <Field label="Title" hint="Short summary — the Dev sees this verbatim.">
           <Input
             autoFocus

--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -209,7 +209,7 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
           }
           const sysMeta = (registry.pmo_systems || []).find((s) => s.id === inst.system)
             || { needs_api_base: false, team_key_label: "Team key",
-                 team_key_help: "", api_base_help: "" };
+                 team_key_help: "", api_base_help: "", operator_note: "" };
           const saved = savedPmoNames.has(inst.name);
           const nameBad = !!dr.errors[`cfg.pmos.${idx}.name`];
           const healthPaused = !!(health.pmo_instances || {})[inst.name]?.intake_paused;
@@ -317,6 +317,11 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
                     ))}
                   </select>
                 </Field>
+                {sysMeta.operator_note ? (
+                  <p className="sm:col-span-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/60 dark:text-amber-300">
+                    {sysMeta.operator_note}
+                  </p>
+                ) : null}
                 <Field label={sysMeta.team_key_label || "Team key"}
                   help={sysMeta.team_key_help || ""}>
                   <Input value={inst.team_key} disabled={!!inst.managed}

--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -322,6 +322,22 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
                     {sysMeta.operator_note}
                   </p>
                 ) : null}
+                {(() => {
+                  const live = (health.pmo_instances || {})[inst.name] || {};
+                  const bits = [];
+                  if (live.relations_supported === false) {
+                    bits.push("live: relations off — child missions will not block each other");
+                  }
+                  if (live.attachments_supported === false) {
+                    bits.push("live: no official file attachments — feed posts a pointer");
+                  }
+                  if (!bits.length) return null;
+                  return (
+                    <p className="sm:col-span-3 text-xs text-amber-800 dark:text-amber-300">
+                      {bits.join(". ")}.
+                    </p>
+                  );
+                })()}
                 <Field label={sysMeta.team_key_label || "Team key"}
                   help={sysMeta.team_key_help || ""}>
                   <Input value={inst.team_key} disabled={!!inst.managed}

--- a/admin/spa/src/lib/registry.js
+++ b/admin/spa/src/lib/registry.js
@@ -14,6 +14,9 @@ const FALLBACK = {
       team_key_help:
         "The team's short key — the prefix of its issue IDs (PRJ for PRJ-123). This instance watches only this team. Empty = instance stays idle.",
       api_base_help: "",
+      operator_note: "",
+      attachments_supported: true,
+      relations_supported: true,
     },
     {
       id: "gitea_issues",
@@ -24,6 +27,9 @@ const FALLBACK = {
         "owner/repo of the dedicated issues board (e.g. devcake-pmo/missions). Empty = idle.",
       api_base_help:
         "Gitea origin from the app container. Bundled: http://gitea:3000. External: https://gitea.example.com",
+      operator_note: "",
+      attachments_supported: true,
+      relations_supported: true,
     },
   ],
   forges: [

--- a/admin/spa/src/lib/registry.js
+++ b/admin/spa/src/lib/registry.js
@@ -31,6 +31,20 @@ const FALLBACK = {
       attachments_supported: true,
       relations_supported: true,
     },
+    {
+      id: "gitlab_issues",
+      display_name: "GitLab Issues",
+      needs_api_base: true,
+      team_key_label: "Issues repo",
+      team_key_help:
+        "path_with_namespace of the dedicated issues board (e.g. mygroup/missions). Empty = idle.",
+      api_base_help:
+        "GitLab origin from the app container. gitlab.com: https://gitlab.com. Self-hosted: https://gitlab.example.com",
+      operator_note:
+        "Blocked-by issue links need GitLab Premium (or self-hosted EE). DevCake probes the live token.",
+      attachments_supported: true,
+      relations_supported: false,
+    },
   ],
   forges: [
     { id: "github", display_name: "GitHub" },

--- a/app/devcake/adapters/gitlab_issues/__init__.py
+++ b/app/devcake/adapters/gitlab_issues/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import GitLabIssuesAdapter
+
+__all__ = ["GitLabIssuesAdapter"]

--- a/app/devcake/adapters/gitlab_issues/adapter.py
+++ b/app/devcake/adapters/gitlab_issues/adapter.py
@@ -1,0 +1,517 @@
+"""GitLab Issues PMOPort adapter (docs/05 forge-issue family).
+
+Separate from adapters.gitlab (ForgePort). team_key is path_with_namespace
+(owner/repo or group/sub/repo). api_base is the GitLab origin reachable from
+the app (default https://gitlab.com).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+from urllib.parse import urlsplit
+
+import httpx
+
+from ...domain.model import (ALL_LABELS, Activity, ActivityEntry, AttachmentRef,
+                             Mission, MissionRef, NormalizedStatus)
+from ...ports.pmo import PMOCapabilities, PMOHealth, PMOTransient
+from .mapping import (CANCEL_FOOTER, mission_key, normalize_priority,
+                      normalize_status, parse_team_ref, project_path_encoded)
+
+log = logging.getLogger("devcake.gitlab_issues")
+
+_LABEL_COLOR = "#6e40c9"
+MAX_COMMENT_PAGES = 10
+MAX_COMMENT_PAGES_FULL = 100
+COMMENTS_PAGE = 50
+ISSUES_PAGE = 50
+MAX_ISSUE_PAGES = 40
+LABELS_PAGE = 50
+MAX_LABEL_PAGES = 10
+DEFAULT_API_ORIGIN = "https://gitlab.com"
+
+
+class GitLabIssuesAdapter:
+    """PMOPort over GitLab Issues REST API (/api/v4). Issue-only missions."""
+
+    def __init__(
+        self,
+        api_base: str | None,
+        token: str,
+        team_ref: str = "",
+        *,
+        instance: str = "",
+        transport: httpx.AsyncBaseTransport | None = None,
+    ):
+        self._instance = instance
+        self._token = token or ""
+        self._transport = transport
+        from ..http import PooledClient
+        self._http = PooledClient(timeout=30, transport=transport)
+        origin = (api_base or "").strip().rstrip("/") or DEFAULT_API_ORIGIN
+        if origin.endswith("/api/v4"):
+            self._origin = origin[: -len("/api/v4")]
+            self._api = origin
+        else:
+            self._origin = origin
+            self._api = f"{origin}/api/v4"
+        self._team_ref = (team_ref or "").strip()
+        self._path = ""
+        if self._team_ref:
+            try:
+                self._path = parse_team_ref(self._team_ref)
+            except ValueError:
+                self._path = ""
+        self._label_names: set[str] = set()  # upper names known on the project
+
+    def _headers(self) -> dict[str, str]:
+        if not self._token.strip():
+            raise PMOTransient("gitlab_issues: API token missing")
+        return {"PRIVATE-TOKEN": self._token}
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+
+    def _proj(self, suffix: str = "") -> str:
+        if not self._path:
+            raise RuntimeError(
+                f"gitlab_issues: invalid team_key {self._team_ref!r} "
+                f"(need namespace/project)")
+        return f"/projects/{project_path_encoded(self._path)}{suffix}"
+
+    async def _req(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict | None = None,
+        json: dict | list | None = None,
+        content: bytes | None = None,
+        headers: dict | None = None,
+        expect_json: bool = True,
+    ) -> Any:
+        if not self._api:
+            raise PMOTransient("gitlab_issues: api_base is empty")
+        url = f"{self._api}{path}"
+        hdrs = {**self._headers(), **(headers or {})}
+        try:
+            resp = await self._http.get().request(
+                method, url, params=params, json=json, content=content,
+                headers=hdrs)
+        except httpx.HTTPError as e:
+            raise PMOTransient(f"gitlab_issues network: {e}") from e
+        if resp.status_code in (429, 500, 502, 503, 504):
+            raise PMOTransient(
+                f"gitlab_issues {method} {path} → {resp.status_code}: "
+                f"{resp.text[:200]}")
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"gitlab_issues {method} {path} → {resp.status_code}: "
+                f"{resp.text[:300]}")
+        if not expect_json or not resp.content:
+            return resp.content if not expect_json else None
+        return resp.json()
+
+    def _require_issue(self, ref: MissionRef) -> None:
+        if ref.kind != "issue":
+            raise RuntimeError(
+                "gitlab_issues: projects are not supported "
+                f"(got kind={ref.kind!r})")
+
+    def _apply_team(self, team_ref: str) -> None:
+        ref = (team_ref or self._team_ref or "").strip()
+        if ref and ref != self._team_ref:
+            self._team_ref = ref
+            self._path = parse_team_ref(ref)
+            self._label_names.clear()
+
+    def _label_set(self, issue: dict) -> set[str]:
+        raw = issue.get("labels") or []
+        names: set[str] = set()
+        for lb in raw:
+            if isinstance(lb, str):
+                names.add(lb)
+            elif isinstance(lb, dict) and lb.get("name"):
+                names.add(lb["name"])
+        return {n for n in names if n}
+
+    def _mission(self, issue: dict) -> Mission:
+        iid = int(issue["iid"])
+        body = issue.get("description") or ""
+        labels = self._label_set(issue)
+        updated = issue.get("updated_at") or issue.get("created_at") or ""
+        try:
+            updated_at = datetime.fromisoformat(updated.replace("Z", "+00:00"))
+        except ValueError:
+            updated_at = datetime.now(timezone.utc)
+        return Mission(
+            pmo_id=str(iid),
+            pmo_kind="issue",
+            key=mission_key(self._path, iid),
+            title=issue.get("title") or "",
+            description=body,
+            status=normalize_status(issue.get("state") or "opened", body),
+            priority=normalize_priority(),
+            labels=labels,
+            updated_at=updated_at,
+            url=issue.get("web_url") or "",
+            parent_ref=None,
+            blocked_by=[],
+            instance=self._instance,
+        )
+
+    async def _blocked_by_ids(self, iid: int) -> list[str]:
+        # Free gitlab.com 403s blocks/is_blocked_by (license). Empty, never fake.
+        try:
+            links = await self._req(
+                "GET", self._proj(f"/issues/{iid}/links"))
+        except RuntimeError as e:
+            if "403" in str(e) or "404" in str(e):
+                return []
+            raise
+        if not isinstance(links, list):
+            return []
+        out: list[str] = []
+        for link in links:
+            lt = (link.get("link_type") or "").lower()
+            if lt not in ("is_blocked_by", "blocks"):
+                continue
+            # is_blocked_by: the *other* issue blocks us.
+            # GitLab returns source + target; we asked from `iid`.
+            other = link.get("target_issue") or link.get("issue") or {}
+            other_iid = other.get("iid")
+            if other_iid is None:
+                continue
+            if lt == "is_blocked_by":
+                out.append(str(other_iid))
+            elif lt == "blocks" and int(other_iid) != iid:
+                # "blocks" from this issue means we block them — skip
+                src = (link.get("source_issue") or {}).get("iid")
+                if src is not None and int(src) != iid:
+                    out.append(str(src))
+        return out
+
+    async def _enrich_blocked_by(self, mission: Mission) -> Mission:
+        if not self.capabilities().relations_supported:
+            return mission
+        blockers = await self._blocked_by_ids(int(mission.pmo_id))
+        return mission.model_copy(update={"blocked_by": blockers})
+
+    async def _list_issues(self, *, state: str = "all") -> list[dict]:
+        from .._toolkit import paginate_rest
+        raw, _ = await paginate_rest(
+            lambda page: self._req(
+                "GET", self._proj("/issues"),
+                params={"state": state, "per_page": ISSUES_PAGE, "page": page}),
+            page_size=ISSUES_PAGE, max_pages=MAX_ISSUE_PAGES,
+            what="gitlab_issues list_issues", on_ceiling="warn")
+        return list(raw)
+
+    async def list_missions(self, team_ref: str) -> list[Mission]:
+        self._apply_team(team_ref)
+        out: list[Mission] = []
+        for raw in await self._list_issues(state="opened"):
+            m = self._mission(raw)
+            if m.status in ("done", "canceled"):
+                continue
+            out.append(await self._enrich_blocked_by(m))
+        return out
+
+    async def list_all(self, team_ref: str) -> list[Mission]:
+        self._apply_team(team_ref)
+        out: list[Mission] = []
+        for raw in await self._list_issues(state="all"):
+            m = self._mission(raw)
+            if m.status not in ("done", "canceled"):
+                m = await self._enrich_blocked_by(m)
+            out.append(m)
+        return out
+
+    async def get(self, ref: MissionRef) -> Mission:
+        self._require_issue(ref)
+        raw = await self._req("GET", self._proj(f"/issues/{ref.pmo_id}"))
+        return await self._enrich_blocked_by(self._mission(raw))
+
+    async def get_activity(self, ref: MissionRef,
+                           full: bool = False) -> Activity:
+        self._require_issue(ref)
+        mission = await self.get(ref)
+        from .._toolkit import paginate_rest
+        max_pages = MAX_COMMENT_PAGES_FULL if full else MAX_COMMENT_PAGES
+        raw_notes, truncated = await paginate_rest(
+            lambda page: self._req(
+                "GET", self._proj(f"/issues/{ref.pmo_id}/notes"),
+                params={"page": page, "per_page": COMMENTS_PAGE,
+                        "sort": "asc"}),
+            page_size=COMMENTS_PAGE, max_pages=max_pages,
+            what="gitlab_issues get_activity", on_ceiling="flag")
+        if truncated:
+            log.error("gitlab_issues get_activity truncated at %s pages",
+                      max_pages)
+        entries = [self._note_entry(n, full=full) for n in raw_notes
+                   if not n.get("system")]
+        entries.sort(key=lambda e: e.ts)
+        return Activity(mission=mission, entries=entries,
+                        mission_attachments=[], truncated=truncated)
+
+    def _note_entry(self, n: dict, *, full: bool) -> ActivityEntry:
+        body = n.get("body") or ""
+        created = n.get("created_at") or ""
+        try:
+            ts = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        except ValueError:
+            ts = datetime.now(timezone.utc)
+        author = ((n.get("author") or {}).get("username")
+                  or (n.get("author") or {}).get("name") or "unknown")
+        return ActivityEntry(
+            ts=ts, author=author, kind="comment", body=body,
+            attachments=self._attachments_from_body(body),
+            entry_id=str(n["id"]) if full and n.get("id") is not None else None,
+            parent_id=None,
+        )
+
+    def _attachments_from_body(self, body: str) -> list[AttachmentRef]:
+        # Markdown from POST /uploads: [name](/uploads/<secret>/<name>)
+        import re
+        found: list[AttachmentRef] = []
+        seen: set[str] = set()
+        for name, secret, fname in re.findall(
+                r"\[([^\]]+)\]\(/uploads/([A-Fa-f0-9]+)/([^)]+)\)",
+                body or ""):
+            url = (f"{self._api}{self._proj(f'/uploads/{secret}/{fname}')}")
+            if url not in seen:
+                seen.add(url)
+                found.append(AttachmentRef(url=url, name=name, kind="file"))
+        return found
+
+    async def children_of(self, ref: MissionRef) -> list[Mission]:
+        return []
+
+    async def post_feed(self, ref: MissionRef, markdown: str) -> None:
+        self._require_issue(ref)
+        await self._req(
+            "POST", self._proj(f"/issues/{ref.pmo_id}/notes"),
+            json={"body": markdown})
+
+    async def set_status(self, ref: MissionRef, status: NormalizedStatus) -> None:
+        self._require_issue(ref)
+        if status in ("done", "canceled"):
+            state_event = "close"
+        else:
+            state_event = "reopen"
+        body_patch: dict[str, Any] = {"state_event": state_event}
+        cur = await self._req("GET", self._proj(f"/issues/{ref.pmo_id}"))
+        body = cur.get("description") or ""
+        if status == "canceled":
+            if CANCEL_FOOTER not in body:
+                body_patch["description"] = (
+                    body.rstrip() + f"\n\n---\n{CANCEL_FOOTER}\n")
+        elif CANCEL_FOOTER in body:
+            cleaned = body.replace(CANCEL_FOOTER, "").replace("\n\n---\n\n", "\n")
+            body_patch["description"] = cleaned
+        await self._req(
+            "PUT", self._proj(f"/issues/{ref.pmo_id}"), json=body_patch)
+
+    async def cancel_mission(self, ref: MissionRef) -> None:
+        self._require_issue(ref)
+        cur = await self._req("GET", self._proj(f"/issues/{ref.pmo_id}"))
+        state = (cur.get("state") or "").lower()
+        if state == "closed" and CANCEL_FOOTER in (cur.get("description") or ""):
+            return
+        await self.set_status(ref, "canceled")
+
+    async def swap_labels(self, ref: MissionRef, remove: set[str],
+                          add: set[str]) -> None:
+        self._require_issue(ref)
+        await self.ensure_labels(self._team_ref, add)
+        cur = await self._req("GET", self._proj(f"/issues/{ref.pmo_id}"))
+        current = self._label_set(cur)
+        next_names = (current - remove) | add
+        missing = [n for n in next_names if n.upper() not in self._label_names
+                   and n.upper() not in {x.upper() for x in next_names}]
+        # GitLab PUT replaces the full label set by *name*.
+        await self._req(
+            "PUT", self._proj(f"/issues/{ref.pmo_id}"),
+            json={"labels": ",".join(sorted(next_names))})
+        _ = missing
+
+    async def create_mission(
+        self, team_ref: str, title: str, description: str,
+        priority: str, label_names: set[str],
+        parent_ref: Optional[str] = None,
+    ) -> tuple[str, str]:
+        self._apply_team(team_ref)
+        await self.ensure_labels(team_ref, label_names)
+        _ = parent_ref
+        _ = priority
+        raw = await self._req(
+            "POST", self._proj("/issues"),
+            json={"title": title, "description": description or "",
+                  "labels": ",".join(sorted(label_names))})
+        iid = int(raw["iid"])
+        return mission_key(self._path, iid), str(iid)
+
+    async def create_relation(self, blocker_id: str, blocked_id: str) -> None:
+        # Free gitlab.com: 403 license. Raise — do not no-op (decomposition
+        # would report success with no scheduler edges).
+        proj = await self._req("GET", self._proj(""))
+        target_pid = proj.get("id")
+        try:
+            await self._req(
+                "POST", self._proj(f"/issues/{int(blocked_id)}/links"),
+                json={"target_project_id": target_pid,
+                      "target_issue_iid": int(blocker_id),
+                      "link_type": "is_blocked_by"})
+        except RuntimeError as e:
+            text = str(e)
+            if "already assigned" in text.lower() or "409" in text:
+                return
+            raise
+
+    async def _fetch_all_labels(self) -> list[dict]:
+        from .._toolkit import paginate_rest
+        labels, _ = await paginate_rest(
+            lambda page: self._req(
+                "GET", self._proj("/labels"),
+                params={"page": page, "per_page": LABELS_PAGE}),
+            page_size=LABELS_PAGE, max_pages=MAX_LABEL_PAGES,
+            what="gitlab_issues labels", on_ceiling="raise",
+            ceiling_error=(
+                f"gitlab_issues: more than {MAX_LABEL_PAGES * LABELS_PAGE} "
+                f"labels on {self._path} — refusing a truncated rewrite"))
+        return labels
+
+    async def ensure_labels(self, team_ref: str, names: set[str]) -> None:
+        self._apply_team(team_ref)
+        existing = await self._fetch_all_labels()
+        by_upper = {(lb.get("name") or "").upper(): lb for lb in existing}
+        self._label_names = set(by_upper)
+        for name in names:
+            u = name.upper()
+            if u in by_upper:
+                continue
+            created = await self._req(
+                "POST", self._proj("/labels"),
+                json={"name": name.upper(), "color": _LABEL_COLOR})
+            by_upper[u] = created
+            self._label_names.add(u)
+
+    async def append_description(self, ref: MissionRef, text: str) -> None:
+        self._require_issue(ref)
+        cur = await self._req("GET", self._proj(f"/issues/{ref.pmo_id}"))
+        body = (cur.get("description") or "") + text
+        await self._req(
+            "PUT", self._proj(f"/issues/{ref.pmo_id}"),
+            json={"description": body})
+
+    async def upload_attachment(self, pmo_id: str, filename: str,
+                                data: bytes) -> str:
+        _ = pmo_id  # GitLab uploads are project-scoped; we reference from a note
+        if not self._api:
+            raise PMOTransient("gitlab_issues: api_base is empty")
+        url = f"{self._api}{self._proj('/uploads')}"
+        try:
+            async with httpx.AsyncClient(
+                    timeout=60, transport=self._transport) as client:
+                resp = await client.post(
+                    url, headers=self._headers(),
+                    files={"file": (filename, data)})
+        except httpx.HTTPError as e:
+            raise PMOTransient(f"gitlab_issues upload network: {e}") from e
+        if resp.status_code in (429, 500, 502, 503, 504):
+            raise PMOTransient(
+                f"gitlab_issues upload → {resp.status_code}: {resp.text[:200]}")
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"gitlab_issues upload → {resp.status_code}: {resp.text[:300]}")
+        payload = resp.json()
+        secret_url = payload.get("url") or ""
+        # /uploads/<secret>/<filename>
+        parts = secret_url.strip("/").split("/")
+        if len(parts) < 3 or parts[0] != "uploads":
+            raise RuntimeError(
+                f"gitlab_issues upload: unexpected url {secret_url!r}")
+        secret, fname = parts[1], parts[2]
+        api_url = f"{self._api}{self._proj(f'/uploads/{secret}/{fname}')}"
+        # Follow-up note so the file is visible on the issue
+        try:
+            md = payload.get("markdown") or f"[{filename}]({secret_url})"
+            await self._req(
+                "POST", self._proj(f"/issues/{pmo_id}/notes"),
+                json={"body": md})
+        except Exception as e:  # noqa: BLE001 — upload already succeeded
+            log.warning("gitlab_issues upload note: %s", e)
+        return api_url
+
+    async def download_asset(self, url: str) -> bytes:
+        if not self._api:
+            raise RuntimeError("gitlab_issues: api_base is empty")
+        from ...domain.asset_fetch import (
+            AssetUrlError, assert_downloadable_asset_url)
+        from .._toolkit import fetch_following_safe_redirects
+        allowed = {h for h in (
+            urlsplit(self._origin).hostname,
+            urlsplit(self._api).hostname,
+        ) if h}
+        try:
+            assert_downloadable_asset_url(
+                url, allowed_hosts=allowed, allow_http=self._origin.startswith("http://"))
+        except AssetUrlError as e:
+            raise RuntimeError(f"gitlab_issues download refused: {e}") from e
+        try:
+            async with httpx.AsyncClient(
+                    timeout=60, transport=self._transport) as client:
+                resp = await fetch_following_safe_redirects(
+                    client, url, allowed_hosts=allowed,
+                    headers=self._headers(),
+                    allow_http=self._origin.startswith("http://"))
+        except httpx.HTTPError as e:
+            raise PMOTransient(f"gitlab_issues download network: {e}") from e
+        except AssetUrlError as e:
+            raise RuntimeError(f"gitlab_issues download refused: {e}") from e
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"gitlab_issues download → {resp.status_code}: {resp.text[:200]}")
+        from ...domain.asset_fetch import (
+            AssetUrlError, enforce_download_byte_cap)
+        try:
+            return enforce_download_byte_cap(
+                resp.content,
+                content_length=resp.headers.get("content-length"),
+                max_bytes=self.capabilities().attachment_max_bytes,
+            )
+        except AssetUrlError as e:
+            raise RuntimeError(f"gitlab_issues download refused: {e}") from e
+
+    async def health_probe(self, team_ref: str) -> PMOHealth:
+        self._apply_team(team_ref)
+        if not self._path:
+            return PMOHealth(ok=False, workspace=team_ref or self._team_ref,
+                             detail="invalid team_key")
+        try:
+            await self._req("GET", self._proj(""))
+            labels = await self._fetch_all_labels()
+        except PMOTransient as e:
+            return PMOHealth(ok=False, workspace=self._path, detail=str(e))
+        except RuntimeError as e:
+            return PMOHealth(ok=False, workspace=self._path, detail=str(e))
+        present = {(lb.get("name") or "").upper() for lb in labels}
+        managed = {n.upper() for n in ALL_LABELS}
+        return PMOHealth(
+            ok=True, workspace=self._path,
+            managed_labels_present=len(present & managed),
+            managed_labels_expected=len(ALL_LABELS),
+        )
+
+    def capabilities(self) -> PMOCapabilities:
+        # Free gitlab.com: blocked-by is Premium (spike 2026-08-15 403 license).
+        return PMOCapabilities(
+            projects_supported=False,
+            project_labels_supported=False,
+            attachment_max_bytes=10 * 1024 * 1024,
+            native_label_swap_atomic=True,
+            relations_supported=False,
+            global_ids=False,
+        )

--- a/app/devcake/adapters/gitlab_issues/adapter.py
+++ b/app/devcake/adapters/gitlab_issues/adapter.py
@@ -22,6 +22,15 @@ from .mapping import (CANCEL_FOOTER, mission_key, normalize_priority,
 
 log = logging.getLogger("devcake.gitlab_issues")
 
+
+class GitLabHTTPError(RuntimeError):
+    """Permanent GitLab Issues HTTP failure carrying the status code."""
+
+    def __init__(self, method: str, path: str, status: int, body: str):
+        super().__init__(
+            f"gitlab_issues {method} {path} → {status}: {body[:300]}")
+        self.status_code = status
+
 _LABEL_COLOR = "#6e40c9"
 MAX_COMMENT_PAGES = 10
 MAX_COMMENT_PAGES_FULL = 100
@@ -65,6 +74,8 @@ class GitLabIssuesAdapter:
             except ValueError:
                 self._path = ""
         self._label_names: set[str] = set()  # upper names known on the project
+        self._relations_probed = False
+        self._relations_supported = False
 
     def _headers(self) -> dict[str, str]:
         if not self._token.strip():
@@ -107,9 +118,8 @@ class GitLabIssuesAdapter:
                 f"gitlab_issues {method} {path} → {resp.status_code}: "
                 f"{resp.text[:200]}")
         if resp.status_code >= 400:
-            raise RuntimeError(
-                f"gitlab_issues {method} {path} → {resp.status_code}: "
-                f"{resp.text[:300]}")
+            raise GitLabHTTPError(
+                method, path, resp.status_code, resp.text or "")
         if not expect_json or not resp.content:
             return resp.content if not expect_json else None
         return resp.json()
@@ -126,6 +136,8 @@ class GitLabIssuesAdapter:
             self._team_ref = ref
             self._path = parse_team_ref(ref)
             self._label_names.clear()
+            self._relations_probed = False
+            self._relations_supported = False
 
     def _label_set(self, issue: dict) -> set[str]:
         raw = issue.get("labels") or []
@@ -162,13 +174,27 @@ class GitLabIssuesAdapter:
             instance=self._instance,
         )
 
+    async def _ensure_relations_probed(self) -> None:
+        """Read-only: GET links on iid 1. 403 = license-off; 200/404 = on."""
+        if self._relations_probed:
+            return
+        supported = False
+        try:
+            await self._req("GET", self._proj("/issues/1/links"))
+            supported = True
+        except GitLabHTTPError as e:
+            supported = e.status_code == 404
+        except (RuntimeError, PMOTransient):
+            supported = False
+        self._relations_supported = supported
+        self._relations_probed = True
+
     async def _blocked_by_ids(self, iid: int) -> list[str]:
-        # Free gitlab.com 403s blocks/is_blocked_by (license). Empty, never fake.
         try:
             links = await self._req(
                 "GET", self._proj(f"/issues/{iid}/links"))
-        except RuntimeError as e:
-            if "403" in str(e) or "404" in str(e):
+        except GitLabHTTPError as e:
+            if e.status_code in (403, 404):
                 return []
             raise
         if not isinstance(links, list):
@@ -194,6 +220,7 @@ class GitLabIssuesAdapter:
         return out
 
     async def _enrich_blocked_by(self, mission: Mission) -> Mission:
+        await self._ensure_relations_probed()
         if not self.capabilities().relations_supported:
             return mission
         blockers = await self._blocked_by_ids(int(mission.pmo_id))
@@ -244,7 +271,7 @@ class GitLabIssuesAdapter:
             lambda page: self._req(
                 "GET", self._proj(f"/issues/{ref.pmo_id}/notes"),
                 params={"page": page, "per_page": COMMENTS_PAGE,
-                        "sort": "asc"}),
+                        "sort": "desc"}),
             page_size=COMMENTS_PAGE, max_pages=max_pages,
             what="gitlab_issues get_activity", on_ceiling="flag")
         if truncated:
@@ -253,8 +280,20 @@ class GitLabIssuesAdapter:
         entries = [self._note_entry(n, full=full) for n in raw_notes
                    if not n.get("system")]
         entries.sort(key=lambda e: e.ts)
+        mission_atts: list[AttachmentRef] = []
+        if full:
+            seen: set[str] = set()
+            for att in self._attachments_from_body(mission.description):
+                if att.url not in seen:
+                    seen.add(att.url)
+                    mission_atts.append(att)
+            for e in entries:
+                for att in e.attachments:
+                    if att.url not in seen:
+                        seen.add(att.url)
+                        mission_atts.append(att)
         return Activity(mission=mission, entries=entries,
-                        mission_attachments=[], truncated=truncated)
+                        mission_attachments=mission_atts, truncated=truncated)
 
     def _note_entry(self, n: dict, *, full: bool) -> ActivityEntry:
         body = n.get("body") or ""
@@ -273,17 +312,26 @@ class GitLabIssuesAdapter:
         )
 
     def _attachments_from_body(self, body: str) -> list[AttachmentRef]:
-        # Markdown from POST /uploads: [name](/uploads/<secret>/<name>)
         import re
         found: list[AttachmentRef] = []
         seen: set[str] = set()
+
+        def _add(name: str, url: str) -> None:
+            if ".." in url or url in seen:
+                return
+            seen.add(url)
+            found.append(AttachmentRef(url=url, name=name, kind="file"))
+
         for name, secret, fname in re.findall(
                 r"\[([^\]]+)\]\(/uploads/([A-Fa-f0-9]+)/([^)]+)\)",
                 body or ""):
-            url = (f"{self._api}{self._proj(f'/uploads/{secret}/{fname}')}")
-            if url not in seen:
-                seen.add(url)
-                found.append(AttachmentRef(url=url, name=name, kind="file"))
+            if ".." in fname or "/" in fname:
+                continue
+            _add(name, f"{self._api}{self._proj(f'/uploads/{secret}/{fname}')}")
+        for name, url in re.findall(
+                r"\[([^\]]+)\]\((https?://[^)\s]+/api/v4/projects/[^)]+/uploads/[^)]+)\)",
+                body or ""):
+            _add(name, url)
         return found
 
     async def children_of(self, ref: MissionRef) -> list[Mission]:
@@ -354,8 +402,10 @@ class GitLabIssuesAdapter:
         return mission_key(self._path, iid), str(iid)
 
     async def create_relation(self, blocker_id: str, blocked_id: str) -> None:
-        # Free gitlab.com: 403 license. Raise — do not no-op (decomposition
-        # would report success with no scheduler edges).
+        await self._ensure_relations_probed()
+        if not self._relations_supported:
+            raise RuntimeError(
+                "gitlab_issues: relations not available on this token")
         proj = await self._req("GET", self._proj(""))
         target_pid = proj.get("id")
         try:
@@ -364,9 +414,8 @@ class GitLabIssuesAdapter:
                 json={"target_project_id": target_pid,
                       "target_issue_iid": int(blocker_id),
                       "link_type": "is_blocked_by"})
-        except RuntimeError as e:
-            text = str(e)
-            if "already assigned" in text.lower() or "409" in text:
+        except GitLabHTTPError as e:
+            if e.status_code == 409:
                 return
             raise
 
@@ -445,6 +494,29 @@ class GitLabIssuesAdapter:
             log.warning("gitlab_issues upload note: %s", e)
         return api_url
 
+    def _finalize_upload_url(self, url: str) -> str:
+        """Pin credentialed GETs to this project's /uploads/ secret/fname."""
+        from urllib.parse import unquote
+        from ...domain.asset_fetch import (
+            AssetUrlError, assert_fetch_netloc, assert_path_prefix)
+        current = url.strip()
+        assert_fetch_netloc(current, self._api)
+        path = unquote(urlsplit(current).path or "")
+        if ".." in path.split("/"):
+            raise AssetUrlError("asset path must not contain ..")
+        prefix = f"/api/v4/projects/{project_path_encoded(self._path)}/uploads/"
+        # encoded and decoded project paths both start with /api/v4/projects/
+        if "/uploads/" not in path:
+            raise AssetUrlError(f"asset path {path!r} is not an upload")
+        assert_path_prefix(current, "/api/v4/projects/")
+        after = path.split("/uploads/", 1)[1]
+        segs = [s for s in after.split("/") if s]
+        if len(segs) != 2:
+            raise AssetUrlError(
+                f"upload path must be secret/filename, got {after!r}")
+        _ = prefix
+        return current
+
     async def download_asset(self, url: str) -> bytes:
         if not self._api:
             raise RuntimeError("gitlab_issues: api_base is empty")
@@ -456,17 +528,21 @@ class GitLabIssuesAdapter:
             urlsplit(self._api).hostname,
         ) if h}
         try:
-            assert_downloadable_asset_url(
-                url, allowed_hosts=allowed, allow_http=self._origin.startswith("http://"))
+            url = assert_downloadable_asset_url(
+                url, allowed_hosts=allowed,
+                allow_http=self._origin.startswith("http://"))
+            url = self._finalize_upload_url(url)
         except AssetUrlError as e:
             raise RuntimeError(f"gitlab_issues download refused: {e}") from e
         try:
             async with httpx.AsyncClient(
-                    timeout=60, transport=self._transport) as client:
+                    timeout=60, transport=self._transport,
+                    follow_redirects=False) as client:
                 resp = await fetch_following_safe_redirects(
                     client, url, allowed_hosts=allowed,
                     headers=self._headers(),
-                    allow_http=self._origin.startswith("http://"))
+                    allow_http=self._origin.startswith("http://"),
+                    pin=self._finalize_upload_url)
         except httpx.HTTPError as e:
             raise PMOTransient(f"gitlab_issues download network: {e}") from e
         except AssetUrlError as e:
@@ -493,25 +569,27 @@ class GitLabIssuesAdapter:
         try:
             await self._req("GET", self._proj(""))
             labels = await self._fetch_all_labels()
+            await self._ensure_relations_probed()
         except PMOTransient as e:
             return PMOHealth(ok=False, workspace=self._path, detail=str(e))
         except RuntimeError as e:
             return PMOHealth(ok=False, workspace=self._path, detail=str(e))
         present = {(lb.get("name") or "").upper() for lb in labels}
         managed = {n.upper() for n in ALL_LABELS}
+        rel = "on" if self._relations_supported else "off"
         return PMOHealth(
             ok=True, workspace=self._path,
             managed_labels_present=len(present & managed),
             managed_labels_expected=len(ALL_LABELS),
+            detail=f"relations={rel}",
         )
 
     def capabilities(self) -> PMOCapabilities:
-        # Free gitlab.com: blocked-by is Premium (spike 2026-08-15 403 license).
         return PMOCapabilities(
             projects_supported=False,
             project_labels_supported=False,
             attachment_max_bytes=10 * 1024 * 1024,
             native_label_swap_atomic=True,
-            relations_supported=False,
+            relations_supported=self._relations_supported,
             global_ids=False,
         )

--- a/app/devcake/adapters/gitlab_issues/adapter.py
+++ b/app/devcake/adapters/gitlab_issues/adapter.py
@@ -174,20 +174,28 @@ class GitLabIssuesAdapter:
             instance=self._instance,
         )
 
-    async def _ensure_relations_probed(self) -> None:
-        """Read-only: GET links on iid 1. 403 = license-off; 200/404 = on."""
-        if self._relations_probed:
-            return
-        supported = False
+    def _link_other_iid(self, link: dict, iid: int):
+        """GitLab GET /issues/:iid/links puts the related issue at TOP level.
+
+        Nested `target_issue` / `source_issue` is the create/get-single
+        shape — accept it as a fallback, never require it.
+        """
+        other = link.get("iid")
+        if other is None:
+            nested = link.get("target_issue") or link.get("issue") or {}
+            other = nested.get("iid") if isinstance(nested, dict) else None
+        if other is None:
+            return None
         try:
-            await self._req("GET", self._proj("/issues/1/links"))
-            supported = True
-        except GitLabHTTPError as e:
-            supported = e.status_code == 404
-        except (RuntimeError, PMOTransient):
-            supported = False
-        self._relations_supported = supported
-        self._relations_probed = True
+            other_i = int(other)
+        except (TypeError, ValueError):
+            return None
+        if other_i == iid:
+            src = (link.get("source_issue") or {}).get("iid")
+            if src is not None and int(src) != iid:
+                return int(src)
+            return None
+        return other_i
 
     async def _blocked_by_ids(self, iid: int) -> list[str]:
         try:
@@ -202,27 +210,16 @@ class GitLabIssuesAdapter:
         out: list[str] = []
         for link in links:
             lt = (link.get("link_type") or "").lower()
-            if lt not in ("is_blocked_by", "blocks"):
+            if lt != "is_blocked_by":
                 continue
-            # is_blocked_by: the *other* issue blocks us.
-            # GitLab returns source + target; we asked from `iid`.
-            other = link.get("target_issue") or link.get("issue") or {}
-            other_iid = other.get("iid")
-            if other_iid is None:
-                continue
-            if lt == "is_blocked_by":
-                out.append(str(other_iid))
-            elif lt == "blocks" and int(other_iid) != iid:
-                # "blocks" from this issue means we block them — skip
-                src = (link.get("source_issue") or {}).get("iid")
-                if src is not None and int(src) != iid:
-                    out.append(str(src))
+            other = self._link_other_iid(link, iid)
+            if other is not None:
+                out.append(str(other))
         return out
 
     async def _enrich_blocked_by(self, mission: Mission) -> Mission:
-        await self._ensure_relations_probed()
-        if not self.capabilities().relations_supported:
-            return mission
+        # Listing links is Free; writing blocking types is Premium. Reads
+        # must not wait on a write probe (health_probe stays read-only).
         blockers = await self._blocked_by_ids(int(mission.pmo_id))
         return mission.model_copy(update={"blocked_by": blockers})
 
@@ -402,10 +399,8 @@ class GitLabIssuesAdapter:
         return mission_key(self._path, iid), str(iid)
 
     async def create_relation(self, blocker_id: str, blocked_id: str) -> None:
-        await self._ensure_relations_probed()
-        if not self._relations_supported:
-            raise RuntimeError(
-                "gitlab_issues: relations not available on this token")
+        # Writing blocks/is_blocked_by is Premium. A 403 here is "unsupported",
+        # not a finalize-escaping error — Free boards must no-op.
         proj = await self._req("GET", self._proj(""))
         target_pid = proj.get("id")
         try:
@@ -416,8 +411,13 @@ class GitLabIssuesAdapter:
                       "link_type": "is_blocked_by"})
         except GitLabHTTPError as e:
             if e.status_code == 409:
+                self._relations_supported = True
+                return
+            if e.status_code == 403:
+                self._relations_supported = False
                 return
             raise
+        self._relations_supported = True
 
     async def _fetch_all_labels(self) -> list[dict]:
         from .._toolkit import paginate_rest
@@ -483,38 +483,34 @@ class GitLabIssuesAdapter:
             raise RuntimeError(
                 f"gitlab_issues upload: unexpected url {secret_url!r}")
         secret, fname = parts[1], parts[2]
-        api_url = f"{self._api}{self._proj(f'/uploads/{secret}/{fname}')}"
-        # Follow-up note so the file is visible on the issue
-        try:
-            md = payload.get("markdown") or f"[{filename}]({secret_url})"
-            await self._req(
-                "POST", self._proj(f"/issues/{pmo_id}/notes"),
-                json={"body": md})
-        except Exception as e:  # noqa: BLE001 — upload already succeeded
-            log.warning("gitlab_issues upload note: %s", e)
-        return api_url
+        # Do not post a follow-up note here — that bypasses the feed
+        # chokepoint and lands unsigned, which freshness treats as human.
+        return f"{self._api}{self._proj(f'/uploads/{secret}/{fname}')}"
 
     def _finalize_upload_url(self, url: str) -> str:
         """Pin credentialed GETs to this project's /uploads/ secret/fname."""
         from urllib.parse import unquote
         from ...domain.asset_fetch import (
-            AssetUrlError, assert_fetch_netloc, assert_path_prefix)
+            AssetUrlError, assert_fetch_netloc)
         current = url.strip()
         assert_fetch_netloc(current, self._api)
         path = unquote(urlsplit(current).path or "")
         if ".." in path.split("/"):
             raise AssetUrlError("asset path must not contain ..")
         prefix = f"/api/v4/projects/{project_path_encoded(self._path)}/uploads/"
-        # encoded and decoded project paths both start with /api/v4/projects/
         if "/uploads/" not in path:
             raise AssetUrlError(f"asset path {path!r} is not an upload")
-        assert_path_prefix(current, "/api/v4/projects/")
+        # Accept the encoded project path we emit, or the decoded form
+        # GitLab sometimes puts in markdown.
+        decoded_prefix = f"/api/v4/projects/{self._path}/uploads/"
+        if not (path.startswith(prefix) or path.startswith(decoded_prefix)):
+            raise AssetUrlError(
+                f"asset path {path!r} is not this project's upload")
         after = path.split("/uploads/", 1)[1]
         segs = [s for s in after.split("/") if s]
         if len(segs) != 2:
             raise AssetUrlError(
                 f"upload path must be secret/filename, got {after!r}")
-        _ = prefix
         return current
 
     async def download_asset(self, url: str) -> bytes:
@@ -569,7 +565,6 @@ class GitLabIssuesAdapter:
         try:
             await self._req("GET", self._proj(""))
             labels = await self._fetch_all_labels()
-            await self._ensure_relations_probed()
         except PMOTransient as e:
             return PMOHealth(ok=False, workspace=self._path, detail=str(e))
         except RuntimeError as e:
@@ -591,5 +586,6 @@ class GitLabIssuesAdapter:
             attachment_max_bytes=10 * 1024 * 1024,
             native_label_swap_atomic=True,
             relations_supported=self._relations_supported,
+            attachments_supported=True,
             global_ids=False,
         )

--- a/app/devcake/adapters/gitlab_issues/mapping.py
+++ b/app/devcake/adapters/gitlab_issues/mapping.py
@@ -1,0 +1,47 @@
+"""Pure normalization helpers for the GitLab Issues PMO adapter.
+
+Forge-issue profile (docs/05 §9.2): opened → backlog; closed → done unless
+the cancel footer is present → canceled. Priority is always medium.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import quote
+
+# Same durable cancel signal as gitea_issues (docs/05 forge-issue family).
+CANCEL_FOOTER = "`devcake:canceled:v1`"
+
+NormalizedStatus = Literal["backlog", "in_progress", "done", "canceled"]
+Priority = Literal["urgent", "high", "medium", "low"]
+
+
+def parse_team_ref(team_ref: str) -> str:
+    """team_key is the GitLab path_with_namespace (owner/repo or group/sub/repo)."""
+    raw = (team_ref or "").strip().strip("/")
+    segs = [s for s in raw.split("/") if s]
+    if len(segs) < 2:
+        raise ValueError(
+            f"gitlab_issues team_key must be namespace/project, got {team_ref!r}")
+    return "/".join(segs)
+
+
+def project_path_encoded(path_with_namespace: str) -> str:
+    return quote(path_with_namespace, safe="")
+
+
+def mission_key(path_with_namespace: str, iid: int) -> str:
+    return f"{path_with_namespace}#{iid}"
+
+
+def normalize_status(state: str, body: str | None) -> NormalizedStatus:
+    st = (state or "").lower()
+    if st not in ("closed",):
+        return "backlog"
+    if CANCEL_FOOTER in (body or ""):
+        return "canceled"
+    return "done"
+
+
+def normalize_priority(_raw: object = None) -> Priority:
+    return "medium"

--- a/app/devcake/adapters/registry.py
+++ b/app/devcake/adapters/registry.py
@@ -89,10 +89,11 @@ PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
         attachments_supported=True,
         relations_supported=False,
         operator_note=(
-            "Blocked-by issue links need GitLab Premium. On Free, DevCake "
-            "cannot write decomposition traffic-control edges on this board "
-            "— child missions will not block each other. File attachments "
-            "work. This is a GitLab license limit, not a DevCake setting."
+            "Blocked-by issue links need GitLab Premium (or self-hosted EE). "
+            "DevCake probes the live token — Free boards will not write "
+            "decomposition traffic-control edges, and child missions will "
+            "not block each other. File attachments work. This is a GitLab "
+            "license limit, not a DevCake setting."
         ),
     ),
 }

--- a/app/devcake/adapters/registry.py
+++ b/app/devcake/adapters/registry.py
@@ -30,6 +30,12 @@ class PMOSystemInfo(BaseModel):
     # issue systems normalize everything to medium — the SPA hides the
     # Priority field instead of offering a control that silently does nothing)
     supports_priority: bool = True
+    # Shown in the admin PMO card (and New Mission) when this system is
+    # selected. Empty = no note. Copy lives here so the SPA stays
+    # system-agnostic (docs/05 §1a).
+    operator_note: str = ""
+    attachments_supported: bool = True
+    relations_supported: bool = True
 
 
 PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
@@ -63,6 +69,32 @@ PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
             "External: https://gitea.example.com"),
         supports_priority=False,   # forge-issue: priority always medium (§9.2)
     ),
+    "gitlab_issues": PMOSystemInfo(
+        id="gitlab_issues",
+        display_name="GitLab Issues",
+        secret_env_vars=["GITLAB_TOKEN", "GITLAB_PAT"],
+        token_patterns=[r"\bglpat-[A-Za-z0-9_\-]{20,}\b"],
+        secret_shape_prefixes=["glpat-"],
+        needs_api_base=True,
+        team_key_label="Issues repo",
+        team_key_help=(
+            "path_with_namespace of the dedicated issues board "
+            "(e.g. mygroup/missions). Not a per-mission work repo. "
+            "Empty = instance stays idle."),
+        api_base_help=(
+            "GitLab origin reachable from the app container. "
+            "gitlab.com: https://gitlab.com. Self-hosted: "
+            "https://gitlab.example.com"),
+        supports_priority=False,
+        attachments_supported=True,
+        relations_supported=False,
+        operator_note=(
+            "Blocked-by issue links need GitLab Premium. On Free, DevCake "
+            "cannot write decomposition traffic-control edges on this board "
+            "— child missions will not block each other. File attachments "
+            "work. This is a GitLab license limit, not a DevCake setting."
+        ),
+    ),
 }
 
 
@@ -80,6 +112,13 @@ def make_pmo(inst) -> PMOPort:
         if inst.api_key:
             register_runtime_secret(f"pmo_key:{inst.name}", inst.api_key)
         return GiteaIssuesAdapter(
+            inst.api_base, inst.api_key, inst.team_key, instance=inst.name)
+    if inst.system == "gitlab_issues":
+        from .gitlab_issues import GitLabIssuesAdapter
+        from ..security import register_runtime_secret
+        if inst.api_key:
+            register_runtime_secret(f"pmo_key:{inst.name}", inst.api_key)
+        return GitLabIssuesAdapter(
             inst.api_base, inst.api_key, inst.team_key, instance=inst.name)
     raise AssertionError("unreachable")  # registry and constructors in sync
 

--- a/app/devcake/api/connections_service.py
+++ b/app/devcake/api/connections_service.py
@@ -290,6 +290,9 @@ async def connections_registry():
                 "team_key_help": s.team_key_help,
                 "api_base_help": s.api_base_help,
                 "supports_priority": s.supports_priority,
+                "operator_note": s.operator_note,
+                "attachments_supported": s.attachments_supported,
+                "relations_supported": s.relations_supported,
             }
             for s in PMO_SYSTEMS.values()
         ],

--- a/app/devcake/api/health.py
+++ b/app/devcake/api/health.py
@@ -187,20 +187,41 @@ async def build_health_payload(*, config, dev_types, managers, stewards,
         cached = _pmo_probe_cache.get(key)
         now = time.monotonic()
         if cached is not None and now - cached["ts"] < _PMO_PROBE_TTL:
-            ok = cached["ok"]
+            row = cached
         else:
             mgr = managers.get(inst.name)
+            detail = ""
+            rel = att = None
             try:
                 async with asyncio.timeout(_PMO_PROBE_TIMEOUT):
-                    ok = bool(mgr) and (
-                        await mgr.pmo.health_probe(inst.team_key)).ok
+                    h = (await mgr.pmo.health_probe(inst.team_key)
+                         ) if mgr else None
+                    ok = bool(h and h.ok)
+                    detail = getattr(h, "detail", "") or "" if h else ""
+                    try:
+                        caps = mgr.pmo.capabilities() if mgr else None
+                        if caps is not None:
+                            rel = bool(caps.relations_supported)
+                            att = bool(getattr(
+                                caps, "attachments_supported", True))
+                    except Exception:  # noqa: BLE001 — caps are advisory on /health
+                        pass
             except Exception:  # noqa: BLE001 — probe contract: any failure (incl. the 5s timeout) → ok:False; /health must never 500
                 ok = False
-            _pmo_probe_cache[key] = {"ts": now, "ok": ok}
-        return inst.name, {
-            "ok": ok, "configured": True, "team": inst.team_key,
+            row = {"ts": now, "ok": ok, "detail": detail,
+                   "relations_supported": rel, "attachments_supported": att}
+            _pmo_probe_cache[key] = row
+        out = {
+            "ok": row["ok"], "configured": True, "team": inst.team_key,
             "intake_paused": bool(inst.intake_paused),
         }
+        if row.get("detail"):
+            out["detail"] = row["detail"]
+        if row.get("relations_supported") is not None:
+            out["relations_supported"] = row["relations_supported"]
+        if row.get("attachments_supported") is not None:
+            out["attachments_supported"] = row["attachments_supported"]
+        return inst.name, out
 
     pmo_instances: dict[str, dict] = dict(
         await asyncio.gather(*(_probe_one(i) for i in config.pmos)))

--- a/app/devcake/domain/orchestrator/decomposition.py
+++ b/app/devcake/domain/orchestrator/decomposition.py
@@ -192,6 +192,10 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
             if blocker_id:
                 rel_key = steps.DECOMP_REL(j, i)
                 async def _rel(blocker_id=blocker_id, child_id=child_id, j=j):
+                    if not mgr._relations_supported():
+                        mgr._audit(child_id, "relation_skipped",
+                                   f"blocked by part {j} ({blocker_id})")
+                        return
                     await mgr.pmo.create_relation(blocker_id, child_id)
                     mgr._audit(child_id, "relation_created",
                                 f"blocked by part {j} ({blocker_id})")
@@ -221,6 +225,10 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
         child_id_set = set(child_ids.values())
 
         async def _inherit(blocker_id: str, blocked_id: str) -> None:
+            if not mgr._relations_supported():
+                mgr._audit(blocked_id, "relation_skipped",
+                           f"{blocker_id} blocks {blocked_id}")
+                return
             try:
                 await mgr.pmo.create_relation(blocker_id, blocked_id)
             except Exception:

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -176,6 +176,13 @@ class MissionManager:
         except Exception:  # noqa: BLE001 — capability probe degrades to the conservative 25 MiB default cap; the zip builder still bounds the payload
             return 25 * 1024 * 1024
 
+    def _relations_supported(self) -> bool:
+        """Port flag — False means skip create_relation (do not abort)."""
+        try:
+            return bool(self.pmo.capabilities().relations_supported)
+        except Exception:  # noqa: BLE001 — missing caps must not drop Linear/Gitea edges
+            return True
+
     def _run_is_ours(self, r) -> bool:
         """Instance-scope a run record (schema v3). Vendor pmo_ids are UUIDs for
         Linear, so the mission_pmo_id filters are already collision-free — this

--- a/app/devcake/domain/orchestrator/steward.py
+++ b/app/devcake/domain/orchestrator/steward.py
@@ -312,6 +312,11 @@ async def apply_steward_edges(mgr, edges: list) -> tuple[int, int]:
             log.info("steward edge %s blocks %s rejected: %s",
                      blocker_key, blocked_key, reason)
             continue
+        if not mgr._relations_supported():
+            rejected += 1
+            mgr._audit(blocked.pmo_id, "relation_skipped",
+                       f"{blocker_key}→{blocked_key}")
+            continue
         await mgr.pmo.create_relation(blocker.pmo_id, blocked.pmo_id)
         graph.setdefault(blocked.pmo_id, set()).add(blocker.pmo_id)
         mgr._audit(blocked.pmo_id, "relation_created",

--- a/app/devcake/ports/pmo.py
+++ b/app/devcake/ports/pmo.py
@@ -38,6 +38,8 @@ class PMOCapabilities(BaseModel):
     attachment_max_bytes: int
     native_label_swap_atomic: bool
     relations_supported: bool = False
+    # Official file-upload API; false skips upload and contract rows 8/13.
+    attachments_supported: bool = True
     # pmo_ids are globally unique across the vendor environment (Linear
     # UUIDs) — only such systems may resolve blockers via PEER adapters or
     # accept peer run history on a locally-resolved foreign id. Colliding-id

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -184,7 +184,7 @@ def make_mission_manager(
     return mgr
 
 
-def fake_pmo_capabilities(*, global_ids=True):
+def fake_pmo_capabilities(*, global_ids=True, relations_supported=True):
     """Shared capability row for the test fakes. Default is Linear-shaped
     (global ids ON, so peer-resolution tests exercise the allowed path);
     colliding-id scenarios pass global_ids=False — the capability replaced
@@ -193,7 +193,7 @@ def fake_pmo_capabilities(*, global_ids=True):
     return PMOCapabilities(
         projects_supported=True, project_labels_supported=True,
         attachment_max_bytes=50 * 1024 * 1024,
-        native_label_swap_atomic=True, relations_supported=True,
+        native_label_swap_atomic=True, relations_supported=relations_supported,
         global_ids=global_ids)
 
 

--- a/app/tests/test_agnosticism.py
+++ b/app/tests/test_agnosticism.py
@@ -155,7 +155,8 @@ def test_no_vendor_name_literals_in_domain():
     decisions belong to capabilities (ForgeCapabilities /
     PMOCapabilities.global_ids) or to the adapter itself
     (InternalForgePort.mission_repo_binding)."""
-    vendors = {"gitea", "github", "gitlab", "linear", "gitea_issues"}
+    vendors = {"gitea", "github", "gitlab", "linear", "gitea_issues",
+               "gitlab_issues"}
     offenders = []
     for path in _package_files():
         rel = path.relative_to(PKG_ROOT)

--- a/app/tests/test_config_schema.py
+++ b/app/tests/test_config_schema.py
@@ -385,7 +385,7 @@ def test_make_pmo_dispatches_from_registry():
     cfg = AppConfig(pmos=[PMOInstance(name="linear", team_key="DEV")])
     assert isinstance(make_pmo(cfg.pmos[0]), LinearAdapter)
     # both in-tree PMO systems (Linear + forge-issue Gitea Issues)
-    assert set(PMO_SYSTEMS) == {"linear", "gitea_issues"}
+    assert set(PMO_SYSTEMS) == {"linear", "gitea_issues", "gitlab_issues"}
     info = PMO_SYSTEMS["linear"]
     # api_key_env_default removed at v4 (secrets are GUI-stored, not env-named)
     assert info.secret_env_vars and info.token_patterns and info.secret_shape_prefixes
@@ -396,6 +396,15 @@ def test_make_pmo_dispatches_from_registry():
         name="gitea", system="gitea_issues", team_key="org/board",
         api_base="http://gitea:3000")])
     assert isinstance(make_pmo(gi.pmos[0]), GiteaIssuesAdapter)
+    from devcake.adapters.gitlab_issues import GitLabIssuesAdapter
+    gl = AppConfig(pmos=[PMOInstance(
+        name="gl", system="gitlab_issues", team_key="org/board",
+        api_base="https://gitlab.com")])
+    assert isinstance(make_pmo(gl.pmos[0]), GitLabIssuesAdapter)
+    assert PMO_SYSTEMS["gitlab_issues"].needs_api_base is True
+    assert PMO_SYSTEMS["gitlab_issues"].supports_priority is False
+    assert PMO_SYSTEMS["gitlab_issues"].relations_supported is False
+    assert PMO_SYSTEMS["gitlab_issues"].operator_note
 
 
 def test_stale_put_bodies_rejected_not_dropped():

--- a/app/tests/test_forge_error_contract.py
+++ b/app/tests/test_forge_error_contract.py
@@ -79,7 +79,8 @@ def test_toolkit_imports_no_vendor_adapter():
 
     import devcake.adapters._toolkit as toolkit
     tree = ast.parse(Path(toolkit.__file__).read_text())
-    vendors = {"linear", "gitea", "gitea_issues", "github", "gitlab", "redis",
+    vendors = {"linear", "gitea", "gitea_issues", "github", "gitlab",
+               "gitlab_issues", "redis",
                "dagu", "files"}
     offenders = []
     for node in ast.walk(tree):

--- a/app/tests/test_gitlab_issues_contract.py
+++ b/app/tests/test_gitlab_issues_contract.py
@@ -58,6 +58,9 @@ class Router:
         }
         self.notes: dict[int, list] = {1: [], 2: []}
         self.uploads: dict[str, bytes] = {}
+        self.links: dict[int, list] = {}
+        self.links_status: dict[int, int] = {}
+        self.note_sort: str | None = None
         self.next_label = 10
         self.next_note = 1
         self.calls: list[str] = []
@@ -142,6 +145,7 @@ class Router:
                     iss["labels"] = [x for x in body["labels"].split(",") if x]
                 return httpx.Response(200, json=iss)
             if rest == "/notes" and method == "GET":
+                self.note_sort = req.url.params.get("sort")
                 return httpx.Response(200, json=self.notes.get(iid, []))
             if rest == "/notes" and method == "POST":
                 c = {
@@ -155,11 +159,21 @@ class Router:
                 self.notes.setdefault(iid, []).append(c)
                 return httpx.Response(201, json=c)
             if rest == "/links" and method == "GET":
-                return httpx.Response(200, json=[])
+                status = self.links_status.get(iid, 200)
+                if status != 200:
+                    return httpx.Response(
+                        status,
+                        json={"message":
+                              "Blocked issues not available for current license"})
+                return httpx.Response(200, json=self.links.get(iid, []))
             if rest == "/links" and method == "POST":
+                status = self.links_status.get(iid, 403)
+                if status == 409:
+                    return httpx.Response(
+                        409, json={"message": "already assigned"})
                 return httpx.Response(
-                    403, json={"message":
-                               "Blocked issues not available for current license"})
+                    status, json={"message":
+                                  "Blocked issues not available for current license"})
 
         return httpx.Response(404, json={"message": f"unhandled {method} {path}"})
 
@@ -228,12 +242,49 @@ def test_health_probe_is_read_only():
     assert not any(c.startswith(("POST", "PUT", "PATCH")) for c in r.calls)
 
 
-def test_capabilities_issue_only_no_relations_on_free_tier():
+def test_capabilities_fail_closed_until_links_probe():
     caps = make_pmo().capabilities()
     assert caps.projects_supported is False
     assert caps.relations_supported is False
     assert caps.global_ids is False
     assert caps.native_label_swap_atomic is True
+
+
+def test_relations_probe_403_stays_false_and_is_read_only():
+    r = Router()
+    r.links_status[1] = 403
+    pmo = make_pmo(r)
+    h = run(pmo.health_probe("o/r"))
+    assert h.ok
+    assert pmo.capabilities().relations_supported is False
+    assert "relations=off" in (h.detail or "")
+    assert not any(c.startswith(("POST", "PUT", "PATCH")) for c in r.calls)
+    m = run(pmo.get(MissionRef("1", "issue")))
+    assert m.blocked_by == []
+
+
+def test_relations_probe_200_sets_true_and_fills_blocked_by():
+    r = Router()
+    r.links[1] = [{
+        "link_type": "is_blocked_by",
+        "issue": {"iid": 2},
+    }]
+    pmo = make_pmo(r)
+    h = run(pmo.health_probe("o/r"))
+    assert h.ok
+    assert pmo.capabilities().relations_supported is True
+    assert "relations=on" in (h.detail or "")
+    m = run(pmo.get(MissionRef("1", "issue")))
+    assert m.blocked_by == ["2"]
+
+
+def test_create_relation_iid_409_license_403_still_raises():
+    r = Router()
+    r.issues[409] = _issue(409)
+    r.links_status[409] = 403
+    pmo = make_pmo(r)
+    with pytest.raises(RuntimeError, match="403"):
+        run(pmo.create_relation("1", "409"))
 
 
 def test_project_ref_get_raises():
@@ -272,3 +323,39 @@ def test_create_relation_surfaces_license_error():
     pmo = make_pmo()
     with pytest.raises(RuntimeError, match="403"):
         run(pmo.create_relation("1", "2"))
+
+
+def test_download_asset_refuses_on_host_path_escape():
+    pmo = make_pmo()
+    with pytest.raises(RuntimeError, match="refused"):
+        run(pmo.download_asset(
+            "https://gitlab.com/api/v4/projects/o%2Fr/uploads/aa/../user"))
+    with pytest.raises(RuntimeError, match="refused"):
+        run(pmo.download_asset("https://gitlab.com/api/v4/user"))
+
+
+def test_get_activity_requests_newest_notes_first():
+    r = Router()
+    pmo = make_pmo(r)
+    run(pmo.get_activity(MissionRef("1", "issue")))
+    assert r.note_sort == "desc"
+
+
+def test_get_activity_full_collects_description_and_api_upload_urls():
+    r = Router()
+    r.issues[1]["description"] = "brief [spec](/uploads/deadbeef/spec.md)"
+    r.notes[1] = [{
+        "id": 9,
+        "body": ("also "
+                 "[plan.md](https://gitlab.com/api/v4/projects/o%2Fr/"
+                 "uploads/abc123/plan.md)"),
+        "created_at": "2026-08-15T12:00:00Z",
+        "author": {"username": "bot"},
+        "system": False,
+    }]
+    pmo = make_pmo(r)
+    act = run(pmo.get_activity(MissionRef("1", "issue"), full=True))
+    names = {a.name for a in act.mission_attachments}
+    assert "spec" in names
+    note_names = {a.name for e in act.entries for a in e.attachments}
+    assert "plan.md" in note_names

--- a/app/tests/test_gitlab_issues_contract.py
+++ b/app/tests/test_gitlab_issues_contract.py
@@ -1,0 +1,274 @@
+"""GitLabIssuesAdapter PMOPort conformance (offline MockTransport)."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import re
+
+import httpx
+import pytest
+
+from devcake.adapters.gitlab_issues.adapter import GitLabIssuesAdapter
+from devcake.adapters.gitlab_issues.mapping import CANCEL_FOOTER
+from devcake.domain.model import ALL_LABELS, MissionRef
+from devcake.ports.pmo import PMOPort, PMOTransient
+
+PORT_METHODS = [n for n, v in vars(PMOPort).items()
+                if callable(v) and not n.startswith("_")]
+
+
+def _params(fn):
+    return [p for p in inspect.signature(fn).parameters if p != "self"]
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_gitlab_issues_implements_full_port():
+    for name in PORT_METHODS:
+        impl = getattr(GitLabIssuesAdapter, name, None)
+        assert impl is not None, f"missing {name}"
+        assert _params(impl) == _params(getattr(PMOPort, name)), name
+
+
+def _issue(iid=1, state="opened", description="", labels=None, title="t"):
+    return {
+        "id": 9000 + iid,
+        "iid": iid,
+        "title": title,
+        "description": description,
+        "state": state,
+        "web_url": f"https://gitlab.com/o/r/-/issues/{iid}",
+        "updated_at": "2026-08-15T00:00:00Z",
+        "labels": labels or [],
+    }
+
+
+class Router:
+    def __init__(self):
+        self.issues = {
+            1: _issue(1, labels=["DEVCAKE"]),
+            2: _issue(2, description="blocked"),
+        }
+        self.labels = {
+            "DEVCAKE": {"id": 1, "name": "DEVCAKE", "color": "#000000"},
+        }
+        self.notes: dict[int, list] = {1: [], 2: []}
+        self.uploads: dict[str, bytes] = {}
+        self.next_label = 10
+        self.next_note = 1
+        self.calls: list[str] = []
+
+    def handler(self, req: httpx.Request) -> httpx.Response:
+        # httpx MockTransport decodes %2F; accept both encodings.
+        from urllib.parse import unquote
+        path = unquote(req.url.path)
+        method = req.method.upper()
+        self.calls.append(f"{method} {path}")
+        body = {}
+        if req.content:
+            try:
+                body = json.loads(req.content)
+            except json.JSONDecodeError:
+                body = {}
+
+        if path == "/api/v4/projects/o/r":
+            return httpx.Response(200, json={"id": 42, "path_with_namespace": "o/r"})
+
+        if path == "/api/v4/projects/o/r/labels":
+            if method == "GET":
+                page = int(req.url.params.get("page", 1))
+                per = int(req.url.params.get("per_page", 50))
+                items = list(self.labels.values())
+                return httpx.Response(
+                    200, json=items[(page - 1) * per: page * per])
+            if method == "POST":
+                name = (body.get("name") or "").upper()
+                self.next_label += 1
+                lb = {"id": self.next_label, "name": name, "color": "#6e40c9"}
+                self.labels[name] = lb
+                return httpx.Response(201, json=lb)
+
+        if path == "/api/v4/projects/o/r/issues":
+            if method == "GET":
+                state = req.url.params.get("state", "all")
+                items = list(self.issues.values())
+                if state == "opened":
+                    items = [i for i in items if i["state"] == "opened"]
+                return httpx.Response(200, json=items)
+            if method == "POST":
+                n = max(self.issues) + 1
+                labs = [x for x in (body.get("labels") or "").split(",") if x]
+                iss = _issue(n, description=body.get("description") or "",
+                             labels=labs, title=body.get("title") or "")
+                self.issues[n] = iss
+                self.notes[n] = []
+                return httpx.Response(201, json=iss)
+
+        if path == "/api/v4/projects/o/r/uploads" and method == "POST":
+            secret = "abc123"
+            self.uploads[f"{secret}/plan.md"] = b"# plan"
+            return httpx.Response(201, json={
+                "url": f"/uploads/{secret}/plan.md",
+                "full_path": f"/-/project/42/uploads/{secret}/plan.md",
+                "markdown": f"[plan.md](/uploads/{secret}/plan.md)",
+            })
+
+        m = re.match(r"^/api/v4/projects/o/r/uploads/([^/]+)/([^/]+)$", path)
+        if m and method == "GET":
+            blob = self.uploads.get(f"{m.group(1)}/{m.group(2)}")
+            if blob is None:
+                return httpx.Response(404, json={"message": "not found"})
+            return httpx.Response(200, content=blob)
+
+        m = re.match(r"^/api/v4/projects/o/r/issues/(\d+)(.*)$", path)
+        if m:
+            iid = int(m.group(1))
+            rest = m.group(2) or ""
+            if rest == "" and method == "GET":
+                return httpx.Response(200, json=self.issues[iid])
+            if rest == "" and method == "PUT":
+                iss = self.issues[iid]
+                if body.get("state_event") == "close":
+                    iss["state"] = "closed"
+                if body.get("state_event") == "reopen":
+                    iss["state"] = "opened"
+                if "description" in body:
+                    iss["description"] = body["description"]
+                if "labels" in body:
+                    iss["labels"] = [x for x in body["labels"].split(",") if x]
+                return httpx.Response(200, json=iss)
+            if rest == "/notes" and method == "GET":
+                return httpx.Response(200, json=self.notes.get(iid, []))
+            if rest == "/notes" and method == "POST":
+                c = {
+                    "id": self.next_note,
+                    "body": body.get("body") or "",
+                    "created_at": "2026-08-15T12:00:00Z",
+                    "author": {"username": "bot"},
+                    "system": False,
+                }
+                self.next_note += 1
+                self.notes.setdefault(iid, []).append(c)
+                return httpx.Response(201, json=c)
+            if rest == "/links" and method == "GET":
+                return httpx.Response(200, json=[])
+            if rest == "/links" and method == "POST":
+                return httpx.Response(
+                    403, json={"message":
+                               "Blocked issues not available for current license"})
+
+        return httpx.Response(404, json={"message": f"unhandled {method} {path}"})
+
+
+def make_pmo(router: Router | None = None) -> GitLabIssuesAdapter:
+    r = router or Router()
+    return GitLabIssuesAdapter(
+        "https://gitlab.com", "tok", "o/r", instance="gl",
+        transport=httpx.MockTransport(r.handler))
+
+
+def test_list_and_get_normalize_opened_to_backlog():
+    pmo = make_pmo()
+    missions = run(pmo.list_all("o/r"))
+    assert all(m.pmo_kind == "issue" for m in missions)
+    m = run(pmo.get(MissionRef("1", "issue")))
+    assert m.status == "backlog"
+    assert m.key == "o/r#1"
+    assert m.pmo_id == "1"
+    assert m.instance == "gl"
+
+
+def test_closed_with_cancel_footer_is_canceled():
+    r = Router()
+    r.issues[1] = _issue(1, state="closed",
+                         description=f"x\n{CANCEL_FOOTER}\n")
+    pmo = make_pmo(r)
+    m = run(pmo.get(MissionRef("1", "issue")))
+    assert m.status == "canceled"
+
+
+def test_cancel_mission_idempotent():
+    r = Router()
+    pmo = make_pmo(r)
+    run(pmo.cancel_mission(MissionRef("1", "issue")))
+    assert r.issues[1]["state"] == "closed"
+    assert CANCEL_FOOTER in r.issues[1]["description"]
+    run(pmo.cancel_mission(MissionRef("1", "issue")))
+
+
+def test_post_feed_and_activity_marker_body():
+    r = Router()
+    pmo = make_pmo(r)
+    marker = "step `devcake:v1` ok"
+    run(pmo.post_feed(MissionRef("1", "issue"), marker))
+    act = run(pmo.get_activity(MissionRef("1", "issue")))
+    assert act.entries[-1].body == marker
+
+
+def test_create_mission_returns_key_and_id():
+    r = Router()
+    pmo = make_pmo(r)
+    key, pid = run(pmo.create_mission(
+        "o/r", "child", "desc `devcake:v1`", "high", {"DEVCAKE"}))
+    assert pid == "3"
+    assert key == "o/r#3"
+
+
+def test_health_probe_is_read_only():
+    r = Router()
+    pmo = make_pmo(r)
+    h = run(pmo.health_probe("o/r"))
+    assert h.ok
+    assert h.workspace == "o/r"
+    assert h.managed_labels_present == 1
+    assert not any(c.startswith(("POST", "PUT", "PATCH")) for c in r.calls)
+
+
+def test_capabilities_issue_only_no_relations_on_free_tier():
+    caps = make_pmo().capabilities()
+    assert caps.projects_supported is False
+    assert caps.relations_supported is False
+    assert caps.global_ids is False
+    assert caps.native_label_swap_atomic is True
+
+
+def test_project_ref_get_raises():
+    pmo = make_pmo()
+    with pytest.raises(RuntimeError, match="projects"):
+        run(pmo.get(MissionRef("1", "project")))
+
+
+def test_429_is_pmo_transient():
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, text="slow down")
+
+    pmo = GitLabIssuesAdapter(
+        "https://gitlab.com", "tok", "o/r",
+        transport=httpx.MockTransport(handler))
+    with pytest.raises(PMOTransient):
+        run(pmo.get(MissionRef("1", "issue")))
+
+
+def test_upload_and_download_round_trip():
+    r = Router()
+    pmo = make_pmo(r)
+    url = run(pmo.upload_attachment("1", "plan.md", b"# plan"))
+    assert "/uploads/abc123/plan.md" in url
+    blob = run(pmo.download_asset(url))
+    assert blob == b"# plan"
+
+
+def test_download_asset_refuses_evil_host():
+    pmo = make_pmo()
+    with pytest.raises(RuntimeError, match="refused"):
+        run(pmo.download_asset("https://evil.example/secret"))
+
+
+def test_create_relation_surfaces_license_error():
+    pmo = make_pmo()
+    with pytest.raises(RuntimeError, match="403"):
+        run(pmo.create_relation("1", "2"))

--- a/app/tests/test_gitlab_issues_contract.py
+++ b/app/tests/test_gitlab_issues_contract.py
@@ -167,13 +167,22 @@ class Router:
                               "Blocked issues not available for current license"})
                 return httpx.Response(200, json=self.links.get(iid, []))
             if rest == "/links" and method == "POST":
-                status = self.links_status.get(iid, 403)
+                status = self.links_status.get(iid, 201)
                 if status == 409:
                     return httpx.Response(
                         409, json={"message": "already assigned"})
-                return httpx.Response(
-                    status, json={"message":
-                                  "Blocked issues not available for current license"})
+                if status != 201:
+                    return httpx.Response(
+                        status,
+                        json={"message":
+                              "Blocked issues not available for current license"})
+                target = int(body.get("target_issue_iid") or 0)
+                self.links.setdefault(iid, []).append({
+                    "id": 84,
+                    "iid": target,
+                    "link_type": body.get("link_type") or "relates_to",
+                })
+                return httpx.Response(201, json={"link_type": body.get("link_type")})
 
         return httpx.Response(404, json={"message": f"unhandled {method} {path}"})
 
@@ -242,49 +251,62 @@ def test_health_probe_is_read_only():
     assert not any(c.startswith(("POST", "PUT", "PATCH")) for c in r.calls)
 
 
-def test_capabilities_fail_closed_until_links_probe():
+def test_capabilities_fail_closed_until_a_write():
     caps = make_pmo().capabilities()
     assert caps.projects_supported is False
     assert caps.relations_supported is False
+    assert caps.attachments_supported is True
     assert caps.global_ids is False
     assert caps.native_label_swap_atomic is True
 
 
-def test_relations_probe_403_stays_false_and_is_read_only():
+def test_health_probe_is_read_only_and_does_not_claim_write_support():
     r = Router()
-    r.links_status[1] = 403
+    r.links[1] = [{
+        "id": 84, "iid": 2, "project_id": 4,
+        "link_type": "is_blocked_by", "title": "blocker",
+    }]
     pmo = make_pmo(r)
     h = run(pmo.health_probe("o/r"))
     assert h.ok
     assert pmo.capabilities().relations_supported is False
     assert "relations=off" in (h.detail or "")
     assert not any(c.startswith(("POST", "PUT", "PATCH")) for c in r.calls)
-    m = run(pmo.get(MissionRef("1", "issue")))
-    assert m.blocked_by == []
 
 
-def test_relations_probe_200_sets_true_and_fills_blocked_by():
+def test_blocked_by_reads_gitlab_list_shape():
+    """GET /issues/:iid/links returns the related issue at top level."""
     r = Router()
     r.links[1] = [{
+        "id": 84,
+        "iid": 2,
+        "project_id": 4,
+        "title": "Issues with auth",
+        "state": "opened",
         "link_type": "is_blocked_by",
-        "issue": {"iid": 2},
     }]
     pmo = make_pmo(r)
-    h = run(pmo.health_probe("o/r"))
-    assert h.ok
-    assert pmo.capabilities().relations_supported is True
-    assert "relations=on" in (h.detail or "")
     m = run(pmo.get(MissionRef("1", "issue")))
     assert m.blocked_by == ["2"]
+    assert pmo.capabilities().relations_supported is False
 
 
-def test_create_relation_iid_409_license_403_still_raises():
+def test_create_relation_403_is_unsupported_not_a_wedge():
     r = Router()
     r.issues[409] = _issue(409)
     r.links_status[409] = 403
     pmo = make_pmo(r)
-    with pytest.raises(RuntimeError, match="403"):
-        run(pmo.create_relation("1", "409"))
+    run(pmo.create_relation("1", "409"))
+    assert pmo.capabilities().relations_supported is False
+
+
+def test_create_relation_success_latches_supported():
+    r = Router()
+    pmo = make_pmo(r)
+    run(pmo.create_relation("1", "2"))
+    assert pmo.capabilities().relations_supported is True
+    m = run(pmo.get(MissionRef("2", "issue")))
+    assert m.blocked_by == ["1"]
 
 
 def test_project_ref_get_raises():
@@ -311,6 +333,7 @@ def test_upload_and_download_round_trip():
     assert "/uploads/abc123/plan.md" in url
     blob = run(pmo.download_asset(url))
     assert blob == b"# plan"
+    assert r.notes[1] == []  # feed chokepoint posts the note, not upload
 
 
 def test_download_asset_refuses_evil_host():
@@ -319,10 +342,14 @@ def test_download_asset_refuses_evil_host():
         run(pmo.download_asset("https://evil.example/secret"))
 
 
-def test_create_relation_surfaces_license_error():
+def test_download_asset_refuses_foreign_project():
     pmo = make_pmo()
-    with pytest.raises(RuntimeError, match="403"):
-        run(pmo.create_relation("1", "2"))
+    with pytest.raises(RuntimeError, match="refused"):
+        run(pmo.download_asset(
+            "https://gitlab.com/api/v4/projects/other%2Frepo/uploads/abc123/x.md"))
+    with pytest.raises(RuntimeError, match="refused"):
+        run(pmo.download_asset(
+            "https://gitlab.com/api/v4/projects/99/uploads/abc123/x.md"))
 
 
 def test_download_asset_refuses_on_host_path_escape():

--- a/app/tests/test_gitlab_issues_mapping.py
+++ b/app/tests/test_gitlab_issues_mapping.py
@@ -1,0 +1,54 @@
+"""Pure forge-issue status/key mapping for GitLab Issues PMO (docs/05).
+
+Independent expected values — no re-deriving production helpers in asserts.
+"""
+
+from devcake.adapters.gitlab_issues.mapping import (
+    CANCEL_FOOTER,
+    mission_key,
+    normalize_priority,
+    normalize_status,
+    parse_team_ref,
+    project_path_encoded,
+)
+
+
+def test_parse_team_ref_owner_repo():
+    assert parse_team_ref("mygroup/missions") == "mygroup/missions"
+    assert parse_team_ref("  org/sub/board  ") == "org/sub/board"
+
+
+def test_parse_team_ref_rejects_bad_shapes():
+    for bad in ("", "solo", "/x"):
+        try:
+            parse_team_ref(bad)
+            assert False, f"expected ValueError for {bad!r}"
+        except ValueError:
+            pass
+
+
+def test_project_path_encoded_encodes_slashes():
+    assert project_path_encoded("org/sub/board") == "org%2Fsub%2Fboard"
+
+
+def test_mission_key_format():
+    assert mission_key("mygroup/missions", 17) == "mygroup/missions#17"
+
+
+def test_normalize_status_opened_is_always_backlog():
+    assert normalize_status("opened", "") == "backlog"
+    assert normalize_status("opened", "body with stuff") == "backlog"
+
+
+def test_normalize_status_closed_is_done_without_cancel_footer():
+    assert normalize_status("closed", "finished work") == "done"
+    assert normalize_status("closed", "") == "done"
+
+
+def test_normalize_status_closed_with_cancel_footer_is_canceled():
+    body = f"oops\n\n---\n{CANCEL_FOOTER}\n"
+    assert normalize_status("closed", body) == "canceled"
+
+
+def test_normalize_priority_always_medium():
+    assert normalize_priority("urgent") == "medium"

--- a/app/tests/test_health_payload.py
+++ b/app/tests/test_health_payload.py
@@ -282,6 +282,23 @@ def test_pmo_probe_is_cached_between_health_calls(tmp_path, monkeypatch):
     assert len(calls) == 2, "reset_health_caches must force a reprobe"
 
 
+def test_pmo_health_exposes_probe_detail_and_capability_flags(tmp_path, monkeypatch):
+    from fakes import fake_pmo_capabilities
+
+    async def probe(team):
+        return SimpleNamespace(ok=True, detail="relations=off (token)")
+
+    cfg, managers = _pmo_world(probe, tmp_path, monkeypatch)
+    managers["linear"].pmo.capabilities = lambda: fake_pmo_capabilities(
+        relations_supported=False)
+    payload = _pmo_payload(cfg, managers, monkeypatch)
+    inst = payload["pmo_instances"]["linear"]
+    assert inst["ok"] is True
+    assert inst["detail"] == "relations=off (token)"
+    assert inst["relations_supported"] is False
+    assert inst["attachments_supported"] is True
+
+
 def test_one_hanging_pmo_cannot_stall_health(tmp_path, monkeypatch):
     """Per-probe 5 s timeout + concurrent gather: a sick PMO reports
     ok:False; /health returns without waiting out a 30 s client timeout."""

--- a/app/tests/test_steward.py
+++ b/app/tests/test_steward.py
@@ -27,12 +27,17 @@ def m(pmo_id, key, status="backlog", blocked_by=()):
 
 
 class MapPMO:
-    def __init__(self, missions, activity=None):
+    def __init__(self, missions, activity=None, *, relations_supported=True):
         self.missions = missions
         self.activity = activity
         self.relations = []
         self.comments = []
         self.activity_calls = []
+        self._relations_supported = relations_supported
+
+    def capabilities(self):
+        from fakes import fake_pmo_capabilities
+        return fake_pmo_capabilities(relations_supported=self._relations_supported)
 
     async def list_all(self, team_ref):
         return self.missions
@@ -120,6 +125,16 @@ def test_apply_steward_edges_validates_everything(tmp_path):
     pmo_id, comment = pmo.comments[-1]
     assert pmo_id == "id" and "T-B" in comment
     assert comment.endswith("`devcake:v1`")        # notification is sentinel-signed
+
+
+def test_apply_steward_edges_skips_when_relations_unsupported(tmp_path):
+    pmo = MapPMO([m("ia", "T-A"), m("id", "T-D")], relations_supported=False)
+    mgr = make_mgr(tmp_path, pmo)
+    created, rejected = run_coro(steward.apply_steward_edges(mgr, [
+        {"blocker": "T-A", "blocked": "T-D"},
+    ]))
+    assert (created, rejected) == (0, 1)
+    assert pmo.relations == []
 
 
 def test_creates_cycle_transitive():

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -34,7 +34,9 @@ class FakePMO:
 
     def capabilities(self):
         from fakes import fake_pmo_capabilities
-        return fake_pmo_capabilities()   # global_ids=True — peer path enabled
+        return fake_pmo_capabilities(
+            relations_supported=getattr(self, "relations_supported", True),
+        )
 
     def __init__(self, mission):
         self.mission = mission
@@ -696,6 +698,20 @@ def test_decomposition_wires_blocked_by_edges(tmp_path):
                              None))
     assert [t for t, _ in fake.created] == ["docs", "code", "polish"]
     assert fake.relations == [("id-1", "id-2"), ("id-1", "id-3"), ("id-2", "id-3")]
+    assert fake.statuses == ["canceled"]
+
+
+def test_decomposition_skips_relations_when_capability_off(tmp_path):
+    m = mission("in_progress", {"DEVCAKE"})
+    mgr, fake, store = make_mgr(tmp_path, m)
+    fake.relations_supported = False
+    drafts = [{"title": "docs", "priority": "high"},
+              {"title": "code", "priority": "high", "blocked_by": [1]}]
+    run_coro(transitions.transition(mgr, _run("ONBOARD", None),
+                             {"outcome": "decomposed", "decomposition": drafts},
+                             None))
+    assert [t for t, _ in fake.created] == ["docs", "code"]
+    assert fake.relations == []
     assert fake.statuses == ["canceled"]
 
 

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -1,6 +1,6 @@
 # 05 — PMO Adapter: `PMOPort`, Linear, and Gitea Issues
 
-> **Audience:** implementers of PMO adapters (Linear, Gitea Issues; later GitHub/GitLab Issues).
+> **Audience:** implementers of PMO adapters (Linear, Gitea Issues, GitLab Issues; later GitHub Issues).
 > **Depends on:** `02-domain-model.md` (Mission, MissionRef, labels), `00-overview.md` (INV-1, INV-4).
 
 The domain core never sees vendor types. It programs against `PMOPort` (`app/devcake/ports/pmo.py`), a Python `Protocol` over the normalized DTOs of `02-domain-model.md`. In-tree adapters: **Linear** (`adapters/linear/`) and **Gitea Issues** (`adapters/gitea_issues/` — a pure `PMOPort`, **not** `ForgePort`). The port + registry (§1a) + contract-test batteries (§7) are **the template for every future PMO System**: adding one = an adapter package under `app/devcake/adapters/{system}/` implementing the full port + one `PMO_SYSTEMS` entry (plus its constructor branch in `make_pmo`).
@@ -312,3 +312,18 @@ Expect all rows **PASS** (1–5, 5b, 8–14 when `relations_supported`). Same sc
 ### 9.6 Path to GitHub / GitLab Issues
 
 Same forge-issue profile (issue-only, label stages, open→backlog, markdown comments, dependency/links). New package per vendor; do **not** grow a shared Issues Port until a second forge-issue adapter exists. Live gate: same `scripts/contract_tests_pmo.py` once the system is registered.
+
+### 9.7 GitLab Issues (`gitlab_issues`)
+
+In-tree as of 2026-08-15. `team_key` is `path_with_namespace` (two or more segments). `api_base` defaults to `https://gitlab.com`. Auth: `PRIVATE-TOKEN` (`glpat-…`).
+
+| Need | Measured |
+|---|---|
+| Status | `opened`→backlog; `closed`→done; cancel footer in description → canceled |
+| Labels | PUT issue `labels=A,B` replaces the set |
+| Feed | issue notes; `` `devcake:v1` `` byte-exact |
+| Attachments | POST `/projects/:id/uploads`; download `GET /api/v4/projects/:id/uploads/:secret/:filename` (web `/uploads/…` path is **403** with a PAT) |
+| Relations | `blocks` / `is_blocked_by` is **Premium**. Free gitlab.com → 403 license. `capabilities.relations_supported=False`; `create_relation` raises (does not no-op). Row 14 of the contract battery skips. |
+
+`pmo_id` is the issue **iid**. `global_ids=False`. Separate PMO PAT from any GitLab *forge* repo-card token. The admin PMO card and New Mission dialog show `operator_note` from the registry when this system is selected.
+

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -3,7 +3,7 @@
 > **Audience:** implementers of PMO adapters (Linear, Gitea Issues, GitLab Issues; later GitHub Issues).
 > **Depends on:** `02-domain-model.md` (Mission, MissionRef, labels), `00-overview.md` (INV-1, INV-4).
 
-The domain core never sees vendor types. It programs against `PMOPort` (`app/devcake/ports/pmo.py`), a Python `Protocol` over the normalized DTOs of `02-domain-model.md`. In-tree adapters: **Linear** (`adapters/linear/`) and **Gitea Issues** (`adapters/gitea_issues/` — a pure `PMOPort`, **not** `ForgePort`). The port + registry (§1a) + contract-test batteries (§7) are **the template for every future PMO System**: adding one = an adapter package under `app/devcake/adapters/{system}/` implementing the full port + one `PMO_SYSTEMS` entry (plus its constructor branch in `make_pmo`).
+The domain core never sees vendor types. It programs against `PMOPort` (`app/devcake/ports/pmo.py`), a Python `Protocol` over the normalized DTOs of `02-domain-model.md`. In-tree adapters: **Linear** (`adapters/linear/`), **Gitea Issues** (`adapters/gitea_issues/`), and **GitLab Issues** (`adapters/gitlab_issues/`) — all pure `PMOPort`, **not** `ForgePort`. The port + registry (§1a) + contract-test batteries (§7) are **the template for every future PMO System**: adding one = an adapter package under `app/devcake/adapters/{system}/` implementing the full port + one `PMO_SYSTEMS` entry (plus its constructor branch in `make_pmo`).
 
 ## 0. The PMO capability contract (normative — any candidate system)
 

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -11,7 +11,7 @@ A PMO system qualifies for a DevCake adapter iff it satisfies all four capabilit
 
 - **(a) Missions as the unit of work.** The system's work items map straightforwardly onto Missions (`02-domain-model.md`): a stable vendor id, title/description, a status that normalizes onto backlog/in-progress/done/canceled, and a priority.
 - **(b) Labels (or an equivalent) assign Mission Steps.** The DEVCAKE-* stage machinery needs an idempotently-creatable, atomically-swappable tag concept readable back on every item (`§5`).
-- **(c) Traffic control via blocked-by relations.** Native "X blocks Y" dependencies, listable per item — the scheduler gate and Relations Steward ride on them (`adr/0007`). When the live token cannot list or write blocked-by (GitLab Free), the adapter **probes** that fact (read-only) and sets `relations_supported=False`; domain skips `create_relation`; the operator sees the residual. Do not hardcode the flag, and do not invent `relates_to` as blocked-by.
+- **(c) Traffic control via blocked-by relations.** Native "X blocks Y" dependencies, listable per item — the scheduler gate and Relations Steward ride on them (`adr/0007`). Listing blocked-by is always attempted (GitLab Free can list `relates_to`; blocking types simply do not appear). Writing a blocking type that the token cannot create (GitLab Free 403) is a no-op that latches `relations_supported=False` — it must not escape finalize. Do not invent `relates_to` as blocked-by.
 - **(d) A reliable activity feed.** Ordered comments with **markdown fidelity** for backticked markers (`devcake:v1`, decomposition manifests, merge-retry markers): the feed is DevCake's persistent record of each mission (long-lived cross-mission memory is the separate notebook system, ADR-0035). Official **file attachments** are required unless `attachments_supported` is false — then the feed chokepoint posts a size-safe pointer (never a raw dump that the vendor will 422) and the operator sees the residual. A PMO that rewrites comment bytes (ADF/rich-text — Jira) needs an explicit fidelity strategy **on the port** before an adapter is attempted (ISSUES #35). Do not start a Jira adapter that greps ADF for markers. Abandonment must be expressible (`cancel_mission` — a canceled/archived terminal state).
 
 ## 1. Port interface (normative signatures)
@@ -98,7 +98,8 @@ class PMOCapabilities(BaseModel):
     project_labels_supported: bool    # Linear: True (project labels since 2025-06)
     attachment_max_bytes: int
     native_label_swap_atomic: bool    # Linear: True via issueUpdate(labelIds)
-    relations_supported: bool = False # probed from the live token; False until a read-only links GET succeeds
+    relations_supported: bool = False # write support latched on create_relation; False until a blocking-link POST succeeds
+    attachments_supported: bool = True  # official file-upload API
     attachments_supported: bool = True  # official file-upload API; false skips upload + contract rows 8/13
 ```
 
@@ -323,7 +324,7 @@ In-tree as of 2026-08-15. `team_key` is `path_with_namespace` (two or more segme
 | Labels | PUT issue `labels=A,B` replaces the set |
 | Feed | issue notes; `` `devcake:v1` `` byte-exact |
 | Attachments | POST `/projects/:id/uploads`; download `GET /api/v4/projects/:id/uploads/:secret/:filename` (web `/uploads/…` path is **403** with a PAT) |
-| Relations | `blocks` / `is_blocked_by` is **Premium**. Free gitlab.com → 403 license. `capabilities.relations_supported=False`; `create_relation` raises (does not no-op). Row 14 of the contract battery skips. |
+| Relations | `blocks` / `is_blocked_by` is **Premium**. Listing links is Free (top-level `iid` + `link_type`). Free gitlab.com → 403 on create: `create_relation` no-ops and latches `relations_supported=False` (must not escape finalize). Row 14 of the contract battery records SKIP, not a vanished pass. |
 
 `pmo_id` is the issue **iid**. `global_ids=False`. Separate PMO PAT from any GitLab *forge* repo-card token. The admin PMO card and New Mission dialog show `operator_note` from the registry when this system is selected.
 

--- a/scripts/contract_tests_pmo.py
+++ b/scripts/contract_tests_pmo.py
@@ -13,7 +13,7 @@ Runs INSIDE the app container:
 Instance selection (first match wins):
   1. ``DEVCAKE_CONTRACT_INSTANCE=<name>`` — configured PMO from config.yaml
   2. Direct harness:
-       DEVCAKE_CONTRACT_SYSTEM=gitea_issues|linear
+       DEVCAKE_CONTRACT_SYSTEM=gitea_issues|linear|gitlab_issues
        DEVCAKE_CONTRACT_TEAM=…  DEVCAKE_CONTRACT_TOKEN=…
        DEVCAKE_CONTRACT_API_BASE=… (gitea_issues)
   3. **Default CI lane** — when ``GITEA_ADMIN_USER`` + ``GITEA_ADMIN_PASSWORD``
@@ -197,6 +197,11 @@ def make_429_probe(system: str, team: str):
         return GiteaIssuesAdapter(
             GITEA_URL, "fake-token", team or "o/r",
             instance="contract", transport=mock)
+    if system == "gitlab_issues":
+        from devcake.adapters.gitlab_issues import GitLabIssuesAdapter
+        return GitLabIssuesAdapter(
+            "https://gitlab.com", "fake-token", team or "o/r",
+            instance="contract", transport=mock)
     raise SystemExit(f"no 429 probe for system {system!r}")
 
 
@@ -290,7 +295,7 @@ async def _run_battery(pmo, system: str, team: str) -> int:
         ref = MissionRef(tid, "issue")
         await pmo.post_feed(ref, "first comment")
         await asyncio.sleep(1.2)
-        if forge_issue:
+        if forge_issue and caps.attachments_supported:
             # Real upload → named markdown link (ROOT_URL may differ from api_base;
             # extraction rewrites host for downloads; body still carries a URL).
             asset_url = await pmo.upload_attachment(
@@ -305,7 +310,9 @@ async def _run_battery(pmo, system: str, team: str) -> int:
         bodies = [e.body.split(",")[0] for e in act.entries
                   if e.body.startswith("first") or e.body.startswith("second")]
         atts = [a.url for e in act.entries for a in e.attachments]
-        ok8 = (bodies == ["first comment", "second"] and len(atts) >= 1)
+        need_atts = (not forge_issue) or caps.attachments_supported
+        ok8 = (bodies == ["first comment", "second"]
+               and (len(atts) >= 1 if need_atts else True))
         note8 = f"{bodies} atts={len(atts)}"
     except Exception as e:
         ok8, note8 = False, str(e)[:160]
@@ -368,7 +375,6 @@ async def _run_battery(pmo, system: str, team: str) -> int:
         check("10", "capabilities truthful (issue-only forge-issue)",
               (not caps.projects_supported
                and not caps.project_labels_supported
-               and caps.relations_supported
                and caps.native_label_swap_atomic
                and all(m.pmo_kind == "issue" for m in all_missions)),
               f"projects={caps.projects_supported} "
@@ -420,20 +426,24 @@ async def _run_battery(pmo, system: str, team: str) -> int:
     check("12", "post_feed marker fidelity (docs/05 §0d)", ok12, note12)
 
     # ── 13 attachment upload/download ─────────────────────────────────────
-    aid = await make_temp_issue(pmo, team, "[CONTRACT] attachment round-trip",
-                                {"DEVCAKE"})
-    ok13, note13 = True, ""
-    try:
-        payload = b"contract-battery attachment \xf0\x9f\x8d\xb0 bytes"
-        url = await pmo.upload_attachment(aid, "contract.md", payload)
-        got = await pmo.download_asset(url)
-        ok13 = got == payload
-        note13 = "" if ok13 else f"{len(got)} bytes back, {len(payload)} sent"
-    except Exception as e:
-        ok13, note13 = False, str(e)[:160]
-    finally:
-        await cleanup_issue(pmo, aid)
-    check("13", "attachment upload/download round-trip", ok13, note13)
+    if not getattr(caps, "attachments_supported", True):
+        check("13", "attachment upload/download round-trip",
+              True, "skipped — attachments_supported=False")
+    else:
+        aid = await make_temp_issue(pmo, team, "[CONTRACT] attachment round-trip",
+                                    {"DEVCAKE"})
+        ok13, note13 = True, ""
+        try:
+            payload = b"contract-battery attachment \xf0\x9f\x8d\xb0 bytes"
+            url = await pmo.upload_attachment(aid, "contract.md", payload)
+            got = await pmo.download_asset(url)
+            ok13 = got == payload
+            note13 = "" if ok13 else f"{len(got)} bytes back, {len(payload)} sent"
+        except Exception as e:
+            ok13, note13 = False, str(e)[:160]
+        finally:
+            await cleanup_issue(pmo, aid)
+        check("13", "attachment upload/download round-trip", ok13, note13)
 
     # ── 14 relations (capability c) — always for systems that claim support
     if caps.relations_supported:

--- a/scripts/contract_tests_pmo.py
+++ b/scripts/contract_tests_pmo.py
@@ -36,14 +36,19 @@ from devcake.config import load_config
 from devcake.domain.model import ALL_LABELS, MissionRef
 from devcake.ports.pmo import PMOTransient
 
-PASS, FAIL = "PASS", "FAIL"
+PASS, FAIL, SKIP = "PASS", "FAIL", "SKIP"
 results: list[tuple[str, str, str]] = []
 
 GITEA_URL = os.environ.get("DEVCAKE_CONTRACT_GITEA_URL", "http://gitea:3000")
 
 
-def check(num: str, name: str, ok: bool, note: str = "") -> None:
-    results.append((num, name, PASS if ok else FAIL + (" — " + note if note else "")))
+def check(num: str, name: str, ok: bool, note: str = "", *,
+          skipped: bool = False) -> None:
+    if skipped:
+        results.append((num, name, SKIP + (" — " + note if note else "")))
+        return
+    suffix = (" — " + note) if note else ""
+    results.append((num, name, (PASS if ok else FAIL) + ("" if ok else suffix)))
 
 
 async def make_temp_issue(pmo, team: str, title: str,
@@ -428,7 +433,7 @@ async def _run_battery(pmo, system: str, team: str) -> int:
     # ── 13 attachment upload/download ─────────────────────────────────────
     if not getattr(caps, "attachments_supported", True):
         check("13", "attachment upload/download round-trip",
-              True, "skipped — attachments_supported=False")
+              True, "attachments_supported=False", skipped=True)
     else:
         aid = await make_temp_issue(pmo, team, "[CONTRACT] attachment round-trip",
                                     {"DEVCAKE"})
@@ -445,37 +450,43 @@ async def _run_battery(pmo, system: str, team: str) -> int:
             await cleanup_issue(pmo, aid)
         check("13", "attachment upload/download round-trip", ok13, note13)
 
-    # ── 14 relations (capability c) — always for systems that claim support
-    if caps.relations_supported:
-        blocker = await make_temp_issue(
-            pmo, team, "[CONTRACT] blocker", {"DEVCAKE"})
-        blocked = await make_temp_issue(
-            pmo, team, "[CONTRACT] blocked", {"DEVCAKE"})
-        ok14, note14 = True, ""
-        try:
-            await pmo.create_relation(blocker, blocked)
-            await pmo.create_relation(blocker, blocked)  # duplicate-tolerant
+    # ── 14 relations — always attempt; SKIP if the adapter cannot write
+    blocker = await make_temp_issue(
+        pmo, team, "[CONTRACT] blocker", {"DEVCAKE"})
+    blocked = await make_temp_issue(
+        pmo, team, "[CONTRACT] blocked", {"DEVCAKE"})
+    ok14, note14, skip14 = True, "", False
+    try:
+        await pmo.create_relation(blocker, blocked)
+        await pmo.create_relation(blocker, blocked)  # duplicate-tolerant
+        if not pmo.capabilities().relations_supported:
+            skip14, note14 = True, "adapter cannot write blocking links"
+        else:
             m = await pmo.get(MissionRef(blocked, "issue"))
             ok14 = blocker in m.blocked_by
             note14 = f"blocked_by={m.blocked_by}"
-        except Exception as e:
-            ok14, note14 = False, str(e)[:160]
-        finally:
-            await cleanup_issue(pmo, blocked)
-            await cleanup_issue(pmo, blocker)
-        check("14", "create_relation + blocked_by (duplicate-tolerant)",
-              ok14, note14)
+    except Exception as e:
+        ok14, note14 = False, str(e)[:160]
+    finally:
+        await cleanup_issue(pmo, blocked)
+        await cleanup_issue(pmo, blocker)
+    check("14", "create_relation + blocked_by (duplicate-tolerant)",
+          ok14, note14, skipped=skip14)
 
     # ── 15 project full-mode activity mirror (project-fidelity fix) ──────
     # Gated on projects_supported AND a discoverable project (the port
     # cannot create projects — the seed fixture provides one on the Linear
     # sandbox lane; skip cleanly otherwise). Posts a sentinel-free update
     # via post_feed and asserts full mode mirrors it byte-for-byte.
-    if caps.projects_supported:
+    if not caps.projects_supported:
+        check("15", "project full-mode mirrors the native feed",
+              True, "projects_supported=False", skipped=True)
+    else:
         proj15 = next((m for m in await pmo.list_all(team)
                        if m.pmo_kind == "project"), None)
         if proj15 is None:
-            print("  test 15  (skipped — no project in the team snapshot)")
+            check("15", "project full-mode mirrors the native feed",
+                  True, "no project in the team snapshot", skipped=True)
         else:
             ok15, note15 = True, ""
             try:
@@ -495,11 +506,14 @@ async def _run_battery(pmo, system: str, team: str) -> int:
                   ok15, note15)
 
     width = max(len(n) for _, n, _ in results)
-    failures = 0
+    failures = skips = 0
     for num, name, res in results:
         print(f"  test {num:>2}  {name:<{width}}  {res}")
-        failures += res != PASS
-    print(f"\n{len(results) - failures}/{len(results)} passed")
+        failures += res.startswith(FAIL)
+        skips += res.startswith(SKIP)
+    passed = len(results) - failures - skips
+    extra = f" ({skips} skipped)" if skips else ""
+    print(f"\n{passed}/{len(results)} passed{extra}")
     return 1 if failures else 0
 
 


### PR DESCRIPTION
## Slice 2 / 3 — GitLab Issues

Depends on # (docs/launch-roster). Pure `PMOPort` package `gitlab_issues`.

- Forge-issue profile (`open`/`opened` → backlog, labels, markdown notes)
- Attachments via uploads API + PAT download path
- `relations_supported=False` (Premium blocked-by); `create_relation` raises
- Registry `operator_note` + SPA amber banner

## Proof
- Hermetic: `test_gitlab_issues_*` + registry/agnosticism
- Live 2026-08-15: `contract_tests_pmo.py` **12/12** on a throwaway gitlab.com project (deleted after). Row 14 skipped.

## Operator
Separate PMO PAT from any GitLab forge token.