### PR TITLE
[CAKE-1] [pre-FOSS] Public repository hygiene and community surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+DevCake is pre-v1. Notable public changes, milestone exit criteria, and the
+living engineering log live in **[`docs/16-roadmap.md`](docs/16-roadmap.md)** —
+that file is the source of truth so history is not maintained twice.
+
+This root `CHANGELOG.md` exists so FOSS and GitHub conventions have a stable
+landing page. When maintainers cut numbered releases, release notes can be
+added here without copying the full roadmap.
+
+## Unreleased (pre-v1)
+
+See the living log and open candidates in
+[`docs/16-roadmap.md`](docs/16-roadmap.md).
+
+Community surface added for public-repo hygiene (no LICENSE change in this
+track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing
+
+Thanks for helping improve DevCake. This file is the short path for a first-time
+contributor. Product contracts live under [`docs/`](docs/); agent coding rules
+live in [`AGENTS.md`](AGENTS.md).
+
+## Prerequisites
+
+- **Docker Engine** with Compose v2 and **Buildx** (images are built with Bake)
+- **Python 3.12** if you run unit tests against the working tree without Docker
+  (`PYTHONPATH=app`)
+- **Node.js** if you change admin SPA helper tests
+  (`npm run test:helpers --prefix admin/spa`)
+
+## Build doctrine (Bake only)
+
+DevCake images are **Bake-only**. Compose never builds them.
+
+| Do | Do not |
+|---|---|
+| `./up.sh --bake` (preferred first-time / lockstep path) | `docker compose build` |
+| `docker buildx bake …` / `bake all` / `bake images` / `bake ci` | `docker compose up --build` for `devcake/*` images |
+| Rebake after edits under `app/`, `admin/`, or `images/` | Expect compose `build:` keys for DevCake images |
+
+Normative detail: [`AGENTS.md`](AGENTS.md) ·
+[`docs/13-deployment.md`](docs/13-deployment.md).
+
+Quickstart (clone the public remote you intend to contribute to, then):
+
+```bash
+cp .env.example .env
+# Strong ADMIN / REDIS / DAGU / OO / GITEA passwords only.
+# Operator PMO/forge/model secrets go in the admin UI after up — not in .env.
+
+./up.sh --bake
+# Admin UI: http://localhost:8080  (basic auth from .env)
+```
+
+## Tests
+
+| Surface | Command |
+|---|---|
+| App unit suite (rebakes `app-test` first) | `./scripts/pytest_app.sh` |
+| Admin hermetic helpers | `npm run test:helpers --prefix admin/spa` |
+| Full local suite (stack + forge battery + dispatch smoke) | `scripts/ci_suite.sh` — needs a host that can run the stack |
+
+**Stale image trap:** `devcake/app-test` copies `app/devcake` and `app/tests`
+at bake time. Re-running pytest on an old image grades the last bake, not your
+tree. Prefer `./scripts/pytest_app.sh` or `PYTHONPATH=app` on Python 3.12.
+
+New behavior is **test-first** at public seams (`app/tests/`, port fakes). See
+[`AGENTS.md`](AGENTS.md) (TDD, SOLID, Always Works™).
+
+## Pull requests
+
+- **One intent per PR.** Prefer small, reviewable diffs.
+- **Always Works™:** prove the change class you touched (docs re-read; bake +
+  health when images/UI/runtime change; pytest when `app/` changes). “Build
+  succeeded” alone is not enough for a run/up path.
+- **Security claims** must not exceed [`docs/14-security.md`](docs/14-security.md).
+  The reviewer token (app-only) is the security-relevant second forge identity;
+  REVIEW is always a pipeline stage.
+- **Docs drift:** if you change a public seam (ports, dispatch spine, lifecycle),
+  update the matching `docs/*` in the same change.
+- Do not commit `.env`, `/data/`, `/workspaces/`, backup tarballs, or real
+  credentials. Test doubles should stay obvious fakes (`example.com`, padded
+  `ghp_…` fixtures, etc.).
+
+## Secrets and local state
+
+| Path | Role |
+|---|---|
+| `.env` | Stack bootstrap only (schema v4) — gitignored; copy from `.env.example` |
+| Admin UI secrets | Operator PMO / forge / model credentials under `/data` |
+| `/workspaces/` | Per-run host workspaces (ADR-0025) — gitignored |
+
+Never put forge/PMO/model tokens in `.env` for normal ops. Vulnerability
+reporting: [`SECURITY.md`](SECURITY.md).
+
+## CI and forks
+
+GitHub Actions for this repository do **not** require custom private org
+secrets for pull-request CI.
+
+| Workflow | Secrets a public fork needs | Notes |
+|---|---|---|
+| `ci.yml` | None beyond default `GITHUB_TOKEN` | Bake group `ci`, ruff, pip-audit, npm audit, pytest, minimal compose dispatch smoke |
+| `docker-images.yml` | None | Path-filtered harness image bake + smoke |
+| `docker-publish.yml` | Default `GITHUB_TOKEN` with `packages: write` on the **target** repo | **Manual** `workflow_dispatch` only; publishes to GHCR for the repo owner. Forks can publish only to their own GHCR if they run the workflow with package write enabled. No custom org secrets. |
+
+If CI fails on a fork for a missing optional external service, that should be
+visible in the workflow logs — PR CI is designed not to depend on private
+tokens the maintainer org holds privately.
+
+## Dependency / SBOM honesty
+
+CI runs `pip-audit` (app-test) and `npm audit --omit=dev` (admin SPA). Manual
+image publish attaches Bake SBOM metadata. There is **no** committed tree-wide
+SBOM or continuous full-repo SBOM pipeline. Details:
+[`SECURITY.md`](SECURITY.md).
+
+## Further reading
+
+| Topic | Doc |
+|---|---|
+| Product overview | [`docs/00-overview.md`](docs/00-overview.md) |
+| Operator duties | [`docs/18-operator-contract.md`](docs/18-operator-contract.md) |
+| Security contract | [`docs/14-security.md`](docs/14-security.md) |
+| Deployment / bake matrix | [`docs/13-deployment.md`](docs/13-deployment.md) |
+| Agent coding rules | [`AGENTS.md`](AGENTS.md) |
+| Changelog / living log | [`CHANGELOG.md`](CHANGELOG.md) → [`docs/16-roadmap.md`](docs/16-roadmap.md) |
+| First mission | [`docs/tutorials/01-first-mission.md`](docs/tutorials/01-first-mission.md) |
+
+### Missions and agent-generated PRs
+
+Some pull requests are opened by DevCake Dev Types (ONBOARD → PLAN → EXECUTE →
+REVIEW). Humans remain in the loop for merge when `auto_merge` is off (default).
+You do not need to understand the full orchestrator to contribute by hand —
+treat agent PRs like any other PR, and keep your own changes independently
+proven.

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ must not exceed [`docs/14-security.md`](docs/14-security.md).
 |---|---|
 | Understand the product and invariants | [`docs/00-overview.md`](docs/00-overview.md) |
 | Onboard as a new engineer (reading path) | [`docs/00-overview.md`](docs/00-overview.md) §6a |
+| Contribute (build, tests, PR expectations) | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Report a vulnerability | [`SECURITY.md`](SECURITY.md) |
 | Understand the security deal | [`docs/14-security.md`](docs/14-security.md) |
 | Know what you own as operator | [`docs/18-operator-contract.md`](docs/18-operator-contract.md) |
 | Run a first mission / operate daily | [`docs/tutorials/`](docs/tutorials/) |
@@ -275,7 +277,7 @@ must not exceed [`docs/14-security.md`](docs/14-security.md).
 | Labels, lifecycle, orchestrator | [`docs/02`](docs/02-domain-model.md) · [`03`](docs/03-mission-lifecycle.md) · [`04`](docs/04-orchestrator.md) |
 | PMO / forge / harnesses | [`05`](docs/05-pmo-adapter.md) · [`06`](docs/06-forge-adapter.md) · [`08`](docs/08-harness-templates.md) |
 | Admin API & UI contract | [`docs/11-admin-panel.md`](docs/11-admin-panel.md) |
-| History and backlog | [`docs/16-roadmap.md`](docs/16-roadmap.md) |
+| History and backlog | [`docs/16-roadmap.md`](docs/16-roadmap.md) · [`CHANGELOG.md`](CHANGELOG.md) |
 | How we talk about it | [`docs/17-positioning.md`](docs/17-positioning.md) |
 | Why this exists — the thesis | [`docs/19-thesis.md`](docs/19-thesis.md) |
 
@@ -288,4 +290,6 @@ Full map and architecture: [`docs/00`](docs/00-overview.md) §7 · [`docs/01`](d
 Self-hosted operator software. Prefer PRs with tests at public seams
 (`app/tests/`) and zero-drift docs when public contracts change. Build with
 **Bake**, target **Python 3.12**, and prove run/up paths — not only “build
-succeeded.” See [`AGENTS.md`](AGENTS.md).
+succeeded.” Full contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md) ·
+coding agents: [`AGENTS.md`](AGENTS.md) · vulnerability reporting:
+[`SECURITY.md`](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ real EXECUTE: §9.
 ## Quickstart
 
 ```bash
-git clone https://github.com/fidecastro/devcake && cd devcake
+# Clone the remote or fork you intend to run (a fixed public product URL is
+# not published yet — pre-FOSS; do not invent one):
+git clone <this-repo-url> && cd devcake
 cp .env.example .env
 # Edit .env: strong ADMIN / REDIS / DAGU / OO / GITEA passwords only.
 # Leave DOCKER_GID blank. Empty/change-me* passwords refuse boot unless

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,86 @@
+# Security
+
+## Product security contract
+
+DevCake's **normative security posture** is
+[`docs/14-security.md`](docs/14-security.md). Read that file before filing a
+report or writing claims about isolation, multi-tenancy, or supply-chain
+controls.
+
+In short: DevCake is a **single-operator agent runtime for a dedicated host**.
+Anyone who can write tickets on a configured PMO instance or land content in a
+configured repository can influence coding agents that hold forge and model
+credentials. Multi-tenant least-privilege SaaS is an **explicit non-goal**.
+The security-relevant second identity on the forge is the **reviewer token**
+(app-only) — not staffing a different Dev Type for the REVIEW pipeline stage.
+
+Do not file issues that ask the project to “fix” accepted design choices
+documented there (prompt injection as trusted input, capable agents with open
+egress, Dagu with host `docker.sock`, basic auth on a dedicated host). Those
+are the product contract (§0 / §10 of `docs/14-security.md`), not defects.
+
+## What to report privately
+
+Report **implementation defects** that break documented hard controls, for
+example:
+
+- A control marked **hard** or **gate** in `docs/14-security.md` that does not
+  hold in a current release
+- Failures of redaction at its documented choke points (`security.redact` /
+  related egress paths)
+- **Credential or secret material committed in the tree** (tokens, private
+  keys, real `.env` contents)
+- Paths that map to no accepted stance in `docs/14` and no residual-risk row —
+  true **unknown unknowns** that expand blast radius beyond the contract
+
+### Private channel
+
+Prefer a **non-public** path so unpatched credential- or RCE-class issues are
+not broadcast:
+
+1. **GitHub Security Advisories (private vulnerability reporting)** on this
+   repository, when the maintainers have enabled it for the public remote —
+   use the repository’s **Security → Advisories / Report a vulnerability** UI.
+2. If private reporting is not yet enabled on the remote you cloned, contact a
+   **maintainer privately** (for example a direct message on a channel they
+   publish, or a private GitHub discussion with a maintainer). **Do not** open
+   a public issue that includes exploit details, live tokens, or steps that
+   make unpatched hosts easy to hit.
+
+There is **no** dedicated public security mailbox published in-tree. Do not
+invent one; do not paste secrets into public issues, PRs, or the PMO feed.
+
+When the defect is already public knowledge (for example a dependency CVE with
+a published advisory and no secret material), an ordinary issue or PR is fine.
+
+## Dependency inventory and SBOM (honest status)
+
+What exists today:
+
+| Check | Where | Scope |
+|---|---|---|
+| `pip-audit` on the app-test image environment | `.github/workflows/ci.yml` | Python packages installed in `devcake/app-test` |
+| `npm audit --omit=dev` | `.github/workflows/ci.yml` | Admin SPA production npm dependencies |
+| Bake `sbom: true` | `.github/workflows/docker-publish.yml` (manual publish to GHCR) | SBOM attached to **published** images only |
+
+What does **not** exist:
+
+- No committed tree-wide SBOM artifact
+- No continuous CycloneDX/Syft (or equivalent) pipeline on every PR
+- CI bake intentionally uses `sbom: false` (see `.github/workflows/ci.yml`)
+
+Roadmap still lists a fuller SBOM under public-release hygiene
+([`docs/16-roadmap.md`](docs/16-roadmap.md)). Do not treat the checks above as
+a complete software bill of materials program.
+
+## Operator secrets (not vulnerability reports)
+
+Stack bootstrap passwords live in `.env` (gitignored; start from
+`.env.example`). Operator PMO/forge/model secrets are entered through the
+admin UI and stored under `/data` — never commit them. See
+[`docs/14-security.md`](docs/14-security.md) §4 and
+[`docs/13-deployment.md`](docs/13-deployment.md).
+
+If you rotate a credential because it may have been exposed historically in
+git history, rotation is an **operator** action outside this repository;
+history rewrite is not performed by routine contributions.

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -22,9 +22,10 @@ RUN npm run build
 # ── serve ───────────────────────────────────────────────────────────────────
 FROM ${NGINX_IMAGE}
 
+# image.source is omitted until a public product remote is published
+# (pre-FOSS — do not hardcode a personal/private URL here).
 LABEL org.opencontainers.image.title="devcake-admin" \
-      org.opencontainers.image.description="DevCake admin SPA (nginx)" \
-      org.opencontainers.image.source="https://github.com/fidecastro/devcake"
+      org.opencontainers.image.description="DevCake admin SPA (nginx)"
 
 # htpasswd (basic auth, docs/11 §5) + curl (compose healthcheck)
 RUN apk add --no-cache \

--- a/admin/spa/src/components/Sidebar.jsx
+++ b/admin/spa/src/components/Sidebar.jsx
@@ -321,10 +321,7 @@ export default function Sidebar({
         )}
         {!collapsed && (
           <p className="text-[10px] text-neutral-500 dark:text-neutral-400">
-            DevCake v0 ·{" "}
-            <a className="underline" href="https://github.com/fidecastro/devcake" target="_blank" rel="noopener">
-              spec &amp; source
-            </a>
+            DevCake v0 · spec &amp; source in-tree under docs/
           </p>
         )}
         <button

--- a/admin/spa/src/pages/OverviewPage.jsx
+++ b/admin/spa/src/pages/OverviewPage.jsx
@@ -543,8 +543,18 @@ export default function OverviewPage({
               icon={GitMerge} title="Gitea (internal forge)"
               desc="The bundled forge — internal repos, PRs and history" />
           )}
-          <QuickLink href="https://github.com/fidecastro/devcake" icon={BookOpen}
-            title="Spec & source" desc="DevCake design docs and repository" />
+          <Card className="flex items-start gap-3 p-4">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent-50 text-accent-700 dark:bg-accent-950/70 dark:text-accent-300">
+              <BookOpen size={16} aria-hidden />
+            </span>
+            <span className="min-w-0">
+              <span className="text-sm font-semibold">Spec &amp; source</span>
+              <span className="mt-0.5 block text-xs text-neutral-500 dark:text-neutral-400">
+                Design docs live in the repository under <code className="text-[11px]">docs/</code>
+                {" "}(no fixed public product URL published yet)
+              </span>
+            </span>
+          </Card>
         </div>
       </div>
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -37,9 +37,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # ── runtime (production) ─────────────────────────────────────────────────────
 FROM ${PYTHON_IMAGE} AS runtime
 
+# image.source is omitted until a public product remote is published
+# (pre-FOSS — do not hardcode a personal/private URL here).
 LABEL org.opencontainers.image.title="devcake-app" \
-      org.opencontainers.image.description="DevCake orchestrator API" \
-      org.opencontainers.image.source="https://github.com/fidecastro/devcake"
+      org.opencontainers.image.description="DevCake orchestrator API"
 
 # Receipt identity (PLAN_CLI_PINS). Default is an obviously invalid
 # sentinel so bare `bake app` / group ci is distinguishable from

--- a/app/tests/test_connection_test.py
+++ b/app/tests/test_connection_test.py
@@ -23,7 +23,7 @@ def test_forge_failed_probe_puts_detail_on_error(tmp_path, monkeypatch):
 
     repo = RepoInstance(
         name="devcakerepo", forge="github",
-        url="https://github.com/flieber-inc/devcake")
+        url="https://github.com/example-org/devcake")
     secrets_store.write_connection_secret("repo", "devcakerepo", "token", "ghp_test")
     reason = (
         "repository access failed (HTTP 404); for a fine-grained PAT, "
@@ -36,7 +36,7 @@ def test_forge_failed_probe_puts_detail_on_error(tmp_path, monkeypatch):
         async def refresh_health(self, name):
             return {
                 "ok": False,
-                "repository": "flieber-inc/devcake",
+                "repository": "example-org/devcake",
                 "can_push": False,
                 "detail": reason,
             }

--- a/docs/07-dev-runtime.md
+++ b/docs/07-dev-runtime.md
@@ -289,7 +289,7 @@ unchanged and bounds the whole loop.
 
 There is **no write access** to the PMO mid-run (INV-4). Writes travel as end-of-run artifacts that the app applies. Mid-run re-fetch of the activity payload uses the same `activity.get` request/reply channel the entrypoint already speaks.
 
-Other tooling (log-platform access and the like) arrives as **MCP plugins** — standalone servers living outside this repo, installed per Dev Type at run time via `mcp_setup_commands` (`08-harness-templates.md` §7, `tutorials/03-mcp-plugins.md`). The official log connector is <https://github.com/fidecastro/devcake-logs-mcp>.
+Other tooling (log-platform access and the like) arrives as **MCP plugins** — standalone servers living outside this repo, installed per Dev Type at run time via `mcp_setup_commands` (`08-harness-templates.md` §7, `tutorials/03-mcp-plugins.md`). The log-connector companion is operator-supplied (`OWNER/REPO` pin) until a public product remote is published.
 
 ## 7. Network and resources
 

--- a/docs/08-harness-templates.md
+++ b/docs/08-harness-templates.md
@@ -284,7 +284,7 @@ Scope caveat: `claude mcp add`'s default (local) scope is **cwd-keyed**, and the
 
 ### Installing MCP plugins at run time
 
-Plugins are standalone MCP servers living OUTSIDE this repo (hexagonal rule: core ships no vendor/connector code). A Dev Type opts in with two `mcp_setup_commands` lines — install, then register (worked example: `tutorials/03-mcp-plugins.md`; the official log connector is <https://github.com/fidecastro/devcake-logs-mcp>):
+Plugins are standalone MCP servers living OUTSIDE this repo (hexagonal rule: core ships no vendor/connector code). A Dev Type opts in with two `mcp_setup_commands` lines — install, then register (worked example: `tutorials/03-mcp-plugins.md`; the log-connector companion is operator-supplied until a public `OWNER/REPO` is published):
 
 ```
 pip install --user --quiet "git+https://${PLUGIN_GIT_TOKEN}@github.com/OWNER/REPO@vX.Y.Z"

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -121,7 +121,7 @@ Exit criteria — **verified 2026-07-11 in a real browser except where noted (M6
 - [x] Config tab CRUD live: Vite/React/Tailwind SPA renders real config; PMO/forge connection tests green from the UI ("✓ team DEV: 9/9 labels" — the managed set of the day; ten today, "✓ github reachable"); saves flow UI→PUT→YAML with hot apply; Dev Type cards with prompts/MCP-warning/credentials; assignment matrix with extra-args + harness-change dialog. *Fresh-operator-from-empty-`/data` run deferred to M7 acceptance (destructive on the live volume).*
 - [x] **GUI OAuth wizard** (founder request): device-code flow runs in a Dagu-spawned harness container, streams the URL + code over Redis into a React modal (observed live: `accounts.x.ai/oauth2/device` + code rendered), polls to completion; the storage tail (file 0600, session completed, `DEV_AUTH` breaker cleared) synthetic-verified. Sessions are in-memory: an app restart orphans a pending wizard (dialog reports it; just retry).
 - [x] Credentials JSON upload endpoint verified (0600 under `/data/secrets/{dev_type}/`, delivered per-run via runspec — the bind-mount wording predates the M1 runspec redesign); subscription OAuth end-to-end proven for Grok since M4.
-- [x] **GitLab verified live (2026-07-11)**: with the operator's sandbox (`gitlab.com/fidecastro/devcake-test`, protected `main`), mission DEV-35 ran the full autonomous lifecycle — ONBOARD → EXECUTE (Grok driving `glab`, forge-aware clone auth + MR playbook) → MR!1 → REVIEW approve → **auto-squash-merge on the protected branch** → Done. Config hot-switched GitHub↔GitLab through the admin API both ways (forge factory reload).
+- [x] **GitLab verified live (2026-07-11)**: with an operator sandbox on gitlab.com (throwaway project, protected `main` — pre-public dogfood, not a product surface), mission DEV-35 ran the full autonomous lifecycle — ONBOARD → EXECUTE (Grok driving `glab`, forge-aware clone auth + MR playbook) → MR!1 → REVIEW approve → **auto-squash-merge on the protected branch** → Done. Config hot-switched GitHub↔GitLab through the admin API both ways (forge factory reload).
 - [x] `auto_merge` + `adoption_mode` confirm dialogs verified by browser automation (incl. Cancel preserving state); `DEVCAKE-SKIP` precedence verified throughout M3–M5; basic auth 401s on both SPA and `/api` (M0, re-checked).
 
 ## M7 — Hardening + acceptance
@@ -951,10 +951,10 @@ posts the full body as sequential `Part i of n` comments (never a truncated
 dump, never a 422). The operator must see the residual (`operator_note` + live
 health flags). Unofficial `uploads.github.com` remains refused.
 
-**Spike evidence (2026-08-15, personal `fidecastro` on github.com +
-gitlab.com — official APIs only).** Throwaway GitHub repo
-`devcake-pmo-contract-gh-20260815-035138` (issues closed; `gh` token lacks
-`delete_repo`) and two GitLab projects (deleted).
+**Spike evidence (2026-08-15, operator personal accounts on github.com +
+gitlab.com — official APIs only; pre-public dogfood, not product surfaces).**
+Throwaway GitHub repo `devcake-pmo-contract-gh-20260815-035138` (issues closed;
+token lacked `delete_repo`) and two GitLab projects (deleted).
 
 | Need | GitHub (measured) | GitLab (measured) |
 |---|---|---|

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -1061,8 +1061,8 @@ the strategy the adapter declares. Sidecar is the honest Jira default.
   until then; opportunity cost is high (CA lifecycle, allowlists, Dagu spawn
   path, every TLS client in the Dev image).
 - **Additional log-connector backends** (Loki; others on demand) in the
-  standalone plugin repo <https://github.com/fidecastro/devcake-logs-mcp>
-  (`LogBackend` seam; core MCP ports already shipped).
+  standalone log-connector plugin (`OWNER/REPO` — companion not yet at a
+  fixed public URL; core MCP ports already shipped).
 - **Priority-conditional Dev Type assignment** (e.g. Urgent EXECUTE → stronger
   Dev Type — relaxes 1 Mission Type → 1 Dev Type). The **instance** dimension
   shipped as ADR-0019 (per-PMO override rows); a condition language did not.
@@ -1076,8 +1076,10 @@ the strategy the adapter declares. Sidecar is the honest Jira default.
 - **First-class OTel metrics layer** — when dashboards need pre-aggregation
   or long retention (`12` §4 still SQL-over-spans).
 - **SQLite `StatePort` swap** — if run history outgrows files.
-- **Public-release hygiene** — LICENSE, SECURITY.md, CONTRIBUTING, CHANGELOG,
-  SBOM (ISSUES #38) if audience expands.
+- **Public-release hygiene (remaining)** — LICENSE and a fuller tree-wide
+  SBOM process (ISSUES #38). Root `SECURITY.md`, `CONTRIBUTING.md`, and
+  `CHANGELOG.md` (pointer to this living log) already landed; CI already
+  runs pip-audit / npm audit and publish-time Bake SBOM.
 - **Internal-forge orphan sweep** — reconcile Gitea org repos/svc users vs
   `/data/secrets/internal_forge/mission-*.json` (pre-v0.1.1 Clear leak;
   leak path itself is fixed).

--- a/docs/tutorials/01-first-mission.md
+++ b/docs/tutorials/01-first-mission.md
@@ -26,7 +26,8 @@ Every step mirrors the project's integration-test shape.
 ## Step 1 — Bootstrap and start
 
 ```bash
-git clone https://github.com/fidecastro/devcake && cd devcake
+# Clone the remote or fork you intend to run (no fixed public product URL yet):
+git clone <this-repo-url> && cd devcake
 cp .env.example .env
 ```
 

--- a/docs/tutorials/03-mcp-plugins.md
+++ b/docs/tutorials/03-mcp-plugins.md
@@ -11,11 +11,11 @@ Type fields on the Config page:
   plugin. Admin-equivalent execution inside the disposable container by
   design (`../14-security.md` §2 Zone B).
 
-Worked example throughout: **devcake-logs-mcp**, the official log-platform
-connector (Datadog / AWS CloudWatch Logs) —
-<https://github.com/fidecastro/devcake-logs-mcp>. Backend-specific detail
-(key scopes, IAM permissions, query dialects) lives in that repo's README,
-not here.
+Worked example throughout: **devcake-logs-mcp**, a log-platform connector
+(Datadog / AWS CloudWatch Logs). The companion is **not yet published** at a
+fixed public URL — substitute your operator's `OWNER/REPO` (and pin a release
+tag) when you install it. Backend-specific detail (key scopes, IAM
+permissions, query dialects) lives in that plugin repo's README, not here.
 
 ## 1. Declare the secret names
 
@@ -41,7 +41,7 @@ permission **Contents: Read-only**.
 **MCP setup commands**, in order (install, then register):
 
 ```
-pip install --user --quiet "git+https://${LOGS_MCP_GIT_TOKEN}@github.com/fidecastro/devcake-logs-mcp@v0.1.0"
+pip install --user --quiet "git+https://${LOGS_MCP_GIT_TOKEN}@github.com/OWNER/REPO@v0.1.0"
 claude mcp add devcake-logs -e DD_API_KEY=$DD_API_KEY -e DD_APP_KEY=$DD_APP_KEY -e DD_SITE=datadoghq.com -- python -m logs_mcp.server
 ```
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -37,9 +37,10 @@ FROM ${NODE_IMAGE} AS node-tools
 # ── Shared Dev base: git, forge CLIs, Python relay deps, non-root user ───────
 FROM ${PYTHON_IMAGE} AS base
 
+# image.source is omitted until a public product remote is published
+# (pre-FOSS — do not hardcode a personal/private URL here).
 LABEL org.opencontainers.image.title="devcake-dev-base" \
-      org.opencontainers.image.description="Shared base for DevCake Dev harnesses" \
-      org.opencontainers.image.source="https://github.com/fidecastro/devcake"
+      org.opencontainers.image.description="Shared base for DevCake Dev harnesses"
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Intent

Prepare the repository for a public clone and first-time contributors (pre-FOSS hygiene). No LICENSE change.

Mission: [CAKE-1](https://linear.app/fidecastro/issue/CAKE-1/pre-foss-public-repository-hygiene-and-community-surface)

## What changed

- **Community surface:** root `CONTRIBUTING.md`, `SECURITY.md`, and `CHANGELOG.md` (honest pointer to `docs/16-roadmap.md` living log — not a duplicate history).
- **README:** Documentation table + Contributing section link the new files; clone quickstart uses `<this-repo-url>` with an explicit pre-public note (no hardcoded product remote that 404s).
- **Honest source URLs (review fix):** removed non-existent `github.com/fidecastro/devcake` from OCI `image.source` labels, admin SPA Overview/Sidebar, and first-mission tutorial; companion `devcake-logs-mcp` install lines use `OWNER/REPO` placeholders (public companion also 404s unauthenticated).
- **Fingerprint scrub:** rephrased pre-public sandbox evidence in `docs/16-roadmap.md`; generalized private dogfood org `flieber-inc` → `example-org` in a connection-test fixture.
- **Roadmap open candidates:** SECURITY/CONTRIBUTING/CHANGELOG marked landed; remaining hygiene is LICENSE + fuller SBOM.
- **CI / SBOM honesty:** CONTRIBUTING + SECURITY document that PR CI needs no private org secrets; pip-audit / npm audit / publish-time Bake SBOM exist; no tree-wide continuous SBOM process.

## Secret scrub (executed)

- No private key armor, committed `.env`/`.pem`/`id_rsa`/`credentials.json`, or backup tarballs in the working tree.
- Token-shaped strings remain intentional fakes / adapter pattern matchers (tests + registry) — left intact.
- Residual scan: no `fidecastro` left in tree; only concrete product-shaped GitHub URL is the `example-org` test fixture.

## Public URL proof (re-run after fix)

```text
curl -sI https://github.com/fidecastro/devcake → 404
curl -s https://api.github.com/repos/fidecastro/devcake → 404
curl -sI https://github.com/fidecastro/devcake-logs-mcp → 404
```

In-tree clone/source no longer claim those remotes.

## How to verify

- Docs re-read: SECURITY vs `docs/14-security.md` (no stronger claims); CONTRIBUTING Bake-only matches AGENTS.md / docs/13.
- `PYTHONPATH=app python3.12 -m pytest app/tests/test_connection_test.py -q` → 2 passed.
- Admin SPA: `npm run build` (vite) succeeded after Overview/Sidebar honesty fix. Host lacks full `docker buildx bake` (Podman buildx without bake); PR CI rebakes admin.
- LICENSE untouched.

## Out of scope

- LICENSE / copyleft text
- Product features, adapter work, full docs corpus rewrite
- Git history rewrite

## Deviations from original plan

- **Canonical public remote:** prior EXECUTE kept `fidecastro/devcake`; REVIEW proved it 404s. This revision uses generic clone placeholders and drops false product URLs rather than inventing an org or advertising private `flieber-inc`.