### PR TITLE
[CAKE-24] App harness registry, pins, staffing, and receipt-gate honesty

### DIFF
--- a/app/devcake/harness.py
+++ b/app/devcake/harness.py
@@ -134,10 +134,14 @@ def resolve_image(dev_type) -> str:
     Empty pin and a stored house pin both name :TAG (keep-set only
     records the effective version). A different stored pin is
     :TAG-cli_version. Hello stays HELLO_IMAGE.
+
+    Unknown harness_template raises — never invents an image ref.
     """
     from .house_pins import effective_cli_version, image_ref
-    return image_ref(
-        dev_type.harness_template, effective_cli_version(dev_type), tag=_TAG)
+    template = dev_type.harness_template
+    if template not in HARNESSES:
+        raise ValueError(f"unknown harness template: {template!r}")
+    return image_ref(template, effective_cli_version(dev_type), tag=_TAG)
 
 
 def missing_referenced_secret_env(dt) -> list[str]:

--- a/app/devcake/house_pins.py
+++ b/app/devcake/house_pins.py
@@ -52,7 +52,10 @@ def effective_cli_version(dev_type) -> str:
     pin = (getattr(dev_type, "cli_version", "") or "").strip()
     if pin:
         return pin
-    return HOUSE_PINS.get(dev_type.harness_template, "")
+    template = dev_type.harness_template
+    if template not in HOUSE_PINS:
+        raise ValueError(f"unknown harness template: {template!r}")
+    return HOUSE_PINS[template]
 
 
 def image_ref(template: str, cli_version: str, *, tag: str | None = None) -> str:
@@ -60,9 +63,12 @@ def image_ref(template: str, cli_version: str, *, tag: str | None = None) -> str
 
     Keep-set records effective versions, so the baker cannot tell a typed
     house pin from an empty field. Both must name the same image.
+    Unknown templates refuse — never invent devcake/dev-{unknown}:….
     """
+    if template not in HOUSE_PINS:
+        raise ValueError(f"unknown harness template: {template!r}")
     tag = tag if tag is not None else os.environ.get("DEVCAKE_TAG", "latest")
     pin = (cli_version or "").strip()
-    if not pin or pin == HOUSE_PINS.get(template, ""):
+    if not pin or pin == HOUSE_PINS[template]:
         return f"devcake/dev-{template}:{tag}"
     return f"devcake/dev-{template}:{tag}-{pin}"

--- a/app/devcake/staffing.py
+++ b/app/devcake/staffing.py
@@ -34,9 +34,9 @@ def require_staffed(dev_type, *, digest: str | None = None,
     """Raise HarnessNotStaffed unless a matching ok receipt exists."""
     if baker_alive is None:
         from .bake_status import baker_liveness, read_bake_status
-        status = read_bake_status()
-        if status.get("heartbeat_at"):
-            baker_alive = bool(baker_liveness(status).get("alive"))
+        # Always evaluate liveness. Missing/never-checked-in heartbeat is
+        # dead (baker_liveness already says so) — do not skip and staff.
+        baker_alive = bool(baker_liveness(read_bake_status()).get("alive"))
     if baker_alive is False:
         raise HarnessNotStaffed(
             "host baker is not running — cannot vouch for images",
@@ -56,7 +56,8 @@ def require_staffed(dev_type, *, digest: str | None = None,
     if rec is None:
         raise HarnessNotStaffed(
             f"no receipt for {template} {version}", kind="missing")
-    if rec.get("gated") is False:
+    # gated must be True — absence or null is fabricated (fail-closed).
+    if rec.get("gated") is not True:
         raise HarnessNotStaffed(
             f"{template} {version} receipt is not gated", kind="fabricated")
     if rec.get("ok") is True:

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -2,13 +2,44 @@
 
 Production images default to DEVCAKE_APP_DIGEST_UNSET (bare bake). Tests
 that want the sentinel pass it explicitly to require_staffed / monkeypatch.
+
+Staffing is fail-closed on baker liveness. Integration tests that are not
+about the baker get baker_alive=True by default via a require_staffed wrap;
+death tests call REAL_REQUIRE_STAFFED or pass baker_alive=False.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from devcake import staffing as _staffing_mod
+
+# Unwrapped production seam — death tests call this directly.
+REAL_REQUIRE_STAFFED = _staffing_mod.require_staffed
+
 
 @pytest.fixture(autouse=True)
 def _non_sentinel_app_digest(monkeypatch):
     monkeypatch.setenv("DEVCAKE_APP_DIGEST", "sha256:test")
+
+
+@pytest.fixture(autouse=True)
+def _default_live_baker_for_staffing(monkeypatch):
+    """Dispatch/OAuth/steward integration paths omit baker_alive; without a
+    host baker heartbeat they would all refuse. Default None → True here.
+    baker_liveness itself is not stubbed (bake_status / health tests need it).
+    """
+
+    def _wrapped(dev_type, *, digest=None, store, baker_alive=None):
+        if baker_alive is None:
+            baker_alive = True
+        return REAL_REQUIRE_STAFFED(
+            dev_type, digest=digest, store=store, baker_alive=baker_alive)
+
+    monkeypatch.setattr(_staffing_mod, "require_staffed", _wrapped)
+    monkeypatch.setattr(
+        "devcake.domain.orchestrator.dispatch.require_staffed", _wrapped)
+    monkeypatch.setattr(
+        "devcake.domain.orchestrator.steward.require_staffed", _wrapped)
+    monkeypatch.setattr(
+        "devcake.domain.oauth.require_staffed", _wrapped)

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -120,12 +120,12 @@ class FakeInternalForge:
 
 
 class OkReceiptStore:
-    """Test double: every lookup is an ok receipt. Production uses FileReceiptStore."""
+    """Test double: every lookup is an ok gated receipt. Production uses FileReceiptStore."""
 
     def get(self, *, digest, template, cli_version):
         return {"digest": digest, "template": template,
-                "cli_version": cli_version, "ok": True, "rows": []}
-
+                "cli_version": cli_version, "ok": True, "gated": True,
+                "rows": []}
 
 def make_mission_manager(
     tmp_path: Path | None = None,

--- a/app/tests/test_cli_version.py
+++ b/app/tests/test_cli_version.py
@@ -66,9 +66,8 @@ def test_staffing_looks_up_the_stored_pin_not_the_house_arg():
                  cli_version="1.0.4")
     store = Store()
     with pytest.raises(HarnessNotStaffed, match="1.0.4"):
-        require_staffed(dt, digest="sha256:abc", store=store)
+        require_staffed(dt, digest="sha256:abc", store=store, baker_alive=True)
     assert store.asked == ("sha256:abc", "grok-build", "1.0.4")
-
 
 def test_keep_set_records_concrete_pins(tmp_path):
     from devcake.keep_set import publish_keep_set

--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -209,8 +209,8 @@ def test_ok_receipt_for_a_gone_image_is_dropped_and_the_pin_rebakes(tmp_path):
         require_staffed(
             DevType(name="d", harness_template="grok-build"),
             digest="sha256:abc",
-            store=FileReceiptStore(receipts))
-
+            store=FileReceiptStore(receipts),
+            baker_alive=True)
 
 def test_receipt_stays_when_the_named_image_is_still_local(tmp_path):
     factory = _load_factory()

--- a/app/tests/test_harness.py
+++ b/app/tests/test_harness.py
@@ -44,6 +44,25 @@ def test_every_registry_template_is_pinnable_and_not_experimental():
         assert payload[name]["cli_pin_allowed"] is True
 
 
+def test_harness_matrix_is_one_set_of_template_ids():
+    """HARNESSES, HOUSE_PINS, LAUNCH_SUPPORTED, and pin maps share one key set.
+
+    Independent expected: set equality across the hand tables — not a
+    recomputed join of production helpers.
+    """
+    from devcake.house_pins import (
+        DOCKERFILE_ARG,
+        HOUSE_PINS,
+        LAUNCH_SUPPORTED,
+        PACKAGE_IDS,
+    )
+
+    keys = set(HARNESSES)
+    assert set(HOUSE_PINS) == keys
+    assert set(LAUNCH_SUPPORTED) == keys
+    assert set(PACKAGE_IDS) == keys
+    assert set(DOCKERFILE_ARG) == keys
+
 def test_dev_type_status_credentials_ready(monkeypatch, tmp_path):
     """Overview 'Devs' card (v0.1.1 B3): readiness is server-computed —
     any ONE of the harness's env keys in the store, or any credential file

--- a/app/tests/test_harness_probe.py
+++ b/app/tests/test_harness_probe.py
@@ -110,7 +110,9 @@ def test_matching_observation_passes_the_row_and_the_receipt():
     assert row["expected"] == GROK_401
     assert row["observed"] == GROK_401
     assert rec["ok"] is True
-
+    # Host receipts must stamp gated so app staffing cannot green-wash
+    # a fabricated {ok: True} without the probe path.
+    assert rec["gated"] is True
 
 def test_every_house_pin_has_the_same_probe_rows():
     """Compile+probe grades the same five names for every registry template."""

--- a/app/tests/test_health_payload.py
+++ b/app/tests/test_health_payload.py
@@ -84,7 +84,7 @@ def test_health_exposes_digest_and_receipt_summary(monkeypatch):
     class Store:
         def get(self, **kw):
             if kw["template"] == "grok-build":
-                return {"ok": True, "digest": "sha256:abc"}
+                return {"ok": True, "gated": True, "digest": "sha256:abc"}
             return None
 
     dts = {

--- a/app/tests/test_resolve_image.py
+++ b/app/tests/test_resolve_image.py
@@ -52,6 +52,21 @@ def test_resolve_image_empty_pin_is_todays_house_image():
     assert resolve_image(dt) == "devcake/dev-codex:latest"
 
 
+def test_resolve_image_refuses_unknown_template():
+    """No silent invent of devcake/dev-not-a-harness:… for unregistered ids."""
+    from types import SimpleNamespace
+
+    import pytest
+
+    from devcake.harness import resolve_image
+    from devcake.house_pins import image_ref
+
+    unknown = SimpleNamespace(harness_template="not-a-harness", cli_version="")
+    with pytest.raises(ValueError, match="unknown harness template"):
+        resolve_image(unknown)
+    with pytest.raises(ValueError, match="unknown harness template"):
+        image_ref("not-a-harness", "", tag="latest")
+
 def test_resolve_image_explicit_pin_is_tag_plus_version():
     """Two pins on one template must not share :TAG — that would collide."""
     from devcake.harness import resolve_image

--- a/app/tests/test_staffing.py
+++ b/app/tests/test_staffing.py
@@ -29,7 +29,8 @@ def test_sentinel_digest_names_the_wrapper_not_a_missing_receipt():
     with pytest.raises(HarnessNotStaffed, match="built without the bake wrapper") as exc:
         require_staffed(
             _dt(), digest=SENTINEL_DIGEST,
-            store=_Store({"ok": True, "digest": SENTINEL_DIGEST}))
+            store=_Store({"ok": True, "gated": True, "digest": SENTINEL_DIGEST}),
+            baker_alive=True)
     assert "no receipt" not in str(exc.value).lower()
 
 
@@ -37,7 +38,8 @@ def test_missing_receipt_refuses():
     from devcake.staffing import HarnessNotStaffed, require_staffed
 
     with pytest.raises(HarnessNotStaffed, match="no receipt"):
-        require_staffed(_dt(), digest="sha256:abc", store=_Store(None))
+        require_staffed(
+            _dt(), digest="sha256:abc", store=_Store(None), baker_alive=True)
 
 
 def test_ok_false_names_the_failing_required_row():
@@ -45,6 +47,7 @@ def test_ok_false_names_the_failing_required_row():
 
     rec = {
         "ok": False,
+        "gated": True,
         "digest": "sha256:abc",
         "rows": [
             {"name": "healthy", "required": True, "status": "pass"},
@@ -52,7 +55,8 @@ def test_ok_false_names_the_failing_required_row():
         ],
     }
     with pytest.raises(HarnessNotStaffed, match="http_401"):
-        require_staffed(_dt(), digest="sha256:abc", store=_Store(rec))
+        require_staffed(
+            _dt(), digest="sha256:abc", store=_Store(rec), baker_alive=True)
 
 
 def test_ok_false_lists_every_required_row_that_did_not_pass():
@@ -60,6 +64,7 @@ def test_ok_false_lists_every_required_row_that_did_not_pass():
 
     rec = {
         "ok": False,
+        "gated": True,
         "digest": "sha256:abc",
         "rows": [
             {"name": "healthy", "required": True, "status": "fail"},
@@ -69,7 +74,8 @@ def test_ok_false_lists_every_required_row_that_did_not_pass():
         ],
     }
     with pytest.raises(HarnessNotStaffed) as caught:
-        require_staffed(_dt(), digest="sha256:abc", store=_Store(rec))
+        require_staffed(
+            _dt(), digest="sha256:abc", store=_Store(rec), baker_alive=True)
     msg = str(caught.value)
     assert "healthy fail" in msg
     assert "resume error" in msg
@@ -84,12 +90,14 @@ def test_required_skip_and_error_are_not_ok():
     for status in ("skipped", "error"):
         rec = {
             "ok": False,
+            "gated": True,
             "digest": "sha256:abc",
             "rows": [{"name": "empty", "required": True, "status": status}],
         }
         with pytest.raises(HarnessNotStaffed, match="empty"):
-            require_staffed(_dt(), digest="sha256:abc", store=_Store(rec))
-
+            require_staffed(
+                _dt(), digest="sha256:abc", store=_Store(rec),
+                baker_alive=True)
 
 def test_dead_baker_refuses_even_with_an_ok_receipt():
     from devcake.staffing import HarnessNotStaffed, require_staffed
@@ -97,8 +105,27 @@ def test_dead_baker_refuses_even_with_an_ok_receipt():
     with pytest.raises(HarnessNotStaffed, match="cannot vouch") as exc:
         require_staffed(
             _dt(), digest="sha256:abc",
-            store=_Store({"ok": True, "digest": "sha256:abc"}),
+            store=_Store({"ok": True, "gated": True, "digest": "sha256:abc"}),
             baker_alive=False)
+    assert exc.value.kind == "baker"
+
+
+def test_absent_baker_heartbeat_refuses_even_with_ok_receipt(monkeypatch):
+    """Missing heartbeat is dead baker — not 'skip liveness and staff'."""
+    import devcake.bake_status as bs
+    from conftest import REAL_REQUIRE_STAFFED
+    from devcake.staffing import HarnessNotStaffed
+
+    monkeypatch.setattr(
+        bs, "read_bake_status",
+        lambda root=None: {"state": "idle", "jobs": [], "detail": ""},
+    )
+
+    with pytest.raises(HarnessNotStaffed, match="cannot vouch") as exc:
+        # Unwrapped seam: baker_alive stays None so production liveness runs.
+        REAL_REQUIRE_STAFFED(
+            _dt(), digest="sha256:abc",
+            store=_Store({"ok": True, "gated": True, "digest": "sha256:abc"}))
     assert exc.value.kind == "baker"
 
 
@@ -107,8 +134,23 @@ def test_ok_true_matching_digest_is_staffed():
 
     require_staffed(
         _dt(), digest="sha256:abc",
-        store=_Store({"ok": True, "digest": "sha256:abc"}))
+        store=_Store({"ok": True, "gated": True, "digest": "sha256:abc"}),
+        baker_alive=True)
 
+
+def test_receipt_without_gated_true_is_refused():
+    """Absence of gated (or null) is fabricated — not fail-open."""
+    from devcake.staffing import HarnessNotStaffed, require_staffed
+
+    for rec in (
+        {"ok": True, "digest": "sha256:abc"},
+        {"ok": True, "digest": "sha256:abc", "gated": None},
+    ):
+        with pytest.raises(HarnessNotStaffed, match="not gated") as exc:
+            require_staffed(
+                _dt(), digest="sha256:abc", store=_Store(rec),
+                baker_alive=True)
+        assert exc.value.kind == "fabricated"
 
 def test_oauth_does_not_launch_when_not_staffed(tmp_path, monkeypatch):
     import json
@@ -126,7 +168,7 @@ def test_oauth_does_not_launch_when_not_staffed(tmp_path, monkeypatch):
     rec_dir.mkdir()
     (rec_dir / "grok-build@0.2.112.json").write_text(json.dumps({
         "digest": "sha256:abc", "template": "grok-build",
-        "cli_version": "0.2.112", "ok": False,
+        "cli_version": "0.2.112", "ok": False, "gated": True,
         "rows": [{"name": "http_401", "required": True, "status": "fail"}],
     }))
     executor = FakeExecutor()
@@ -156,7 +198,7 @@ def test_steward_does_not_launch_when_not_staffed(tmp_path, monkeypatch):
     rec_dir = tmp_path / "harness_receipts"
     rec_dir.mkdir()
     (rec_dir / "grok-build@0.2.112.json").write_text(json.dumps({
-        "digest": "sha256:test", "ok": False,
+        "digest": "sha256:test", "ok": False, "gated": True,
         "rows": [{"name": "empty", "required": True, "status": "error"}],
     }))
     from test_oauth import FakeExecutor, NullMessaging
@@ -203,7 +245,8 @@ def test_fabricated_ungated_receipt_is_refused():
 
     rec = {"ok": True, "digest": "sha256:abc", "gated": False, "rows": []}
     with pytest.raises(HarnessNotStaffed, match="not gated"):
-        require_staffed(_dt(), digest="sha256:abc", store=_Store(rec))
+        require_staffed(
+            _dt(), digest="sha256:abc", store=_Store(rec), baker_alive=True)
 
 
 def test_every_registry_template_is_gated_the_same_way():
@@ -214,8 +257,8 @@ def test_every_registry_template_is_gated_the_same_way():
     for template in HARNESSES:
         with pytest.raises(HarnessNotStaffed, match="no receipt"):
             require_staffed(
-                _dt(template), digest="sha256:abc", store=_Store(None))
-
+                _dt(template), digest="sha256:abc", store=_Store(None),
+                baker_alive=True)
 
 def test_pin_summary_has_no_host_command():
     """The host baker watches the keep-set. SPA must not assign terminal homework."""

--- a/docs/08-harness-templates.md
+++ b/docs/08-harness-templates.md
@@ -27,9 +27,15 @@ Changing a Dev Type's model does not add a template.
 
 Every registry template is **launch-supported**. The bake verb is the same
 for all six: compile the image, run the hermetic probe matrix, write a
-receipt. Staffing is fail-closed on that receipt. `DevType.cli_version`
-accepts a stored semver on every template (empty = house ARG). Hello is
-not a harness template and is not gated.
+receipt. Staffing (`require_staffed`) is fail-closed: missing receipt,
+`ok` not true, `gated` not true (host `compile_receipt` stamps
+`gated: true`), sentinel app digest, or a dead/never-checked-in host
+baker all refuse launch. `HARNESSES`, `HOUSE_PINS` / `LAUNCH_SUPPORTED`,
+and pin maps are one template-id matrix (ratchet-tested).
+`resolve_image` / `image_ref` refuse unknown templates — they do not
+invent `devcake/dev-*` refs. `DevType.cli_version` accepts a stored
+semver on every template (empty = house ARG). Hello is not a harness
+template and is not gated.
 
 Each template defines: base image, invocation pattern, plan-mode mapping, credential modes, MCP registration syntax, transcript source, and token-extraction strategy.
 

--- a/scripts/harness_probe/receipt.py
+++ b/scripts/harness_probe/receipt.py
@@ -35,8 +35,10 @@ def compile_receipt(
         "cli_version": cli_version,
         "rows": rows,
         "ok": _ok(specs, rows),
+        # App staffing requires gated is True (fail-closed on absence).
+        # Host compile path is the only honest producer of that stamp.
+        "gated": True,
     }
-
 
 def receipt_ok(receipt: Mapping[str, Any]) -> bool:
     """Reader-side: required matrix rows must be present and status==pass."""


### PR DESCRIPTION
## Summary

Close app-side harness chokepoint honesty gaps so staffing/receipt/pin gates cannot green-wash without real, gated receipts and a live baker, and so image resolution refuses unknown templates.

### Changes
- **Baker fail-closed:** `require_staffed` always evaluates `baker_liveness` when `baker_alive` is omitted; missing/never-checked-in heartbeat refuses (kind `baker`).
- **`gated` fail-closed:** staffing requires `gated is True` (absence/null refuses as fabricated). Host `compile_receipt` stamps `"gated": true`.
- **One matrix ratchet:** test asserts `set(HARNESSES) == set(HOUSE_PINS) == set(LAUNCH_SUPPORTED) == set(PACKAGE_IDS) == set(DOCKERFILE_ARG)`.
- **Honest image refs:** `resolve_image` / `image_ref` raise on unknown harness templates (no invented `devcake/dev-*` strings).
- **Docs:** `docs/08-harness-templates.md` fail-closed / matrix seam wording.

### Tests
- New/updated public-seam tests in `test_staffing`, `test_harness`, `test_resolve_image`, `test_harness_probe`.
- Local proof: `PYTHONPATH=app` on Python 3.12 — focused suite green; full suite minus env-only mount/redis tests: 2272 passed (6 env failures: `/data` perms, redis ACL — not this change).

## Mission
https://linear.app/fidecastro/issue/CAKE-24/app-harness-registry-pins-staffing-and-receipt-gate-honesty