### PR TITLE
feat(harness): fail-closed staffing on matching ok receipts

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -41,10 +41,16 @@ LABEL org.opencontainers.image.title="devcake-app" \
       org.opencontainers.image.description="DevCake orchestrator API" \
       org.opencontainers.image.source="https://github.com/fidecastro/devcake"
 
+# Receipt identity (PLAN_CLI_PINS). Default is an obviously invalid
+# sentinel so bare `bake app` / group ci is distinguishable from
+# "no receipt for this version." The bake wrapper overwrites this.
+ARG DEVCAKE_APP_DIGEST=DEVCAKE_APP_DIGEST_UNSET
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PATH="/opt/venv/bin:$PATH" \
-    DEVCAKE_DATA_DIR=/data
+    DEVCAKE_DATA_DIR=/data \
+    DEVCAKE_APP_DIGEST=${DEVCAKE_APP_DIGEST}
 
 # git + git-lfs: the repo source mirror (ADR-0024) — the app's ONLY
 # subprocess consumer (adapters/git.py). /mirrors pre-created app-owned so

--- a/app/devcake/api/health.py
+++ b/app/devcake/api/health.py
@@ -16,6 +16,7 @@ import redis.asyncio as aioredis
 
 from .. import security
 from ..adapters.dagu import DAGU_URL
+from ..staffing import app_digest, receipt_summary
 from ..domain.claims import claims_depth, claims_queue_capped
 from ..domain.forge_runtime import PROBE_CONCURRENCY
 from ..prompts import templates as prompt_templates
@@ -23,6 +24,11 @@ from ..telemetry import OO_URL
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
 REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD", "")
+
+
+def _harness_pins(dev_types, receipt_store) -> dict:
+    return receipt_summary(
+        dev_types or {}, digest=app_digest(), store=receipt_store)
 
 
 async def _check_redis() -> bool:
@@ -163,7 +169,8 @@ async def build_health_payload(*, config, dev_types, managers, stewards,
                                internal_forge, poll_rt,
                                backend_degraded: dict | None = None,
                                repo_cache=None, workspaces=None,
-                               cron=None) -> dict:
+                               cron=None,
+                               receipt_store=None) -> dict:
     """The /api/v1/health body (docs/11 §0). All deps explicit — unit-testable
     with fakes; the route in main.py is a one-line forward."""
     redis_ok, dagu_ok, oo_ok = await asyncio.gather(
@@ -326,4 +333,5 @@ async def build_health_payload(*, config, dev_types, managers, stewards,
             "leaked": workspaces.leaked_count(store) if workspaces else 0,
             "disk": workspaces.disk_stats() if workspaces else None,
         },
+        "harness_pins": _harness_pins(dev_types, receipt_store),
     }

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -275,7 +275,8 @@ async def health():
         shared_breakers=s.shared_breakers, store=s.store,
         internal_forge=s.internal_forge, poll_rt=s.poll_rt,
         backend_degraded=s.shared_backend_degraded, repo_cache=s.repo_cache,
-        workspaces=s.workspaces, cron=s.cron)
+        workspaces=s.workspaces, cron=s.cron,
+        receipt_store=s.receipt_store)
 
 
 @app.get("/api/v1/health/live")

--- a/app/devcake/api/services.py
+++ b/app/devcake/api/services.py
@@ -111,6 +111,7 @@ class Services:
                 mgr.skills = self.skill_service
                 mgr.blocker_locator = self.blocker_locator
                 mgr.repo_cache = self.repo_cache
+                mgr.receipt_store = self.receipt_store
             else:
                 self.managers[name] = MissionManager(
                     self.config, self.dev_types, p, self.forge_runtime,
@@ -120,7 +121,8 @@ class Services:
                     skills=self.skill_service,
                     backend_degraded=self.shared_backend_degraded,
                     blocker_locator=self.blocker_locator,
-                    repo_cache=self.repo_cache)
+                    repo_cache=self.repo_cache,
+                    receipt_store=self.receipt_store)
                 self.stewards[name] = StewardService(
                     self.config, self.dev_types, self.managers[name])
                 # ADR-0033: harvest's event trigger for the discovery lane —
@@ -260,16 +262,17 @@ def build_services() -> Services:
     s.blocker_locator = BlockerLocator(
         s.managers, lambda bid: poll_rt.mission_owner.get(bid))
 
+    from ..adapters.files.receipts import FileReceiptStore
+    s.receipt_store = FileReceiptStore()
     s.forge_runtime.rebuild(config.repos, make_forge)
     s.build_managers()
     s.finalizer = FinalizerRouter(s.managers, store, messaging)
     manager.set_finalizer(s.finalizer)  # RunFinalizer seam: routes on run.pmo_ref
     s.oauth_mgr = OAuthManager(manager, messaging, dev_types,
-                               breakers=s.shared_breakers)
+                               breakers=s.shared_breakers,
+                               receipt_store=s.receipt_store)
     manager.oauth_mgr = s.oauth_mgr
     manager.runlog = runlog
-    from ..adapters.files.receipts import FileReceiptStore
-    s.receipt_store = FileReceiptStore()
     from ..keep_set import publish_keep_set
     publish_keep_set(dev_types)
     return s

--- a/app/devcake/domain/oauth.py
+++ b/app/devcake/domain/oauth.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from typing import Any, MutableMapping, Optional
 
 from ..harness import HARNESSES, resolve_image
+from ..staffing import app_digest, require_staffed
 from .ids import make_run_id
 from .run import Run, utcnow
 
@@ -22,12 +23,14 @@ log = logging.getLogger("devcake.oauth")
 
 class OAuthManager:
     def __init__(self, runs, messaging, dev_types,
-                 breakers: MutableMapping[str, str] | None = None):
+                 breakers: MutableMapping[str, str] | None = None,
+                 receipt_store=None):
         self.runs = runs
         self.messaging = messaging
         self.dev_types = dev_types
         # optional shared breaker map (MissionManager.breakers); cleared on success
         self.breakers = breakers
+        self.receipt_store = receipt_store
         self.sessions: dict[str, dict[str, Any]] = {}  # run_id → status
 
     async def start(self, dev_type_name: str) -> dict:
@@ -58,6 +61,8 @@ class OAuthManager:
                   spec_env={"DEVCAKE_OAUTH_MODE": dev_type.harness_template,
                             "DEVCAKE_OAUTH_LOGIN_CMD": flow.login_cmd,
                             "DEVCAKE_OAUTH_AUTH_PATH": flow.auth_path})
+        require_staffed(dev_type, digest=app_digest(),
+                        store=self.receipt_store)
         await self.runs.bootstrap.launch(run, image=resolve_image(dev_type))
         # snapshot everything on_result needs: a dev type deleted or re-harnessed
         # mid-login must not misroute (or KeyError) the credential

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -14,6 +14,7 @@ from opentelemetry.propagate import inject
 from opentelemetry.trace import SpanKind, Status, StatusCode
 
 from ...harness import HARNESSES, missing_referenced_secret_env, resolve_image
+from ...staffing import HarnessNotStaffed, app_digest, require_staffed
 from ...ports.forge import mission_branch
 from ...telemetry import OTEL_COLLECTOR_URL
 from ...config import DevType, assignment_for
@@ -564,8 +565,14 @@ async def dispatch(mgr, mission: Mission, mtype: MissionType,
         run.stage_label_at_dispatch = stage_of(live)
         run.mission_pmo_id = mission.pmo_id
         try:
+            require_staffed(dev_type, digest=app_digest(),
+                            store=getattr(mgr, "receipt_store", None))
             await mgr.runs.bootstrap.launch(
                 run, image=resolve_image(dev_type))
+        except HarnessNotStaffed as e:
+            mgr.blocked_reasons[live.pmo_id] = str(e)
+            log.warning("dispatch of %s refused — %s", live.key, e)
+            return None
         except WorkspaceUnavailable as e:
             # AUD-001/002: the workspace base is unusable — gate exactly like
             # the mirror precondition above (no attempt burned; the run was

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -52,7 +52,8 @@ class MissionManager:
                  instance=None, breakers: dict[str, str] | None = None,
                  internal_forge=None, skills=None,
                  backend_degraded: dict[str, str] | None = None,
-                 blocker_locator=None, repo_cache=None):
+                 blocker_locator=None, repo_cache=None,
+                 receipt_store=None):
         self.config = config
         self.dev_types = dev_types
         # per-config-generation once-latch (audit F3): the poll cycle
@@ -83,6 +84,7 @@ class MissionManager:
         # window only; an unset locator fails loud at the first gate, never
         # silently degrades to single-instance resolution.
         self.blocker_locator = blocker_locator
+        self.receipt_store = receipt_store
         # ADR-0024: the ONE deployment-wide repo mirror (like `forges`).
         # None only in tests — make_mission_manager injects a NullRepoCache;
         # main injects the real one on every manager.

--- a/app/devcake/domain/orchestrator/steward.py
+++ b/app/devcake/domain/orchestrator/steward.py
@@ -9,6 +9,7 @@ from opentelemetry.propagate import inject
 from opentelemetry.trace import SpanKind
 
 from ...harness import HARNESSES, resolve_image
+from ...staffing import HarnessNotStaffed, app_digest, require_staffed
 from ...security import redact_value
 from ...config import DevType
 from .. import costing
@@ -107,8 +108,14 @@ async def _launch_steward(mgr, dev_type: DevType, *, duty: str,
                 prompt_text, dev_type.skills_required, run.spec_skills),
             run.memory_mounts)
         try:
+            require_staffed(dev_type, digest=app_digest(),
+                            store=getattr(mgr, "receipt_store", None))
             await mgr.runs.bootstrap.launch(
                 run, image=resolve_image(dev_type))
+        except HarnessNotStaffed as e:
+            log.warning("steward dispatch for %s skipped — not staffed: %s",
+                        mgr.instance_name, e)
+            return None
         except WorkspaceUnavailable as e:
             # AUD-001: STEWARD is periodic and shares the poll segment — a bad
             # workspace base must skip this run cleanly, never raise into the

--- a/app/devcake/house_pins.py
+++ b/app/devcake/house_pins.py
@@ -1,0 +1,38 @@
+"""House CLI pin versions — the app-side half of Q1.
+
+Dockerfile ARG defaults stay the bake source. A ratchet in
+test_harness_cli_pins keeps these literals equal to those ARGs.
+Package identities (npm / x.ai) still live only in the Dockerfile.
+"""
+
+from __future__ import annotations
+
+import os
+
+SENTINEL_DIGEST = "DEVCAKE_APP_DIGEST_UNSET"
+
+# Launch-supported first; experimental stay house-pin only (probe v1
+# does not grade them, so fail-closed does not gate them).
+HOUSE_PINS: dict[str, str] = {
+    "claude-code": "2.1.229",
+    "codex": "0.147.0",
+    "grok-build": "0.2.112",
+    "pi": "0.84.2",
+    "opencode": "1.18.18",
+    "qwen-code": "0.21.12",
+}
+
+LAUNCH_SUPPORTED = frozenset({"claude-code", "codex", "grok-build"})
+
+DOCKERFILE_ARG: dict[str, str] = {
+    "claude-code": "CLAUDE_CODE_VERSION",
+    "codex": "CODEX_VERSION",
+    "grok-build": "GROK_VERSION",
+    "pi": "PI_VERSION",
+    "opencode": "OPENCODE_VERSION",
+    "qwen-code": "QWEN_CODE_VERSION",
+}
+
+
+def app_digest() -> str:
+    return os.environ.get("DEVCAKE_APP_DIGEST", SENTINEL_DIGEST)

--- a/app/devcake/staffing.py
+++ b/app/devcake/staffing.py
@@ -1,0 +1,109 @@
+"""Is this Dev Type staffable for the running app digest?
+
+Chokepoint for Slice 2: dispatch, steward, and OAuth call require_staffed
+before bootstrap.launch. Hello never does. Domain depends on ReceiptStore
+(port), not the file adapter.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .house_pins import (
+    HOUSE_PINS,
+    LAUNCH_SUPPORTED,
+    SENTINEL_DIGEST,
+    app_digest,
+)
+
+
+class HarnessNotStaffed(Exception):
+    """Pin is not staffable. `row` names the failing required row when known."""
+
+    def __init__(self, message: str, *, row: str | None = None,
+                 kind: str = "receipt"):
+        super().__init__(message)
+        self.row = row
+        self.kind = kind
+
+
+def require_staffed(dev_type, *, digest: str | None = None,
+                    store) -> None:
+    """Raise HarnessNotStaffed unless a matching ok receipt exists.
+
+    Experimental templates are not gated (no v1 probe matrix).
+    """
+    template = dev_type.harness_template
+    if template not in LAUNCH_SUPPORTED:
+        return
+    digest = SENTINEL_DIGEST if digest is None else digest
+    if digest == SENTINEL_DIGEST:
+        raise HarnessNotStaffed(
+            "this app was built without the bake wrapper",
+            kind="sentinel")
+    version = HOUSE_PINS[template]
+    rec = None if store is None else store.get(
+        digest=digest, template=template, cli_version=version)
+    if rec is None:
+        raise HarnessNotStaffed(
+            f"no receipt for {template} {version}", kind="missing")
+    if rec.get("ok") is True:
+        return
+    row = _first_unpassed_required(rec)
+    named = f" ({row})" if row else ""
+    raise HarnessNotStaffed(
+        f"{template} {version} receipt is not ok{named}",
+        row=row, kind="receipt")
+
+
+def _first_unpassed_required(rec: Mapping[str, Any]) -> str | None:
+    for row in rec.get("rows") or []:
+        if not isinstance(row, Mapping):
+            continue
+        if row.get("required") and row.get("status") != "pass":
+            name = row.get("name")
+            return str(name) if name else None
+    return None
+
+
+def receipt_summary(dev_types: Mapping[str, Any], *, digest: str,
+                    store) -> dict:
+    """Per-template staffing view for /health (and Slice 3 copy)."""
+    templates = sorted({dt.harness_template for dt in dev_types.values()})
+    rows = {}
+    for template in templates:
+        version = HOUSE_PINS.get(template, "")
+        entry: dict[str, Any] = {
+            "cli_version": version,
+            "gated": template in LAUNCH_SUPPORTED,
+        }
+        if template not in LAUNCH_SUPPORTED:
+            entry["ok"] = None
+            entry["reason"] = "experimental — house pin only"
+            rows[template] = entry
+            continue
+        if digest == SENTINEL_DIGEST:
+            entry["ok"] = False
+            entry["reason"] = "this app was built without the bake wrapper"
+            rows[template] = entry
+            continue
+        rec = None if store is None else store.get(
+            digest=digest, template=template, cli_version=version)
+        if rec is None:
+            entry["ok"] = False
+            entry["reason"] = f"no receipt for {template} {version}"
+            rows[template] = entry
+            continue
+        entry["ok"] = rec.get("ok") is True
+        if not entry["ok"]:
+            row = _first_unpassed_required(rec)
+            entry["row"] = row
+            entry["reason"] = (
+                f"{template} {version} receipt is not ok"
+                + (f" ({row})" if row else ""))
+        rows[template] = entry
+    return {
+        "digest": digest,
+        "sentinel": digest == SENTINEL_DIGEST,
+        "templates": rows,
+    }

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Unit tests run with a non-sentinel app digest.
+
+Production images default to DEVCAKE_APP_DIGEST_UNSET (bare bake). Tests
+that want the sentinel pass it explicitly to require_staffed / monkeypatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _non_sentinel_app_digest(monkeypatch):
+    monkeypatch.setenv("DEVCAKE_APP_DIGEST", "sha256:test")

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -119,6 +119,14 @@ class FakeInternalForge:
         self.deleted.append(repo_name)
 
 
+class OkReceiptStore:
+    """Test double: every lookup is an ok receipt. Production uses FileReceiptStore."""
+
+    def get(self, *, digest, template, cli_version):
+        return {"digest": digest, "template": template,
+                "cli_version": cli_version, "ok": True, "rows": []}
+
+
 def make_mission_manager(
     tmp_path: Path | None = None,
     *,
@@ -169,7 +177,7 @@ def make_mission_manager(
     mgr = MissionManager(
         cfg, dts, pmo, fr, runs, msg,
         instance=inst, breakers=breakers, internal_forge=internal_forge,
-        skills=skills,
+        skills=skills, receipt_store=OkReceiptStore(),
     )
     # Locator is a required gate/dispatch dependency in production
     # (build_managers sets ONE shared instance); single-manager tests get a

--- a/app/tests/test_harness_cli_pins.py
+++ b/app/tests/test_harness_cli_pins.py
@@ -37,6 +37,31 @@ def test_grok_house_pin_is_the_arg_literal():
     assert match.group(1) == HOUSE_GROK
 
 
+def test_app_dockerfile_digest_arg_defaults_to_the_sentinel():
+    from devcake.house_pins import SENTINEL_DIGEST
+
+    candidates = [
+        Path(__file__).resolve().parents[2] / "app" / "Dockerfile",
+        Path("/srv/app.Dockerfile"),
+    ]
+    path = next((p for p in candidates if p.is_file()), None)
+    assert path is not None, "app/Dockerfile missing — bind /srv/app.Dockerfile"
+    text = path.read_text()
+    assert f"ARG DEVCAKE_APP_DIGEST={SENTINEL_DIGEST}" in text
+
+
+def test_house_pins_module_matches_dockerfile_arg_defaults():
+    """Q1 start: app literals stay equal to the bake ARGs."""
+    from devcake.house_pins import DOCKERFILE_ARG, HOUSE_PINS
+
+    text = _dockerfile()
+    for template, version in HOUSE_PINS.items():
+        arg = DOCKERFILE_ARG[template]
+        match = re.search(rf"^ARG {re.escape(arg)}=(\S+)\s*$", text, re.M)
+        assert match is not None, arg
+        assert match.group(1) == version, template
+
+
 def test_grok_installer_run_passes_the_arg():
     """Ungated `bash /tmp/grok-install.sh` is the hole. The ARG must be argv."""
     assert re.search(

--- a/app/tests/test_health_payload.py
+++ b/app/tests/test_health_payload.py
@@ -47,6 +47,42 @@ def _payload(fr, monkeypatch, repo_cache=None, workspaces=None):
         repo_cache=repo_cache, workspaces=workspaces))
 
 
+def test_health_payload_carries_harness_pins(monkeypatch):
+    fr = _forge_runtime(last_full_probe_at=datetime.now(timezone.utc))
+    got = _payload(fr, monkeypatch)
+    pins = got["harness_pins"]
+    assert "digest" in pins
+    assert "sentinel" in pins
+    assert "templates" in pins
+
+
+def test_health_exposes_digest_and_receipt_summary(monkeypatch):
+    from devcake.config import DevType
+    from devcake.house_pins import SENTINEL_DIGEST
+    from devcake.staffing import receipt_summary
+
+    class Store:
+        def get(self, **kw):
+            if kw["template"] == "grok-build":
+                return {"ok": True, "digest": "sha256:abc"}
+            return None
+
+    dts = {
+        "implementer": DevType(name="implementer", harness_template="grok-build"),
+        "judgment": DevType(name="judgment", harness_template="claude-code"),
+    }
+    summary = receipt_summary(dts, digest="sha256:abc", store=Store())
+    assert summary["digest"] == "sha256:abc"
+    assert summary["sentinel"] is False
+    assert summary["templates"]["grok-build"]["ok"] is True
+    assert summary["templates"]["claude-code"]["ok"] is False
+    assert "no receipt" in summary["templates"]["claude-code"]["reason"]
+
+    sent = receipt_summary(dts, digest=SENTINEL_DIGEST, store=Store())
+    assert sent["sentinel"] is True
+    assert "bake wrapper" in sent["templates"]["grok-build"]["reason"]
+
+
 def test_merged_advisories_qualify_keys_when_n_gt_1(monkeypatch):
     """Dual-PMO colliding pmo_ids (gitea issue numbers) must not clobber
     each other in merge_handoffs / needs_human. Keys follow the same

--- a/app/tests/test_oauth.py
+++ b/app/tests/test_oauth.py
@@ -44,7 +44,9 @@ def make_mgr(tmp_path, monkeypatch):
         "second-grok": DevType(name="second-grok", harness_template="grok-build"),
         "senior-dev": DevType(name="senior-dev", harness_template="claude-code"),
     }
-    return OAuthManager(runs, messaging, dev_types, breakers=breakers)
+    from fakes import OkReceiptStore
+    return OAuthManager(runs, messaging, dev_types, breakers=breakers,
+                        receipt_store=OkReceiptStore())
 
 
 def test_start_rejects_unknown_and_flowless(tmp_path, monkeypatch):

--- a/app/tests/test_run_bootstrap.py
+++ b/app/tests/test_run_bootstrap.py
@@ -272,9 +272,10 @@ def test_oauth_start_uses_bootstrap_spine(tmp_path, monkeypatch):
     store = InMemoryStore()
     executor = FakeExecutor(store)
     runs = RunManager(store, FakeMessaging(), executor)
+    from fakes import OkReceiptStore
     mgr = OAuthManager(runs, FakeMessaging(), {
         "main-dev": DevType(name="main-dev", harness_template="grok-build"),
-    })
+    }, receipt_store=OkReceiptStore())
     result = run_coro(mgr._start_inner("main-dev"))
     run_id = result["run_id"]
 

--- a/app/tests/test_staffing.py
+++ b/app/tests/test_staffing.py
@@ -1,0 +1,160 @@
+"""Slice 2: refuse launch unless a matching ok receipt exists.
+
+Public seam: require_staffed(dev_type, *, digest, store).
+Independent expected values are the message literals and row names.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from devcake.config import DevType
+
+
+class _Store:
+    def __init__(self, rec):
+        self.rec = rec
+
+    def get(self, *, digest, template, cli_version):
+        return self.rec
+
+
+def _dt(template="grok-build"):
+    return DevType(name="implementer", harness_template=template)
+
+
+def test_sentinel_digest_names_the_wrapper_not_a_missing_receipt():
+    from devcake.staffing import SENTINEL_DIGEST, HarnessNotStaffed, require_staffed
+
+    with pytest.raises(HarnessNotStaffed, match="built without the bake wrapper") as exc:
+        require_staffed(
+            _dt(), digest=SENTINEL_DIGEST,
+            store=_Store({"ok": True, "digest": SENTINEL_DIGEST}))
+    assert "no receipt" not in str(exc.value).lower()
+
+
+def test_missing_receipt_refuses():
+    from devcake.staffing import HarnessNotStaffed, require_staffed
+
+    with pytest.raises(HarnessNotStaffed, match="no receipt"):
+        require_staffed(_dt(), digest="sha256:abc", store=_Store(None))
+
+
+def test_ok_false_names_the_failing_required_row():
+    from devcake.staffing import HarnessNotStaffed, require_staffed
+
+    rec = {
+        "ok": False,
+        "digest": "sha256:abc",
+        "rows": [
+            {"name": "healthy", "required": True, "status": "pass"},
+            {"name": "http_401", "required": True, "status": "fail"},
+        ],
+    }
+    with pytest.raises(HarnessNotStaffed, match="http_401"):
+        require_staffed(_dt(), digest="sha256:abc", store=_Store(rec))
+
+
+def test_required_skip_and_error_are_not_ok():
+    from devcake.staffing import HarnessNotStaffed, require_staffed
+
+    for status in ("skipped", "error"):
+        rec = {
+            "ok": False,
+            "digest": "sha256:abc",
+            "rows": [{"name": "empty", "required": True, "status": status}],
+        }
+        with pytest.raises(HarnessNotStaffed, match="empty"):
+            require_staffed(_dt(), digest="sha256:abc", store=_Store(rec))
+
+
+def test_ok_true_matching_digest_is_staffed():
+    from devcake.staffing import require_staffed
+
+    require_staffed(
+        _dt(), digest="sha256:abc",
+        store=_Store({"ok": True, "digest": "sha256:abc"}))
+
+
+def test_oauth_does_not_launch_when_not_staffed(tmp_path, monkeypatch):
+    import json
+    from pathlib import Path
+
+    from devcake.adapters.files.receipts import FileReceiptStore
+    from devcake.domain.oauth import OAuthManager
+    from devcake.domain.runs import RunManager
+    from devcake.staffing import HarnessNotStaffed
+    from test_oauth import FakeExecutor, NullMessaging
+
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DEVCAKE_APP_DIGEST", "sha256:abc")
+    rec_dir = tmp_path / "harness_receipts"
+    rec_dir.mkdir()
+    (rec_dir / "grok-build@0.2.112.json").write_text(json.dumps({
+        "digest": "sha256:abc", "template": "grok-build",
+        "cli_version": "0.2.112", "ok": False,
+        "rows": [{"name": "http_401", "required": True, "status": "fail"}],
+    }))
+    executor = FakeExecutor()
+    from devcake.adapters.files.run_store import RunStore
+    runs = RunManager(RunStore(tmp_path / "runs"), NullMessaging(), executor)
+    mgr = OAuthManager(
+        runs, NullMessaging(),
+        {"main-dev": _dt()},
+        receipt_store=FileReceiptStore(rec_dir))
+    import asyncio
+    with pytest.raises(HarnessNotStaffed, match="http_401"):
+        asyncio.new_event_loop().run_until_complete(mgr._start_inner("main-dev"))
+    assert executor.params is None
+
+
+def test_steward_does_not_launch_when_not_staffed(tmp_path, monkeypatch):
+    import json
+    from datetime import datetime, timezone
+
+    from devcake.adapters.files.receipts import FileReceiptStore
+    from devcake.adapters.github import GitHubForge
+    from devcake.config import AppConfig
+    from devcake.domain.model import Mission
+    from fakes import make_mission_manager
+
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    rec_dir = tmp_path / "harness_receipts"
+    rec_dir.mkdir()
+    (rec_dir / "grok-build@0.2.112.json").write_text(json.dumps({
+        "digest": "sha256:test", "ok": False,
+        "rows": [{"name": "empty", "required": True, "status": "error"}],
+    }))
+    from test_oauth import FakeExecutor, NullMessaging
+    from devcake.adapters.files.run_store import RunStore
+    from devcake.domain.runs import RunManager
+    executor = FakeExecutor()
+    runs = RunManager(RunStore(tmp_path / "runs"), NullMessaging(), executor)
+    mgr = make_mission_manager(
+        runs=runs, messaging=NullMessaging(),
+        forge=GitHubForge("https://github.com/o/r", "tok"),
+        config=AppConfig())
+    mgr.receipt_store = FileReceiptStore(rec_dir)
+    dt = _dt()
+    m = Mission(pmo_id="p1", pmo_kind="issue", key="T-1", title="t",
+                status="backlog", labels={"DEVCAKE"},
+                updated_at=datetime.now(timezone.utc))
+    import asyncio
+    run = asyncio.new_event_loop().run_until_complete(
+        mgr.dispatch_steward(dt, [m]))
+    assert run is None
+    assert executor.params is None
+
+
+def test_hello_launch_path_does_not_import_staffing():
+    from pathlib import Path
+    text = (Path(__file__).resolve().parents[1] / "devcake" / "domain"
+            / "runs.py").read_text()
+    assert "require_staffed" not in text
+    assert "HELLO_IMAGE" in text
+
+
+def test_experimental_template_is_not_gated():
+    from devcake.staffing import SENTINEL_DIGEST, require_staffed
+
+    require_staffed(_dt("pi"), digest=SENTINEL_DIGEST, store=_Store(None))

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -24,6 +24,10 @@ variable "DEVCAKE_TAG" {
   default = ""
 }
 
+variable "DEVCAKE_APP_DIGEST" {
+  default = "DEVCAKE_APP_DIGEST_UNSET"
+}
+
 # Local export/import path for BuildKit cache (override if needed).
 variable "BAKE_CACHE_DIR" {
   default = ".buildx-cache"
@@ -74,6 +78,9 @@ target "app" {
   dockerfile = "Dockerfile"
   target     = "runtime"
   tags       = ["devcake/app:${image_tag()}"]
+  args = {
+    DEVCAKE_APP_DIGEST = DEVCAKE_APP_DIGEST
+  }
 }
 
 target "app-test" {
@@ -82,6 +89,9 @@ target "app-test" {
   dockerfile = "Dockerfile"
   target     = "test"
   tags       = ["devcake/app-test:${image_tag()}"]
+  args = {
+    DEVCAKE_APP_DIGEST = DEVCAKE_APP_DIGEST
+  }
 }
 
 target "admin" {

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -298,7 +298,7 @@ docker buildx bake all
 docker compose up -d          # compose reads DEVCAKE_TAG for app/admin
 ```
 
-Harness image tags follow **`DEVCAKE_TAG`** (same as app/admin — default `latest`): `HARNESSES[…].image` in `app/devcake/harness.py` is `devcake/dev-*:${DEVCAKE_TAG}`. Dispatch, steward, and OAuth go through **`resolve_image(dev_type)`** — empty pin is that house string. Hello stays `HELLO_IMAGE`. Digest pinning at dispatch is **not** implemented; re-bake lockstep with app upgrades and keep `DEVCAKE_TAG` exported for `compose up` so dispatch matches what you baked.
+Harness image tags follow **`DEVCAKE_TAG`** (same as app/admin — default `latest`): `HARNESSES[…].image` in `app/devcake/harness.py` is `devcake/dev-*:${DEVCAKE_TAG}`. Dispatch, steward, and OAuth go through **`resolve_image(dev_type)`** — empty pin is that house string — and **`require_staffed`**: a launch-supported template refuses unless `/data/harness_receipts` has an `ok` receipt whose digest equals the app's `DEVCAKE_APP_DIGEST` ARG. Hello stays `HELLO_IMAGE` and is not gated. Bare `bake app` leaves the sentinel `DEVCAKE_APP_DIGEST_UNSET`; the wrapper computes `scripts/app_digest.py` and passes it to the app target and the probe. Keep `DEVCAKE_TAG` exported for `compose up` so dispatch matches what you baked.
 
 Which Dev image a run uses is `resolve_image(dev_type)` (`08-harness-templates.md` §2); `docker_image` is no longer stored config. Since any harness is selectable from the admin panel at any time, **all three `devcake/dev-*` images must be baked locally**.
 

--- a/scripts/app_digest.py
+++ b/scripts/app_digest.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Content digest of the files receipts are keyed on.
+
+The running app compares receipt.digest to its DEVCAKE_APP_DIGEST ARG.
+This is not DEVCAKE_TAG. Bare `bake app` leaves the sentinel.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Paths whose change must invalidate receipts (harness images, probe, pins).
+_TREES = ("images", "scripts/harness_probe", "app/devcake/house_pins.py")
+
+
+def compute(root: Path | None = None) -> str:
+    base = Path(root) if root is not None else ROOT
+    digest = hashlib.sha256()
+    files: list[Path] = []
+    for rel in _TREES:
+        p = base / rel
+        if p.is_file():
+            files.append(p)
+        elif p.is_dir():
+            files.extend(sorted(q for q in p.rglob("*")
+                                if q.is_file() and "__pycache__" not in q.parts))
+    for path in files:
+        digest.update(path.relative_to(base).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def main() -> int:
+    print(compute())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/harness_probe/host_probe.sh
+++ b/scripts/harness_probe/host_probe.sh
@@ -8,7 +8,13 @@ TEMPLATE="${1:?template}"
 VERSION="${2:?cli_version}"
 IMAGE="${3:-devcake/dev-${TEMPLATE}:latest}"
 OUT="${4:-${DEVCAKE_RECEIPTS_DIR:-/tmp/harness_receipts}}"
-DIGEST="${5:-${DEVCAKE_APP_DIGEST:-DEVCAKE_APP_DIGEST_UNSET}}"
+if [[ -n "${5:-}" ]]; then
+  DIGEST="$5"
+elif [[ -n "${DEVCAKE_APP_DIGEST:-}" && "${DEVCAKE_APP_DIGEST}" != "DEVCAKE_APP_DIGEST_UNSET" ]]; then
+  DIGEST="$DEVCAKE_APP_DIGEST"
+else
+  DIGEST="$(python3 scripts/app_digest.py)"
+fi
 
 mkdir -p "$OUT"
 # Image user is uid 1000; receipts must be writable by that user.


### PR DESCRIPTION
Stacked on #167 (`resolve_image`). **No `cli_version` field.**

## What

- `require_staffed(dev_type, *, digest, store)` is the refuse chokepoint. Dispatch, steward, and OAuth call it before `bootstrap.launch`.
- Missing / `ok: false` / required skip / required error → launch is not called. The message names the row.
- App ARG `DEVCAKE_APP_DIGEST` defaults to the sentinel `DEVCAKE_APP_DIGEST_UNSET` (bare `bake app` / `group ci`). That refuse says **“this app was built without the bake wrapper,”** not “no receipt for this version.”
- Digest mismatch is a miss (`FileReceiptStore.get`).
- Experimental templates (`pi`, `opencode`, `qwen-code`) are not gated — no v1 probe matrix.
- Hello stays `HELLO_IMAGE` and never calls `require_staffed`.
- `GET /health` includes `harness_pins`: digest, sentinel flag, per-template ok/reason/row.
- House versions live in `house_pins.py`, ratcheted equal to `images/Dockerfile` ARG defaults. Package identities still Dockerfile-only.
- `scripts/app_digest.py` hashes `images/`, `scripts/harness_probe/`, and `house_pins.py`. `host_probe.sh` writes that digest onto receipts unless one is passed.

## Proof

`./scripts/pytest_app.sh` after rebake: **2201 passed**, 1 skipped. Same pre-existing `main` failure from #165 (`test_run_model_projects_to_the_pinned_columns` — `harness_version` / `mission_url`). This PR does not touch `Run`.

Hello is structurally ungated. A host whose app was baked **without** the wrapper will refuse launch-supported missions and show the sentinel on `/health` — that is the product. Rebake app with `DEVCAKE_APP_DIGEST=$(python3 scripts/app_digest.py)` and re-run the probe so receipts match.

## Not in this PR

No pin field, no latest gesture, no prune, no virgin-host ritual.