### PR TITLE
[CAKE-14] [pre-FOSS] Finalize, transitions, completion, steps, and legal outcomes audit

### DIFF
--- a/app/devcake/domain/orchestrator/markers.py
+++ b/app/devcake/domain/orchestrator/markers.py
@@ -38,7 +38,7 @@ PART_LINE = re.compile(r"^Part (\d+) of (\d+)$")
 
 # Stage label each checkpointed swap leaves on the mission (None = stage label
 # removed). Consulted by the redelivery external-transition check in
-# _transition: a live stage matching a present marker's value is our own swap
+# transitions.transition: a live stage matching a present marker's value is our own swap
 # resuming, anything else is an external change and halts the finalize.
 # DERIVED from the step registry (ADR-0034) — a new stage-swapping checkpoint
 # declares its stage_after at registration in steps.py; the old hand-copy

--- a/app/devcake/domain/orchestrator/transitions.py
+++ b/app/devcake/domain/orchestrator/transitions.py
@@ -46,10 +46,10 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
             mgr._audit(pmo_id, "project_bad_outcome_parked", outcome)
         await mgr._checkpoint(run, steps.TRANSITION_PROJECT_PARK, _proj_park)
         run.verdict = redact(
-            f"rejected: project returned {outcome} (only decomposed "
-            f"is legal) — parked with DEVCAKE-SKIP")
-        log.warning("project %s returned %s (only decomposed is legal) — parked",
-                    run.mission_key, outcome)
+            f"rejected: project returned {outcome} (only decomposed/"
+            f"human_needed are legal) — parked with DEVCAKE-SKIP")
+        log.warning("project %s returned %s (only decomposed/human_needed "
+                    "are legal) — parked", run.mission_key, outcome)
         return
     # A redelivery must not mistake its OWN checkpointed label swap for an
     # external change — but a change a human made BETWEEN deliveries (e.g.
@@ -138,21 +138,31 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
     elif outcome == "decomposed":
         await decomposition.finalize_decomposition(mgr, run, result)
     elif outcome == "plan_needed" and plan_md:
+        # Mirror the planned path's attach contract: skip upload when the
+        # PMO has no attachment API (GitHub Issues raises), and on redelivery
+        # after a checkpointed upload re-inline plan_md rather than a dead
+        # link (plan_url_box is always empty on a fresh transition entry).
         plan_name = f"PLAN_{run.seq}.md"
         plan_url_box: list[str] = []
 
         async def _plan_attach_upload():
+            if not feed._attachments_supported(mgr):
+                return
             url = await mgr.pmo.upload_attachment(
                 pmo_id, plan_name, redact(plan_md).encode())
             plan_url_box.clear()
             plan_url_box.append(url)
 
         async def _plan_attach_feed():
-            url = plan_url_box[0] if plan_url_box else f"(see {plan_name})"
-            await mgr._feed(
-                pmo_id, run.pmo_kind,
-                f"📋 DevCake attached an opportunistic plan from triage: "
-                f"[{plan_name}]({url}) — skipping the PLAN step.")
+            if plan_url_box:
+                url = plan_url_box[0]
+                body = (f"📋 DevCake attached an opportunistic plan from triage: "
+                        f"[{plan_name}]({url}) — skipping the PLAN step.")
+            else:
+                body = (f"📋 DevCake attached an opportunistic plan from triage "
+                        f"(`{plan_name}`) — skipping the PLAN step:\n\n"
+                        + (redact(plan_md or "") or f"(see {plan_name})"))
+            await mgr._feed(pmo_id, run.pmo_kind, body)
 
         async def _plan_attach_labels():
             await mgr.pmo.swap_labels(MissionRef(pmo_id, "issue"),

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -654,6 +654,68 @@ def test_onboard_opportunistic_plan_skips_plan_stage(tmp_path):
     assert ({"DEVCAKE-EXECUTE"} in [add for _, add in fake.swaps])
 
 
+def test_plan_needed_attach_without_attachments_posts_plan_inline(tmp_path):
+    """Parity with planned: GitHub Issues has no attachment API. The
+    opportunistic-plan path must not call upload_attachment (which raises
+    and wedges finalize in finalizing) — post the plan bytes inline and
+    still jump to EXECUTE."""
+    m = mission("in_progress", {"DEVCAKE"})
+    mgr, fake, _store = make_mgr(tmp_path, m)
+    fake.attachments_supported = False
+
+    async def _boom(*a, **k):
+        raise RuntimeError("github_issues: attachments are not supported")
+    fake.upload_attachment = _boom
+    plan = "## Plan\nappend the line to README.md"
+    run_coro(transitions.transition(
+        mgr, _run("ONBOARD", None),
+        {"outcome": "plan_needed", "summary": "s"}, plan))
+    assert fake.uploads == []
+    assert any("opportunistic plan" in c and "append the line" in c
+               for c in fake.comments)
+    assert "DEVCAKE-EXECUTE" in m.labels
+    assert "DEVCAKE-PLAN" not in m.labels
+    assert "DEVCAKE-SKIP" not in m.labels
+
+
+def test_plan_needed_attach_redelivery_after_upload_inlines_plan(tmp_path):
+    """If upload was checkpointed but feed has not run yet, redelivery
+    re-enters with an empty plan_url_box. Must not post a dead
+    ``[(see PLAN_n.md)]`` link — inline the plan bytes (same contract as
+    the planned path)."""
+    m = mission("in_progress", {"DEVCAKE"})
+    mgr, fake, store = make_mgr(tmp_path, m)
+    run = _run("ONBOARD", None)
+    run.finalized_steps = ["transition:plan_needed_attach:upload"]
+    store.save(run)
+    plan = "## Plan\ndo X then Y"
+    run_coro(transitions.transition(
+        mgr, run, {"outcome": "plan_needed", "summary": "s"}, plan))
+    assert fake.uploads == []
+    assert any("opportunistic plan" in c and "do X then Y" in c
+               for c in fake.comments)
+    assert "DEVCAKE-EXECUTE" in m.labels
+    assert "transition:plan_needed_attach:feed" in run.finalized_steps
+    assert "transition:plan_needed_attach:labels" in run.finalized_steps
+
+
+def test_project_park_message_names_both_legal_outcomes(tmp_path):
+    """Projects accept decomposed and human_needed; the park copy must not
+    claim only decomposed is legal (honesty — human_needed is the other
+    legal project outcome and has its own handler)."""
+    m = mission("in_progress", {"DEVCAKE"})
+    m.pmo_kind = "project"
+    mgr, fake, _store = make_mgr(tmp_path, m)
+    run = _run("ONBOARD", None)
+    run.pmo_kind = "project"
+    run_coro(transitions.transition(
+        mgr, run, {"outcome": "plan_needed", "summary": "s"}, None))
+    assert "DEVCAKE-SKIP" in m.labels
+    assert "decomposed" in run.verdict
+    assert "human_needed" in run.verdict
+    assert "only decomposed is legal" not in run.verdict
+
+
 def test_apply_health_and_latch_noop_for_unregistered_repo():
     """Audit A29 (resurrection race): a probe or finalize latch completing
     AFTER a rebuild/delete removed the repo must not re-create health or


### PR DESCRIPTION
## Intent

Pre-FOSS audit of finalize / transitions / completion / steps / legal outcomes, then fix real defects with red→green tests at public seams.

## Findings fixed

1. **Correctness / stranding — `plan_needed` + `plan_md` attach path** (`transitions.transition`)
   - The `planned` path already skipped `upload_attachment` when `attachments_supported` is false and inlined the plan.
   - The opportunistic ONBOARD attach path always called `upload_attachment`. On GitHub Issues that raises, which is not a `ValueError`, so finalize does not classify it as `DEV_BAD_OUTPUT` and the run can sit in `finalizing` until the watchdog.
   - **Fix:** mirror the planned attach contract — skip upload when unsupported; on redelivery after a checkpointed upload, inline `plan_md` instead of a dead `[(see PLAN_n.md)]` link.

2. **Honesty — project park verdict** claimed “only decomposed is legal” while `human_needed` is also legal for projects (and has its own handler).

3. **Readability — `markers._SWAP_MARKER_STAGE` comment** still named the old `_transition` private; now names `transitions.transition`.

## Audit checklist (not changed — already sound)

| Area | Result |
|---|---|
| `complete_merged` chokepoint | Sole merge-completion path; review + sweeps call it |
| Checkpoint keys | All in-scope producers resolve through `steps.py`; structure guards green |
| `LEGAL_OUTCOMES` ↔ entrypoint pin | Honest (STEWARD entrypoint-only) |
| Pre-v1 `executed_trivially` | Parks as illegal (existing test) |
| `TRANSITION_UNKNOWN_PARK` else | Defense-in-depth if `LEGAL_OUTCOMES` gains a row without a handler — left |

## How to verify

```bash
# fresh bake then pytest (or equivalent: docker build -f app/Dockerfile --target test …)
./scripts/pytest_app.sh app/tests/test_transitions.py app/tests/test_completion.py \
  app/tests/test_steps_registry.py app/tests/test_legal_outcomes_pin.py \
  app/tests/test_structure_guards.py
```

Observed: **180 passed** (targeted) and **276 passed** with multi-instance + token-report suites.

## Risk

Low — attach path behavior now matches the already-shipped `planned` path. No schema / record format change.

## Out of scope (per mission)

Dispatch/RunBootstrap, failure_taxonomy/watchdog/reconcile, review/freshness modules, decomposition, steward, SPA, adapters.

## Mission

https://linear.app/fidecastro/issue/CAKE-14/pre-foss-finalize-transitions-completion-steps-and-legal-outcomes