### PR TITLE
test: pin Run.harness_version and mission_url as scalar columns

### DIFF
--- a/app/tests/test_token_report_shape.py
+++ b/app/tests/test_token_report_shape.py
@@ -178,6 +178,8 @@ RUN_SCALAR_COLUMNS = {
     "last_heartbeat", "timeout_seconds", "traceparent", "auth_digest",
     "artifact_bytes", "error", "error_class", "attempt_counted", "verdict",
     "continuations_used", "store_gen",
+    # #165 — provision stamps harness --version; dispatch snapshots mission.url
+    "harness_version", "mission_url",
 }
 RUN_BLOB_COLUMNS = {
     "blocker_work", "mirror_repos", "spec_skills", "spec_env",


### PR DESCRIPTION
#165 added `harness_version` and `mission_url` to `Run` and left the ADR-0029 would-be-DDL pin unchanged. `test_run_model_projects_to_the_pinned_columns` has been red on `main` and on every PR stacked after it.

The test's own instruction is to widen the pin deliberately. Both fields are scalars (`str`).

This is the same one-liner already cherry-picked onto #166–#169 so those CI runs can go green without waiting for this merge.