### PR TITLE
fix(admin): show the connection-test failure reason

### DIFF
--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -431,7 +431,7 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
                   <span className={`text-sm ${tr.ok ? "text-green-700 dark:text-green-400" : "text-red-600"}`}>
                     {tr.ok
                       ? `✓ team ${tr.team}: ${tr.labels}/${tr.labels_expected ?? 10} labels, ${tr.missions_visible} items visible`
-                      : `✗ ${tr.error}`}
+                      : `✗ ${tr.error || tr.detail || "connection test failed"}`}
                   </span>
                 )}
               </div>

--- a/admin/spa/src/pages/ReposPage.jsx
+++ b/admin/spa/src/pages/ReposPage.jsx
@@ -550,7 +550,7 @@ export default function ReposPage({ onHealthChange }) {
                       ? tr.reference_only
                         ? `✓ ${tr.forge} reachable (read-only) — reference-only repo`
                         : `✓ ${tr.forge} reachable · reviewer token: ${tr.reviewer_token_configured ? "yes" : "no"}`
-                      : `✗ ${tr.error}`}
+                      : `✗ ${tr.error || tr.detail || "connection test failed"}`}
                   </span>
                 )}
               </div>

--- a/app/devcake/api/connections_service.py
+++ b/app/devcake/api/connections_service.py
@@ -306,6 +306,16 @@ async def connections_registry():
     }
 
 
+def _with_error(payload: dict, *, detail: str = "") -> dict:
+    """SPA Test connection prints `error`. Probe DTOs use `detail`."""
+    if payload.get("ok"):
+        return payload
+    err = (payload.get("error") or payload.get("detail") or detail or "").strip()
+    if not err:
+        err = "connection probe failed — see app logs for details"
+    return {**payload, "error": err}
+
+
 def _probe_client_error(e: Exception) -> str:
     """Client-facing probe error: never echo raw vendor bodies (tokens/URLs).
 
@@ -336,11 +346,14 @@ async def test_pmo(name: str, *, config, managers):
     try:
         h = await mgr.pmo.health_probe(inst.team_key)
         missions = await mgr.pmo.list_all(inst.team_key)
-        return {"ok": h.ok, "instance": name,
-                "team": h.workspace or inst.team_key,
-                "labels": h.managed_labels_present,
-                "labels_expected": h.managed_labels_expected,
-                "missions_visible": len(missions)}
+        return _with_error({
+            "ok": h.ok, "instance": name,
+            "team": h.workspace or inst.team_key,
+            "labels": h.managed_labels_present,
+            "labels_expected": h.managed_labels_expected,
+            "missions_visible": len(missions),
+            "detail": h.detail,
+        })
     except Exception as e:  # noqa: BLE001 — connection-test contract: any probe failure → ok:False + error in the response, never a 500
         return {"ok": False, "error": _probe_client_error(e)}
 
@@ -365,7 +378,7 @@ async def test_forge(name: str, *, config, forge_runtime):
     try:
         health = await forge_runtime.refresh_health(name)
         if not health["ok"]:
-            return health
+            return _with_error(health)
         # reference-only: read access is the WHOLE contract — the PR-listing
         # and branch-protection probes need API scopes a read-only PAT may
         # lack, and DevCake never opens PRs here anyway

--- a/app/tests/test_connection_test.py
+++ b/app/tests/test_connection_test.py
@@ -1,0 +1,72 @@
+"""Connection-test HTTP contract: ok:False always carries `error`.
+
+The SPA Test connection buttons print `tr.error`. Probe DTOs use `detail`.
+Independent expected values are the planted detail strings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from devcake.config import AppConfig, PMOInstance, RepoInstance
+from devcake.ports.pmo import PMOHealth
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_forge_failed_probe_puts_detail_on_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import secrets as secrets_store
+    from devcake.api import connections_service as cs
+
+    repo = RepoInstance(
+        name="devcakerepo", forge="github",
+        url="https://github.com/flieber-inc/devcake")
+    secrets_store.write_connection_secret("repo", "devcakerepo", "token", "ghp_test")
+    reason = (
+        "repository access failed (HTTP 404); for a fine-grained PAT, "
+        "select this repository and grant Contents and Pull requests read/write")
+
+    class Runtime:
+        def get(self, name):
+            return object()
+
+        async def refresh_health(self, name):
+            return {
+                "ok": False,
+                "repository": "flieber-inc/devcake",
+                "can_push": False,
+                "detail": reason,
+            }
+
+    out = _run(cs.test_forge(
+        "devcakerepo", config=AppConfig(repos=[repo]), forge_runtime=Runtime()))
+    assert out["ok"] is False
+    assert out["error"] == reason
+
+
+def test_pmo_failed_probe_puts_detail_on_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import secrets as secrets_store
+    from devcake.api import connections_service as cs
+
+    inst = PMOInstance(name="linear", system="linear", team_key="DEV")
+    secrets_store.write_connection_secret("pmo", "linear", "api_key", "lin_test")
+    reason = "team not found"
+
+    class Adapter:
+        async def health_probe(self, team_ref):
+            return PMOHealth(ok=False, detail=reason)
+
+        async def list_all(self, team_ref):
+            return []
+
+    class Mgr:
+        pmo = Adapter()
+
+    out = _run(cs.test_pmo(
+        "linear", config=AppConfig(pmos=[inst]), managers={"linear": Mgr()}))
+    assert out["ok"] is False
+    assert out["error"] == reason


### PR DESCRIPTION
A failed repo or PMO Test connection printed `✗ undefined`.

The probe already had the reason in `detail` (for example the GitHub 404 / fine-grained PAT sentence). Both buttons printed `error`. That field was only set on the early-out paths (empty URL, not saved, no token).

## What changed

- `test_forge` and `test_pmo` always set `error` from `detail` when `ok` is false.
- Both Test connection buttons fall back to `detail`, then a generic sentence, so they cannot print `undefined` again.

Live check after rebake: `POST /connections/forge/devcakerepo/test` now returns the 404 PAT sentence on `error`. The bundled PMO test is green on this host; the fail path is the new unit test.