### PR TITLE
fix(baker): bake missing pins together

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Design and refactors must respect SOLID. Prefer **deep modules** (small interfac
 
 ### Quick anti-patterns (reject these)
 
+- Leftover ≠ decided. If a locked decision is unimplemented, implement it or refuse the PR. Do not comment the gap.
 - Implementing a feature then “adding tests later”
 - Typing domain code against concrete `DaguExecutor` / `Messaging` / `RunStore` instead of ports
 - Duplicating the ACL → digest → save → start spine outside `RunBootstrap`

--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import io
 import json
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -277,6 +278,76 @@ def test_reconcile_bakes_missing_pins_then_is_ready(tmp_path):
     )
     assert baked == []
     assert again["state"] == "ready"
+
+
+def test_reconcile_bakes_missing_pins_together(tmp_path):
+    """Two missing pins must overlap. A barrier times out if they run in series."""
+    factory = _load_factory()
+    dest = tmp_path / "harness_keep_set.json"
+    dest.write_text(json.dumps({
+        "pins": [
+            {"template": "grok-build", "cli_version": "1.0.4"},
+            {"template": "claude-code", "cli_version": "2.1.229"},
+        ],
+    }))
+    house = {"grok-build": "0.2.112", "claude-code": "2.1.229"}
+    ran = []
+    gate = threading.Barrier(2, timeout=2)
+
+    def baker(job):
+        ran.append(job.cli_version)
+        gate.wait()
+
+    out = factory.reconcile(
+        keep_set_path=dest,
+        receipts_dir=tmp_path / "receipts",
+        status_path=tmp_path / "harness_bake_status.json",
+        digest="sha256:abc",
+        baker=baker,
+        tag="latest",
+        house=house,
+    )
+    assert sorted(ran) == ["1.0.4", "2.1.229"]
+    assert out["state"] == "ready"
+    assert {j["cli_version"]: j["state"] for j in out["jobs"]} == {
+        "1.0.4": "ok", "2.1.229": "ok",
+    }
+
+
+def test_reconcile_finishes_every_job_when_one_fails(tmp_path):
+    factory = _load_factory()
+    dest = tmp_path / "harness_keep_set.json"
+    dest.write_text(json.dumps({
+        "pins": [
+            {"template": "grok-build", "cli_version": "1.0.4"},
+            {"template": "claude-code", "cli_version": "2.1.229"},
+        ],
+    }))
+    house = {"grok-build": "0.2.112", "claude-code": "2.1.229"}
+    ran = []
+    gate = threading.Barrier(2, timeout=2)
+
+    def baker(job):
+        ran.append(job.cli_version)
+        gate.wait()
+        if job.cli_version == "1.0.4":
+            raise RuntimeError("layer failed")
+
+    out = factory.reconcile(
+        keep_set_path=dest,
+        receipts_dir=tmp_path / "receipts",
+        status_path=tmp_path / "harness_bake_status.json",
+        digest="sha256:abc",
+        baker=baker,
+        tag="latest",
+        house=house,
+    )
+    assert sorted(ran) == ["1.0.4", "2.1.229"]
+    assert out["state"] == "error"
+    assert "layer failed" in out["detail"]
+    assert {j["cli_version"]: j["state"] for j in out["jobs"]} == {
+        "1.0.4": "error", "2.1.229": "ok",
+    }
 
 
 def test_arg_names_match_the_app_house_pins():

--- a/scripts/dev_factory/__init__.py
+++ b/scripts/dev_factory/__init__.py
@@ -39,6 +39,7 @@ from .core import (
     plan_bakes,
     reconcile,
     run_bake,
+    touch_status,
     write_status,
 )
 
@@ -63,5 +64,6 @@ __all__ = [
     "reconcile",
     "run_bake",
     "tick_decision",
+    "touch_status",
     "write_status",
 ]

--- a/scripts/dev_factory/core.py
+++ b/scripts/dev_factory/core.py
@@ -10,10 +10,14 @@ import json
 import os
 import re
 import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping
+
+_STATUS_LOCK = threading.Lock()
 
 # Bake-images targets minus hello. Must stay equal to HARNESSES keys
 # (ratchet in test_harness_cli_pins / factory tests).
@@ -196,6 +200,25 @@ def load_receipts(receipts_dir: Path | str) -> dict[tuple[str, str], dict]:
 def write_status(path: Path | str, payload: Mapping) -> dict:
     dest = Path(path)
     dest.parent.mkdir(parents=True, exist_ok=True)
+    with _STATUS_LOCK:
+        return _write_status_unlocked(dest, dict(payload))
+
+
+def touch_status(path: Path | str) -> dict:
+    """Refresh the heartbeat without dropping jobs or state."""
+    dest = Path(path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with _STATUS_LOCK:
+        try:
+            body = json.loads(dest.read_text())
+            if not isinstance(body, dict):
+                body = {}
+        except (OSError, json.JSONDecodeError):
+            body = {"state": "baking", "jobs": []}
+        return _write_status_unlocked(dest, body)
+
+
+def _write_status_unlocked(dest: Path, payload: Mapping) -> dict:
     body = dict(payload)
     body.setdefault("updated_at", datetime.now(timezone.utc).isoformat())
     from .liveness import stamp_heartbeat
@@ -224,11 +247,7 @@ def reconcile(
     tag: str,
     house: Mapping[str, str],
 ) -> dict:
-    """One watch tick. Baker is injected — this module does not call Docker.
-
-    Jobs run one after another. PLAN_CLI_PINS §1.18 said do not serialize
-    unless measured; this is a known deviation, not the settled answer.
-    """
+    """One watch tick. Baker is injected — this module does not call Docker."""
     try:
         keep_set = load_keep_set(keep_set_path)
     except InvalidKeepSet as exc:
@@ -259,7 +278,7 @@ def reconcile(
             "template": j.template,
             "cli_version": j.cli_version,
             "image": image_ref(j.template, j.cli_version, tag=tag, house=house),
-            "state": "pending",
+            "state": "baking",
         }
         for j in jobs
     ]
@@ -269,26 +288,40 @@ def reconcile(
         "jobs": listed,
         "detail": "",
     })
-    for i, job in enumerate(jobs):
-        listed[i]["state"] = "baking"
-        write_status(status_path, {
-            "state": "baking",
-            "digest": digest,
-            "jobs": listed,
-            "detail": "",
-        })
+
+    def run_one(i: int, job: BakeJob) -> None:
+        err: BaseException | None = None
         try:
             baker(job)
         except Exception as exc:  # noqa: BLE001 — baker is the host verb; any failure is an operator-visible error
-            listed[i]["state"] = "error"
-            listed[i]["detail"] = str(exc)
-            return write_status(status_path, {
-                "state": "error",
+            err = exc
+        dest = Path(status_path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with _STATUS_LOCK:
+            if err is None:
+                listed[i]["state"] = "ok"
+            else:
+                listed[i]["state"] = "error"
+                listed[i]["detail"] = str(err)
+            _write_status_unlocked(dest, {
+                "state": "baking",
                 "digest": digest,
                 "jobs": listed,
-                "detail": str(exc),
+                "detail": "",
             })
-        listed[i]["state"] = "ok"
+
+    with ThreadPoolExecutor(max_workers=len(jobs)) as pool:
+        futs = [pool.submit(run_one, i, job) for i, job in enumerate(jobs)]
+        for fut in as_completed(futs):
+            fut.result()
+    failed = [row for row in listed if row.get("state") == "error"]
+    if failed:
+        return write_status(status_path, {
+            "state": "error",
+            "digest": digest,
+            "jobs": listed,
+            "detail": str(failed[0].get("detail") or ""),
+        })
     return write_status(status_path, {
         "state": "ready",
         "digest": digest,

--- a/scripts/dev_factory/watch.py
+++ b/scripts/dev_factory/watch.py
@@ -20,6 +20,7 @@ from .core import (
     house_from_dockerfile,
     reconcile,
     run_bake,
+    touch_status,
     write_status,
 )
 from .run import tee_run
@@ -175,14 +176,11 @@ def beating_run(work: Path):
     """subprocess.run-shaped: heartbeat while waiting, tee output, keep a tail."""
 
     def stamp() -> None:
-        current = {}
-        path = work / STATUS
-        if path.is_file():
-            try:
-                current = json.loads(path.read_text())
-            except (OSError, json.JSONDecodeError):
-                current = {}
-        publish_status(work, current or {"state": "baking", "jobs": []})
+        body = touch_status(work / STATUS)
+        try:
+            compose_write(STATUS, json.dumps(body, indent=2) + "\n")
+        except RuntimeError:
+            pass
 
     def run(argv, **kw):
         return tee_run(


### PR DESCRIPTION
A keep-set tick with more than one missing pin used to bake them one after another. That loop was leftover, not a decision (PLAN §1.18 said do not serialize).

## What changed

- `reconcile` starts every missing pin together.
- One failed bake no longer drops the others. The tick is `error` if any job failed, `ready` if all succeeded.
- Concurrent heartbeats go through `touch_status` so a stamp cannot overwrite another job's state.
- The "known deviation" comment is gone.

`AGENTS.md`: leftover ≠ decided. If a locked decision is unimplemented, implement it or refuse the PR. Do not comment the gap.

## Proof

The two new tests failed on the old `for` loop (only the first pin entered the baker). After the change, `./scripts/pytest_app.sh` rebaked `app-test` and the suite was 2263 passed, 1 skipped.