### PR TITLE
fix(baker): see prune requests while idle; skip dangling tags

### DIFF
--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -212,6 +212,21 @@ def test_plan_prune_keeps_pins_running_and_hello_and_ignores_nginx():
     assert gone == ("devcake/dev-qwen-code:latest",)
 
 
+def test_plan_prune_skips_dangling_none_tags_instead_of_aborting():
+    factory = _load_factory()
+    gone = factory.plan_prune(
+        keep_images=("devcake/dev-hello:latest",),
+        running_images=("devcake/dev-hello:<none>",),
+        local_images=(
+            "devcake/dev-hello:latest",
+            "devcake/dev-hello:<none>",
+            "devcake/dev-qwen-code:latest",
+            "<none>:<none>",
+        ),
+    )
+    assert gone == ("devcake/dev-qwen-code:latest",)
+
+
 def test_run_prune_is_docker_rmi_of_the_planned_refs_only():
     factory = _load_factory()
     calls = []

--- a/scripts/dev_factory/core.py
+++ b/scripts/dev_factory/core.py
@@ -161,21 +161,19 @@ def plan_prune(
 ) -> tuple[str, ...]:
     """Local `devcake/dev-*` images that no pin, running container, or hello needs.
 
-    Names that are not `devcake/dev-*` are ignored as candidates (never
-    deleted). Keep/running names that *are* `devcake/dev-*` are validated.
+    Only well-formed `devcake/dev-name:tag` refs are keep or delete
+    candidates. `nginx`, dangling `<none>` tags, and bare ids are ignored.
     """
     keep: set[str] = set()
     for ref in (*keep_images, *running_images):
-        if not str(ref).startswith(_IMAGE_PREFIX):
-            continue
-        keep.add(_require_dev_image(ref))
+        if _IMAGE_REF.fullmatch(str(ref)):
+            keep.add(ref)
     gone: list[str] = []
     for ref in local_images:
-        if not str(ref).startswith(_IMAGE_PREFIX):
+        if not _IMAGE_REF.fullmatch(str(ref)):
             continue
-        name = _require_dev_image(ref)
-        if name not in keep:
-            gone.append(name)
+        if ref not in keep:
+            gone.append(ref)
     return tuple(sorted(set(gone)))
 
 

--- a/scripts/dev_factory/watch.py
+++ b/scripts/dev_factory/watch.py
@@ -38,7 +38,6 @@ from .liveness import (
     unhealthy_verdict,
 )
 INTERVAL = float(os.environ.get("DEVCAKE_FACTORY_INTERVAL", "5"))
-READY_INTERVAL = float(os.environ.get("DEVCAKE_FACTORY_READY_INTERVAL", "30"))
 KEEP_SET = "harness_keep_set.json"
 STATUS = "harness_bake_status.json"
 RECEIPTS = "harness_receipts"
@@ -50,7 +49,8 @@ def compose_read(rel: str) -> str | None:
     try:
         out = subprocess.check_output(
             ["docker", "compose", "exec", "-T", "app", "cat", f"/data/{rel}"],
-            cwd=REPO, text=True, timeout=15)
+            cwd=REPO, text=True, timeout=15,
+            stderr=subprocess.DEVNULL)
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
     return out
@@ -389,7 +389,9 @@ def main(argv: list[str] | None = None) -> int:
                 except (OSError, json.JSONDecodeError):
                     current = {}
             publish_status(work, current or {"state": "ready", "jobs": []})
-            time.sleep(READY_INTERVAL)
+            # Wake often enough to see a prune request; skip_reconcile already
+            # avoided the digest/bake work.
+            time.sleep(INTERVAL)
             continue
         if cached_digest is None or cached_trees != trees:
             cached_digest = _checkout_digest()
@@ -443,7 +445,7 @@ def main(argv: list[str] | None = None) -> int:
             last_state = status.get("state")
         last_trees = trees
         last_keep = keep_m
-        time.sleep(READY_INTERVAL if last_state in _IDLE else INTERVAL)
+        time.sleep(INTERVAL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Local exercise of #174 found three baker bugs:

1. After a ready tick the loop slept 30s, so a prune request was ignored until that sleep ended.
2. `plan_prune` raised on dangling `devcake/dev-*:&lt;none&gt;` tags and aborted the whole prune.
3. Every tick `cat` missing `/data/harness_prune_request.json` into watch.log.

Idle wake is 5s. Dangling names are skipped. `compose_read` hides the missing-file cat.

Live: second prune returned `nothing to prune` on the next tick; `devcake/dev-hello:latest` and `devcake/dev-grok-build:latest-1.0.4` stayed.