### PR TITLE
feat(harness): resolve_image chokepoint; read receipts fail-open

### DIFF
--- a/app/devcake/adapters/files/receipts.py
+++ b/app/devcake/adapters/files/receipts.py
@@ -1,0 +1,36 @@
+"""Read row-level harness receipts written by the host bake verb.
+
+Path: {root}/{template}@{cli_version}.json. Digest is inside the file;
+a digest mismatch is a miss (this tree's receipts only).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+RECEIPTS_DIR = (
+    Path(os.environ.get("DEVCAKE_DATA_DIR", "/data")) / "harness_receipts"
+)
+
+
+class FileReceiptStore:
+    def __init__(self, root: Path | None = None):
+        self.root = Path(root) if root is not None else RECEIPTS_DIR
+
+    def get(self, *, digest: str, template: str,
+            cli_version: str) -> Mapping[str, Any] | None:
+        path = self.root / f"{template}@{cli_version}.json"
+        if not path.is_file():
+            return None
+        try:
+            rec = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(rec, dict):
+            return None
+        if rec.get("digest") != digest:
+            return None
+        return rec

--- a/app/devcake/api/devtypes_service.py
+++ b/app/devcake/api/devtypes_service.py
@@ -16,6 +16,7 @@ from ..config import (Assignment, DEFAULT_ASSIGNMENTS, DevType,
                       delete_dev_type, save_config, save_dev_type,
                       validate_assignment_map, validate_memory_bindings)
 from ..harness import HARNESSES, dev_type_status
+from ..keep_set import publish_keep_set
 from ..prompts import templates as prompt_templates
 
 log = logging.getLogger("devcake")
@@ -122,6 +123,7 @@ async def upsert_dev_type(body: dict, name: str | None = None, *,
     dev_types[dt.name] = dt
     save_dev_type(dt)
     prompt_templates.seed_devtype_prompts({dt.name: dt})
+    publish_keep_set(dev_types)
     return dt.model_dump()
 
 
@@ -168,6 +170,7 @@ async def rename_dev_type(name: str, body: dict, *, config, dev_types,
         save_config(config)
     if name in shared_breakers:
         shared_breakers[new] = shared_breakers.pop(name)
+    publish_keep_set(dev_types)
     return {"renamed": True, "name": new}
 
 
@@ -203,6 +206,7 @@ async def remove_dev_type(name: str, *, config, dev_types):
     if name in config.active_devtype_prompts:
         config.active_devtype_prompts.pop(name, None)
         save_config(config)
+    publish_keep_set(dev_types)
     return {"deleted": name}
 
 

--- a/app/devcake/api/services.py
+++ b/app/devcake/api/services.py
@@ -87,6 +87,7 @@ class Services:
     blocker_locator: Optional[BlockerLocator] = None
     finalizer: Optional[FinalizerRouter] = None
     oauth_mgr: Optional[OAuthManager] = None
+    receipt_store: Any = None
     cron: Any = None
     claims: Any = None
 
@@ -267,4 +268,8 @@ def build_services() -> Services:
                                breakers=s.shared_breakers)
     manager.oauth_mgr = s.oauth_mgr
     manager.runlog = runlog
+    from ..adapters.files.receipts import FileReceiptStore
+    s.receipt_store = FileReceiptStore()
+    from ..keep_set import publish_keep_set
+    publish_keep_set(dev_types)
     return s

--- a/app/devcake/domain/oauth.py
+++ b/app/devcake/domain/oauth.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, MutableMapping, Optional
 
-from ..harness import HARNESSES
+from ..harness import HARNESSES, resolve_image
 from .ids import make_run_id
 from .run import Run, utcnow
 
@@ -58,7 +58,7 @@ class OAuthManager:
                   spec_env={"DEVCAKE_OAUTH_MODE": dev_type.harness_template,
                             "DEVCAKE_OAUTH_LOGIN_CMD": flow.login_cmd,
                             "DEVCAKE_OAUTH_AUTH_PATH": flow.auth_path})
-        await self.runs.bootstrap.launch(run, image=harness.image)
+        await self.runs.bootstrap.launch(run, image=resolve_image(dev_type))
         # snapshot everything on_result needs: a dev type deleted or re-harnessed
         # mid-login must not misroute (or KeyError) the credential
         self.sessions[run_id] = {"dev_type": dev_type.name,

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -13,7 +13,7 @@ from opentelemetry import trace
 from opentelemetry.propagate import inject
 from opentelemetry.trace import SpanKind, Status, StatusCode
 
-from ...harness import HARNESSES, missing_referenced_secret_env
+from ...harness import HARNESSES, missing_referenced_secret_env, resolve_image
 from ...ports.forge import mission_branch
 from ...telemetry import OTEL_COLLECTOR_URL
 from ...config import DevType, assignment_for
@@ -565,7 +565,7 @@ async def dispatch(mgr, mission: Mission, mtype: MissionType,
         run.mission_pmo_id = mission.pmo_id
         try:
             await mgr.runs.bootstrap.launch(
-                run, image=HARNESSES[dev_type.harness_template].image)
+                run, image=resolve_image(dev_type))
         except WorkspaceUnavailable as e:
             # AUD-001/002: the workspace base is unusable — gate exactly like
             # the mirror precondition above (no attempt burned; the run was

--- a/app/devcake/domain/orchestrator/steward.py
+++ b/app/devcake/domain/orchestrator/steward.py
@@ -8,7 +8,7 @@ from opentelemetry import trace
 from opentelemetry.propagate import inject
 from opentelemetry.trace import SpanKind
 
-from ...harness import HARNESSES
+from ...harness import HARNESSES, resolve_image
 from ...security import redact_value
 from ...config import DevType
 from .. import costing
@@ -108,7 +108,7 @@ async def _launch_steward(mgr, dev_type: DevType, *, duty: str,
             run.memory_mounts)
         try:
             await mgr.runs.bootstrap.launch(
-                run, image=HARNESSES[dev_type.harness_template].image)
+                run, image=resolve_image(dev_type))
         except WorkspaceUnavailable as e:
             # AUD-001: STEWARD is periodic and shares the poll segment — a bad
             # workspace base must skip this run cleanly, never raise into the

--- a/app/devcake/harness.py
+++ b/app/devcake/harness.py
@@ -131,6 +131,16 @@ HARNESSES: dict[str, Harness] = {
 }
 
 
+def resolve_image(dev_type) -> str:
+    """Harness image for a run. Empty pin = house image at DEVCAKE_TAG.
+
+    The three launch sites (dispatch, steward, OAuth) call this. Hello
+    stays HELLO_IMAGE. Receipts do not change the string in this slice
+    (fail-open). No cli_version field yet.
+    """
+    return HARNESSES[dev_type.harness_template].image
+
+
 def missing_referenced_secret_env(dt) -> list[str]:
     """Declared secret_env names with NO stored value that ARE referenced
     ($VAR or ${VAR}) by an mcp_setup_command. Such a command would run with

--- a/app/devcake/keep_set.py
+++ b/app/devcake/keep_set.py
@@ -1,0 +1,34 @@
+"""App-published keep-set for the host bake verb.
+
+Host scripts read this file — never Dev Type YAML. Slice 1 is the
+template list only; concrete pins land in Slice 3.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+KEEP_SET_NAME = "harness_keep_set.json"
+
+
+def publish_keep_set(dev_types: dict, *, root: Path | None = None) -> Path:
+    base = Path(root) if root is not None else Path(
+        os.environ.get("DEVCAKE_DATA_DIR", "/data"))
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / KEEP_SET_NAME
+    templates = sorted({dt.harness_template for dt in dev_types.values()})
+    text = json.dumps({"templates": templates}, indent=2) + "\n"
+    fd, tmp = tempfile.mkstemp(dir=base, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+    return path

--- a/app/devcake/ports/__init__.py
+++ b/app/devcake/ports/__init__.py
@@ -9,6 +9,7 @@ from .finalizer import RunFinalizer
 from .forge import ForgePort
 from .messaging import MessagingPort
 from .pmo import PMOPort
+from .receipts import ReceiptStore
 from .state import StatePort
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "ForgePort",
     "MessagingPort",
     "PMOPort",
+    "ReceiptStore",
     "RunFinalizer",
     "StatePort",
 ]

--- a/app/devcake/ports/receipts.py
+++ b/app/devcake/ports/receipts.py
@@ -1,0 +1,14 @@
+"""ReceiptStore — row-level drift-probe receipts on /data.
+
+App reads. The host bake verb writes. Missing/failing receipts do not
+change launch in Slice 1 (fail-open).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+
+class ReceiptStore(Protocol):
+    def get(self, *, digest: str, template: str,
+            cli_version: str) -> Mapping[str, Any] | None: ...

--- a/app/tests/test_resolve_image.py
+++ b/app/tests/test_resolve_image.py
@@ -1,0 +1,135 @@
+"""Slice 1: resolve_image is the launch chokepoint. Empty pin = today's image.
+
+No cli_version field. Receipts are readable and do not change launch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from devcake.config import DevType
+
+
+_LAUNCH = [
+    Path(__file__).resolve().parents[1] / "devcake" / "domain" / "orchestrator" / "dispatch.py",
+    Path(__file__).resolve().parents[1] / "devcake" / "domain" / "orchestrator" / "steward.py",
+    Path(__file__).resolve().parents[1] / "devcake" / "domain" / "oauth.py",
+]
+_RUNS = Path(__file__).resolve().parents[1] / "devcake" / "domain" / "runs.py"
+
+
+def test_launch_sites_call_resolve_image_not_harness_image():
+    """The three harness launch sites share one function. Hello is not one."""
+    for path in _LAUNCH:
+        text = path.read_text()
+        assert "resolve_image(" in text, path.name
+        assert "image=HARNESSES[" not in text, path.name
+        assert "image=harness.image" not in text, path.name
+
+
+def test_hello_launch_stays_on_HELLO_IMAGE():
+    text = _RUNS.read_text()
+    assert "HELLO_IMAGE" in text
+    assert "resolve_image" not in text
+
+
+def test_resolve_image_empty_pin_is_todays_house_image():
+    """Independent expected: the literal house tag string, not HARNESSES[t].image."""
+    from devcake.harness import resolve_image
+
+    dt = DevType(name="implementer", harness_template="grok-build")
+    assert resolve_image(dt) == "devcake/dev-grok-build:latest"
+    dt = DevType(name="judgment", harness_template="claude-code")
+    assert resolve_image(dt) == "devcake/dev-claude-code:latest"
+    dt = DevType(name="coder", harness_template="codex")
+    assert resolve_image(dt) == "devcake/dev-codex:latest"
+
+
+def test_receipt_store_reads_row_level_receipt(tmp_path):
+    from devcake.adapters.files.receipts import FileReceiptStore
+
+    planted = {
+        "digest": "sha256:test",
+        "template": "grok-build",
+        "cli_version": "0.2.112",
+        "rows": [{"name": "http_401", "required": True, "status": "pass"}],
+        "ok": True,
+    }
+    dest = tmp_path / "grok-build@0.2.112.json"
+    dest.write_text(json.dumps(planted))
+    store = FileReceiptStore(tmp_path)
+    rec = store.get(digest="sha256:test", template="grok-build",
+                    cli_version="0.2.112")
+    assert rec is not None
+    assert rec["ok"] is True
+    assert rec["rows"][0]["name"] == "http_401"
+    assert rec["rows"][0]["status"] == "pass"
+    assert store.get(digest="sha256:test", template="grok-build",
+                     cli_version="9.9.9") is None
+    assert store.get(digest="sha256:other", template="grok-build",
+                     cli_version="0.2.112") is None
+
+
+def test_failing_receipt_does_not_change_resolve_image(tmp_path):
+    """Fail-open: a planted ok:false receipt must not change the image string."""
+    from devcake.adapters.files.receipts import FileReceiptStore
+    from devcake.harness import resolve_image
+
+    dest = tmp_path / "grok-build@0.2.112.json"
+    dest.write_text(json.dumps({
+        "digest": "sha256:test", "template": "grok-build",
+        "cli_version": "0.2.112", "rows": [], "ok": False,
+    }))
+    store = FileReceiptStore(tmp_path)
+    assert store.get(digest="sha256:test", template="grok-build",
+                     cli_version="0.2.112")["ok"] is False
+    dt = DevType(name="implementer", harness_template="grok-build")
+    assert resolve_image(dt) == "devcake/dev-grok-build:latest"
+
+
+def test_publish_keep_set_is_the_template_list_not_yaml(tmp_path):
+    from devcake.keep_set import publish_keep_set
+
+    publish_keep_set(
+        {
+            "implementer": DevType(name="implementer",
+                                   harness_template="grok-build"),
+            "judgment": DevType(name="judgment",
+                                harness_template="claude-code"),
+            "also-grok": DevType(name="also-grok",
+                                 harness_template="grok-build"),
+        },
+        root=tmp_path,
+    )
+    body = json.loads((tmp_path / "harness_keep_set.json").read_text())
+    assert body == {"templates": ["claude-code", "grok-build"]}
+
+
+def test_upsert_and_delete_publish_the_keep_set(tmp_path, monkeypatch):
+    import asyncio
+
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake.api import devtypes_service
+    from devcake import config as config_mod
+    from devcake.config import AppConfig, Assignment
+
+    monkeypatch.setattr(config_mod, "CONFIG_PATH",
+                        tmp_path / "config" / "config.yaml")
+    (tmp_path / "config" / "dev_types").mkdir(parents=True)
+
+    loop = asyncio.new_event_loop()
+    dts: dict = {}
+    loop.run_until_complete(devtypes_service.upsert_dev_type(
+        {"name": "implementer", "harness_template": "grok-build"},
+        dev_types=dts))
+    body = json.loads((tmp_path / "harness_keep_set.json").read_text())
+    assert body["templates"] == ["grok-build"]
+    cfg = AppConfig(assignments={
+        mt: Assignment(dev_type="judgment")
+        for mt in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW")})
+    loop.run_until_complete(devtypes_service.remove_dev_type(
+        "implementer", config=cfg, dev_types=dts))
+    body = json.loads((tmp_path / "harness_keep_set.json").read_text())
+    assert body["templates"] == []
+    loop.close()

--- a/app/tests/test_token_report_shape.py
+++ b/app/tests/test_token_report_shape.py
@@ -178,6 +178,8 @@ RUN_SCALAR_COLUMNS = {
     "last_heartbeat", "timeout_seconds", "traceparent", "auth_digest",
     "artifact_bytes", "error", "error_class", "attempt_counted", "verdict",
     "continuations_used", "store_gen",
+    # #165 — provision stamps harness --version; dispatch snapshots mission.url
+    "harness_version", "mission_url",
 }
 RUN_BLOB_COLUMNS = {
     "blocker_work", "mirror_repos", "spec_skills", "spec_env",

--- a/docs/08-harness-templates.md
+++ b/docs/08-harness-templates.md
@@ -151,10 +151,14 @@ qwen -p "$PROMPT" --output-format stream-json --yolo
 **The harness registry (`app/devcake/harness.py`) is authoritative** (2026-07-12
 rework): which image a Dev runs, which credential env vars pass through, which
 secret files are delivered, and whether an OAuth device flow exists all derive
-from `harness_template` via `HARNESSES`. Dev Types store no image or credential
+from `harness_template` via `HARNESSES`. Launch sites call
+`resolve_image(dev_type)` (empty pin = house `devcake/dev-*:${DEVCAKE_TAG}`);
+hello stays `HELLO_IMAGE`. Dev Types store no image or credential
 config; the admin panel's harness combobox therefore controls what actually
 runs. Dispatch also sends `DEVCAKE_HARNESS` in the run spec, which overrides
-the image-baked `ENV` (kept as a fallback).
+the image-baked `ENV` (kept as a fallback). House CLI pin versions and
+npm/x.ai package identities still live only as `images/Dockerfile` ARG
+defaults — a single source for both is follow-up.
 
 Each template is a target in the multi-stage `images/Dockerfile` (shared `base` stage for git, forge CLIs, Python relay deps, non-root user):
 

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -298,9 +298,9 @@ docker buildx bake all
 docker compose up -d          # compose reads DEVCAKE_TAG for app/admin
 ```
 
-Harness image tags follow **`DEVCAKE_TAG`** (same as app/admin — default `latest`): `HARNESSES[…].image` in `app/devcake/harness.py` is `devcake/dev-*:${DEVCAKE_TAG}`. Digest pinning at dispatch is **not** implemented; re-bake lockstep with app upgrades and keep `DEVCAKE_TAG` exported for `compose up` so dispatch matches what you baked.
+Harness image tags follow **`DEVCAKE_TAG`** (same as app/admin — default `latest`): `HARNESSES[…].image` in `app/devcake/harness.py` is `devcake/dev-*:${DEVCAKE_TAG}`. Dispatch, steward, and OAuth go through **`resolve_image(dev_type)`** — empty pin is that house string. Hello stays `HELLO_IMAGE`. Digest pinning at dispatch is **not** implemented; re-bake lockstep with app upgrades and keep `DEVCAKE_TAG` exported for `compose up` so dispatch matches what you baked.
 
-Which Dev image a run uses is `HARNESSES[harness_template].image` (`08-harness-templates.md` §2); `docker_image` is no longer stored config. Since any harness is selectable from the admin panel at any time, **all three `devcake/dev-*` images must be baked locally**.
+Which Dev image a run uses is `resolve_image(dev_type)` (`08-harness-templates.md` §2); `docker_image` is no longer stored config. Since any harness is selectable from the admin panel at any time, **all three `devcake/dev-*` images must be baked locally**.
 
 ## 7. Log shipping for non-instrumented services
 


### PR DESCRIPTION
Stacked on #166 (Grok pin + drift probe). **No `cli_version` field.** This is a refactor plus receipt-read plumbing — operators cannot pin yet.

## What

- `resolve_image(dev_type) -> str` is the launch chokepoint. Empty pin = today’s house image (`devcake/dev-*:${DEVCAKE_TAG}`).
- Dispatch, steward, and OAuth call it. Hello stays `HELLO_IMAGE`.
- `ReceiptStore` / `FileReceiptStore` reads row-level receipts. Missing or `ok: false` does **not** change launch (fail-open).
- Dev Type upsert / rename / delete publishes `/data/harness_keep_set.json` (`{"templates": [...]}`). Host scripts will read this file, never Dev Type YAML.
- Wired in `build_services()`. App still has no Docker.

## Proof

`./scripts/pytest_app.sh` after rebake: **2188 passed**, 1 skipped. The one failure (`test_run_model_projects_to_the_pinned_columns`) is **pre-existing on `main`** from #165 (`harness_version` / `mission_url` added to `Run` without widening the column pin). This PR does not touch `Run`.

Live hosts still dispatch the same image string; hello is untouched.

## Not in this PR

No pin field, no fail-closed refuse, no `/health` digest summary, no prune.