### PR TITLE
fix: inherited forge-issue and capture-rig defects

### DIFF
--- a/app/devcake/adapters/_toolkit.py
+++ b/app/devcake/adapters/_toolkit.py
@@ -16,6 +16,7 @@ import it.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Awaitable, Callable
 
 import httpx
@@ -93,4 +94,89 @@ async def paginate_rest(
                              f"entries — refusing a truncated read")
     if on_ceiling == "warn":
         log.warning("%s hit page ceiling (%s pages)", what, max_pages)
+    return items, True
+
+
+_LAST_PAGE_RE = re.compile(r'[?&]page=(\d+)[^>]*>\s*;\s*rel="last"', re.I)
+
+
+def last_page_from_headers(headers, *, page_size: int) -> int | None:
+    """GitHub/Gitea Link rel=last, or X-Total-Count / page_size."""
+    if headers is None:
+        return None
+    # httpx headers are case-insensitive; plain dicts in tests are not.
+    link = ""
+    total = None
+    if hasattr(headers, "get"):
+        link = headers.get("link") or headers.get("Link") or ""
+        total = headers.get("x-total-count") or headers.get("X-Total-Count")
+    hit = _LAST_PAGE_RE.search(link)
+    if hit:
+        return int(hit.group(1))
+    if total and page_size > 0:
+        try:
+            n = int(total)
+        except (TypeError, ValueError):
+            return None
+        if n <= 0:
+            return 1
+        return (n + page_size - 1) // page_size
+    return None
+
+
+def _rest_ceiling(what: str, max_pages: int, page_size: int,
+                  on_ceiling: str, ceiling_error: str | None) -> None:
+    if on_ceiling == "raise":
+        raise RuntimeError(
+            ceiling_error or f"{what}: more than {max_pages * page_size} "
+                             f"entries — refusing a truncated read")
+    if on_ceiling == "warn":
+        log.warning("%s hit page ceiling (%s pages)", what, max_pages)
+
+
+async def paginate_rest_newest(
+        fetch_page: Callable[[int], Awaitable[tuple[list, int | None]]],
+        *, page_size: int, max_pages: int, what: str,
+        on_ceiling: str = "warn",
+        ceiling_error: str | None = None) -> tuple[list, bool]:
+    """Oldest-first REST: keep the newest `max_pages` when the ceiling hits.
+
+    fetch_page(n) → (items, last_page or None). Returns items chronological.
+    last_page comes from last_page_from_headers. If the vendor never
+    discloses a last page and page 1 is full, we cannot find the tail —
+    walk forward (legacy) and still flag truncated at the ceiling.
+    """
+    first, last = await fetch_page(1)
+    if not first:
+        return [], False
+    if last is None and len(first) < page_size:
+        return list(first), False
+    if last is None:
+        items = list(first)
+        for page in range(2, max_pages + 1):
+            batch, hinted = await fetch_page(page)
+            if hinted is not None:
+                last = hinted
+                break
+            if not batch:
+                return items, False
+            items.extend(batch)
+            if len(batch) < page_size:
+                return items, False
+        else:
+            _rest_ceiling(what, max_pages, page_size, on_ceiling, ceiling_error)
+            return items, True
+    assert last is not None
+    if last <= max_pages:
+        items = []
+        for page in range(1, last + 1):
+            batch, _ = await fetch_page(page)
+            items.extend(batch)
+        return items, False
+    start = last - max_pages + 1
+    items = []
+    for page in range(start, last + 1):
+        batch, _ = await fetch_page(page)
+        items.extend(batch)
+    _rest_ceiling(what, max_pages, page_size, on_ceiling, ceiling_error)
     return items, True

--- a/app/devcake/adapters/forge_issue.py
+++ b/app/devcake/adapters/forge_issue.py
@@ -1,0 +1,39 @@
+"""Shared forge-issue body conventions (ADR-0034).
+
+GitHub / GitLab / Gitea Issues all encode cancel as a durable footer in
+the issue body. Apply and strip live here so a second adapter cannot
+invent a global `---` wipe.
+"""
+
+from __future__ import annotations
+
+CANCEL_FOOTER = "`devcake:canceled:v1`"
+
+_SEP = "\n\n---\n"
+_SEP_SHORT = "\n---\n"
+
+
+def apply_cancel_footer(body: str) -> str:
+    """Append the cancel block once. Idempotent."""
+    text = body or ""
+    if CANCEL_FOOTER in text:
+        return text
+    return text.rstrip() + f"{_SEP}{CANCEL_FOOTER}\n"
+
+
+def strip_cancel_footer(body: str) -> str:
+    """Remove only the cancel block. Human `---` rules stay."""
+    text = body or ""
+    idx = text.find(CANCEL_FOOTER)
+    if idx < 0:
+        return text
+    start = idx
+    prefix = text[:idx]
+    if prefix.endswith(_SEP):
+        start -= len(_SEP)
+    elif prefix.endswith(_SEP_SHORT):
+        start -= len(_SEP_SHORT)
+    end = idx + len(CANCEL_FOOTER)
+    if end < len(text) and text[end] == "\n":
+        end += 1
+    return text[:start] + text[end:]

--- a/app/devcake/adapters/gitea_issues/adapter.py
+++ b/app/devcake/adapters/gitea_issues/adapter.py
@@ -17,9 +17,11 @@ from urllib.parse import urlsplit, urlunsplit
 import httpx
 
 from ...domain.model import (ALL_LABELS, Activity, ActivityEntry, AttachmentRef,
-                             Mission, MissionRef, NormalizedStatus)
+                             Mission, MissionRef, NormalizedStatus,
+                             canonicalize_labels)
 from ...ports.pmo import PMOCapabilities, PMOHealth, PMOTransient
-from .mapping import (CANCEL_FOOTER, mission_key, normalize_priority,
+from ..forge_issue import CANCEL_FOOTER, apply_cancel_footer, strip_cancel_footer
+from .mapping import (mission_key, normalize_priority,
                       normalize_status, parse_team_ref)
 
 log = logging.getLogger("devcake.gitea_issues")
@@ -168,6 +170,7 @@ class GiteaIssuesAdapter:
         content: bytes | None = None,
         headers: dict | None = None,
         expect_json: bool = True,
+        as_response: bool = False,
     ) -> Any:
         if not self._api:
             raise PMOTransient("gitea_issues: api_base is empty")
@@ -190,6 +193,8 @@ class GiteaIssuesAdapter:
             raise RuntimeError(
                 f"gitea_issues {method} {path} → {resp.status_code}: "
                 f"{resp.text[:300]}")
+        if as_response:
+            return resp
         if not expect_json or not resp.content:
             return resp.content if not expect_json else None
         return resp.json()
@@ -216,9 +221,8 @@ class GiteaIssuesAdapter:
     def _mission(self, issue: dict) -> Mission:
         number = int(issue["number"])
         body = issue.get("body") or ""
-        labels = { (lb.get("name") or "") for lb in (issue.get("labels") or [])
-                   if lb.get("name") }
-        labels = {n for n in labels if n}
+        labels = canonicalize_labels(
+            lb.get("name") or "" for lb in (issue.get("labels") or []))
         # blocked_by filled by callers that fetch dependencies
         updated = issue.get("updated_at") or issue.get("created_at") or ""
         try:
@@ -324,12 +328,20 @@ class GiteaIssuesAdapter:
         # and the old fabricated Mission answer made misroutes invisible.
         self._require_issue(ref)
         mission = await self.get(ref)
-        from .._toolkit import paginate_rest
+        from .._toolkit import last_page_from_headers, paginate_rest_newest
         max_pages = MAX_COMMENT_PAGES_FULL if full else MAX_COMMENT_PAGES
-        raw_comments, truncated = await paginate_rest(
-            lambda page: self._req(
+
+        async def _comments_page(page: int):
+            resp = await self._req(
                 "GET", self._repo_path(f"/issues/{ref.pmo_id}/comments"),
-                params={"page": page, "limit": COMMENTS_PAGE}),
+                params={"page": page, "limit": COMMENTS_PAGE},
+                as_response=True)
+            items = resp.json() if resp.content else []
+            last = last_page_from_headers(resp.headers, page_size=COMMENTS_PAGE)
+            return items or [], last
+
+        raw_comments, truncated = await paginate_rest_newest(
+            _comments_page,
             page_size=COMMENTS_PAGE, max_pages=max_pages,
             what="gitea_issues get_activity", on_ceiling="flag")
         if truncated:
@@ -422,16 +434,14 @@ class GiteaIssuesAdapter:
             cur = await self._req(
                 "GET", self._repo_path(f"/issues/{ref.pmo_id}"))
             body = cur.get("body") or ""
-            if CANCEL_FOOTER not in body:
-                body_patch["body"] = body.rstrip() + f"\n\n---\n{CANCEL_FOOTER}\n"
+            body_patch["body"] = apply_cancel_footer(body)
         elif status in ("backlog", "in_progress", "done"):
             # opening or completing: strip cancel footer if present so done ≠ canceled
             cur = await self._req(
                 "GET", self._repo_path(f"/issues/{ref.pmo_id}"))
             body = cur.get("body") or ""
             if CANCEL_FOOTER in body:
-                cleaned = body.replace(CANCEL_FOOTER, "").replace("\n\n---\n\n", "\n")
-                body_patch["body"] = cleaned
+                body_patch["body"] = strip_cancel_footer(body)
         await self._req(
             "PATCH", self._repo_path(f"/issues/{ref.pmo_id}"),
             json=body_patch)
@@ -533,7 +543,7 @@ class GiteaIssuesAdapter:
                 f"gitea_issues: issue {pmo_id} has more than "
                 f"{MAX_LABEL_PAGES * LABELS_PAGE} labels — refusing a "
                 f"full-set rewrite from a truncated read"))
-        return {(lb.get("name") or "") for lb in labels}
+        return canonicalize_labels(lb.get("name") or "" for lb in labels)
 
     async def _fetch_all_labels(self) -> list[dict]:
         """Every label on the repo, paginated with a fail-loud ceiling.

--- a/app/devcake/adapters/gitea_issues/mapping.py
+++ b/app/devcake/adapters/gitea_issues/mapping.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 from typing import Literal
 
 # Durable cancel signal in the issue body (plan lock-in: do not expand
-# ALL_LABELS). cancel_mission appends this; normalize_status reads it.
-CANCEL_FOOTER = "`devcake:canceled:v1`"
+# ALL_LABELS). One constant — adapters/forge_issue.py.
+from ..forge_issue import CANCEL_FOOTER
 
 NormalizedStatus = Literal["backlog", "in_progress", "done", "canceled"]
 Priority = Literal["urgent", "high", "medium", "low"]

--- a/app/devcake/adapters/github_issues/adapter.py
+++ b/app/devcake/adapters/github_issues/adapter.py
@@ -14,9 +14,11 @@ from typing import Any, Optional
 import httpx
 
 from ...domain.model import (ALL_LABELS, Activity, ActivityEntry,
-                             Mission, MissionRef, NormalizedStatus)
+                             Mission, MissionRef, NormalizedStatus,
+                             canonicalize_labels)
 from ...ports.pmo import PMOCapabilities, PMOHealth, PMOTransient
-from .mapping import (CANCEL_FOOTER, mission_key, normalize_priority,
+from ..forge_issue import CANCEL_FOOTER, apply_cancel_footer, strip_cancel_footer
+from .mapping import (mission_key, normalize_priority,
                       normalize_status, parse_team_ref)
 
 log = logging.getLogger("devcake.github_issues")
@@ -86,6 +88,7 @@ class GitHubIssuesAdapter:
         *,
         params: dict | None = None,
         json: dict | list | None = None,
+        as_response: bool = False,
     ) -> Any:
         if not self._api:
             raise PMOTransient("github_issues: api_base is empty")
@@ -109,6 +112,8 @@ class GitHubIssuesAdapter:
             raise RuntimeError(
                 f"github_issues {method} {path} → {resp.status_code}: "
                 f"{body[:300]}")
+        if as_response:
+            return resp
         if not resp.content:
             return None
         return resp.json()
@@ -127,8 +132,8 @@ class GitHubIssuesAdapter:
             self._label_names.clear()
 
     def _label_set(self, issue: dict) -> set[str]:
-        return {(lb.get("name") or "") for lb in (issue.get("labels") or [])
-                if lb.get("name")}
+        return canonicalize_labels(
+            lb.get("name") or "" for lb in (issue.get("labels") or []))
 
     def _mission(self, issue: dict) -> Mission:
         number = int(issue["number"])
@@ -213,12 +218,20 @@ class GitHubIssuesAdapter:
                            full: bool = False) -> Activity:
         self._require_issue(ref)
         mission = await self.get(ref)
-        from .._toolkit import paginate_rest
+        from .._toolkit import last_page_from_headers, paginate_rest_newest
         max_pages = MAX_COMMENT_PAGES_FULL if full else MAX_COMMENT_PAGES
-        raw_comments, truncated = await paginate_rest(
-            lambda page: self._req(
+
+        async def _comments_page(page: int):
+            resp = await self._req(
                 "GET", self._repo_path(f"/issues/{ref.pmo_id}/comments"),
-                params={"page": page, "per_page": COMMENTS_PAGE}),
+                params={"page": page, "per_page": COMMENTS_PAGE},
+                as_response=True)
+            items = resp.json() if resp.content else []
+            last = last_page_from_headers(resp.headers, page_size=COMMENTS_PAGE)
+            return items or [], last
+
+        raw_comments, truncated = await paginate_rest_newest(
+            _comments_page,
             page_size=COMMENTS_PAGE, max_pages=max_pages,
             what="github_issues get_activity", on_ceiling="flag")
         if truncated:
@@ -260,11 +273,9 @@ class GitHubIssuesAdapter:
         cur = await self._req("GET", self._repo_path(f"/issues/{ref.pmo_id}"))
         body = cur.get("body") or ""
         if status == "canceled":
-            if CANCEL_FOOTER not in body:
-                body_patch["body"] = body.rstrip() + f"\n\n---\n{CANCEL_FOOTER}\n"
+            body_patch["body"] = apply_cancel_footer(body)
         elif CANCEL_FOOTER in body:
-            cleaned = body.replace(CANCEL_FOOTER, "").replace("\n\n---\n\n", "\n")
-            body_patch["body"] = cleaned
+            body_patch["body"] = strip_cancel_footer(body)
         await self._req(
             "PATCH", self._repo_path(f"/issues/{ref.pmo_id}"), json=body_patch)
 

--- a/app/devcake/adapters/github_issues/mapping.py
+++ b/app/devcake/adapters/github_issues/mapping.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-CANCEL_FOOTER = "`devcake:canceled:v1`"
+from ..forge_issue import CANCEL_FOOTER
 
 NormalizedStatus = Literal["backlog", "in_progress", "done", "canceled"]
 Priority = Literal["urgent", "high", "medium", "low"]

--- a/app/devcake/adapters/gitlab_issues/adapter.py
+++ b/app/devcake/adapters/gitlab_issues/adapter.py
@@ -15,9 +15,11 @@ from urllib.parse import urlsplit
 import httpx
 
 from ...domain.model import (ALL_LABELS, Activity, ActivityEntry, AttachmentRef,
-                             Mission, MissionRef, NormalizedStatus)
+                             Mission, MissionRef, NormalizedStatus,
+                             canonicalize_labels)
 from ...ports.pmo import PMOCapabilities, PMOHealth, PMOTransient
-from .mapping import (CANCEL_FOOTER, mission_key, normalize_priority,
+from ..forge_issue import CANCEL_FOOTER, apply_cancel_footer, strip_cancel_footer
+from .mapping import (mission_key, normalize_priority,
                       normalize_status, parse_team_ref, project_path_encoded)
 
 log = logging.getLogger("devcake.gitlab_issues")
@@ -141,13 +143,13 @@ class GitLabIssuesAdapter:
 
     def _label_set(self, issue: dict) -> set[str]:
         raw = issue.get("labels") or []
-        names: set[str] = set()
+        names: list[str] = []
         for lb in raw:
             if isinstance(lb, str):
-                names.add(lb)
+                names.append(lb)
             elif isinstance(lb, dict) and lb.get("name"):
-                names.add(lb["name"])
-        return {n for n in names if n}
+                names.append(lb["name"])
+        return canonicalize_labels(names)
 
     def _mission(self, issue: dict) -> Mission:
         iid = int(issue["iid"])
@@ -350,12 +352,9 @@ class GitLabIssuesAdapter:
         cur = await self._req("GET", self._proj(f"/issues/{ref.pmo_id}"))
         body = cur.get("description") or ""
         if status == "canceled":
-            if CANCEL_FOOTER not in body:
-                body_patch["description"] = (
-                    body.rstrip() + f"\n\n---\n{CANCEL_FOOTER}\n")
+            body_patch["description"] = apply_cancel_footer(body)
         elif CANCEL_FOOTER in body:
-            cleaned = body.replace(CANCEL_FOOTER, "").replace("\n\n---\n\n", "\n")
-            body_patch["description"] = cleaned
+            body_patch["description"] = strip_cancel_footer(body)
         await self._req(
             "PUT", self._proj(f"/issues/{ref.pmo_id}"), json=body_patch)
 

--- a/app/devcake/adapters/gitlab_issues/adapter.py
+++ b/app/devcake/adapters/gitlab_issues/adapter.py
@@ -373,13 +373,14 @@ class GitLabIssuesAdapter:
         cur = await self._req("GET", self._proj(f"/issues/{ref.pmo_id}"))
         current = self._label_set(cur)
         next_names = (current - remove) | add
-        missing = [n for n in next_names if n.upper() not in self._label_names
-                   and n.upper() not in {x.upper() for x in next_names}]
+        missing = [n for n in next_names if n.upper() not in self._label_names]
+        if missing:
+            raise RuntimeError(
+                f"label {missing[0]} missing — ensure_labels not run?")
         # GitLab PUT replaces the full label set by *name*.
         await self._req(
             "PUT", self._proj(f"/issues/{ref.pmo_id}"),
             json={"labels": ",".join(sorted(next_names))})
-        _ = missing
 
     async def create_mission(
         self, team_ref: str, title: str, description: str,
@@ -456,7 +457,7 @@ class GitLabIssuesAdapter:
 
     async def upload_attachment(self, pmo_id: str, filename: str,
                                 data: bytes) -> str:
-        _ = pmo_id  # GitLab uploads are project-scoped; we reference from a note
+        _ = pmo_id  # GitLab uploads are project-scoped, not issue-scoped
         if not self._api:
             raise PMOTransient("gitlab_issues: api_base is empty")
         url = f"{self._api}{self._proj('/uploads')}"
@@ -482,8 +483,6 @@ class GitLabIssuesAdapter:
             raise RuntimeError(
                 f"gitlab_issues upload: unexpected url {secret_url!r}")
         secret, fname = parts[1], parts[2]
-        # Do not post a follow-up note here — that bypasses the feed
-        # chokepoint and lands unsigned, which freshness treats as human.
         return f"{self._api}{self._proj(f'/uploads/{secret}/{fname}')}"
 
     def _finalize_upload_url(self, url: str) -> str:

--- a/app/devcake/adapters/gitlab_issues/mapping.py
+++ b/app/devcake/adapters/gitlab_issues/mapping.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 from typing import Literal
 from urllib.parse import quote
 
-# Same durable cancel signal as gitea_issues (docs/05 forge-issue family).
-CANCEL_FOOTER = "`devcake:canceled:v1`"
+from ..forge_issue import CANCEL_FOOTER
 
 NormalizedStatus = Literal["backlog", "in_progress", "done", "canceled"]
 Priority = Literal["urgent", "high", "medium", "low"]

--- a/app/devcake/domain/model.py
+++ b/app/devcake/domain/model.py
@@ -1,6 +1,7 @@
 """PMO domain: normalized DTOs, the managed label set, and Mission Type
 derivation (docs/02). Pure logic — no I/O, no vendor types (docs/01 §3)."""
 
+from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
 from typing import Literal, NamedTuple, Optional
@@ -29,6 +30,22 @@ ALL_LABELS = {LABEL_OPTIN, LABEL_PLAN, LABEL_EXECUTE, LABEL_REVIEW, LABEL_MERGE,
               LABEL_CREATED, LABEL_FAILED, LABEL_SKIP, LABEL_TRACKING,
               LABEL_NEEDS_HUMAN, LABEL_DISCOVERY}
 STAGE_LABELS = {LABEL_PLAN, LABEL_EXECUTE, LABEL_REVIEW}
+
+
+def canonicalize_labels(names: Iterable[str]) -> set[str]:
+    """Map vendor-cased names onto ALL_LABELS. Unmanaged names stay as stored.
+
+    GitHub/Gitea/GitLab fold case; a human `Devcake-Plan` is the same label
+    as `DEVCAKE-PLAN`. derive() and swap_labels are exact-string — adapters
+    must emit these spellings.
+    """
+    canon = {n.upper(): n for n in ALL_LABELS}
+    out: set[str] = set()
+    for raw in names:
+        if not raw:
+            continue
+        out.add(canon.get(raw.upper(), raw))
+    return out
 
 NormalizedStatus = Literal["backlog", "in_progress", "done", "canceled"]
 Priority = Literal["urgent", "high", "medium", "low"]

--- a/app/devcake/domain/orchestrator/feed.py
+++ b/app/devcake/domain/orchestrator/feed.py
@@ -39,6 +39,9 @@ def _comment_max_chars(mgr) -> int | None:
 
 
 _PART_LABEL_BUDGET = len("Part 999 of 999") + 2  # label + blank line
+# GitHub secondary write limits (~80 content creations / minute). A 50 MB
+# dump at comment_max_chars=65536 is ~800 comments; refuse before we try.
+MAX_VENDOR_COMMENT_PARTS = 40
 
 
 def _part_label(i: int, n: int) -> str:
@@ -99,6 +102,10 @@ def split_vendor_comments(markdown: str, limit: int) -> list[str]:
         room = 64
     chunks = _chunk_text(text, room)
     n = len(chunks)
+    if n > MAX_VENDOR_COMMENT_PARTS:
+        raise ValueError(
+            f"paginated comment would post more than "
+            f"{MAX_VENDOR_COMMENT_PARTS} parts ({n}) — refusing")
     parts = [_attach_part_label(c, i, n) for i, c in enumerate(chunks, 1)]
     for part in parts:
         if len(part) + sentinel_over > limit:
@@ -272,8 +279,9 @@ async def _feed(mgr, pmo_id: str, kind: str, markdown: str, *,
     long text already lives in its own attachment). When the vendor
     declares `comment_max_chars` and the body will not fit, `_feed` posts
     the FULL text as sequential `Part i of n` comments (markers stay on
-    part 1; each page carries the sentinel). Never a truncated dump, never
-    a 422. The sentinel
+    part 1; each page carries the sentinel) up to MAX_VENDOR_COMMENT_PARTS.
+    Never a truncated dump, never a 422; over the part cap is ValueError.
+    The sentinel
     goes on the comment, never inside the attachment, so provenance
     classification keeps working. Upload failures fall back to posting
     inline — an upload outage must never lose feed content. Projects have

--- a/app/tests/test_canonicalize_labels.py
+++ b/app/tests/test_canonicalize_labels.py
@@ -1,0 +1,38 @@
+"""Managed labels are matched case-insensitively onto ALL_LABELS.
+
+Forge vendors (GitHub, Gitea, GitLab) fold case; a human-created
+`Devcake-Plan` must become the domain name so derive()/swap_labels see it.
+Unmanaged names keep their stored spelling.
+"""
+
+from datetime import datetime, timezone
+
+from devcake.domain.model import (LABEL_OPTIN, LABEL_PLAN, Mission,
+                                  canonicalize_labels, derive)
+
+
+def test_canonicalize_labels_maps_managed_names_case_insensitively():
+    assert canonicalize_labels(["Devcake-Plan", "devcake"]) == {
+        LABEL_PLAN, LABEL_OPTIN}
+
+
+def test_canonicalize_labels_keeps_unmanaged_spelling():
+    assert canonicalize_labels(["bug", "Needs-QA"]) == {"bug", "Needs-QA"}
+
+
+def test_canonicalize_labels_drops_empty():
+    assert canonicalize_labels(["", "DEVCAKE"]) == {LABEL_OPTIN}
+
+
+def test_mixed_case_stage_label_is_visible_to_derive():
+    """The adapter must emit ALL_LABELS spellings; derive is exact-string."""
+    m = Mission(
+        pmo_id="1", pmo_kind="issue", key="o/r#1", title="t",
+        status="backlog",
+        labels=canonicalize_labels(["DEVCAKE", "Devcake-Plan"]),
+        updated_at=datetime.now(timezone.utc),
+    )
+    d = derive(m, "opt_in")
+    assert d.mission_type is not None
+    assert d.mission_type.value == "PLAN"
+    assert "LABEL_CONFLICT" not in d.reason

--- a/app/tests/test_forge_issue.py
+++ b/app/tests/test_forge_issue.py
@@ -1,0 +1,39 @@
+"""Forge-issue cancel footer — one apply/strip, not a global --- wipe."""
+
+from devcake.adapters.forge_issue import (
+    CANCEL_FOOTER, apply_cancel_footer, strip_cancel_footer)
+
+
+def test_apply_is_idempotent_and_uses_the_separator_block():
+    body = apply_cancel_footer("shipped the thing")
+    assert body.endswith(f"\n\n---\n{CANCEL_FOOTER}\n")
+    assert apply_cancel_footer(body) == body
+
+
+def test_strip_inverts_apply_and_keeps_human_horizontal_rules():
+    original = (
+        "Intro\n\n"
+        "---\n\n"
+        "Section two with a rule above\n\n"
+        "---\n\n"
+        "Closing"
+    )
+    posted = apply_cancel_footer(original)
+    assert posted.count("---") == 3
+    restored = strip_cancel_footer(posted)
+    assert CANCEL_FOOTER not in restored
+    assert restored.count("---") == 2
+    assert "Section two with a rule above" in restored
+    assert restored.rstrip() == original.rstrip()
+
+
+def test_strip_without_footer_is_a_no_op():
+    body = "plain\n\n---\n\ntext"
+    assert strip_cancel_footer(body) == body
+
+
+def test_three_adapters_share_the_same_footer_constant():
+    from devcake.adapters.gitea_issues.mapping import CANCEL_FOOTER as ge
+    from devcake.adapters.github_issues.mapping import CANCEL_FOOTER as gh
+    from devcake.adapters.gitlab_issues.mapping import CANCEL_FOOTER as gl
+    assert gh is ge is gl is CANCEL_FOOTER

--- a/app/tests/test_gitea_issues_contract.py
+++ b/app/tests/test_gitea_issues_contract.py
@@ -133,7 +133,14 @@ class Router:
                     iss["body"] = body["body"]
                 return httpx.Response(200, json=iss)
             if rest == "/comments" and method == "GET":
-                return httpx.Response(200, json=self.comments.get(num, []))
+                page = int(req.url.params.get("page", 1))
+                limit = int(req.url.params.get("limit", 50))
+                all_c = self.comments.get(num, [])
+                start = (page - 1) * limit
+                chunk = all_c[start:start + limit]
+                return httpx.Response(
+                    200, json=chunk,
+                    headers={"X-Total-Count": str(len(all_c))})
             if rest == "/comments" and method == "POST":
                 c = {
                     "id": self.next_comment,
@@ -238,6 +245,25 @@ def test_cancel_mission_idempotent():
     run(pmo.cancel_mission(MissionRef("1", "issue")))  # no raise
 
 
+def test_mixed_case_managed_label_normalizes_and_can_be_swapped():
+    r = Router()
+    r.labels["DEVCAKE-PLAN"] = {
+        "id": 2, "name": "Devcake-Plan", "color": "111"}
+    r.issues[1]["labels"] = [
+        r.labels["DEVCAKE"], r.labels["DEVCAKE-PLAN"]]
+    pmo = make_pmo(r)
+    m = run(pmo.get(MissionRef("1", "issue")))
+    assert "DEVCAKE-PLAN" in m.labels
+    assert "Devcake-Plan" not in m.labels
+    run(pmo.swap_labels(MissionRef("1", "issue"),
+                        {"DEVCAKE-PLAN"}, {"DEVCAKE-EXECUTE"}))
+    names = {lb["name"] for lb in r.issues[1]["labels"]}
+    assert "Devcake-Plan" not in names
+    assert "DEVCAKE-PLAN" not in names
+    assert "DEVCAKE-EXECUTE" in names
+    assert "DEVCAKE" in names
+
+
 def test_swap_labels_put_replace():
     r = Router()
     r.labels["DEVCAKE-PLAN"] = {"id": 2, "name": "DEVCAKE-PLAN", "color": "111"}
@@ -261,6 +287,21 @@ def test_create_relation_and_blocked_by():
     m2 = run(pmo.get(MissionRef("2", "issue")))
     assert m2.blocked_by == ["1"]
     run(pmo.create_relation("1", "2"))  # duplicate tolerant
+
+
+def test_get_activity_ceiling_keeps_newest_comments(monkeypatch):
+    from devcake.adapters.gitea_issues import adapter as gi
+    monkeypatch.setattr(gi, "MAX_COMMENT_PAGES", 2)
+    monkeypatch.setattr(gi, "COMMENTS_PAGE", 2)
+    r = Router()
+    r.comments[1] = [
+        {"id": i, "body": f"c{i}", "created_at": f"2026-07-20T12:00:{i:02d}Z",
+         "user": {"login": "bot"}, "assets": []}
+        for i in range(1, 8)
+    ]
+    act = run(make_pmo(r).get_activity(MissionRef("1", "issue")))
+    assert act.truncated is True
+    assert [e.body for e in act.entries] == ["c5", "c6", "c7"]
 
 
 def test_post_feed_and_activity_marker_body():

--- a/app/tests/test_github_issues_contract.py
+++ b/app/tests/test_github_issues_contract.py
@@ -120,7 +120,16 @@ class Router:
                     iss["body"] = body["body"]
                 return httpx.Response(200, json=iss)
             if rest == "/comments" and method == "GET":
-                return httpx.Response(200, json=self.comments.get(num, []))
+                page = int(req.url.params.get("page", 1))
+                per = int(req.url.params.get("per_page", 50))
+                all_c = self.comments.get(num, [])
+                start = (page - 1) * per
+                chunk = all_c[start:start + per]
+                last = max(1, (len(all_c) + per - 1) // per) if all_c else 1
+                headers = {
+                    "Link": f'<https://api.github.com/x?page={last}>; rel="last"',
+                }
+                return httpx.Response(200, json=chunk, headers=headers)
             if rest == "/comments" and method == "POST":
                 c = {"id": self.next_comment, "body": body.get("body") or "",
                      "created_at": "2026-08-15T12:00:00Z",
@@ -173,6 +182,18 @@ def test_list_filters_pull_requests():
     assert all(m.pmo_id != "9" for m in missions)
 
 
+def test_uncancel_keeps_human_horizontal_rules():
+    r = Router()
+    r.issues[1]["body"] = "Intro\n\n---\n\nSection"
+    pmo = make_pmo(r)
+    run(pmo.cancel_mission(MissionRef("1", "issue")))
+    run(pmo.set_status(MissionRef("1", "issue"), "done"))
+    body = r.issues[1]["body"]
+    assert CANCEL_FOOTER not in body
+    assert "---" in body
+    assert "Section" in body
+
+
 def test_cancel_mission_idempotent():
     r = Router()
     pmo = make_pmo(r)
@@ -180,6 +201,22 @@ def test_cancel_mission_idempotent():
     assert r.issues[1]["state"] == "closed"
     assert CANCEL_FOOTER in r.issues[1]["body"]
     run(pmo.cancel_mission(MissionRef("1", "issue")))
+
+
+def test_get_activity_ceiling_keeps_newest_comments(monkeypatch):
+    from devcake.adapters.github_issues import adapter as gh
+    monkeypatch.setattr(gh, "MAX_COMMENT_PAGES", 2)
+    monkeypatch.setattr(gh, "COMMENTS_PAGE", 2)
+    r = Router()
+    r.comments[1] = [
+        {"id": i, "body": f"c{i}", "created_at": f"2026-08-15T12:00:{i:02d}Z",
+         "user": {"login": "bot"}}
+        for i in range(1, 8)
+    ]
+    act = run(make_pmo(r).get_activity(MissionRef("1", "issue")))
+    assert act.truncated is True
+    bodies = [e.body for e in act.entries]
+    assert bodies == ["c5", "c6", "c7"]
 
 
 def test_post_feed_marker_round_trip():
@@ -252,3 +289,22 @@ def test_403_permission_is_permanent():
 def test_project_ref_raises():
     with pytest.raises(RuntimeError, match="projects"):
         run(make_pmo().get(MissionRef("1", "project")))
+
+
+def test_mixed_case_managed_label_normalizes_and_can_be_swapped():
+    """GitHub folds case. A human `Devcake-Plan` must not wedge the stage."""
+    r = Router()
+    r.labels["DEVCAKE-PLAN"] = {
+        "id": 2, "name": "Devcake-Plan", "color": "6e40c9"}
+    r.issues[1] = _issue(1, labels=["DEVCAKE", "Devcake-Plan"])
+    pmo = make_pmo(r)
+    m = run(pmo.get(MissionRef("1", "issue")))
+    assert "DEVCAKE-PLAN" in m.labels
+    assert "Devcake-Plan" not in m.labels
+    run(pmo.swap_labels(MissionRef("1", "issue"),
+                        {"DEVCAKE-PLAN"}, {"DEVCAKE-EXECUTE"}))
+    names = {lb["name"] for lb in r.issues[1]["labels"]}
+    assert "Devcake-Plan" not in names
+    assert "DEVCAKE-PLAN" not in names
+    assert "DEVCAKE-EXECUTE" in names
+    assert "DEVCAKE" in names

--- a/app/tests/test_gitlab_issues_contract.py
+++ b/app/tests/test_gitlab_issues_contract.py
@@ -205,6 +205,24 @@ def test_list_and_get_normalize_opened_to_backlog():
     assert m.instance == "gl"
 
 
+def test_mixed_case_managed_label_normalizes_and_can_be_swapped():
+    r = Router()
+    r.labels["DEVCAKE-PLAN"] = {
+        "id": 2, "name": "Devcake-Plan", "color": "#6e40c9"}
+    r.issues[1] = _issue(1, labels=["DEVCAKE", "Devcake-Plan"])
+    pmo = make_pmo(r)
+    m = run(pmo.get(MissionRef("1", "issue")))
+    assert "DEVCAKE-PLAN" in m.labels
+    assert "Devcake-Plan" not in m.labels
+    run(pmo.swap_labels(MissionRef("1", "issue"),
+                        {"DEVCAKE-PLAN"}, {"DEVCAKE-EXECUTE"}))
+    names = set(r.issues[1]["labels"])
+    assert "Devcake-Plan" not in names
+    assert "DEVCAKE-PLAN" not in names
+    assert "DEVCAKE-EXECUTE" in names
+    assert "DEVCAKE" in names
+
+
 def test_closed_with_cancel_footer_is_canceled():
     r = Router()
     r.issues[1] = _issue(1, state="closed",

--- a/app/tests/test_gitlab_issues_contract.py
+++ b/app/tests/test_gitlab_issues_contract.py
@@ -223,6 +223,22 @@ def test_mixed_case_managed_label_normalizes_and_can_be_swapped():
     assert "DEVCAKE" in names
 
 
+def test_swap_labels_never_puts_a_set_with_unresolved_names(monkeypatch):
+    """The old guard was always empty (`n in next_names` twice) and discarded."""
+    r = Router()
+    r.issues[1] = _issue(1, labels=["GHOST"])
+    pmo = make_pmo(r)
+
+    async def ensure_noop(team_ref, names):
+        return None
+
+    monkeypatch.setattr(pmo, "ensure_labels", ensure_noop)
+    with pytest.raises(RuntimeError, match="label GHOST missing"):
+        run(pmo.swap_labels(MissionRef("1", "issue"), set(), set()))
+    assert not any(c.endswith("/issues/1") and c.startswith("PUT")
+                   for c in r.calls)
+
+
 def test_closed_with_cancel_footer_is_canceled():
     r = Router()
     r.issues[1] = _issue(1, state="closed",

--- a/app/tests/test_harness_capture_rig.py
+++ b/app/tests/test_harness_capture_rig.py
@@ -1,0 +1,63 @@
+"""Capture rig must fail closed — no Claude default, no `other` alias."""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("DEVCAKE_RUN_ID", "test-capture-rig")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6399/0")
+os.environ.setdefault("REDIS_USER", "test")
+os.environ.setdefault("REDIS_PASSWORD", "test")
+
+_CAPTURE_CANDIDATES = [
+    Path(__file__).resolve().parents[2] / "scripts" / "harness_capture",
+    Path("/srv/repo-scripts/harness_capture"),
+]
+CAPTURE = next((p for p in _CAPTURE_CANDIDATES if p.is_dir()), None)
+
+_COMMON_CANDIDATES = [
+    Path(__file__).resolve().parents[2] / "images" / "common",
+    Path("/srv/images/common"),
+]
+COMMON = next((p for p in _COMMON_CANDIDATES if p.is_dir()), None)
+
+
+def test_capture_script_has_no_claude_fall_through():
+    assert CAPTURE is not None, "scripts/harness_capture missing"
+    src = (CAPTURE / "in_container.py").read_text()
+    tree = ast.parse(src)
+    offenders = []
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and node.args[1].value == "claude"):
+            offenders.append(f"line {node.lineno}: .get(..., 'claude')")
+        if (isinstance(node, ast.Attribute)
+                and node.attr == "claude_text_dump"):
+            offenders.append(f"line {node.lineno}: claude_text_dump")
+        if (isinstance(node, ast.Constant)
+                and node.value == "other"):
+            offenders.append(f"line {node.lineno}: harness choice 'other'")
+    assert not offenders, (
+        "capture rig still falls through to Claude:\n  "
+        + "\n  ".join(offenders))
+
+
+def test_capture_cli_name_and_dump_fail_closed_on_unknown_id():
+    assert CAPTURE is not None and COMMON is not None
+    for root in (str(COMMON), str(CAPTURE)):
+        if root not in sys.path:
+            sys.path.insert(0, root)
+    import in_container as rig
+    with pytest.raises(ValueError, match="unknown harness"):
+        rig.cli_name("something-new")
+    with pytest.raises(ValueError, match="unknown harness"):
+        rig.capture_dump("something-new", "", workspace=Path("/tmp"))

--- a/app/tests/test_paginate_rest_newest.py
+++ b/app/tests/test_paginate_rest_newest.py
@@ -1,0 +1,46 @@
+"""paginate_rest_newest: oldest-first vendors keep the newest pages."""
+
+from __future__ import annotations
+
+import asyncio
+
+from devcake.adapters._toolkit import (
+    last_page_from_headers, paginate_rest_newest)
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_last_page_from_github_link_header():
+    link = (
+        '<https://api.github.com/x?page=2>; rel="next", '
+        '<https://api.github.com/x?page=12>; rel="last"'
+    )
+    assert last_page_from_headers({"Link": link}, page_size=50) == 12
+
+
+def test_last_page_from_x_total_count():
+    assert last_page_from_headers(
+        {"X-Total-Count": "251"}, page_size=50) == 6
+
+
+def test_newest_walk_keeps_the_tail_when_ceiling_hits():
+    """11 pages, ceiling 2 → pages 10 and 11 (items 10..11), truncated."""
+    async def fetch(page):
+        return [page], 11
+
+    items, truncated = run(paginate_rest_newest(
+        fetch, page_size=1, max_pages=2, what="test", on_ceiling="flag"))
+    assert truncated is True
+    assert items == [10, 11]
+
+
+def test_newest_walk_returns_everything_when_under_ceiling():
+    async def fetch(page):
+        return [page], 3
+
+    items, truncated = run(paginate_rest_newest(
+        fetch, page_size=1, max_pages=10, what="test", on_ceiling="flag"))
+    assert truncated is False
+    assert items == [1, 2, 3]

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -1432,6 +1432,15 @@ def test_split_vendor_comments_labels_every_page_and_preserves_bytes():
     assert rejoined.count("beta line") == 4_000
 
 
+def test_split_vendor_comments_refuses_more_than_max_parts():
+    """Size is bounded by the vendor cap; count must be too (GitHub write limits)."""
+    from devcake.domain.orchestrator.feed import (
+        MAX_VENDOR_COMMENT_PARTS, split_vendor_comments)
+    body = "x" * (MAX_VENDOR_COMMENT_PARTS * 200)
+    with pytest.raises(ValueError, match="more than"):
+        split_vendor_comments(body, 200)
+
+
 def _comment_payload(comment: str) -> str:
     """Strip sentinel and the pagination line; keep the substance."""
     from devcake.domain.orchestrator.markers import COMMENT_SENTINEL

--- a/docs/02-domain-model.md
+++ b/docs/02-domain-model.md
@@ -16,7 +16,7 @@ A **Mission** is a normalized DTO produced by the PMO adapter from a live Linear
 | `description` | `str` | Markdown body. |
 | `status` | `"backlog" \| "in_progress" \| "done" \| "canceled"` | Normalized (mapping tables in `05-pmo-adapter.md` §3). |
 | `priority` | `"urgent" \| "high" \| "medium" \| "low"` | Normalized; a Mission with no priority in the PMO System is `medium`. Always read live (INV-1). |
-| `labels` | `set[str]` | Label names as they appear in the PMO System. |
+| `labels` | `set[str]` | Label names as they appear in the PMO System. Managed `DEVCAKE-*` names are canonicalized case-insensitively onto `ALL_LABELS` (`canonicalize_labels`) — GitHub/Gitea/GitLab fold case, and `derive()`/`swap_labels` are exact-string. |
 | `updated_at` | `datetime` | PMO-side last update. Scheduling tiebreaker. |
 | `url` | `str` | Deep link into the PMO System. |
 | `parent_ref` | `str \| None` | For Issues that belong to a Project: the project's `pmo_id`. |

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -337,7 +337,7 @@ Same forge-issue profile (issue-only, label stages, open→backlog, markdown com
 | Status | `open`→backlog; `closed`→done; cancel footer in body → canceled |
 | Labels | PUT `/issues/{n}/labels` replaces the set |
 | Feed | issue comments; `` `devcake:v1` `` byte-exact. Oldest-first pages; `paginate_rest_newest` keeps the newest at the ceiling. |
-| Attachments | **No official API.** `attachments_supported=False` (founder option B). `upload_attachment` raises. `comment_max_chars=65536`. Feed chokepoint posts the full body as sequential `Part i of n` comments (each ≤ the cap, each sentinel-signed). startswith-markers stay the first line of part 1. |
+| Attachments | **No official API.** `attachments_supported=False` (founder option B). `upload_attachment` raises. `comment_max_chars=65536`. Feed chokepoint posts the full body as sequential `Part i of n` comments (each ≤ the cap, each sentinel-signed, at most `MAX_VENDOR_COMMENT_PARTS`). startswith-markers stay the first line of part 1. |
 | Relations | Works on personal repos if `issue_id` is the global numeric id. Duplicate → 422 `already been taken`. |
 
 `pmo_id` is the issue **number**. `/issues` includes PRs — filtered. Separate PMO PAT from any GitHub *forge* repo-card token. Registry `operator_note` explains the attachment limit in the SPA.

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -270,15 +270,15 @@ Internal vs external is **only** `api_base` + token + board path — one system,
 | `key` | `{owner}/{repo}#{number}` |
 | `pmo_kind` | always `issue` (`projects_supported=False`) |
 
-`cancel_mission` closes the issue and appends the cancel footer (idempotent). Closing an issue that still has **open blockers** 412s on Gitea 1.24 — the adapter **clears dependencies first** then closes (scheduler already consumed them).
+`cancel_mission` closes the issue and appends the cancel footer (idempotent). Opening or completing strips **only** that footer block (`adapters/forge_issue.strip_cancel_footer`) — never every markdown `---` in the body. Closing an issue that still has **open blockers** 412s on Gitea 1.24 — the adapter **clears dependencies first** then closes (scheduler already consumed them).
 
 **Cross-instance blockers are unsupported for Gitea Issues** (ADR-0009 amendment): `pmo_id` is a repo-scoped issue *number*, so ids collide across instances — the `BlockerLocator` hard-refuses peer resolution and peer run history for `gitea_issues` (never best-effort). Same-instance blocker semantics are unaffected.
 
 ### 9.3 Relations, labels, feed, attachments
 
 - **Relations:** `POST/GET/DELETE …/issues/{index}/dependencies` with `IssueMeta{owner,repo,index}`. `create_relation(blocker, blocked)` makes `blocked` depend on `blocker`. Duplicate create returns 500 “does already exist” → treated as success. `ensure_labels` enables `internal_tracker.enable_issue_dependencies` on the board (off by default on new repos).
-- **Labels:** repo labels; `PUT …/issues/{index}/labels` replaces the full set (`native_label_swap_atomic=True`). Managed set ensured uppercase.
-- **Feed:** issue comments; markdown markers round-trip byte-for-byte (live-verified).
+- **Labels:** repo labels; `PUT …/issues/{index}/labels` replaces the full set (`native_label_swap_atomic=True`). Managed set ensured uppercase. Vendor-cased managed names (`Devcake-Plan`) are mapped onto `ALL_LABELS` by `canonicalize_labels` so `derive()`/`swap_labels` see them.
+- **Feed:** issue comments; markdown markers round-trip byte-for-byte (live-verified). Gitea pages oldest-first; `paginate_rest_newest` keeps the newest pages at the ceiling (same newest-first survival as Linear).
 - **Attachments:** multipart `POST …/issues/{index}/assets`. Gitea returns `browser_download_url` with **ROOT_URL** / `GITEA_UI_URL` (bundled: `localhost:3300`); the adapter rewrites **presentation hosts** (`api_base` host, `GITEA_UI_URL` host, loopback) onto `api_base` so the app container can download, pins path to `/attachments/` and origin netloc, and refuses off-allowlist redirects with the PMO token (docs/14 §11). Operator use of the Gitea UI and direct git remains unrestricted.
 
 ### 9.4 The default board (ADR-0030) — and manual setup for external Gitea
@@ -336,7 +336,7 @@ Same forge-issue profile (issue-only, label stages, open→backlog, markdown com
 |---|---|
 | Status | `open`→backlog; `closed`→done; cancel footer in body → canceled |
 | Labels | PUT `/issues/{n}/labels` replaces the set |
-| Feed | issue comments; `` `devcake:v1` `` byte-exact |
+| Feed | issue comments; `` `devcake:v1` `` byte-exact. Oldest-first pages; `paginate_rest_newest` keeps the newest at the ceiling. |
 | Attachments | **No official API.** `attachments_supported=False` (founder option B). `upload_attachment` raises. `comment_max_chars=65536`. Feed chokepoint posts the full body as sequential `Part i of n` comments (each ≤ the cap, each sentinel-signed). startswith-markers stay the first line of part 1. |
 | Relations | Works on personal repos if `issue_id` is the global numeric id. Duplicate → 422 `already been taken`. |
 

--- a/docs/adr/0034-chokepoints-one-authoritative-path.md
+++ b/docs/adr/0034-chokepoints-one-authoritative-path.md
@@ -93,6 +93,9 @@ Corollaries, each load-bearing:
 | Dev bus chunking | `hello_dev.py` hand-copy (already drifted: `SHRINKABLE_FIELDS`) | shared import or field-by-field pinned mirror |
 | Layering rule (domain never imports adapters) | prose + review culture; 2 sanctioned seams undocumented/half-documented | import-ban ratchet with a 2-entry allowlist naming both seams |
 | Vendor-cap comment pagination | split in `feed.py`; join/coalesce reimplemented in `activity_payload` (`isalnum` glue) | `feed.split_vendor_comments` / `feed.join_vendor_comments` / `feed.coalesced_step_files`; `activity_payload` only calls; AST ratchet |
+| Forge-issue cancel footer | three `replace("---")` copies that deleted every horizontal rule | `adapters/forge_issue.apply_cancel_footer` / `strip_cancel_footer`; mapping modules re-export one `CANCEL_FOOTER` |
+| Managed-label case fold | `ensure_labels` matched upper, `swap_labels`/`Mission.labels` used stored case | `model.canonicalize_labels` next to `ALL_LABELS`; three forge-issue adapters call it |
+| Oldest-first comment ceiling | `paginate_rest` kept the oldest pages on GitHub/Gitea | `_toolkit.paginate_rest_newest` + `last_page_from_headers`; GitLab already sorts desc |
 
 Out of scope, deliberately: unifying the checkpoint-vs-sweep idempotency
 regimes (different failure economics, would change PMO read costs);

--- a/scripts/harness_capture/in_container.py
+++ b/scripts/harness_capture/in_container.py
@@ -67,14 +67,41 @@ def load_entrypoint():
     sys.exit(f"no dev_entrypoint.py at any of {ENTRYPOINT_CANDIDATES}")
 
 
-CLI_BY_HARNESS = {"claude-code": "claude", "codex": "codex",
-                  "grok-build": "grok", "pi": "pi", "opencode": "opencode",
-                  "qwen-code": "qwen"}
+def _ensure_dialects() -> None:
+    for p in (
+        pathlib.Path("/srv/images/common"),
+        pathlib.Path(__file__).resolve().parents[2] / "images" / "common",
+        pathlib.Path("/"),
+    ):
+        if (p / "devcake_dev").is_dir() and str(p) not in sys.path:
+            sys.path.insert(0, str(p))
+            return
+
+
+def cli_name(harness: str) -> str:
+    """argv[0] from the production dialect. Unknown ids raise."""
+    _ensure_dialects()
+    from devcake_dev.harness.dialect import get_dialect
+    return get_dialect(harness).argv(".")[0]
+
+
+def capture_dump(harness: str, stdout: str, *, workspace, model: str = "") -> str:
+    """Transcript dump via HarnessDialect.parse_run — no Claude else-arm."""
+    _ensure_dialects()
+    from devcake_dev.harness.dialect import get_dialect
+    return get_dialect(harness).parse_run(
+        stdout, workspace=pathlib.Path(workspace), model=model).dump
+
+
+def known_harnesses() -> list[str]:
+    _ensure_dialects()
+    from devcake_dev.harness.dialect import dialects
+    return sorted(dialects())
 
 
 def cli_version(harness: str) -> str:
     """The version of the CLI actually about to run, read from this container."""
-    exe = CLI_BY_HARNESS.get(harness, "claude")
+    exe = cli_name(harness)
     try:
         r = subprocess.run([exe, "--version"], capture_output=True, text=True,
                            timeout=60)
@@ -128,19 +155,6 @@ def make_workspace(root: pathlib.Path, prompt: str) -> pathlib.Path:
         subprocess.run(cmd, cwd=wd, env=env, capture_output=True, text=True,
                        timeout=60)
     return wd
-
-
-def grok_export(session_id: str, workdir: pathlib.Path) -> str:
-    """grok's `dump` is the session export — THE input to its activity test, and
-    the pivot question of this whole batch (does it echo the prompt?)."""
-    if not session_id:
-        return ""
-    try:
-        r = subprocess.run(["grok", "export", session_id], cwd=workdir,
-                           capture_output=True, text=True, timeout=120)
-        return r.stdout if r.returncode == 0 else ""
-    except Exception:                           # noqa: BLE001 — absence is data
-        return ""
 
 
 def grok_session_id(out: str) -> str:
@@ -248,18 +262,7 @@ def execute_argv(ep, args, argv: list, workdir: pathlib.Path,
     session_id = (sid_fn(args.harness, stdout) if sid_fn
                   else grok_session_id(stdout)
                   if args.harness == "grok-build" else "")
-    if args.harness == "codex":
-        dump = ep.codex_text_dump(stdout)
-    elif args.harness == "grok-build":
-        dump = grok_export(session_id, workdir)
-    elif args.harness == "pi":
-        dump = ep.pi_text_dump(stdout)
-    elif args.harness == "opencode":
-        dump = ep.opencode_text_dump(stdout)
-    elif args.harness == "qwen-code":
-        dump = ep.qwen_text_dump(stdout)
-    else:
-        dump = ep.claude_text_dump(stdout)
+    dump = capture_dump(args.harness, stdout, workspace=workdir)
 
     # grade the CURRENT predicate — the whole point of the exercise
     fault = ep.harness_fault(args.harness, stdout, exit_code, dump=dump,
@@ -295,7 +298,7 @@ def execute_argv(ep, args, argv: list, workdir: pathlib.Path,
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--harness", required=True,
-                    choices=sorted(CLI_BY_HARNESS) + ["other"])
+                    choices=known_harnesses())
     ap.add_argument("--name", required=True, help="capture basename")
     ap.add_argument("--prompt-file", required=True)
     ap.add_argument("--out", default="/out")


### PR DESCRIPTION
First-review leftovers I had deferred. Each process has one implementation.

## Labels
`Devcake-Plan` on GitHub/Gitea/GitLab is the same label as `DEVCAKE-PLAN`. `ensure_labels` already matched case-insensitively; `swap_labels` and `Mission.labels` did not, so the stage machine missed it while health looked fine.

`canonicalize_labels` lives next to `ALL_LABELS`. The three forge-issue adapters call it.

## Cancel footer
Un-cancel was `replace("---")` and deleted every horizontal rule in the issue body. `adapters/forge_issue.py` owns apply/strip; mapping modules re-export one `CANCEL_FOOTER`.

## Capture rig
`scripts/harness_capture/in_container.py` defaulted to Claude (`dict.get(..., "claude")`, dump `else`, `--harness other`). It now uses `get_dialect` — unknown ids raise. AST ratchet in `test_harness_capture_rig`.

## Comment paging
GitHub/Gitea only return oldest-first. The ceiling was dropping the newest comments (markers). `_toolkit.paginate_rest_newest` + `last_page_from_headers` keeps the tail. GitLab already sorts desc.

## Proof
`./scripts/pytest_app.sh` — **2156 passed**, 1 skipped.

Independent of #163 (feed join chokepoint).