### PR TITLE
[CAKE-25] Launch matrix: dialects, Bake targets, hermetic captures, Bake-only path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
             -e REDIS_PASSWORD=ci-redis-pass \
             -v "${{ github.workspace }}/images/common:/srv/images/common:ro" \
             -v "${{ github.workspace }}/images/hello:/srv/images/hello:ro" \
+            -v "${{ github.workspace }}/images:/srv/images-tree:ro" \
+            -v "${{ github.workspace }}/docker-compose.yml:/srv/docker-compose.yml:ro" \
             -v "${{ github.workspace }}/docker-bake.hcl:/srv/docker-bake.hcl:ro" \
             -v "${{ github.workspace }}/.github/workflows/docker-publish.yml:/srv/docker-publish.yml:ro" \
             -v "${{ github.workspace }}/dagu/dags:/srv/dagu-dags:ro" \

--- a/app/tests/test_harness.py
+++ b/app/tests/test_harness.py
@@ -34,7 +34,8 @@ def test_every_registry_template_is_pinnable_and_not_experimental():
     from devcake.house_pins import HOUSE_PINS, LAUNCH_SUPPORTED
 
     assert LAUNCH_SUPPORTED == frozenset(HOUSE_PINS)
-    # Keep-set / baker allowlist and registry ids are one set — no drift.
+    # Launch identity is split (HARNESSES vs HOUSE_PINS) but the key sets must
+    # not drift — staffing/bake pin off HOUSE_PINS; image metadata is HARNESSES.
     assert set(HARNESSES) == set(HOUSE_PINS)
     payload = run_coro(list_harnesses())
     assert set(payload) == set(HARNESSES)

--- a/app/tests/test_harness_captures.py
+++ b/app/tests/test_harness_captures.py
@@ -163,14 +163,16 @@ CRASH = (None, 10, "DEV_CRASH")
 # (capture, intended verdict). Comments record WHY a row is what it is, and in
 # particular which predicate arm each one keeps honest.
 CAPTURES = [
-    # ── claude-code 2.1.210 — the conservatism baseline ──────────────────────
+    # ── claude-code house 2.1.229 — the conservatism baseline ───────────────
+    # Rig-covered rows (healthy/refusal/resume) recaptured at 2.1.229. Pre-sidecar
+    # empty/fault streams still grade the same structural arms (test_entrypoint_fault).
     # The arm that must NEVER fire. A refusal is protocol-identical to a healthy
     # run (same subtype, same terminal_reason, only shorter text), which is why
     # empty_completion has to be structural.
     ("claude_healthy", NO_FAULT),
     ("claude_refusal", NO_FAULT),
 
-    # ── codex-cli 0.146.0 (0.147.0 bump: rig re-run, streams measured
+    # ── codex-cli house 0.147.0 (recaptured from 0.146.0; streams measured
     #    shape-identical — fixtures keep their recorded truth) ───────────────
     # Reaches empty_completion only because error items are bucketed apart from
     # tool activity: with `-m` naming a model the backend does not advertise,
@@ -250,22 +252,25 @@ CAPTURES = [
     # leg's session. Every leg exits 0 with no fault (the stub writes no
     # result.json, so all six still land exit 11 — the row-9 shape ADR-0022's
     # loop takes over). What each pair PROVES, and what RESUME_SPECS encodes:
-    #   grok 0.2.117:  `-p P -r SID` composes headless; the resumed `end` event
-    #     carries the SAME sessionId (no fork), no history replay in stdout,
-    #     usage/num_turns are PER-INVOCATION (leg 2 reports 1 turn, one call's
-    #     tokens) → usage_cumulative=False. Version drift note: 0.2.117 says
-    #     stopReason "end_turn" where the 0.2.112 captures say "EndTurn", and
-    #     adds available_commands/usage event types — nothing branches on
-    #     either (GROK_FAULT_STOP_REASONS is empty by design; unknown event
-    #     types are skipped), the docs/08 unpinned-CLI caveat in action.
+    # Only claude/codex/grok are in RESUME_SPECS; pi/opencode/qwen-code skip
+    # the probe resume row until a capture pair lands (matrix.py).
+    #   grok resume pair captured at 0.2.117 (house pin remains 0.2.112):
+    #     `-p P -r SID` composes headless; the resumed `end` event carries the
+    #     SAME sessionId (no fork), no history replay in stdout, usage/num_turns
+    #     are PER-INVOCATION (leg 2 reports 1 turn, one call's tokens) →
+    #     usage_cumulative=False. Version drift note: 0.2.117 says stopReason
+    #     "end_turn" where the 0.2.112 captures say "EndTurn", and adds
+    #     available_commands/usage event types — nothing branches on either
+    #     (GROK_FAULT_STOP_REASONS is empty by design; unknown event types are
+    #     skipped), the docs/08 unpinned-CLI caveat in action.
     ("grok_resume_nudge", NO_FAULT),
     ("grok_resume_nudge_resume", NO_FAULT),
-    #   claude 2.1.210: `-p P --resume SID` composes headless; same session_id
-    #     on the resumed result event, no replay, per-invocation usage
-    #     → usage_cumulative=False.
+    #   claude house 2.1.229: `-p P --resume SID` composes headless; same
+    #     session_id on the resumed result event, no replay, per-invocation
+    #     usage → usage_cumulative=False.
     ("claude_resume_nudge", NO_FAULT),
     ("claude_resume_nudge_resume", NO_FAULT),
-    #   codex 0.146.0: `exec resume THREAD P` composes headless; same
+    #   codex house 0.147.0: `exec resume THREAD P` composes headless; same
     #     thread_id, no replay, and usage is CUMULATIVE over the session —
     #     leg 2's turn.completed reports input 240/output 48, both calls'
     #     worth (docs/08 §5's `codex exec resume` caveat, now measured)
@@ -273,7 +278,7 @@ CAPTURES = [
     ("codex_resume_nudge", NO_FAULT),
     ("codex_resume_nudge_resume", NO_FAULT),
 
-    # ── pi 0.84.2 (`@earendil-works/pi-coding-agent`, --mode json) ──────────
+    # ── pi house 0.84.2 (`@earendil-works/pi-coding-agent`, --mode json) ────
     # Pi exits 0 even on HTTP 401/429/500: the failure is `stopReason: error`
     # + `errorMessage: "401: …"` on the assistant message, then `agent_end`.
     # Auth still latches 12 via in-band status (same precedence as nonzero).
@@ -287,7 +292,7 @@ CAPTURES = [
     ("pi_http_500", TERMINAL),
     ("pi_truncated", TERMINAL),          # errorMessage "terminated" after stub hang-up
 
-    # ── opencode 1.18.18 (`opencode run --format json --auto`) ────────────
+    # ── opencode house 1.18.18 (`opencode run --format json --auto`) ──────
     # HTTP errors exit 1 and carry APIError.data.statusCode. 401 latches 12.
     ("opencode_healthy", NO_FAULT),
     ("opencode_refusal", NO_FAULT),
@@ -299,7 +304,7 @@ CAPTURES = [
     ("opencode_http_500", TERMINAL),
     ("opencode_truncated", TERMINAL),
 
-    # ── qwen-code 0.21.12 (`qwen -p --output-format stream-json --yolo`) ──
+    # ── qwen-code house 0.21.12 (`qwen -p --output-format stream-json --yolo`)
     # Stream is Claude-shaped (system/init, assistant, result). HTTP and
     # empty completions are wrapped as assistant `[API Error: …]` with
     # subtype=success / is_error=false / exit 0 — so the predicate must

--- a/app/tests/test_harness_dialect.py
+++ b/app/tests/test_harness_dialect.py
@@ -38,6 +38,19 @@ _PUBLISH_CANDIDATES = [
 ]
 PUBLISH = next((p for p in _PUBLISH_CANDIDATES if p.exists()), None)
 
+_COMPOSE_CANDIDATES = [
+    Path(__file__).resolve().parents[2] / "docker-compose.yml",
+    Path("/srv/docker-compose.yml"),
+]
+COMPOSE = next((p for p in _COMPOSE_CANDIDATES if p.is_file()), None)
+
+# Full images/ tree (not only common/hello binds) — Bake-only path.
+_IMAGES_TREE_CANDIDATES = [
+    Path(__file__).resolve().parents[2] / "images",
+    Path("/srv/images-tree"),
+]
+IMAGES_TREE = next((p for p in _IMAGES_TREE_CANDIDATES if p.is_dir()), None)
+
 
 def _dialects():
     assert COMMON is not None, (
@@ -116,4 +129,33 @@ def test_images_common_has_no_harness_identity_branch():
                 offenders.append(f"{rel}:{node.lineno} .get(harness, default)")
     assert not offenders, (
         "identity branching leaked out of dialects.py (docs/16 H1):\n  "
+        + "\n  ".join(offenders))
+
+
+def test_compose_never_builds_devcake_images():
+    """Bake-only: compose may pull/run third-party images, never build devcake/*."""
+    assert COMPOSE is not None, (
+        "docker-compose.yml missing — bind it at /srv/docker-compose.yml")
+    text = COMPOSE.read_text()
+    # No compose `build:` key at all today; if one appears later it must not
+    # target a DevCake image (app / admin / dev-*). Hard fail on any build: —
+    # resurrecting compose-built DevCake images is the regression this guards.
+    assert re.search(r"(?m)^\s*build\s*:", text) is None, (
+        "docker-compose.yml must not build images — use docker buildx bake "
+        "(AGENTS.md / docs/13)")
+
+
+def test_no_per_harness_dockerfile_under_images():
+    """Single multi-target images/Dockerfile — no images/<harness>/Dockerfile."""
+    assert IMAGES_TREE is not None, (
+        "images/ tree missing — bind it at /srv/images-tree")
+    root_dockerfile = IMAGES_TREE / "Dockerfile"
+    assert root_dockerfile.is_file(), "images/Dockerfile is the only allowed Dockerfile"
+    offenders = sorted(
+        p.relative_to(IMAGES_TREE).as_posix()
+        for p in IMAGES_TREE.rglob("Dockerfile")
+        if p.resolve() != root_dockerfile.resolve()
+    )
+    assert not offenders, (
+        "per-harness Dockerfiles are forbidden (Bake multi-target only):\n  "
         + "\n  ".join(offenders))

--- a/app/tests/test_harness_probe.py
+++ b/app/tests/test_harness_probe.py
@@ -117,9 +117,10 @@ def test_matching_observation_passes_the_row_and_the_receipt():
 def test_every_house_pin_has_the_same_probe_rows():
     """Compile+probe grades the same five names for every registry template."""
     _load_probe()
-    from harness_probe.matrix import matrix_for
+    from harness_probe.matrix import matrix_for, matrix_templates
     from devcake.house_pins import HOUSE_PINS
 
+    assert matrix_templates() == frozenset(HOUSE_PINS)
     names = ("healthy", "http_401", "empty", "plan_mode", "resume")
     for template in HOUSE_PINS:
         got = tuple(spec.name for spec in matrix_for(template))
@@ -128,6 +129,21 @@ def test_every_house_pin_has_the_same_probe_rows():
         assert by["healthy"].required is True
         assert by["empty"].required is True
         assert by["plan_mode"].required is True
+
+
+def test_intentional_probe_skips_stay_visible_and_non_required():
+    """Matrix honesty: optional rows must not silently pass as required."""
+    _load_probe()
+    from harness_probe.matrix import matrix_for
+
+    claude = {s.name: s for s in matrix_for("claude-code")}
+    assert claude["http_401"].required is False
+    assert "claude_http_401" in claude["http_401"].skip_reason
+
+    for template in ("pi", "opencode", "qwen-code"):
+        resume = {s.name: s for s in matrix_for(template)}["resume"]
+        assert resume.required is False, template
+        assert "RESUME_SPECS" in resume.skip_reason, template
 
 
 def test_loader_refuses_the_working_tree_entrypoint(tmp_path):

--- a/docs/08-harness-templates.md
+++ b/docs/08-harness-templates.md
@@ -37,6 +37,17 @@ invent `devcake/dev-*` refs. `DevType.cli_version` accepts a stored
 semver on every template (empty = house ARG). Hello is not a harness
 template and is not gated.
 
+The probe matrix names the same five rows for every template (`healthy`,
+`http_401`, `empty`, `plan_mode`, `resume`). Required rows grade live against
+the stub; optional rows skip with a visible `skip_reason` — not a silent pass.
+Today those skips are: `claude-code` `http_401` (no committed
+`claude_http_401` capture; Claude has never been stub-driven in a failure
+scenario) and `pi` / `opencode` / `qwen-code` `resume` (not in `RESUME_SPECS`
+until a `<id>_resume_nudge` capture pair lands). Dev images remain **Bake-only**
+(`docker buildx bake` / group `images`); compose never builds `devcake/*`, and
+there is no per-harness Dockerfile under `images/<harness>/` — only the
+multi-target `images/Dockerfile`.
+
 Each template defines: base image, invocation pattern, plan-mode mapping, credential modes, MCP registration syntax, transcript source, and token-extraction strategy.
 
 > **Version-currency doctrine (founder, 2026-08-04).** DevCake follows the

--- a/scripts/ci_suite.sh
+++ b/scripts/ci_suite.sh
@@ -62,6 +62,8 @@ docker run --rm \
   -e "REDIS_PASSWORD=${REDIS_PASSWORD}" \
   -v "$(pwd)/images/common:/srv/images/common:ro" \
   -v "$(pwd)/images/hello:/srv/images/hello:ro" \
+  -v "$(pwd)/images:/srv/images-tree:ro" \
+  -v "$(pwd)/docker-compose.yml:/srv/docker-compose.yml:ro" \
   -v "$(pwd)/docker-bake.hcl:/srv/docker-bake.hcl:ro" \
   -v "$(pwd)/.github/workflows/docker-publish.yml:/srv/docker-publish.yml:ro" \
   -v "$(pwd)/dagu/dags:/srv/dagu-dags:ro" \

--- a/scripts/harness_probe/matrix.py
+++ b/scripts/harness_probe/matrix.py
@@ -92,6 +92,11 @@ _MATRIX: dict[str, tuple[RowSpec, ...]] = {
 }
 
 
+def matrix_templates() -> frozenset[str]:
+    """Ids that have a probe matrix row set — must equal HOUSE_PINS keys."""
+    return frozenset(_MATRIX)
+
+
 def matrix_for(template: str) -> tuple[RowSpec, ...]:
     try:
         return _MATRIX[template]

--- a/scripts/pytest_app.sh
+++ b/scripts/pytest_app.sh
@@ -65,6 +65,8 @@ docker run --rm \
   "${ENV_ARGS[@]}" \
   -v "$(pwd)/images/common:/srv/images/common:ro" \
   -v "$(pwd)/images/hello:/srv/images/hello:ro" \
+  -v "$(pwd)/images:/srv/images-tree:ro" \
+  -v "$(pwd)/docker-compose.yml:/srv/docker-compose.yml:ro" \
   -v "$(pwd)/docker-bake.hcl:/srv/docker-bake.hcl:ro" \
   -v "$(pwd)/.github/workflows/docker-publish.yml:/srv/docker-publish.yml:ro" \
   -v "$(pwd)/dagu/dags:/srv/dagu-dags:ro" \


### PR DESCRIPTION
## Intent

Make the launch-matrix claim honest and regression-proof: every **launch-supported** harness has dialect + Bake target + hermetic probe/capture coverage (or documented non-required skips), and Dev images stay **Bake-only**.

Mission: https://linear.app/fidecastro/issue/CAKE-25/launch-matrix-dialects-bake-targets-hermetic-captures-bake-only-path

## What changed

Audit found the six `HOUSE_PINS` templates already wired (dialect, Bake `images` targets, multi-target `images/Dockerfile`, probe rows, capture fixtures). This PR closes the honesty gaps rather than scaffolding greenfield:

| Change | Why |
|---|---|
| `set(HARNESSES) == set(HOUSE_PINS)` ratchet | Launch identity is split; keys must not drift |
| `matrix_templates() == HOUSE_PINS` + visible skip tests | Probe matrix must match launch set; optional rows stay non-required |
| Compose `build:` ban + no `images/<harness>/Dockerfile` | Bake-only structure guards (plan §4) |
| Bind `docker-compose.yml` + `images/` into app-test runners | Guards hard-fail when mounts missing |
| CAPTURES comments + `docs/08` | House pins and intentional skips (`claude` http_401; pi/opencode/qwen resume) named explicitly |

## How to verify

```bash
./scripts/pytest_app.sh \
  app/tests/test_harness_dialect.py \
  app/tests/test_harness_cli_pins.py \
  app/tests/test_harness_probe.py \
  app/tests/test_harness_captures.py \
  app/tests/test_harness_capture_rig.py \
  app/tests/test_harness.py
```

Evidence from this run: `PYTHONPATH=app` on Python 3.12 — **192 passed** for those modules (Podman host lacks `docker buildx bake`; no image Dockerfile/dialect path changed, so image bake was not required).

## Intentional non-required probe rows (unchanged product policy)

- `claude-code` `http_401` — no committed `claude_http_401` capture
- `pi` / `opencode` / `qwen-code` `resume` — not in `RESUME_SPECS` until capture pairs land

## Out of scope

- Staffing/receipt greenwash (`gated` field) — sibling surface
- Entrypoint legal-outcome / finalize redesign
- New vendors or full H5 scaffold redesign
- Greenfield resume/401 capture work (would prefer overclaims corrected)