### PR TITLE
feat(harness): fail-closed HarnessDialect and HARNESSES-backed ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
             -e REDIS_PASSWORD=ci-redis-pass \
             -v "${{ github.workspace }}/images/common:/srv/images/common:ro" \
             -v "${{ github.workspace }}/images/hello:/srv/images/hello:ro" \
+            -v "${{ github.workspace }}/docker-bake.hcl:/srv/docker-bake.hcl:ro" \
             -v "${{ github.workspace }}/dagu/dags:/srv/dagu-dags:ro" \
             -v "${{ github.workspace }}/app/Dockerfile:/srv/app.Dockerfile:ro" \
             -v "${{ github.workspace }}/docs:/srv/docs:ro" \

--- a/admin/spa/src/components/DevTypeEditor.jsx
+++ b/admin/spa/src/components/DevTypeEditor.jsx
@@ -84,12 +84,16 @@ export default function DevTypeEditor({ name, draftDt, serverDt, harnesses, setF
             hidden by the fold. */}
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <Field label="Harness template"
-            help="Which coding agent this Dev runs: claude-code (Claude Code), grok-build (Grok Build) or codex (Codex). Authoritative — the Docker image and credential requirements under Advanced follow it automatically on Save.">
+            help="Which coding agent this Dev runs: claude-code (Claude Code), grok-build (Grok Build) or codex (Codex). Authoritative — the Docker image and credential requirements under Advanced follow it automatically on Save. Experimental ids have not passed a live operator battery.">
             <Select
               value={d.harness_template}
               onChange={(e) => set("harness_template", e.target.value)}
             >
-              {Object.keys(harnesses).map((t) => <option key={t}>{t}</option>)}
+              {Object.keys(harnesses).map((t) => (
+                <option key={t} value={t}>
+                  {t}{harnesses[t]?.experimental ? " (experimental)" : ""}
+                </option>
+              ))}
             </Select>
           </Field>
           <Field label="Model" hint="Empty = harness default"
@@ -99,6 +103,13 @@ export default function DevTypeEditor({ name, draftDt, serverDt, harnesses, setF
               onChange={(e) => set("model", e.target.value)} />
           </Field>
         </div>
+        {h.experimental && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            Experimental — in-tree so it can be dispatched, but it has not
+            passed a live operator battery. Dialect, stream, and credential
+            shape may still churn.
+          </p>
+        )}
         {pending && (
           <p className="text-xs text-amber-600 dark:text-amber-400">
             ⚠ Unsaved harness change: on Save this Dev Type runs {h.docker_image} and

--- a/admin/spa/src/components/NewDevTypeDialog.jsx
+++ b/admin/spa/src/components/NewDevTypeDialog.jsx
@@ -33,11 +33,21 @@ export default function NewDevTypeDialog({ harnesses, onClose, onCreated }) {
             onKeyDown={(e) => e.key === "Enter" && name.trim() && !busy && create()} />
         </Field>
         <Field label="Harness template"
-          help="Which coding agent this Dev runs. The Docker image and credential requirements follow it — both can be changed later.">
+          help="Which coding agent this Dev runs. The Docker image and credential requirements follow it — both can be changed later. Experimental ids have not passed a live operator battery.">
           <Select value={harness} onChange={(e) => setHarness(e.target.value)}>
-            {Object.keys(harnesses).map((t) => <option key={t}>{t}</option>)}
+            {Object.keys(harnesses).map((t) => (
+              <option key={t} value={t}>
+                {t}{harnesses[t]?.experimental ? " (experimental)" : ""}
+              </option>
+            ))}
           </Select>
         </Field>
+        {harnesses[harness]?.experimental && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            Experimental — in-tree so it can be dispatched, but it has not
+            passed a live operator battery.
+          </p>
+        )}
         {err && <p className="text-sm text-red-600 dark:text-red-400">✗ {err}</p>}
         <div className="flex justify-end gap-2">
           <Button kind="ghost" disabled={busy} onClick={onClose}>Cancel</Button>

--- a/app/devcake/api/devtypes_service.py
+++ b/app/devcake/api/devtypes_service.py
@@ -99,7 +99,8 @@ async def list_harnesses():
                    "credential_env": h.credential_env,
                    "credential_files": [cf.model_dump() for cf in h.credential_files],
                    "oauth_available": h.oauth is not None,
-                   "skills_dir": h.skills_dir}
+                   "skills_dir": h.skills_dir,
+                   "experimental": h.experimental}
             for name, h in HARNESSES.items()}
 
 

--- a/app/devcake/config.py
+++ b/app/devcake/config.py
@@ -576,12 +576,13 @@ class DevType(BaseModel):
     Deliberately slim: the Docker image, credential requirements, and OAuth
     flow all DERIVE from harness_template via harness.HARNESSES — the admin
     panel's harness combobox is authoritative. Unknown YAML keys are ignored
-    on load and dropped on the next save (pydantic's default)."""
+    on load and dropped on the next save (pydantic's default). Allowed
+    template ids are HARNESSES keys (docs/16 H2), not a parallel Literal."""
     # no ":" — dev-type breakers share /health's circuit_breakers map with
     # per-repo `repo:<name>` entries (M10); a colon would let a dev type
     # collide with (and mask) a repo breaker
     name: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
-    harness_template: Literal["claude-code", "grok-build", "codex"]
+    harness_template: str
     identifying_prompt: str = ""
     mcp_setup_commands: list[str] = Field(default_factory=list)
     # Skill-store skills installed to the harness's registry-declared skills
@@ -620,6 +621,15 @@ class DevType(BaseModel):
             if name not in out:
                 out.append(name)
         return out
+
+    @field_validator("harness_template")
+    @classmethod
+    def _known_harness_template(cls, v: str) -> str:
+        from .harness import HARNESSES
+        if v not in HARNESSES:
+            raise ValueError(
+                f"unknown harness_template {v!r}; known: {sorted(HARNESSES)}")
+        return v
 
     @field_validator("memory_repos")
     @classmethod

--- a/app/devcake/harness.py
+++ b/app/devcake/harness.py
@@ -43,6 +43,9 @@ class Harness(BaseModel):
     # selector). Snapshotted onto the Run at dispatch (run.spec_skills_dir)
     # so dir, skill content, and image all come from the same registry read.
     skills_dir: str | None = None
+    # True = ships in-tree but has not passed a live operator battery.
+    # The admin picker surfaces this so experimental is not prose-only.
+    experimental: bool = False
 
 
 # Dispatch must use the same tag the operator baked (AGENTS.md pin workflow:
@@ -132,6 +135,7 @@ def dev_type_status(dt) -> dict:
             "credential_files": [cf.model_dump() for cf in h.credential_files],
             "oauth_available": h.oauth is not None,
             "skills_dir": h.skills_dir,
+            "experimental": h.experimental,
         },
         "secrets_present": present,
         # ✓/✗ per declared secret env var (DevType.secret_env) — presence

--- a/app/tests/test_entrypoint_continuation.py
+++ b/app/tests/test_entrypoint_continuation.py
@@ -138,16 +138,17 @@ def test_resume_argv_extras_come_last_so_they_can_override():
         assert argv[-2:] == ["--zz", "1"]
 
 
-def test_resume_argv_unknown_harness_is_none_not_the_claude_fallback():
-    """Both builders fail closed on unknown ids — resume already returned
-    None; harness_argv now raises instead of falling through to Claude."""
-    assert ep.harness_resume_argv("other", "S", "P") is None
+def test_resume_argv_unknown_harness_raises():
+    with pytest.raises(ValueError, match="unknown harness"):
+        ep.harness_resume_argv("other", "S", "P")
 
 
 # ── RESUME_SPECS — capture-verified facts only ───────────────────────────────
 
 def test_resume_specs_cover_exactly_the_captured_harnesses():
     assert set(ep.RESUME_SPECS) == {"grok-build", "claude-code", "codex"}
+    for hid, spec in ep.RESUME_SPECS.items():
+        assert ep.get_dialect(hid).resume_spec == spec
 
 
 def test_codex_usage_is_cumulative_and_the_others_are_not():

--- a/app/tests/test_entrypoint_continuation.py
+++ b/app/tests/test_entrypoint_continuation.py
@@ -95,8 +95,10 @@ def test_session_identity_never_raises_on_hostile_shapes():
         J({"type": "end", "sessionId": {"nested": True}}),
         J({"type": "thread.started", "thread_id": ["a"]}),
         "not json", J([1, 2])])
-    for harness in ("grok-build", "codex", "claude-code", "unknown"):
+    for harness in ("grok-build", "codex", "claude-code"):
         assert isinstance(ep.session_identity(harness, hostile), str)
+    with pytest.raises(ValueError, match="unknown harness"):
+        ep.session_identity("unknown", hostile)
 
 
 # ── harness_resume_argv — the per-harness resume dialects ────────────────────

--- a/app/tests/test_entrypoint_fault.py
+++ b/app/tests/test_entrypoint_fault.py
@@ -291,9 +291,13 @@ def test_grok_producing_nothing_at_all_is_a_fault():
     assert reason(ep.harness_fault("grok-build", out, 0)) == ep.FAULT_EMPTY_COMPLETION
 
 
-def test_unknown_harness_falls_back_to_the_claude_predicate():
+def test_unknown_harness_fault_fails_closed():
+    """docs/16 H1: a typo must not silently run the Claude predicate."""
     out = fx("claude_empty_completion.jsonl")
-    assert reason(ep.harness_fault("something-new", out, 0)) == ep.FAULT_EMPTY_COMPLETION
+    with pytest.raises(ValueError, match="unknown harness"):
+        ep.harness_fault("something-new", out, 0)
+    with pytest.raises(ValueError, match="unknown harness"):
+        ep.harness_api_error_status("something-new", out)
 
 
 # ── forensics ────────────────────────────────────────────────────────────────
@@ -370,8 +374,10 @@ def test_terminal_evidence_never_raises_on_hostile_shapes():
         J({"type": "turn.completed", "usage": "none"}),
         J({"type": "result", "subtype": 7, "usage": []}),
         "not json at all", J([1, 2, 3])])
-    for harness in ("grok-build", "codex", "claude-code", "unknown"):
+    for harness in ("grok-build", "codex", "claude-code"):
         ep.terminal_evidence(harness, hostile)  # must not raise
+    with pytest.raises(ValueError, match="unknown harness"):
+        ep.terminal_evidence("unknown", hostile)
 
 
 # ── misplaced result.json ────────────────────────────────────────────────────

--- a/app/tests/test_harness.py
+++ b/app/tests/test_harness.py
@@ -3,7 +3,9 @@ requirements, and OAuth flow derive from harness_template (docs/08 §2, §4)."""
 
 import asyncio
 from datetime import datetime, timezone
-from typing import get_args
+
+import pytest
+from pydantic import ValidationError
 
 from devcake.config import PMOInstance, AppConfig, DevType
 from fakes import FakeForgeRuntime
@@ -18,9 +20,12 @@ def run_coro(c):
     return asyncio.new_event_loop().run_until_complete(c)
 
 
-def test_registry_covers_every_harness_literal():
-    literals = get_args(DevType.model_fields["harness_template"].annotation)
-    assert set(HARNESSES) == set(literals)
+def test_dev_type_accepts_exactly_the_registry_ids():
+    """docs/16 H2: HARNESSES is the allowed set — not a parallel Literal."""
+    for name in HARNESSES:
+        DevType(name="t", harness_template=name)
+    with pytest.raises(ValidationError, match="unknown harness_template"):
+        DevType(name="t", harness_template="not-a-harness")
 
 
 def test_dev_type_status_credentials_ready(monkeypatch, tmp_path):

--- a/app/tests/test_harness.py
+++ b/app/tests/test_harness.py
@@ -28,6 +28,19 @@ def test_dev_type_accepts_exactly_the_registry_ids():
         DevType(name="t", harness_template="not-a-harness")
 
 
+def test_registry_and_admin_payload_carry_experimental():
+    """Picker blast-radius: experimental is a registry flag, not prose."""
+    from devcake.api.devtypes_service import list_harnesses
+    for name, h in HARNESSES.items():
+        assert h.experimental is False, name
+        st = dev_type_status(DevType(name="t", harness_template=name))
+        assert st["harness"]["experimental"] is False
+    payload = run_coro(list_harnesses())
+    assert set(payload) == set(HARNESSES)
+    for name, row in payload.items():
+        assert row["experimental"] is False, name
+
+
 def test_dev_type_status_credentials_ready(monkeypatch, tmp_path):
     """Overview 'Devs' card (v0.1.1 B3): readiness is server-computed —
     any ONE of the harness's env keys in the store, or any credential file

--- a/app/tests/test_harness_dialect.py
+++ b/app/tests/test_harness_dialect.py
@@ -1,0 +1,95 @@
+"""H1/H2 ratchets: identity lives on HarnessDialect; ids come from HARNESSES.
+
+AST + registry + Bake alignment — not a second hand-maintained id list.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from devcake.harness import HARNESSES
+
+_COMMON_CANDIDATES = [
+    Path(__file__).resolve().parents[2] / "images" / "common",
+    Path("/srv/images/common"),
+]
+COMMON = next((p for p in _COMMON_CANDIDATES if p.is_dir()), None)
+
+_BAKE_CANDIDATES = [
+    Path(__file__).resolve().parents[2] / "docker-bake.hcl",
+    Path("/srv/docker-bake.hcl"),
+]
+BAKE = next((p for p in _BAKE_CANDIDATES if p.exists()), None)
+
+
+def _dialects():
+    assert COMMON is not None, (
+        "images/common missing — bind it at /srv/images/common")
+    root = str(COMMON)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    from devcake_dev.harness.dialect import dialects
+    return dialects()
+
+
+def test_every_registry_id_has_a_dialect_and_the_unknown_id_fails_closed():
+    table = _dialects()
+    assert set(table) == set(HARNESSES)
+    from devcake_dev.harness.dialect import get_dialect
+    with pytest.raises(ValueError, match="unknown harness"):
+        get_dialect("something-new")
+
+
+def test_every_registry_id_is_a_bake_images_target():
+    """docs/16 H2: a new HARNESSES key must also land in group images."""
+    assert BAKE is not None, (
+        "docker-bake.hcl missing — bind it at /srv/docker-bake.hcl")
+    text = BAKE.read_text()
+    match = re.search(
+        r'group\s+"images"\s*\{\s*targets\s*=\s*\[([^\]]+)\]', text)
+    assert match, "group images not found in docker-bake.hcl"
+    targets = {part.strip().strip('"')
+               for part in match.group(1).split(",") if part.strip()}
+    assert set(HARNESSES) == targets - {"hello"}
+    for name, h in HARNESSES.items():
+        assert f'target "{name}"' in text, name
+        assert h.image.startswith(f"devcake/dev-{name}:"), h.image
+
+
+def _is_harness_eq_string(node: ast.Compare) -> bool:
+    if not (isinstance(node.left, ast.Name) and node.left.id == "harness"):
+        return False
+    if not any(isinstance(op, ast.Eq) for op in node.ops):
+        return False
+    return any(isinstance(c, ast.Constant) and isinstance(c.value, str)
+               for c in node.comparators)
+
+
+def _is_harness_get_with_default(node: ast.Call) -> bool:
+    """`.get(harness, render_claude)` is the old Claude fall-through."""
+    if not (isinstance(node.func, ast.Attribute) and node.func.attr == "get"):
+        return False
+    if len(node.args) < 2:
+        return False
+    return isinstance(node.args[0], ast.Name) and node.args[0].id == "harness"
+
+
+def test_images_common_has_no_harness_identity_branch():
+    """docs/16 H1: parse/fault/dump/render/argv branch only inside dialects."""
+    assert COMMON is not None, (
+        "images/common missing — bind it at /srv/images/common")
+    offenders = []
+    for path in sorted(COMMON.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        rel = path.relative_to(COMMON)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Compare) and _is_harness_eq_string(node):
+                offenders.append(f"{rel}:{node.lineno} if harness == …")
+            elif isinstance(node, ast.Call) and _is_harness_get_with_default(node):
+                offenders.append(f"{rel}:{node.lineno} .get(harness, default)")
+    assert not offenders, (
+        "identity branching leaked out of dialects.py (docs/16 H1):\n  "
+        + "\n  ".join(offenders))

--- a/app/tests/test_harness_dialect.py
+++ b/app/tests/test_harness_dialect.py
@@ -78,7 +78,8 @@ def _is_harness_get_with_default(node: ast.Call) -> bool:
 
 
 def test_images_common_has_no_harness_identity_branch():
-    """docs/16 H1: parse/fault/dump/render/argv branch only inside dialects."""
+    """Bans `if harness ==` and `.get(harness, default)` under images/common.
+    Does not prove the capture rig or every membership test is gone."""
     assert COMMON is not None, (
         "images/common missing — bind it at /srv/images/common")
     offenders = []

--- a/app/tests/test_harness_dialect.py
+++ b/app/tests/test_harness_dialect.py
@@ -4,6 +4,7 @@ AST + registry + Bake alignment — not a second hand-maintained id list.
 """
 
 import ast
+import os
 import re
 import sys
 from pathlib import Path
@@ -11,6 +12,13 @@ from pathlib import Path
 import pytest
 
 from devcake.harness import HARNESSES
+
+# dialects → render → bus reads these at import. Other entrypoint tests set
+# them as a side effect; this file must stand alone (per-file / sharded runs).
+os.environ.setdefault("DEVCAKE_RUN_ID", "test-harness-dialect")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6399/0")
+os.environ.setdefault("REDIS_USER", "test")
+os.environ.setdefault("REDIS_PASSWORD", "test")
 
 _COMMON_CANDIDATES = [
     Path(__file__).resolve().parents[2] / "images" / "common",

--- a/docs/08-harness-templates.md
+++ b/docs/08-harness-templates.md
@@ -22,6 +22,11 @@ Changing a Dev Type's model does not add a template.
 | `grok-build` | Grok Build (`grok`) | Registry default `grok-4.5` | `implementer` leaves the model empty and receives that registry default |
 | `codex` | Codex CLI (`codex`) | CLI default | *(none seeded)* |
 
+`Harness.experimental` is a registry flag (`GET /api/v1/harnesses`, the
+admin picker). Launch-supported templates leave it false. A later dialect
+that has not passed a live operator battery must set it true — prose in this
+document is not the blast-radius control.
+
 Each template defines: base image, invocation pattern, plan-mode mapping, credential modes, MCP registration syntax, transcript source, and token-extraction strategy.
 
 > **Version-currency doctrine (founder, 2026-08-04).** DevCake follows the

--- a/docs/08-harness-templates.md
+++ b/docs/08-harness-templates.md
@@ -12,8 +12,9 @@ these are the *inner* model harnesses that the DevCake meta-harness staffs
 image, credentials, invocation, artifact parsing, OAuth, and skills delivery.
 It does **not** own a fixed model. Exactly three templates exist as entries in
 the harness registry (`app/devcake/harness.py`, `HARNESSES` — §2). Adding a
-fourth crosses the registry, config schema, image/Bake, entrypoint, tests, and
-this document (§8); changing a Dev Type's model does not add a template.
+fourth crosses the registry, Bake/image, a dialect module, captures, tests,
+and this document (§9); config accepts registry ids automatically (docs/16 H2).
+Changing a Dev Type's model does not add a template.
 
 | Template id | Harness CLI | Empty `DevType.model` resolves to | Seeded Dev Types |
 |---|---|---|---|
@@ -324,8 +325,9 @@ codex `-c` block verbatim — is `11-admin-panel.md` §3.
 
 ## 9. Adding or changing a template (checklist)
 
-1. Add a `HARNESSES` entry in `app/devcake/harness.py` (`image`, `credential_env`, `credential_files`, optional `oauth` flow, optional `skills_dir` — the home-relative dir the CLI reads personal skills from; leave unset if unsupported) and the new value to `DevType.harness_template`'s Literal (`config.py`).
+1. Add a `HARNESSES` entry in `app/devcake/harness.py` (`image`, `credential_env`, `credential_files`, optional `oauth` flow, optional `skills_dir` — the home-relative dir the CLI reads personal skills from; leave unset if unsupported). `DevType.harness_template` validates against that dict (no second Literal).
 2. Add a target to `images/Dockerfile` (bake `ENV DEVCAKE_HARNESS=<id>` as fallback) and a matching target in `docker-bake.hcl` (group `images` / `all`).
-3. Add the invocation + renderer + token-extraction branches in `images/common/dev_entrypoint.py` (§1, §1a, §5).
-4. Run the M1 hello-world DAG with the new image, then the M3 ONBOARD end-to-end demo.
-5. Update the token-extraction section (§5) and this document.
+3. Add a `HarnessDialect` implementation in `images/common/devcake_dev/harness/dialects.py` (argv, render, parse, fault, session identity — docs/16 H1). Unknown ids fail closed; do not add `if harness ==` in the entrypoint.
+4. Capture the fixture matrix (`scripts/harness_capture/`) and add rows in `test_harness_captures.py`. Resume stays off until a committed `<id>_resume_nudge` pair lands in `RESUME_SPECS`.
+5. Run the M1 hello-world DAG with the new image, then an ONBOARD end-to-end on that harness.
+6. Update the token-extraction section (§5) and this document.

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -753,11 +753,11 @@ aborts with a clear error — **no Claude fallback**.
 out-of-repo plugin harnesses (app↔image remain lockstep — docs/13).
 
 **Exit criteria:**
-- [ ] All three existing templates are pure dialect modules; `dev_entrypoint`
+- [x] All three existing templates are pure dialect modules; `dev_entrypoint`
       has no `if harness ==` for parse/fault/dump/render/argv.
-- [ ] Capture rig imports dialects only; no duplicated argv construction.
-- [ ] Planted unknown harness id fails closed (unit test).
-- [ ] Full harness capture suite green; `bake images` + entrypoint import smoke.
+- [x] Capture rig imports dialects only; no duplicated argv construction.
+- [x] Planted unknown harness id fails closed (unit test).
+- [x] Full harness capture suite green; `bake images` + entrypoint import smoke.
 
 **Demo:** delete the Claude fall-through; suite still green; intentional
 unknown-id run dies loudly.
@@ -767,16 +767,16 @@ unknown-id run dies loudly.
 **Goal:** config schema cannot drift from `HARNESSES` keys.
 **Implements:** `app/devcake/harness.py` + `config.py` `DevType.harness_template`.
 
-Today: `Literal["claude-code", "grok-build", "codex"]` is hand-maintained
-beside the registry dict. Prefer validation against `HARNESSES` (frozen id set
-or pydantic constraint) so a new template is one registration, not two.
+Shipped: `DevType.harness_template` validates against `HARNESSES` keys
+(no parallel Literal). A new template is one registry entry + dialect +
+Bake target; config accepts the id automatically.
 
 **Exit criteria:**
-- [ ] Adding a registry key alone is what config accepts (or a single shared
+- [x] Adding a registry key alone is what config accepts (or a single shared
       id tuple imported by both).
-- [ ] Structure/unit test: every `HARNESSES` key is a valid `DevType.harness_template`
+- [x] Structure/unit test: every `HARNESSES` key is a valid `DevType.harness_template`
       and every accepted template has a dialect (H1) and a Bake image name.
-- [ ] SPA still loads ids from `GET /harnesses` (no hard-coded combobox list).
+- [x] SPA still loads ids from `GET /harnesses` (no hard-coded combobox list).
 
 #### H3 — Credential registry extensions (only where declarative)
 

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -755,7 +755,9 @@ out-of-repo plugin harnesses (app↔image remain lockstep — docs/13).
 **Exit criteria:**
 - [x] All three existing templates are pure dialect modules; `dev_entrypoint`
       has no `if harness ==` for parse/fault/dump/render/argv.
-- [x] Capture rig imports dialects only; no duplicated argv construction.
+- [ ] Capture rig imports dialects only; no duplicated argv construction
+      (argv goes through `harness_argv`; dump/last_message still branch, and
+      unknown `--harness` still falls through to the Claude dump).
 - [x] Planted unknown harness id fails closed (unit test).
 - [x] Full harness capture suite green; `bake images` + entrypoint import smoke.
 

--- a/images/common/dev_entrypoint.py
+++ b/images/common/dev_entrypoint.py
@@ -72,6 +72,7 @@ from devcake_dev.harness.argv import (  # noqa: E402
     harness_argv,
     harness_resume_argv,
 )
+from devcake_dev.harness.dialect import get_dialect  # noqa: E402
 from devcake_dev.harness.continuation import (  # noqa: E402
     ContinuationConfig,
     ContinuationDecision,
@@ -519,6 +520,7 @@ def harness_main() -> None:
     extra = shlex.split(env.get("DEVCAKE_EXTRA_ARGS", ""))
     model = env.get("DEVCAKE_MODEL", "").strip()  # per-DevType pin; "" = harness default
     try:
+        dialect = get_dialect(harness)
         cmd = harness_argv(harness, prompt, plan_mode=plan_mode, model=model,
                            extra=extra)
     except ValueError as e:
@@ -593,8 +595,7 @@ def harness_main() -> None:
         relay and its flusher deliberately live outside the loop."""
         out_lines: list[str] = []
         err_lines: list[str] = []
-        render = {"codex": render_codex,
-                  "grok-build": GrokCoalescer()}.get(harness, render_claude)
+        render = dialect.renderer()
         with tracer.start_as_current_span("harness.exec", context=dev_ctx) as hspan:
             hspan.set_attribute("devcake.continuation", attempt)
             proc = subprocess.Popen(argv_now, cwd=workdir, stdout=subprocess.PIPE,
@@ -641,81 +642,15 @@ def harness_main() -> None:
         span.set_attribute("devcake.outcome", "harness_exit_%d" % harness_exit)
 
         # ── token extraction + result text (docs/08 §5) ──────────────────────
-        token_report = unavailable_report(model=harness)
-        result_text, transcript_body = "", ""
-        codex_last = ""  # RAW `-o` content: result_text is overwritten with a
-        #                  stdout tail on any parse failure, so the fault
-        #                  predicate must not read it (fixtures README)
-        if harness == "codex":
-            try:
-                last = WORKSPACE / "out" / "last_message.txt"
-                codex_last = last.read_text() if last.exists() else ""
-                result_text = codex_last
-                token_report = codex_token_report(out) or token_report
-                if not result_text:
-                    result_text = out[-4000:]
-            except Exception:
-                result_text = out[-4000:]
-        elif harness == "grok-build":
-            sid, terminal = "", None  # `terminal`: the event carrying usage/turns
-            try:
-                parsed = grok_stream_parse(out)
-                if parsed is not None:
-                    result_text, sid = parsed
-                    terminal = grok_end_event(out)
-                else:  # EXTRA_ARGS overrode the format back to a plain json blob
-                    j = json.loads(out)
-                    result_text = j.get("text") or ""
-                    sid = j.get("sessionId") or ""
-                    terminal = j   # same {usage, num_turns, modelUsage} keys
-            except Exception:
-                result_text = out[-4000:]
-            # Token report — its own guard, because a failure here must cost only
-            # the report (INV-5 then posts "unavailable"), never the result text or
-            # the transcript. The `end` event is PREFERRED: at 0.2.112 it carries
-            # the full split inline, needing no session id and no filesystem read
-            # (docs/08 §5). `signals.json` stays as the fallback — its survival at
-            # this version is an uncommitted campaign note, so dropping it would be
-            # as much of a guess as relying on it.
-            try:
-                token_report = (grok_end_report(terminal)
-                                or grok_signals_report(sid) or token_report)
-            except Exception:  # noqa: BLE001 — the artifact path outranks its own token report
-                print("token extraction failed; reporting unavailable", file=sys.stderr)
-            try:
-                # no sessionId ⇒ nothing to export: an `error` event never carries
-                # one, and the export is the only grok dump source (docs/08 §6)
-                exp = (subprocess.run(["grok", "export", sid], capture_output=True,
-                                      text=True) if sid else None)
-                if exp is not None and exp.returncode == 0 and exp.stdout.strip():
-                    transcript_body = exp.stdout
-            except Exception:  # noqa: BLE001 — no export ⇒ no dump; the fault predicate handles an empty one
-                print("grok export failed; transcript falls back to the agent report",
-                      file=sys.stderr)
-        else:
-            try:
-                # stream-json: the final result event carries the exact fields of
-                # the old --output-format json blob (verified live); blob fallback
-                # covers an EXTRA_ARGS format override
-                j = claude_result_event(out) or json.loads(out)
-                token_report = claude_token_report(j)
-                result_text = j.get("result") or ""
-            except Exception:
-                result_text = out[-4000:]
-
-        # ADR-0014 D1: the full dump of assistant-visible text, per harness
-        # (grok: the `grok export` session already includes every message).
-        # Guarded like every other parse of `out` — a dump failure must never
-        # abort the artifact path (the no-dump fallback handles "").
-        try:
-            if harness == "codex":
-                inv_dump = codex_text_dump(out)
-            elif harness == "grok-build":
-                inv_dump = transcript_body
-            else:
-                inv_dump = claude_text_dump(out)
-        except Exception:
-            inv_dump = ""
+        # Identity lives on the dialect (docs/16 H1). last_message is the RAW
+        # `-o` file for codex: result_text is overwritten with a stdout tail
+        # on any parse failure, so the fault predicate must not read it
+        # (fixtures README).
+        view = dialect.parse_run(out, workspace=WORKSPACE, model=model)
+        token_report = view.token_report
+        result_text = view.result_text
+        inv_dump = view.dump
+        last_message = view.last_message
 
         # ── continuation aggregation (ADR-0022) ──────────────────────────────
         # Everything kept across invocations is SMALL (reports, sids, dump
@@ -725,8 +660,8 @@ def harness_main() -> None:
         inv_reports.append(token_report)
         inv_modes.append(mode)
         record_session(chains, session_identity(harness, out), mode)
-        if (harness == "grok-build" and mode == "resume" and dump_segments
-                and (inv_dump or "").strip()):
+        if (dialect.dump_cumulative_on_resume and mode == "resume"
+                and dump_segments and (inv_dump or "").strip()):
             # the resumed export is cumulative over the chain — supersede
             dump_segments[-1] = inv_dump
             dump_labels[-1] = f"continuation {cont.used} (resume)"
@@ -748,7 +683,7 @@ def harness_main() -> None:
         # own dump and prompt (the nudge, on relaunches — what separates the
         # export's echo from new work). Compute BEFORE `out` is released.
         fault = harness_fault(harness, out, harness_exit, dump=inv_dump,
-                              last_message=codex_last, prompt=inv_prompt)
+                              last_message=last_message, prompt=inv_prompt)
         # Every harness, not just claude: codex and grok expose no structured
         # status field, so without this a 401 on either lands on 15 (excusable,
         # correlation-eligible) instead of 12 (latch the breaker, tell the operator).

--- a/images/common/devcake_dev/domain/fault.py
+++ b/images/common/devcake_dev/domain/fault.py
@@ -364,18 +364,11 @@ def grok_run_fault(out: str, harness_exit: int, *, dump: str = "",
 
 def harness_fault(harness: str, out: str, harness_exit: int, *, dump: str = "",
                   last_message: str = "", prompt: str = ""):
-    """Did the harness actually work? Fault dict or None. An unknown harness
-    name falls through to the claude predicate, mirroring main()'s renderer
-    dispatch."""
-    if harness == "codex":
-        return codex_run_fault(out, harness_exit, last_message=last_message)
-    if harness == "grok-build":
-        # `dump` is the `grok export` transcript for this harness — forwarding
-        # it is what keeps a silent-but-productive run from reading as empty,
-        # and `prompt` is what separates the run's own output from the echo of
-        # that prompt the export opens with (grok_export_activity).
-        return grok_run_fault(out, harness_exit, dump=dump, prompt=prompt)
-    return claude_run_fault(out, harness_exit, dump=dump)
+    """Did the harness actually work? Fault dict or None. Unknown ids raise
+    (docs/16 H1) — never the Claude predicate."""
+    from ..harness.dialect import get_dialect
+    return get_dialect(harness).fault(
+        out, harness_exit, dump=dump, last_message=last_message, prompt=prompt)
 
 
 # HTTP status from CLI transport wording (not model prose). Precision over
@@ -406,17 +399,10 @@ def harness_error_messages(out: str) -> list:
 
 
 def harness_api_error_status(harness: str, out: str):
-    """HTTP status the harness reported (int), or None. Feeds auth precedence."""
-    patterns = HARNESS_STATUS_PATTERNS.get(harness)
-    if patterns is None:  # claude-code has api_error_status on the result event
-        status = _dict(claude_result_event(out)).get("api_error_status")
-        return status if isinstance(status, int) else None
-    for message in harness_error_messages(out):
-        for rx in patterns:
-            hit = rx.search(message)
-            if hit:
-                return int(hit.group(1))
-    return None
+    """HTTP status the harness reported (int), or None. Feeds auth precedence.
+    Unknown ids raise (docs/16 H1)."""
+    from ..harness.dialect import get_dialect
+    return get_dialect(harness).api_error_status(out)
 
 
 def classify_nonzero_exit(err_text: str, fault, api_error_status=None) -> tuple:

--- a/images/common/devcake_dev/harness/__init__.py
+++ b/images/common/devcake_dev/harness/__init__.py
@@ -1,1 +1,1 @@
-"""Harness dialect: render, dumps, argv."""
+"""Harness dialect: argv, render, parse, fault, session identity."""

--- a/images/common/devcake_dev/harness/argv.py
+++ b/images/common/devcake_dev/harness/argv.py
@@ -6,16 +6,16 @@ argv production uses.
 """
 from __future__ import annotations
 
-from .dialect import ResumeSpec, WORKSPACE, get_dialect
+from .dialect import ResumeSpec, WORKSPACE, dialects, get_dialect
 
-# The continuation loop's resume gate: a harness earns its entry ONLY through
-# a committed `<harness>_resume_nudge` capture pair. Still a separate table
-# from DIALECTS — a dialect may exist before its resume pair is captured.
-RESUME_SPECS: dict[str, ResumeSpec] = {
-    "grok-build": ResumeSpec(usage_cumulative=False),
-    "claude-code": ResumeSpec(usage_cumulative=False),
-    "codex": ResumeSpec(usage_cumulative=True),
-}
+
+def resume_specs() -> dict[str, ResumeSpec]:
+    """Capture-verified resume facts, derived from each dialect's resume_spec."""
+    return {d.id: d.resume_spec for d in dialects().values()
+            if d.resume_spec is not None}
+
+
+RESUME_SPECS: dict[str, ResumeSpec] = resume_specs()
 
 
 def forge_dialect(env: dict) -> tuple:
@@ -59,13 +59,10 @@ def harness_resume_argv(harness: str, session_id: str, prompt: str, *,
     in RESUME_SPECS; the capture rig calls it directly to TEST a candidate —
     same builder both times, so a fixture cannot drift from the invocation
     production would use. No plan_mode parameter: plan runs never continue.
-    Unknown ids return None (same fail-closed contract as harness_argv, which
-    raises): an unverified resume flag on the wrong CLI is not a Claude argv."""
+    Unknown ids raise (same contract as harness_argv / get_dialect). None
+    means a known dialect has no resume candidate."""
     extra = list(extra)
-    try:
-        return get_dialect(harness).resume_argv(
-            session_id, prompt, model=model, extra=extra, out_dir=out_dir)
-    except ValueError:
-        return None
+    return get_dialect(harness).resume_argv(
+        session_id, prompt, model=model, extra=extra, out_dir=out_dir)
 
 

--- a/images/common/devcake_dev/harness/argv.py
+++ b/images/common/devcake_dev/harness/argv.py
@@ -1,37 +1,22 @@
-"""Harness argv construction (docs/08 §1)."""
+"""Harness argv construction (docs/08 §1).
+
+Identity lives on HarnessDialect (docs/16 H1). This module is the stable
+import path for the capture rig and the entrypoint: one function, same
+argv production uses.
+"""
 from __future__ import annotations
 
-import dataclasses
-import pathlib
-
-WORKSPACE = pathlib.Path("/workspace")
-
-
-@dataclasses.dataclass(frozen=True)
-class ResumeSpec:
-    """Capture-verified resume facts for one harness (ADR-0022 Phase 0).
-
-    usage_cumulative: the resumed terminal event reports usage over the WHOLE
-    session, so summing per-invocation reports would double-count — the token
-    merge goes last-wins within a resume chain instead."""
-    usage_cumulative: bool
-
+from .dialect import ResumeSpec, WORKSPACE, get_dialect
 
 # The continuation loop's resume gate: a harness earns its entry ONLY through
-# a committed `<harness>_resume_nudge` capture pair (fixtures README rules) —
-# absence means fresh-only under `auto`, stop under `resume-only`. The
-# candidate argv in harness_resume_argv exists INDEPENDENTLY of this dict so
-# the capture rig can exercise a composition before it is verified — the rig
-# is the only road into this table. usage_cumulative is a PER-HARNESS fact,
-# measured, not assumed: codex reports session-cumulative usage on a resumed
-# turn.completed, grok and claude report per-invocation (the capture pairs).
+# a committed `<harness>_resume_nudge` capture pair. Still a separate table
+# from DIALECTS — a dialect may exist before its resume pair is captured.
 RESUME_SPECS: dict[str, ResumeSpec] = {
-    "grok-build": ResumeSpec(usage_cumulative=False),    # grok_resume_nudge_*
-    "claude-code": ResumeSpec(usage_cumulative=False),   # claude_resume_nudge_*
-    "codex": ResumeSpec(usage_cumulative=True),          # codex_resume_nudge_*
+    "grok-build": ResumeSpec(usage_cumulative=False),
+    "claude-code": ResumeSpec(usage_cumulative=False),
+    "codex": ResumeSpec(usage_cumulative=True),
 }
 
-KNOWN_HARNESSES = frozenset(RESUME_SPECS)
 
 def forge_dialect(env: dict) -> tuple:
     """(clone_user, git_name, git_email, cli_token_envs) for the clone
@@ -58,27 +43,8 @@ def harness_argv(harness: str, prompt: str, *, plan_mode: bool = False,
     points it at a throwaway directory.
     """
     extra = list(extra)
-    out = pathlib.Path(out_dir) if out_dir is not None else WORKSPACE / "out"
-    if harness not in KNOWN_HARNESSES:
-        raise ValueError(f"unknown harness {harness!r} — refusing Claude fall-through")
-    if harness == "grok-build":
-        mode = ["--permission-mode", "plan"] if plan_mode else ["--always-approve"]
-        pin = ["--model", model] if model else []
-        return ["grok", "-p", prompt, "--output-format", "streaming-json",
-                *mode, *pin, *extra]
-    if harness == "codex":
-        mode = (["--sandbox", "read-only"] if plan_mode
-                else ["--dangerously-bypass-approvals-and-sandbox"])
-        pin = ["-m", model] if model else []
-        return ["codex", "exec", prompt, "--json",
-                "-o", str(out / "last_message.txt"),
-                "--skip-git-repo-check", *mode, *pin, *extra]
-    mode = (["--permission-mode", "plan"] if plan_mode
-            else ["--dangerously-skip-permissions"])
-    pin = ["--model", model] if model else []
-    # --verbose is REQUIRED with -p + stream-json (the CLI errors out without it)
-    return ["claude", "-p", prompt, "--output-format", "stream-json",
-            "--verbose", *mode, *pin, *extra]
+    return get_dialect(harness).argv(
+        prompt, plan_mode=plan_mode, model=model, extra=extra, out_dir=out_dir)
 
 
 def harness_resume_argv(harness: str, session_id: str, prompt: str, *,
@@ -93,24 +59,13 @@ def harness_resume_argv(harness: str, session_id: str, prompt: str, *,
     in RESUME_SPECS; the capture rig calls it directly to TEST a candidate —
     same builder both times, so a fixture cannot drift from the invocation
     production would use. No plan_mode parameter: plan runs never continue.
-    There is deliberately no default-harness fallback (unlike harness_argv):
-    an unverified resume flag on the wrong CLI is a crash, not a default."""
+    Unknown ids return None (same fail-closed contract as harness_argv, which
+    raises): an unverified resume flag on the wrong CLI is not a Claude argv."""
     extra = list(extra)
-    out = pathlib.Path(out_dir) if out_dir is not None else WORKSPACE / "out"
-    pin_dashed = ["--model", model] if model else []
-    if harness == "grok-build":
-        return ["grok", "-p", prompt, "-r", session_id,
-                "--output-format", "streaming-json", "--always-approve",
-                *pin_dashed, *extra]
-    if harness == "codex":
-        pin = ["-m", model] if model else []
-        return ["codex", "exec", "resume", session_id, prompt, "--json",
-                "-o", str(out / "last_message.txt"), "--skip-git-repo-check",
-                "--dangerously-bypass-approvals-and-sandbox", *pin, *extra]
-    if harness == "claude-code":
-        return ["claude", "-p", prompt, "--resume", session_id,
-                "--output-format", "stream-json", "--verbose",
-                "--dangerously-skip-permissions", *pin_dashed, *extra]
-    return None
+    try:
+        return get_dialect(harness).resume_argv(
+            session_id, prompt, model=model, extra=extra, out_dir=out_dir)
+    except ValueError:
+        return None
 
 

--- a/images/common/devcake_dev/harness/continuation.py
+++ b/images/common/devcake_dev/harness/continuation.py
@@ -3,10 +3,8 @@ continuation loop, plus the stream → evidence helpers it shares with the
 exit-11 forensics.
 
 Dev-side domain like fault.py: no Redis, no subprocess, no filesystem — the
-entrypoint façade composes, this module decides. A separate module because
-its helpers need BOTH tokens.py (grok_end_event) and fault.py
-(claude_result_event) — landing them in either would cycle the import
-between those two (tokens already imports from fault).
+entrypoint façade composes, this module decides. Session identity and
+terminal evidence dispatch through HarnessDialect (docs/16 H1).
 
 Turn-budget interplay, accepted and deliberate: every relaunch resets the
 CLI's own --max-turns counter, so a run's effective turn budget is
@@ -16,11 +14,9 @@ lines keep the multiplication operator-visible.
 from __future__ import annotations
 
 import dataclasses
-import json
 
-from devcake_dev.domain.fault import _dict, _one_line, claude_result_event
-from devcake_dev.harness.tokens import (grok_end_event, token_report_v1,
-                                        unavailable_report)
+from devcake_dev.domain.fault import _dict, _one_line
+from devcake_dev.harness.tokens import token_report_v1, unavailable_report
 
 POLICY_AUTO = "auto"
 POLICY_RESUME_ONLY = "resume-only"
@@ -272,50 +268,17 @@ def merged_transcript_dump(segments, labels) -> str:
         f"## Continuation segment — {lab}\n\n{seg}" for seg, lab in present)
 
 
-def _grok_error_event(out: str):
-    """Last {"type":"error"} event, or None. An error event outranks nothing:
-    on the exit-11 paths it cannot occur (an error event is a fault, exit 15),
-    but this helper must stay honest for any stream it is handed."""
-    found = None
-    for line in out.splitlines():
-        try:
-            ev = json.loads(line)
-        except Exception:  # noqa: BLE001 — one unparseable line never costs the evidence
-            continue
-        if isinstance(ev, dict) and ev.get("type") == "error":
-            found = ev
-    return found
-
-
 def session_identity(harness: str, out: str) -> str:
     """The harness's session handle for a resume relaunch, or "".
 
     grok: the LAST `sessionId` on any stream event (the `end` event carries
     it; `error` events never do — docs/08 §1). claude: `session_id` on the
-    result event. codex: the `thread_id` of `thread.started`. An unknown
-    harness falls through to the claude arm, mirroring harness_fault."""
+    result event. codex: the `thread_id` of `thread.started`. Unknown ids
+    raise (docs/16 H1) — never the Claude arm."""
+    from .dialect import get_dialect
+    dialect = get_dialect(harness)
     try:
-        if harness == "grok-build":
-            sid = ""
-            for line in out.splitlines():
-                try:
-                    ev = json.loads(line)
-                except Exception:  # noqa: BLE001 — one bad line never costs the handle
-                    continue
-                if isinstance(ev, dict) and ev.get("sessionId"):
-                    sid = str(ev["sessionId"])
-            return sid
-        if harness == "codex":
-            for line in out.splitlines():
-                try:
-                    ev = json.loads(line)
-                except Exception:  # noqa: BLE001 — as above
-                    continue
-                if (isinstance(ev, dict) and ev.get("type") == "thread.started"
-                        and ev.get("thread_id")):
-                    return str(ev["thread_id"])
-            return ""
-        return str(_dict(claude_result_event(out)).get("session_id") or "")
+        return dialect.session_identity(out)
     except Exception:  # noqa: BLE001 — no handle ⇒ fresh-mode degradation, never a crash
         return ""
 
@@ -329,41 +292,10 @@ def terminal_evidence(harness: str, out: str):
     cleanly but early" (grok stopReason EndTurn, the narrate-and-stop shape)
     from a truncated stream; this names which one happened. Guarded like
     every stream parser — model-adjacent bytes must never abort the artifact
-    path. An unknown harness falls through to the claude arm, mirroring
-    main()'s renderer dispatch and harness_fault."""
+    path. Unknown ids raise (docs/16 H1)."""
+    from .dialect import get_dialect
+    dialect = get_dialect(harness)
     try:
-        if harness == "grok-build":
-            ev = grok_end_event(out)
-            if ev is not None:
-                return {"event": "end",
-                        "stop_reason": str(ev.get("stopReason") or ""),
-                        "num_turns": ev.get("num_turns"),
-                        "session_id": str(ev.get("sessionId") or "")}
-            err = _grok_error_event(out)
-            if err is not None:
-                return {"event": "error",
-                        "message": _one_line(str(err.get("message") or ""), 120)}
-            return None
-        if harness == "codex":
-            completed = None
-            for line in out.splitlines():
-                try:
-                    ev = json.loads(line)
-                except Exception:  # noqa: BLE001 — as above
-                    continue
-                if isinstance(ev, dict) and ev.get("type") == "turn.completed":
-                    completed = ev
-            if completed is None:
-                return None
-            return {"event": "turn.completed",
-                    "output_tokens": _dict(completed.get("usage")).get("output_tokens")}
-        ev = claude_result_event(out)
-        if ev is None:
-            return None
-        return {"event": "result",
-                "subtype": str(ev.get("subtype") or ""),
-                "terminal_reason": str(ev.get("terminal_reason") or ""),
-                "num_turns": ev.get("num_turns"),
-                "is_error": bool(ev.get("is_error"))}
+        return dialect.terminal_evidence(out)
     except Exception:  # noqa: BLE001 — evidence is advisory; the fail() path outranks it
         return None

--- a/images/common/devcake_dev/harness/dialect.py
+++ b/images/common/devcake_dev/harness/dialect.py
@@ -1,0 +1,88 @@
+"""HarnessDialect — one chokepoint for per-CLI container behavior (docs/16 H1).
+
+The app registry (`devcake.harness.HARNESSES`) owns image, credentials,
+OAuth, and skills_dir. This module owns argv, render, parse, fault, and
+session identity. Unknown ids fail closed — never fall through to Claude.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from typing import Protocol
+
+WORKSPACE = pathlib.Path("/workspace")
+
+
+@dataclasses.dataclass(frozen=True)
+class ResumeSpec:
+    """Capture-verified resume facts (ADR-0022). usage_cumulative: the
+    resumed terminal event reports the WHOLE session — last-wins merge."""
+    usage_cumulative: bool
+
+
+@dataclasses.dataclass
+class InvocationView:
+    """What one harness invocation produced (docs/08 §5)."""
+    result_text: str
+    token_report: dict
+    dump: str
+    last_message: str = ""
+
+
+class HarnessDialect(Protocol):
+    id: str
+    resume_spec: ResumeSpec | None
+    dump_cumulative_on_resume: bool
+
+    def argv(self, prompt: str, *, plan_mode: bool = False, model: str = "",
+             extra=(), out_dir=None) -> list[str]: ...
+
+    def resume_argv(self, session_id: str, prompt: str, *, model: str = "",
+                    extra=(), out_dir=None) -> list[str] | None: ...
+
+    def renderer(self):
+        """Callable raw-line → condensed line | None (may be stateful)."""
+        ...
+
+    def parse_run(self, out: str, *, workspace: pathlib.Path,
+                  model: str = "") -> InvocationView: ...
+
+    def fault(self, out: str, harness_exit: int, *, dump: str = "",
+              last_message: str = "", prompt: str = ""): ...
+
+    def api_error_status(self, out: str): ...
+
+    def session_identity(self, out: str) -> str: ...
+
+    def terminal_evidence(self, out: str): ...
+
+
+_DIALECTS: dict[str, HarnessDialect] = {}
+
+
+def register(dialect: HarnessDialect) -> HarnessDialect:
+    _DIALECTS[dialect.id] = dialect
+    return dialect
+
+
+def dialects() -> dict[str, HarnessDialect]:
+    if not _DIALECTS:
+        _load()
+    return _DIALECTS
+
+
+def get_dialect(harness: str) -> HarnessDialect:
+    table = dialects()
+    d = table.get(harness)
+    if d is None:
+        raise ValueError(
+            f"unknown harness {harness!r} — refusing Claude fall-through "
+            f"(known: {sorted(table)})")
+    return d
+
+
+def _load() -> None:
+    # Imported for side-effect registration. Keep this list = HARNESSES keys.
+    from . import dialects as _d  # noqa: F401
+    _d.load_all()

--- a/images/common/devcake_dev/harness/dialects.py
+++ b/images/common/devcake_dev/harness/dialects.py
@@ -1,0 +1,286 @@
+"""The three in-tree dialects. Parsers stay in tokens/fault/render — this
+module only binds identity to those functions (docs/16 H1)."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+from . import dialect as _reg
+from .dialect import ResumeSpec, WORKSPACE
+from .render import GrokCoalescer, render_claude, render_codex
+from .tokens import (
+    claude_text_dump, claude_token_report,
+    codex_text_dump, codex_token_report,
+    grok_end_event, grok_end_report, grok_signals_report, grok_stream_parse,
+    unavailable_report,
+)
+from ..domain.fault import (
+    HARNESS_STATUS_PATTERNS, _dict, _one_line, claude_result_event,
+    claude_run_fault, codex_run_fault, grok_run_fault,
+    harness_error_messages,
+)
+
+
+class _Claude:
+    id = "claude-code"
+    resume_spec = ResumeSpec(usage_cumulative=False)
+    dump_cumulative_on_resume = False
+
+    def argv(self, prompt, *, plan_mode=False, model="", extra=(), out_dir=None):
+        extra = list(extra)
+        mode = (["--permission-mode", "plan"] if plan_mode
+                else ["--dangerously-skip-permissions"])
+        pin = ["--model", model] if model else []
+        return ["claude", "-p", prompt, "--output-format", "stream-json",
+                "--verbose", *mode, *pin, *extra]
+
+    def resume_argv(self, session_id, prompt, *, model="", extra=(), out_dir=None):
+        extra = list(extra)
+        pin = ["--model", model] if model else []
+        return ["claude", "-p", prompt, "--resume", session_id,
+                "--output-format", "stream-json", "--verbose",
+                "--dangerously-skip-permissions", *pin, *extra]
+
+    def renderer(self):
+        return render_claude
+
+    def parse_run(self, out, *, workspace, model=""):
+        report = unavailable_report(model=self.id)
+        try:
+            j = claude_result_event(out) or json.loads(out)
+            report = claude_token_report(j)
+            result = j.get("result") or ""
+        except Exception:  # noqa: BLE001 — a parse miss still posts the tail
+            result = out[-4000:]
+        try:
+            dump = claude_text_dump(out)
+        except Exception:  # noqa: BLE001 — no dump ⇒ the no-dump fallback
+            dump = ""
+        return _reg.InvocationView(result_text=result, token_report=report,
+                                   dump=dump)
+
+    def fault(self, out, harness_exit, *, dump="", last_message="", prompt=""):
+        return claude_run_fault(out, harness_exit, dump=dump)
+
+    def api_error_status(self, out):
+        status = _dict(claude_result_event(out)).get("api_error_status")
+        return status if isinstance(status, int) else None
+
+    def session_identity(self, out):
+        try:
+            return str(_dict(claude_result_event(out)).get("session_id") or "")
+        except Exception:  # noqa: BLE001 — no handle ⇒ fresh-mode degradation
+            return ""
+
+    def terminal_evidence(self, out):
+        try:
+            ev = claude_result_event(out)
+            if ev is None:
+                return None
+            return {"event": "result",
+                    "subtype": str(ev.get("subtype") or ""),
+                    "terminal_reason": str(ev.get("terminal_reason") or ""),
+                    "num_turns": ev.get("num_turns"),
+                    "is_error": bool(ev.get("is_error"))}
+        except Exception:  # noqa: BLE001 — evidence is advisory
+            return None
+
+
+class _Grok:
+    id = "grok-build"
+    resume_spec = ResumeSpec(usage_cumulative=False)
+    dump_cumulative_on_resume = True
+
+    def argv(self, prompt, *, plan_mode=False, model="", extra=(), out_dir=None):
+        extra = list(extra)
+        mode = ["--permission-mode", "plan"] if plan_mode else ["--always-approve"]
+        pin = ["--model", model] if model else []
+        return ["grok", "-p", prompt, "--output-format", "streaming-json",
+                *mode, *pin, *extra]
+
+    def resume_argv(self, session_id, prompt, *, model="", extra=(), out_dir=None):
+        extra = list(extra)
+        pin = ["--model", model] if model else []
+        return ["grok", "-p", prompt, "-r", session_id,
+                "--output-format", "streaming-json", "--always-approve",
+                *pin, *extra]
+
+    def renderer(self):
+        return GrokCoalescer()
+
+    def parse_run(self, out, *, workspace, model=""):
+        report = unavailable_report(model=self.id)
+        sid, terminal = "", None
+        try:
+            parsed = grok_stream_parse(out)
+            if parsed is not None:
+                result, sid = parsed
+                terminal = grok_end_event(out)
+            else:
+                j = json.loads(out)
+                result = j.get("text") or ""
+                sid = j.get("sessionId") or ""
+                terminal = j
+        except Exception:  # noqa: BLE001 — a parse miss still posts the tail
+            result = out[-4000:]
+        try:
+            report = (grok_end_report(terminal)
+                      or grok_signals_report(sid) or report)
+        except Exception:  # noqa: BLE001 — the artifact path outranks its own token report
+            print("token extraction failed; reporting unavailable", file=sys.stderr)
+        dump = ""
+        try:
+            exp = (subprocess.run(["grok", "export", sid], capture_output=True,
+                                  text=True) if sid else None)
+            if exp is not None and exp.returncode == 0 and exp.stdout.strip():
+                dump = exp.stdout
+        except Exception:  # noqa: BLE001 — no export ⇒ no dump; the fault predicate handles an empty one
+            print("grok export failed; transcript falls back to the agent report",
+                  file=sys.stderr)
+        return _reg.InvocationView(result_text=result, token_report=report,
+                                   dump=dump)
+
+    def fault(self, out, harness_exit, *, dump="", last_message="", prompt=""):
+        return grok_run_fault(out, harness_exit, dump=dump, prompt=prompt)
+
+    def api_error_status(self, out):
+        for message in harness_error_messages(out):
+            for rx in HARNESS_STATUS_PATTERNS[self.id]:
+                hit = rx.search(message)
+                if hit:
+                    return int(hit.group(1))
+        return None
+
+    def session_identity(self, out):
+        sid = ""
+        try:
+            for line in out.splitlines():
+                try:
+                    ev = json.loads(line)
+                except Exception:  # noqa: BLE001 — one bad line never costs the handle
+                    continue
+                if isinstance(ev, dict) and ev.get("sessionId"):
+                    sid = str(ev["sessionId"])
+        except Exception:  # noqa: BLE001 — no handle ⇒ fresh-mode degradation
+            return ""
+        return sid
+
+    def terminal_evidence(self, out):
+        try:
+            ev = grok_end_event(out)
+            if ev is not None:
+                return {"event": "end",
+                        "stop_reason": str(ev.get("stopReason") or ""),
+                        "num_turns": ev.get("num_turns"),
+                        "session_id": str(ev.get("sessionId") or "")}
+            found = None
+            for line in out.splitlines():
+                try:
+                    ev = json.loads(line)
+                except Exception:  # noqa: BLE001 — one unparseable line never costs the evidence
+                    continue
+                if isinstance(ev, dict) and ev.get("type") == "error":
+                    found = ev
+            if found is not None:
+                return {"event": "error",
+                        "message": _one_line(str(found.get("message") or ""), 120)}
+            return None
+        except Exception:  # noqa: BLE001 — evidence is advisory
+            return None
+
+
+class _Codex:
+    id = "codex"
+    resume_spec = ResumeSpec(usage_cumulative=True)
+    dump_cumulative_on_resume = False
+
+    def argv(self, prompt, *, plan_mode=False, model="", extra=(), out_dir=None):
+        extra = list(extra)
+        out = pathlib.Path(out_dir) if out_dir is not None else WORKSPACE / "out"
+        mode = (["--sandbox", "read-only"] if plan_mode
+                else ["--dangerously-bypass-approvals-and-sandbox"])
+        pin = ["-m", model] if model else []
+        return ["codex", "exec", prompt, "--json",
+                "-o", str(out / "last_message.txt"),
+                "--skip-git-repo-check", *mode, *pin, *extra]
+
+    def resume_argv(self, session_id, prompt, *, model="", extra=(), out_dir=None):
+        extra = list(extra)
+        out = pathlib.Path(out_dir) if out_dir is not None else WORKSPACE / "out"
+        pin = ["-m", model] if model else []
+        return ["codex", "exec", "resume", session_id, prompt, "--json",
+                "-o", str(out / "last_message.txt"), "--skip-git-repo-check",
+                "--dangerously-bypass-approvals-and-sandbox", *pin, *extra]
+
+    def renderer(self):
+        return render_codex
+
+    def parse_run(self, out, *, workspace, model=""):
+        report = unavailable_report(model=self.id)
+        last = workspace / "out" / "last_message.txt"
+        try:
+            last_text = last.read_text() if last.exists() else ""
+            result = last_text
+            report = codex_token_report(out) or report
+            if not result:
+                result = out[-4000:]
+        except Exception:  # noqa: BLE001 — a parse miss still posts the tail
+            last_text = ""
+            result = out[-4000:]
+        try:
+            dump = codex_text_dump(out)
+        except Exception:  # noqa: BLE001 — no dump ⇒ the no-dump fallback
+            dump = ""
+        return _reg.InvocationView(result_text=result, token_report=report,
+                                   dump=dump, last_message=last_text)
+
+    def fault(self, out, harness_exit, *, dump="", last_message="", prompt=""):
+        return codex_run_fault(out, harness_exit, last_message=last_message)
+
+    def api_error_status(self, out):
+        for message in harness_error_messages(out):
+            for rx in HARNESS_STATUS_PATTERNS[self.id]:
+                hit = rx.search(message)
+                if hit:
+                    return int(hit.group(1))
+        return None
+
+    def session_identity(self, out):
+        try:
+            for line in out.splitlines():
+                try:
+                    ev = json.loads(line)
+                except Exception:  # noqa: BLE001 — one bad line never costs the handle
+                    continue
+                if (isinstance(ev, dict) and ev.get("type") == "thread.started"
+                        and ev.get("thread_id")):
+                    return str(ev["thread_id"])
+        except Exception:  # noqa: BLE001 — no handle ⇒ fresh-mode degradation
+            return ""
+        return ""
+
+    def terminal_evidence(self, out):
+        try:
+            completed = None
+            for line in out.splitlines():
+                try:
+                    ev = json.loads(line)
+                except Exception:  # noqa: BLE001 — one unparseable line never costs the evidence
+                    continue
+                if isinstance(ev, dict) and ev.get("type") == "turn.completed":
+                    completed = ev
+            if completed is None:
+                return None
+            return {"event": "turn.completed",
+                    "output_tokens": _dict(completed.get("usage")).get("output_tokens")}
+        except Exception:  # noqa: BLE001 — evidence is advisory
+            return None
+
+
+def load_all() -> None:
+    _reg.register(_Claude())
+    _reg.register(_Grok())
+    _reg.register(_Codex())

--- a/scripts/ci_suite.sh
+++ b/scripts/ci_suite.sh
@@ -62,6 +62,7 @@ docker run --rm \
   -e "REDIS_PASSWORD=${REDIS_PASSWORD}" \
   -v "$(pwd)/images/common:/srv/images/common:ro" \
   -v "$(pwd)/images/hello:/srv/images/hello:ro" \
+  -v "$(pwd)/docker-bake.hcl:/srv/docker-bake.hcl:ro" \
   -v "$(pwd)/dagu/dags:/srv/dagu-dags:ro" \
   -v "$(pwd)/app/Dockerfile:/srv/app.Dockerfile:ro" \
   -v "$(pwd)/docs:/srv/docs:ro" \

--- a/scripts/pytest_app.sh
+++ b/scripts/pytest_app.sh
@@ -65,6 +65,7 @@ docker run --rm \
   "${ENV_ARGS[@]}" \
   -v "$(pwd)/images/common:/srv/images/common:ro" \
   -v "$(pwd)/images/hello:/srv/images/hello:ro" \
+  -v "$(pwd)/docker-bake.hcl:/srv/docker-bake.hcl:ro" \
   -v "$(pwd)/dagu/dags:/srv/dagu-dags:ro" \
   -v "$(pwd)/app/Dockerfile:/srv/app.Dockerfile:ro" \
   -v "$(pwd)/docs:/srv/docs:ro" \


### PR DESCRIPTION
## Why

Adding a fourth coding CLI today means forking `if harness ==` across argv, render, parse, fault, dump, and the entrypoint — and **unknown ids silently ran the Claude path**. Docs/16 H1–H2: one fail-closed dialect seam in the image, and config ids that cannot drift from `HARNESSES`.

## What

**H1 — `HarnessDialect`.** `images/common/devcake_dev/harness/dialect.py` is the chokepoint. The three in-tree CLIs (`claude-code`, `grok-build`, `codex`) are dialect modules. `dev_entrypoint` has no identity branch for parse/fault/dump/render/argv. Unknown `DEVCAKE_HARNESS` raises (`ValueError`) instead of falling through to Claude.

**H2 — registry is the id set.** `DevType.harness_template` validates against `HARNESSES` keys (no parallel `Literal`). Structure tests: every registry id has a dialect and a Bake `images` target; the SPA still loads ids from `GET /harnesses`.

`RESUME_SPECS` stays a separate capture-gated table — a dialect may exist before its resume pair is committed.

## Proof

- Capture + fault + continuation + dialect ratchets: `405 passed` on the harness set (`PYTHONPATH=app`, Python 3.12).
- `docker buildx bake app images` + import smoke in all three harness images (fail-closed unknown id).
- Live grok-build ONBOARD: `BOARD-devcake-pmo-missions-4-1-ONBOARD-40YV4C` → `finished`, verdict `handed off: needs human on ONBOARD`, model `grok-4.6-build`, `[grok] done: end_turn` on the relay. Throwaway issue parked (`DEVCAKE-SKIP`).

## Out of scope

H3 credential extensions, H4 capture-matrix CI gate, H5 Bake scaffold. Next harness (Pi / OpenCode / Qwen) is a dialect module + registry + Bake + captures, not another entrypoint fork.