### PR TITLE
fix: GitHub comment cap; GitLab writes fire; Qwen whole-field

### DIFF
--- a/app/devcake/adapters/github_issues/adapter.py
+++ b/app/devcake/adapters/github_issues/adapter.py
@@ -391,5 +391,6 @@ class GitHubIssuesAdapter:
             native_label_swap_atomic=True,
             relations_supported=True,
             attachments_supported=False,
+            comment_max_chars=65536,
             global_ids=False,
         )

--- a/app/devcake/adapters/gitlab_issues/adapter.py
+++ b/app/devcake/adapters/gitlab_issues/adapter.py
@@ -74,8 +74,9 @@ class GitLabIssuesAdapter:
             except ValueError:
                 self._path = ""
         self._label_names: set[str] = set()  # upper names known on the project
-        self._relations_probed = False
-        self._relations_supported = False
+        # None = unprobed (capabilities True so the domain gate will try);
+        # True/False latched on create_relation.
+        self._relations_write: bool | None = None
 
     def _headers(self) -> dict[str, str]:
         if not self._token.strip():
@@ -136,8 +137,7 @@ class GitLabIssuesAdapter:
             self._team_ref = ref
             self._path = parse_team_ref(ref)
             self._label_names.clear()
-            self._relations_probed = False
-            self._relations_supported = False
+            self._relations_write = None
 
     def _label_set(self, issue: dict) -> set[str]:
         raw = issue.get("labels") or []
@@ -411,13 +411,13 @@ class GitLabIssuesAdapter:
                       "link_type": "is_blocked_by"})
         except GitLabHTTPError as e:
             if e.status_code == 409:
-                self._relations_supported = True
+                self._relations_write = True
                 return
             if e.status_code == 403:
-                self._relations_supported = False
+                self._relations_write = False
                 return
             raise
-        self._relations_supported = True
+        self._relations_write = True
 
     async def _fetch_all_labels(self) -> list[dict]:
         from .._toolkit import paginate_rest
@@ -571,7 +571,12 @@ class GitLabIssuesAdapter:
             return PMOHealth(ok=False, workspace=self._path, detail=str(e))
         present = {(lb.get("name") or "").upper() for lb in labels}
         managed = {n.upper() for n in ALL_LABELS}
-        rel = "on" if self._relations_supported else "off"
+        if self._relations_write is None:
+            rel = "unprobed"
+        elif self._relations_write:
+            rel = "on"
+        else:
+            rel = "off"
         return PMOHealth(
             ok=True, workspace=self._path,
             managed_labels_present=len(present & managed),
@@ -585,7 +590,8 @@ class GitLabIssuesAdapter:
             project_labels_supported=False,
             attachment_max_bytes=10 * 1024 * 1024,
             native_label_swap_atomic=True,
-            relations_supported=self._relations_supported,
+            # Unprobed means "try the write" — False only after a 403.
+            relations_supported=self._relations_write is not False,
             attachments_supported=True,
             global_ids=False,
         )

--- a/app/devcake/domain/orchestrator/feed.py
+++ b/app/devcake/domain/orchestrator/feed.py
@@ -13,7 +13,8 @@ from ...security import redact
 from ..model import Mission, MissionRef, STAGE_LABELS
 from ..run import utcnow
 from . import markers
-from .markers import COMMENT_SENTINEL, FEED_INLINE_MAX, SENTINEL_RE
+from .markers import (COMMENT_SENTINEL, DELIVERABLE_MARKER, FEED_INLINE_MAX,
+                      REPLY_MARKER, SENTINEL_RE, STEP_MARKER)
 
 log = logging.getLogger("devcake.missions")
 tracer = trace.get_tracer("devcake")
@@ -25,6 +26,48 @@ def _attachments_supported(mgr) -> bool:
         return bool(mgr.pmo.capabilities().attachments_supported)
     except Exception:  # noqa: BLE001 — missing/broken caps must not drop feed
         return True
+
+
+def _comment_max_chars(mgr) -> int | None:
+    """Vendor issue-comment cap, or None when the adapter does not declare one."""
+    try:
+        n = mgr.pmo.capabilities().comment_max_chars
+    except Exception:  # noqa: BLE001 — missing caps must not drop the feed
+        return None
+    return int(n) if n else None
+
+
+def _fit_vendor_comment(markdown: str, limit: int) -> str:
+    """Keep the body (plus the sentinel _feed appends) under `limit`.
+
+    Marker-bearing unquoted lines stay; the rest is truncated. A pointer
+    sentence without those lines is how GitHub PLAN used to freeze seq at 1.
+    """
+    text = markdown.rstrip()
+    room = limit - len("\n\n") - len(COMMENT_SENTINEL)
+    if room < 64:
+        room = 64
+    if len(text) <= room:
+        return text
+    notice = (
+        f"\n\n… truncated — this PMO cannot attach files and the vendor "
+        f"comment limit is {limit} characters."
+    )
+    keep = []
+    for line in unquoted(text).splitlines():
+        if (REPLY_MARKER in line or DELIVERABLE_MARKER in line
+                or STEP_MARKER.search(line)):
+            keep.append(line)
+    header = "\n".join(keep)
+    reserved = len(header) + (2 if header else 0) + len(notice)
+    if reserved >= room:
+        body = header or text[: max(0, room - len(notice))]
+        return (body + notice)[:room]
+    fill = room - reserved
+    prefix = text[:fill]
+    if header:
+        return f"{header}\n\n{prefix}{notice}"
+    return f"{prefix}{notice}"
 
 
 def _audit(mgr, pmo_id: str, action: str, detail: str = "") -> None:
@@ -65,7 +108,10 @@ async def _feed(mgr, pmo_id: str, kind: str, markdown: str, *,
     sentinel. Bodies over FEED_INLINE_MAX are uploaded as .md attachments
     and replaced by a short referencing comment (docs/05 §4) unless the
     caller opts out (externalize=False — the ADR-0014 finalize post, whose
-    long text already lives in its own attachment); the sentinel
+    long text already lives in its own attachment). When the vendor
+    declares `comment_max_chars` the posted body (plus sentinel) is fitted
+    under that cap, keeping marker lines — never a raw dump the vendor
+    will 422. The sentinel
     goes on the comment, never inside the attachment, so provenance
     classification keeps working. Upload failures fall back to posting
     inline — an upload outage must never lose feed content. Projects have
@@ -95,6 +141,9 @@ async def _feed(mgr, pmo_id: str, kind: str, markdown: str, *,
                         + f"… — full text attached: [{name}]({url})")
         except Exception:
             log.exception("feed attachment upload failed — posting inline")
+    cap = _comment_max_chars(mgr)
+    if cap is not None:
+        markdown = _fit_vendor_comment(markdown, cap)
     await mgr.pmo.post_feed(
         MissionRef(pmo_id, "issue"),
         markdown.rstrip() + "\n\n" + COMMENT_SENTINEL)

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -177,9 +177,11 @@ class MissionManager:
             return 25 * 1024 * 1024
 
     def _relations_supported(self) -> bool:
-        """Port flag — False means skip create_relation (do not abort)."""
+        """Skip create_relation only after the adapter has proven it cannot
+        write. Unprobed / missing caps must attempt the write — GitLab
+        latches False on 403, and a False start would skip every site."""
         try:
-            return bool(self.pmo.capabilities().relations_supported)
+            return self.pmo.capabilities().relations_supported is not False
         except Exception:  # noqa: BLE001 — missing caps must not drop Linear/Gitea edges
             return True
 

--- a/app/devcake/ports/pmo.py
+++ b/app/devcake/ports/pmo.py
@@ -43,6 +43,10 @@ class PMOCapabilities(BaseModel):
     # contract row 13 records SKIP. Default True so Linear / Gitea / GitLab
     # stay unchanged.
     attachments_supported: bool = True
+    # Vendor issue-comment character cap. None = no extra cap (attachments
+    # handle long bodies). GitHub Issues is 65536; the feed chokepoint must
+    # never post a raw dump the vendor will 422.
+    comment_max_chars: int | None = None
     # pmo_ids are globally unique across the vendor environment (Linear
     # UUIDs) — only such systems may resolve blockers via PEER adapters or
     # accept peer run history on a locally-resolved foreign id. Colliding-id

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -185,7 +185,8 @@ def make_mission_manager(
 
 
 def fake_pmo_capabilities(*, global_ids=True, relations_supported=True,
-                          attachments_supported=True):
+                          attachments_supported=True,
+                          comment_max_chars=None):
     """Shared capability row for the test fakes. Default is Linear-shaped
     (global ids ON, so peer-resolution tests exercise the allowed path);
     colliding-id scenarios pass global_ids=False — the capability replaced
@@ -196,6 +197,7 @@ def fake_pmo_capabilities(*, global_ids=True, relations_supported=True,
         attachment_max_bytes=50 * 1024 * 1024,
         native_label_swap_atomic=True, relations_supported=relations_supported,
         attachments_supported=attachments_supported,
+        comment_max_chars=comment_max_chars,
         global_ids=global_ids)
 
 

--- a/app/tests/test_entrypoint_fault.py
+++ b/app/tests/test_entrypoint_fault.py
@@ -710,6 +710,18 @@ def test_qwen_quoted_api_error_in_assistant_text_is_not_a_fault():
     assert ep.harness_api_error_status("qwen-code", stream) is None
 
 
+def test_qwen_quoted_api_error_in_result_text_is_not_a_fault():
+    """The result field is the model's final answer — a quote is not a wrapper."""
+    stream = json.dumps({
+        "type": "result", "subtype": "success", "is_error": False,
+        "result": ('fixed the check that logged '
+                   '"[API Error: 401 Incorrect API key provided]"'),
+        "num_turns": 1,
+    })
+    assert ep.qwen_run_fault(stream, 0) is None
+    assert ep.harness_api_error_status("qwen-code", stream) is None
+
+
 def test_qwen_result_api_error_wrapper_is_still_a_fault():
     stream = json.dumps({
         "type": "result", "subtype": "success", "is_error": False,

--- a/app/tests/test_github_issues_contract.py
+++ b/app/tests/test_github_issues_contract.py
@@ -207,6 +207,7 @@ def test_upload_attachment_refuses():
 def test_capabilities_option_b():
     caps = make_pmo().capabilities()
     assert caps.attachments_supported is False
+    assert caps.comment_max_chars == 65536
     assert caps.relations_supported is True
     assert caps.projects_supported is False
     assert caps.global_ids is False

--- a/app/tests/test_gitlab_issues_contract.py
+++ b/app/tests/test_gitlab_issues_contract.py
@@ -251,16 +251,16 @@ def test_health_probe_is_read_only():
     assert not any(c.startswith(("POST", "PUT", "PATCH")) for c in r.calls)
 
 
-def test_capabilities_fail_closed_until_a_write():
+def test_capabilities_try_writes_until_a_403():
     caps = make_pmo().capabilities()
     assert caps.projects_supported is False
-    assert caps.relations_supported is False
+    assert caps.relations_supported is True
     assert caps.attachments_supported is True
     assert caps.global_ids is False
     assert caps.native_label_swap_atomic is True
 
 
-def test_health_probe_is_read_only_and_does_not_claim_write_support():
+def test_health_probe_is_read_only_and_reports_unprobed():
     r = Router()
     r.links[1] = [{
         "id": 84, "iid": 2, "project_id": 4,
@@ -269,9 +269,19 @@ def test_health_probe_is_read_only_and_does_not_claim_write_support():
     pmo = make_pmo(r)
     h = run(pmo.health_probe("o/r"))
     assert h.ok
-    assert pmo.capabilities().relations_supported is False
-    assert "relations=off" in (h.detail or "")
+    assert pmo.capabilities().relations_supported is True
+    assert "relations=unprobed" in (h.detail or "")
     assert not any(c.startswith(("POST", "PUT", "PATCH")) for c in r.calls)
+
+
+def test_domain_gate_attempts_unprobed_gitlab_writes():
+    """The flag must not start False — every create_relation site sits
+    behind MissionManager._relations_supported()."""
+    from devcake.domain.orchestrator.manager import MissionManager
+    pmo = make_pmo()
+    mgr = MissionManager.__new__(MissionManager)
+    mgr.pmo = pmo
+    assert mgr._relations_supported() is True
 
 
 def test_blocked_by_reads_gitlab_list_shape():
@@ -288,7 +298,7 @@ def test_blocked_by_reads_gitlab_list_shape():
     pmo = make_pmo(r)
     m = run(pmo.get(MissionRef("1", "issue")))
     assert m.blocked_by == ["2"]
-    assert pmo.capabilities().relations_supported is False
+    assert pmo.capabilities().relations_supported is True
 
 
 def test_create_relation_403_is_unsupported_not_a_wedge():

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -37,6 +37,7 @@ class FakePMO:
         return fake_pmo_capabilities(
             relations_supported=getattr(self, "relations_supported", True),
             attachments_supported=getattr(self, "attachments_supported", True),
+            comment_max_chars=getattr(self, "comment_max_chars", None),
         )
 
     def __init__(self, mission):
@@ -58,6 +59,10 @@ class FakePMO:
 
     async def post_feed(self, ref, markdown):
         self._check_ref(ref)
+        limit = getattr(self, "comment_max_chars", None)
+        if limit is not None and len(markdown) > limit:
+            raise RuntimeError(
+                f"body is too long (maximum is {limit} characters)")
         if ref.kind == "project":
             self.project_updates = getattr(self, "project_updates", [])
             self.project_updates.append((ref.pmo_id, markdown))
@@ -1358,6 +1363,43 @@ def test_planned_without_attachments_posts_plan_inline(tmp_path):
                for c in fake.comments)
     assert "DEVCAKE-EXECUTE" in m.labels
     assert "DEVCAKE-PLAN" not in m.labels
+
+
+GITHUB_COMMENT_MAX = 65536
+
+
+def test_huge_transcript_fits_github_limit_and_keeps_step_marker(tmp_path):
+    """GitHub rejects bodies over 65536. Finalize only catches ValueError,
+    so an oversized post wedges every run in finalizing."""
+    from devcake.domain.model import Activity, ActivityEntry
+    m = mission("in_progress", {"DEVCAKE"})
+    mgr, fake, store = make_mgr(tmp_path, m)
+    fake.attachments_supported = False
+    fake.comment_max_chars = GITHUB_COMMENT_MAX
+    run = _saved_run(store)
+    run_coro(mgr.finalize(run, _finalize_payload(
+        transcript_md="x" * 140_800, last_message_md="Done.")))
+    assert run.state != "finalizing"
+    comment = next(c for c in fake.comments if "`1_ONBOARD.md`" in c)
+    assert len(comment) <= GITHUB_COMMENT_MAX
+    entry = ActivityEntry(ts=datetime.now(timezone.utc), author="cake",
+                          kind="comment", body=comment)
+    assert dispatch._derive_seq(
+        Activity(mission=m, entries=[entry])) == 2
+
+
+def test_huge_plan_fits_github_limit(tmp_path):
+    m = mission("in_progress", {"DEVCAKE", "DEVCAKE-PLAN"})
+    mgr, fake, store = make_mgr(tmp_path, m)
+    fake.attachments_supported = False
+    fake.comment_max_chars = GITHUB_COMMENT_MAX
+    plan = "# the plan\n\n" + ("do the thing\n" * 8_000)
+    assert len(plan) > GITHUB_COMMENT_MAX
+    run_coro(transitions.transition(
+        mgr, _run("PLAN", "DEVCAKE-PLAN"), {"outcome": "planned"}, plan))
+    posted = next(c for c in fake.comments if "the plan" in c)
+    assert len(posted) <= GITHUB_COMMENT_MAX
+    assert "DEVCAKE-EXECUTE" in m.labels
 
 
 def test_finalize_upload_failure_posts_quoted_inline(tmp_path):

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -324,7 +324,7 @@ Same forge-issue profile (issue-only, label stages, open→backlog, markdown com
 | Labels | PUT issue `labels=A,B` replaces the set |
 | Feed | issue notes; `` `devcake:v1` `` byte-exact |
 | Attachments | POST `/projects/:id/uploads`; download `GET /api/v4/projects/:id/uploads/:secret/:filename` (web `/uploads/…` path is **403** with a PAT) |
-| Relations | `blocks` / `is_blocked_by` is **Premium**. Listing links is Free (top-level `iid` + `link_type`). Free gitlab.com → 403 on create: `create_relation` no-ops and latches `relations_supported=False` (must not escape finalize). Row 14 of the contract battery records SKIP, not a vanished pass. |
+| Relations | `blocks` / `is_blocked_by` is **Premium**. Listing links is Free (top-level `iid` + `link_type`). Unprobed starts as "try the write" so the domain gate actually calls `create_relation`. Free gitlab.com → 403: no-op and latch `relations_supported=False`. Health reports `unprobed` / `on` / `off`. Row 14 of the contract battery records SKIP, not a vanished pass. |
 
 `pmo_id` is the issue **iid**. `global_ids=False`. Separate PMO PAT from any GitLab *forge* repo-card token. The admin PMO card and New Mission dialog show `operator_note` from the registry when this system is selected.
 
@@ -337,7 +337,7 @@ Same forge-issue profile (issue-only, label stages, open→backlog, markdown com
 | Status | `open`→backlog; `closed`→done; cancel footer in body → canceled |
 | Labels | PUT `/issues/{n}/labels` replaces the set |
 | Feed | issue comments; `` `devcake:v1` `` byte-exact |
-| Attachments | **No official API.** `attachments_supported=False` (founder option B). `upload_attachment` raises. Feed chokepoint posts inline; activity repo still holds transcripts/plans. |
+| Attachments | **No official API.** `attachments_supported=False` (founder option B). `upload_attachment` raises. `comment_max_chars=65536`. Feed chokepoint keeps markers and truncates to that cap — never a raw dump the vendor will 422. |
 | Relations | Works on personal repos if `issue_id` is the global numeric id. Duplicate → 422 `already been taken`. |
 
 `pmo_id` is the issue **number**. `/issues` includes PRs — filtered. Separate PMO PAT from any GitHub *forge* repo-card token. Registry `operator_note` explains the attachment limit in the SPA.

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -938,12 +938,10 @@ There is no official public REST/GraphQL “upload file to an issue” API. The
 web UI uses undocumented `uploads.github.com/user-attachments`. **C
 (unofficial upload) is refused.** **A** (wait for an official API) is the
 rejected alternative. **B** is the accepted residual:
-`attachments_supported=False`; the feed chokepoint posts a size-safe pointer
-+ token report on the issue; the full dump lives in the Clear-swept activity
-repo. That repo is **not** the durable PMO record (INV-5 / ADR-0014 / docs/14
-still name the PMO as SoT). The operator must see the residual
-(`operator_note` + live health flags). Unofficial `uploads.github.com`
-remains refused.
+`attachments_supported=False`; `comment_max_chars=65536`; the feed chokepoint
+keeps marker-bearing lines and truncates to that cap (never a raw dump the
+vendor will 422). The operator must see the residual (`operator_note` + live
+health flags). Unofficial `uploads.github.com` remains refused.
 
 **Spike evidence (2026-08-15, personal `fidecastro` on github.com +
 gitlab.com — official APIs only).** Throwaway GitHub repo
@@ -955,7 +953,7 @@ gitlab.com — official APIs only).** Throwaway GitHub repo
 | Replace-all labels | PUT `/issues/{n}/labels` works | PUT issue `labels=A,B` works |
 | Marker `` `devcake:v1` `` | comment body **byte-exact** | note body **byte-exact** |
 | Attachments | GET `/issues/{n}/assets` and `/attachments` **404**; comment octet-stream **400**. No official upload. | POST `/projects/:id/uploads` **201** (`url`, `full_path`, `markdown`). Web path + PAT → **403 HTML**. Download **is** `GET /api/v4/projects/:id/uploads/:secret/:filename` → **200** `application/octet-stream`. |
-| Blocked-by | Works on a **personal** repo if `issue_id` is the global numeric `id` (not the number). Number → 404. Duplicate → 422 `already been taken` (treat as success). | `is_blocked_by` / `blocks` → **403** on free gitlab.com (`Blocked issues not available for current license`). `relates_to` works — **not** blocked-by. **Do not hardcode `relations_supported=False`.** The adapter probes the live token (read-only links GET); domain skips `create_relation` when the flag is false; the operator sees on/off. |
+| Blocked-by | Works on a **personal** repo if `issue_id` is the global numeric `id` (not the number). Number → 404. Duplicate → 422 `already been taken` (treat as success). | `is_blocked_by` / `blocks` → **403** on free gitlab.com (`Blocked issues not available for current license`). `relates_to` works — **not** blocked-by. **Do not start `relations_supported=False`.** Unprobed means the domain gate will attempt `create_relation`; a 403 no-ops and latches the flag off. Health reports `unprobed` / `on` / `off`. |
 | PR-as-issue | `/issues` includes PRs (`pull_request` key) — filter | Issues API does not list MRs |
 | `pmo_id` | issue **number** for URLs/keys; dependency POST needs global **id** (adapter-internal lookup) | issue **iid** for paths; still `global_ids=False` (iid collides across projects) |
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -339,13 +339,14 @@ RUN HOME=/root npm install -g "@qwen-code/qwen-code@${QWEN_CODE_VERSION}" \
     && HOME=/root npm cache clean --force
 
 # Vendor usage-stats default on; auto-update against a root-owned global
-# install is wasted I/O. Bake the off switches — do not rely on the
-# operator's uploaded credential file.
+# install is wasted I/O. The system file outranks an operator-uploaded
+# ~/.qwen/settings.json (no env override for auto-update). Bake both.
 USER root
-RUN mkdir -p /home/dev/.qwen \
+RUN mkdir -p /home/dev/.qwen /etc/qwen-code \
  && printf '%s\n' \
       '{"privacy":{"usageStatisticsEnabled":false},"general":{"enableAutoUpdate":false}}' \
       > /home/dev/.qwen/settings.json \
+ && cp /home/dev/.qwen/settings.json /etc/qwen-code/settings.json \
  && chown -R 1000:1000 /home/dev/.qwen
 USER dev
 # --yolo + no sandbox prints a one-line stderr warning; the Dev is the

--- a/images/common/devcake_dev/domain/fault.py
+++ b/images/common/devcake_dev/domain/fault.py
@@ -393,9 +393,14 @@ def _qwen_api_error_bodies(out: str, ev=None) -> list[str]:
     bodies = []
 
     def _take(text):
-        if not isinstance(text, str) or "[API Error:" not in text:
+        if not isinstance(text, str):
             return
-        for m in _QWEN_API_ERROR.finditer(text):
+        # Whole-field match: the CLI puts the wrapper in result/error by
+        # itself. A model answer that quotes "[API Error: 401 …]" is not
+        # a credential fault.
+        stripped = " ".join(text.split())
+        m = _QWEN_API_ERROR.fullmatch(stripped)
+        if m:
             body = " ".join(m.group(1).split())
             if body and body not in bodies:
                 bodies.append(body)


### PR DESCRIPTION
Follow-up to the #153–#159 review. Two of those fixes moved the bug instead of removing it.

**GitHub.** `_feed` no longer posts raw dumps over 65,536 characters. `comment_max_chars=65536` is a capability; the chokepoint keeps marker lines and truncates. Tests use 140,800-character transcripts and a FakePMO that raises the vendor `body is too long` error — finalize must not sit in `finalizing`.

**GitLab.** `relations_supported` starts as "try the write" (unprobed). The domain gate was skipping every `create_relation` because the flag started false and was only set inside the method it refused to call. 403 still no-ops and latches off. Health reports `unprobed` / `on` / `off`.

**Qwen.** `[API Error:]` must be the whole `result`/`error` field, not a quote inside the model's answer. System settings at `/etc/qwen-code/settings.json` pin auto-update off (no env override; the system file outranks an uploaded user file).

Not in this PR: capture-tool Claude fall-through, label casing, cancel-footer `---` strip.