### PR TITLE
[CAKE-22] [pre-FOSS] Secondary ports and infrastructure adapters audit + fix

### DIFF
--- a/app/devcake/adapters/dagu/__init__.py
+++ b/app/devcake/adapters/dagu/__init__.py
@@ -1,3 +1,3 @@
-from .executor import DAGU_URL, DaguExecutor, DuplicateRun
+from .executor import DAGU_URL, DaguExecutor, DuplicateRun, ExecutorError
 
-__all__ = ["DAGU_URL", "DaguExecutor", "DuplicateRun"]
+__all__ = ["DAGU_URL", "DaguExecutor", "DuplicateRun", "ExecutorError"]

--- a/app/devcake/adapters/dagu/executor.py
+++ b/app/devcake/adapters/dagu/executor.py
@@ -1,4 +1,8 @@
-"""ExecutorPort implementation: Dagu REST API (docs/13 §4 — endpoints verified live)."""
+"""ExecutorPort implementation: Dagu REST API (docs/13 §4 — endpoints verified live).
+
+Wire failures surface as ports.executor.ExecutorError / DuplicateRun —
+never raw httpx types (same contract as forge_request / ForgeError).
+"""
 
 import json
 import logging
@@ -7,15 +11,18 @@ from typing import Any, Optional
 
 import httpx
 
+from ...ports.executor import DuplicateRun, ExecutorError
+
 log = logging.getLogger("devcake.dagu")
 
 DAGU_URL = os.environ.get("DAGU_URL", "http://dagu:8080")
 DAG_NAME = "dev-run"
 _AUTH = (os.environ.get("DAGU_USER", ""), os.environ.get("DAGU_PASSWORD", ""))
 
-
-class DuplicateRun(Exception):
-    """Dagu returned 409 already_exists for this dagRunId."""
+# Re-export so `from adapters.dagu import DuplicateRun` keeps working for
+# composition-root and API call sites that already import the adapter package.
+__all__ = ["DAGU_URL", "DAG_NAME", "DaguExecutor", "DuplicateRun", "ExecutorError",
+           "extract_node_errors"]
 
 
 def extract_node_errors(status: Optional[dict]) -> list[dict[str, str]]:
@@ -34,6 +41,16 @@ def extract_node_errors(status: Optional[dict]) -> list[dict[str, str]]:
     return out
 
 
+def _raise_for_status(resp: httpx.Response, *, what: str) -> None:
+    """Map non-2xx to ExecutorError without leaking HTTPStatusError."""
+    if resp.status_code < 400:
+        return
+    raise ExecutorError(
+        f"dagu {what} → {resp.status_code}: {resp.text[:200]}",
+        status=resp.status_code,
+    )
+
+
 class DaguExecutor:
     def __init__(
         self,
@@ -50,30 +67,42 @@ class DaguExecutor:
         return httpx.AsyncClient(
             timeout=timeout, auth=self._auth, transport=self._transport)
 
+    async def _request(self, method: str, path: str, *, timeout: float = 10,
+                       **kwargs) -> httpx.Response:
+        """One Dagu call; network failures → ExecutorError(status=None)."""
+        try:
+            async with self._client(timeout) as client:
+                return await client.request(method, f"{self.base}{path}", **kwargs)
+        except httpx.HTTPError as e:
+            raise ExecutorError(
+                f"dagu {method} {path} → network: {e}", status=None) from e
+
     async def start(self, params: dict[str, str], dag_run_id: str) -> None:
-        async with self._client(10) as client:
-            resp = await client.post(
-                f"{self.base}/api/v1/dags/{DAG_NAME}/start",
-                json={"params": json.dumps(params), "dagRunId": dag_run_id},
-            )
-            if resp.status_code == 409:
-                raise DuplicateRun(dag_run_id)
-            resp.raise_for_status()
+        resp = await self._request(
+            "POST", f"/api/v1/dags/{DAG_NAME}/start",
+            json={"params": json.dumps(params), "dagRunId": dag_run_id},
+        )
+        if resp.status_code == 409:
+            raise DuplicateRun(dag_run_id)
+        _raise_for_status(resp, what=f"start {dag_run_id}")
 
     async def stop(self, dag_run_id: str) -> bool:
-        async with self._client(10) as client:
-            resp = await client.post(
-                f"{self.base}/api/v1/dag-runs/{DAG_NAME}/{dag_run_id}/stop"
-            )
-            return resp.status_code < 300
+        # bool-success contract: network/HTTP failures report False so kill
+        # paths can continue teardown without catching wire types.
+        try:
+            resp = await self._request(
+                "POST", f"/api/v1/dag-runs/{DAG_NAME}/{dag_run_id}/stop")
+        except ExecutorError:
+            return False
+        return resp.status_code < 300
 
     async def status(self, dag_run_id: str) -> Optional[dict[str, Any]]:
-        async with self._client(10) as client:
-            resp = await client.get(f"{self.base}/api/v1/dag-runs/{DAG_NAME}/{dag_run_id}")
-            if resp.status_code == 404:
-                return None
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._request(
+            "GET", f"/api/v1/dag-runs/{DAG_NAME}/{dag_run_id}")
+        if resp.status_code == 404:
+            return None
+        _raise_for_status(resp, what=f"status {dag_run_id}")
+        return resp.json()
 
     async def node_errors(self, dag_run_id: str) -> list[dict[str, str]]:
         """Step errors (with stderr tails) for one run; [] when none/unknown."""
@@ -81,47 +110,48 @@ class DaguExecutor:
 
     async def stop_all(self) -> list[str]:
         """Stop every in-flight run of the dev-run DAG. Returns any error strings."""
-        async with self._client(30) as client:
-            resp = await client.post(f"{self.base}/api/v1/dags/{DAG_NAME}/stop-all")
-            if resp.status_code == 404:
-                return []
-            resp.raise_for_status()
-            return list((resp.json() or {}).get("errors") or [])
+        resp = await self._request(
+            "POST", f"/api/v1/dags/{DAG_NAME}/stop-all", timeout=30)
+        if resp.status_code == 404:
+            return []
+        _raise_for_status(resp, what="stop-all")
+        return list((resp.json() or {}).get("errors") or [])
 
     async def list_all_run_ids(self) -> list[str]:
         """Paginate through every historical dagRunId for the dev-run DAG."""
         ids: list[str] = []
         cursor: Optional[str] = None
-        async with self._client(30) as client:
-            while True:
-                params: dict[str, Any] = {"limit": 500}
-                if cursor:
-                    params["cursor"] = cursor
-                resp = await client.get(
-                    f"{self.base}/api/v1/dag-runs/{DAG_NAME}", params=params
-                )
-                resp.raise_for_status()
-                body = resp.json() or {}
-                for r in body.get("dagRuns") or []:
-                    rid = r.get("dagRunId")
-                    if rid:
-                        ids.append(rid)
-                cursor = body.get("nextCursor") or None
-                if not cursor:
-                    break
+        while True:
+            params: dict[str, Any] = {"limit": 500}
+            if cursor:
+                params["cursor"] = cursor
+            resp = await self._request(
+                "GET", f"/api/v1/dag-runs/{DAG_NAME}", timeout=30, params=params)
+            _raise_for_status(resp, what="list dag-runs")
+            body = resp.json() or {}
+            for r in body.get("dagRuns") or []:
+                rid = r.get("dagRunId")
+                if rid:
+                    ids.append(rid)
+            cursor = body.get("nextCursor") or None
+            if not cursor:
+                break
         return ids
 
     async def delete(self, dag_run_id: str) -> bool:
         """Permanently remove one DAG-run record. True if deleted (or already gone)."""
-        async with self._client(15) as client:
-            resp = await client.delete(
-                f"{self.base}/api/v1/dag-runs/{DAG_NAME}/{dag_run_id}"
-            )
-            if resp.status_code in (204, 404):
-                return True
-            if resp.status_code == 400:
-                # still running / not deletable yet
-                log.warning("dagu delete refused for %s: %s", dag_run_id, resp.text[:200])
-                return False
-            resp.raise_for_status()
+        try:
+            resp = await self._request(
+                "DELETE", f"/api/v1/dag-runs/{DAG_NAME}/{dag_run_id}", timeout=15)
+        except ExecutorError:
+            return False
+        if resp.status_code in (204, 404):
             return True
+        if resp.status_code == 400:
+            # still running / not deletable yet
+            log.warning("dagu delete refused for %s: %s", dag_run_id, resp.text[:200])
+            return False
+        if resp.status_code >= 400:
+            log.warning("dagu delete failed for %s: %s", dag_run_id, resp.text[:200])
+            return False
+        return True

--- a/app/devcake/adapters/redis/messaging.py
+++ b/app/devcake/adapters/redis/messaging.py
@@ -23,10 +23,14 @@ from redis.exceptions import (ConnectionError as RedisConnectionError,
                               ResponseError,
                               TimeoutError as RedisTimeoutError)
 
+from ...ports.messaging import MessagingError
 from ...security import MASK, register_runtime_secret, unregister_runtime_secret
 
 log = logging.getLogger("devcake.messaging")
 tracer = trace.get_tracer("devcake")
+
+# Wire failures that must never escape Protocol surface methods as redis types
+_REDIS_WIRE = (RedisConnectionError, RedisTimeoutError, ResponseError, OSError)
 
 INGRESS = "devcake:ingress"
 # concurrent run.artifacts finalizes (audit F11) — bounded so a burst of
@@ -84,7 +88,10 @@ class Messaging:
             await self.redis.xgroup_create(INGRESS, GROUP, id="0", mkstream=True)
         except ResponseError as e:
             if "BUSYGROUP" not in str(e):
-                raise
+                raise MessagingError(
+                    f"setup: consumer group create failed: {e}") from e
+        except (RedisConnectionError, RedisTimeoutError, OSError) as e:
+            raise MessagingError(f"setup: network failure: {e}") from e
 
     # ── per-run ACL users (docs/09 §1a) ──────────────────────────────────────
 
@@ -93,20 +100,28 @@ class Messaging:
         # Redis 7 key selectors (ISSUES #14): write-only on shared ingress so a
         # concurrent Dev cannot XREAD other runs' plaintext `auth` envelopes;
         # read/write only on this run's reply stream.
-        await self.redis.execute_command(
-            "ACL", "SETUSER", f"dev-{run_id}", "on", f">{password}",
-            f"%W~{INGRESS}", f"%RW~{reply_stream(run_id)}",
-            "+xadd", "+xread", "+xlen", "+ping", "+client|setinfo",
-        )
-        await self._acl_save()
+        try:
+            await self.redis.execute_command(
+                "ACL", "SETUSER", f"dev-{run_id}", "on", f">{password}",
+                f"%W~{INGRESS}", f"%RW~{reply_stream(run_id)}",
+                "+xadd", "+xread", "+xlen", "+ping", "+client|setinfo",
+            )
+            await self._acl_save()
+        except _REDIS_WIRE as e:
+            raise MessagingError(
+                f"create_run_user({run_id}): network/ACL failure: {e}") from e
         # the only place the plaintext exists app-side — register it here so
         # redact() masks it in everything PMO-bound (docs/14 §5)
         register_runtime_secret(run_id, password)
         return password
 
     async def delete_run_user(self, run_id: str) -> None:
-        await self.redis.execute_command("ACL", "DELUSER", f"dev-{run_id}")
-        await self._acl_save()
+        try:
+            await self.redis.execute_command("ACL", "DELUSER", f"dev-{run_id}")
+            await self._acl_save()
+        except _REDIS_WIRE as e:
+            raise MessagingError(
+                f"delete_run_user({run_id}): network/ACL failure: {e}") from e
         unregister_runtime_secret(run_id)
 
     async def revoke_leftover_run_users(self) -> int:
@@ -155,16 +170,25 @@ class Messaging:
             "v": 1, "run_id": run_id, "kind": kind,
             "ts": datetime.now(timezone.utc).isoformat(), "payload": payload,
         }
-        pipe = self.redis.pipeline(transaction=False)
-        pipe.xadd(stream, {"m": json.dumps(envelope)})
-        pipe.expire(stream, REPLY_TTL_SECONDS)   # one round-trip: the TTL is
-        # the docs/09 §5 secret-lingering guard — never separated from the add
-        await pipe.execute()
+        try:
+            pipe = self.redis.pipeline(transaction=False)
+            pipe.xadd(stream, {"m": json.dumps(envelope)})
+            pipe.expire(stream, REPLY_TTL_SECONDS)   # one round-trip: the TTL is
+            # the docs/09 §5 secret-lingering guard — never separated from the add
+            await pipe.execute()
+        except _REDIS_WIRE as e:
+            raise MessagingError(
+                f"reply({run_id}, {kind}): network failure: {e}") from e
 
     async def delete_runspec_result(self, run_id: str) -> None:
         """XDEL runspec.result entries as soon as the Dev acknowledges (docs/09 §1a)."""
         stream = reply_stream(run_id)
-        for entry_id, fields in await self.redis.xrange(stream):
+        try:
+            entries = await self.redis.xrange(stream)
+        except _REDIS_WIRE as e:
+            raise MessagingError(
+                f"delete_runspec_result({run_id}): network failure: {e}") from e
+        for entry_id, fields in entries:
             try:
                 if json.loads(fields.get("m", "{}")).get("kind") == "runspec.result":
                     await self.redis.xdel(stream, entry_id)
@@ -174,7 +198,11 @@ class Messaging:
                 continue
 
     async def delete_reply_stream(self, run_id: str) -> None:
-        await self.redis.delete(reply_stream(run_id))
+        try:
+            await self.redis.delete(reply_stream(run_id))
+        except _REDIS_WIRE as e:
+            raise MessagingError(
+                f"delete_reply_stream({run_id}): network failure: {e}") from e
 
     # ── ingress consumption (Devs → app) ─────────────────────────────────────
 
@@ -264,20 +292,27 @@ class Messaging:
         resume it)."""
         out: set[str] = set()
         start = "-"
-        while True:
-            entries = await self.redis.xrange(INGRESS, min=start, max="+", count=200)
-            for _entry_id, fields in entries:
-                try:
-                    envelope = json.loads((fields or {}).get("m", "{}"))
-                    run_id = str(envelope.get("run_id", ""))
-                except Exception:  # noqa: BLE001 — scan must finish; skip is logged
-                    log.warning("ingress run-id scan: skipping unparseable entry %s", _entry_id)
-                    continue
-                if run_id:
-                    out.add(run_id)
-            if len(entries) < 200:
-                return out
-            start = "(" + entries[-1][0]
+        try:
+            while True:
+                entries = await self.redis.xrange(
+                    INGRESS, min=start, max="+", count=200)
+                for _entry_id, fields in entries:
+                    try:
+                        envelope = json.loads((fields or {}).get("m", "{}"))
+                        run_id = str(envelope.get("run_id", ""))
+                    except Exception:  # noqa: BLE001 — scan must finish; skip is logged
+                        log.warning(
+                            "ingress run-id scan: skipping unparseable entry %s",
+                            _entry_id)
+                        continue
+                    if run_id:
+                        out.add(run_id)
+                if len(entries) < 200:
+                    return out
+                start = "(" + entries[-1][0]
+        except _REDIS_WIRE as e:
+            raise MessagingError(
+                f"unresolved_run_ids: network failure: {e}") from e
 
     async def _ack_delete(self, entry_ids: list[str]) -> None:
         if not entry_ids:

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel
 from opentelemetry import trace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
-from ..adapters.dagu import DuplicateRun
+from ..ports.executor import DuplicateRun
 from .. import secrets as secrets_store
 from .. import security
 from ..domain.model import ALL_LABELS
@@ -913,5 +913,5 @@ async def dispatch_hello(sleep: int = 3, payload_kb: int = 1,
     try:
         run = await svc().manager.dispatch_hello(sleep, payload_kb, timeout_seconds)
     except DuplicateRun as e:
-        raise HTTPException(409, f"duplicate dagRunId {e}")
+        raise HTTPException(409, str(e))
     return {"run_id": run.run_id, "state": run.state}

--- a/app/devcake/ports/__init__.py
+++ b/app/devcake/ports/__init__.py
@@ -2,23 +2,29 @@
 
 PMOPort / ForgePort (pluggable vendors — ADR-0008).
 ExecutorPort / StatePort / MessagingPort / RunFinalizer (run infrastructure).
+ReceiptStore / HarnessVersionSource / ClaimsNotebooks (secondary infra).
 CronStore (scheduled-task fire ledger — ADR-0035).
 """
 
+from .claims import ClaimsNotebooks
 from .cron import CronStore
-from .executor import ExecutorPort
+from .executor import DuplicateRun, ExecutorError, ExecutorPort
 from .finalizer import RunFinalizer
 from .forge import ForgePort
-from .messaging import MessagingPort
+from .messaging import MessagingError, MessagingPort
 from .pmo import PMOPort
 from .receipts import ReceiptStore
 from .state import StatePort
 from .versions import HarnessVersionSource
 
 __all__ = [
+    "ClaimsNotebooks",
     "CronStore",
+    "DuplicateRun",
+    "ExecutorError",
     "ExecutorPort",
     "ForgePort",
+    "MessagingError",
     "MessagingPort",
     "PMOPort",
     "HarnessVersionSource",

--- a/app/devcake/ports/__init__.py
+++ b/app/devcake/ports/__init__.py
@@ -4,6 +4,7 @@ PMOPort / ForgePort (pluggable vendors — ADR-0008).
 ExecutorPort / StatePort / MessagingPort / RunFinalizer (run infrastructure).
 ReceiptStore / HarnessVersionSource / ClaimsNotebooks (secondary infra).
 CronStore (scheduled-task fire ledger — ADR-0035).
+OidcTokenPort (control-plane OAuth refresh) is imported from ports.oidc_token.
 """
 
 from .claims import ClaimsNotebooks

--- a/app/devcake/ports/executor.py
+++ b/app/devcake/ports/executor.py
@@ -2,11 +2,34 @@
 
 One adapter today: adapters.dagu.DaguExecutor. A second (in-memory) adapter
 lives in tests — two adapters justify the seam.
+
+Adapters must never leak httpx (or other wire-client) types upward —
+surface `ExecutorError` / `DuplicateRun` instead.
 """
 
 from __future__ import annotations
 
 from typing import Any, Protocol
+
+
+class ExecutorError(Exception):
+    """Raised by ExecutorPort adapters for HTTP-level failures (docs/13 §4).
+
+    `status` carries the HTTP status code when one exists. Network failures
+    use status=None. Adapters must never leak httpx exceptions upward.
+    """
+
+    def __init__(self, msg: str, status: int | None = None):
+        super().__init__(msg)
+        self.status = status
+
+
+class DuplicateRun(ExecutorError):
+    """The executor already has a run for this dagRunId (Dagu 409)."""
+
+    def __init__(self, dag_run_id: str):
+        super().__init__(f"duplicate dagRunId {dag_run_id}", status=409)
+        self.dag_run_id = dag_run_id
 
 
 class ExecutorPort(Protocol):

--- a/app/devcake/ports/messaging.py
+++ b/app/devcake/ports/messaging.py
@@ -2,6 +2,11 @@
 
 One adapter today: adapters.redis.Messaging. Slice scope uses create_run_user;
 reply/teardown methods are part of the same seam for RunManager and later slices.
+
+Adapters must never leak redis-py exception types upward — surface
+`MessagingError` on Protocol methods (create_run_user, reply, …). The
+long-running consumer loop handles reconnect internally and does not
+raise MessagingError for transient disconnects.
 """
 
 from __future__ import annotations
@@ -9,6 +14,14 @@ from __future__ import annotations
 from typing import Any, Awaitable, Callable, Protocol
 
 Handler = Callable[[str, str, dict[str, Any]], Awaitable[None]]
+
+
+class MessagingError(Exception):
+    """Raised by MessagingPort adapters for wire-level failures (docs/09).
+
+    Covers redis connection/timeout/response errors on request/reply and
+    ACL lifecycle methods. Adapters must never leak redis.exceptions upward.
+    """
 
 
 class MessagingPort(Protocol):

--- a/app/devcake/ports/receipts.py
+++ b/app/devcake/ports/receipts.py
@@ -1,7 +1,13 @@
 """ReceiptStore — row-level drift-probe receipts on /data.
 
-App reads. The host bake verb writes. Missing/failing receipts do not
-change launch in Slice 1 (fail-open).
+App reads. The host bake verb writes. Production adapter:
+`adapters/files/receipts.py` (`FileReceiptStore`).
+
+Staffing is **fail-closed** on this port: `require_staffed` (dispatch,
+steward, OAuth — not hello) refuses launch unless `get` returns a matching
+ok receipt for the app digest + template + effective CLI pin (docs/08,
+docs/13). A miss (`None`) or non-ok / ungated row is a hard refuse, never a
+silent continue.
 """
 
 from __future__ import annotations

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -76,6 +76,9 @@ class FakeExecutor:
     async def status(self, dag_run_id):
         return None
 
+    async def node_errors(self, dag_run_id):
+        return []
+
 
 DEFAULT_INSTANCE = PMOInstance(name="linear", team_key="DEV")
 

--- a/app/tests/test_dagu_executor.py
+++ b/app/tests/test_dagu_executor.py
@@ -11,7 +11,8 @@ import json
 import httpx
 import pytest
 
-from devcake.adapters.dagu.executor import DAG_NAME, DaguExecutor, DuplicateRun
+from devcake.adapters.dagu.executor import DAG_NAME, DaguExecutor
+from devcake.ports.executor import DuplicateRun
 
 
 def run_coro(c):

--- a/app/tests/test_dagu_executor.py
+++ b/app/tests/test_dagu_executor.py
@@ -12,7 +12,7 @@ import httpx
 import pytest
 
 from devcake.adapters.dagu.executor import DAG_NAME, DaguExecutor
-from devcake.ports.executor import DuplicateRun, ExecutorError
+from devcake.ports.executor import DuplicateRun
 
 
 def run_coro(c):
@@ -129,9 +129,9 @@ def test_delete_accepts_204_and_404():
     assert run_coro(ex.delete("ok")) is True
     assert run_coro(ex.delete("gone")) is True
     assert run_coro(ex.delete("running")) is False
-    with pytest.raises(ExecutorError) as exc:
-        run_coro(ex.delete("boom"))
-    assert exc.value.status == 500
+    # Unexpected statuses also report not-deleted instead of raising, so
+    # clear_dagu can keep an honest failed-list without a try/except per id.
+    assert run_coro(ex.delete("boom")) is False
 
 
 def test_list_all_run_ids_paginates():

--- a/app/tests/test_dagu_executor.py
+++ b/app/tests/test_dagu_executor.py
@@ -12,7 +12,7 @@ import httpx
 import pytest
 
 from devcake.adapters.dagu.executor import DAG_NAME, DaguExecutor
-from devcake.ports.executor import DuplicateRun
+from devcake.ports.executor import DuplicateRun, ExecutorError
 
 
 def run_coro(c):
@@ -129,8 +129,9 @@ def test_delete_accepts_204_and_404():
     assert run_coro(ex.delete("ok")) is True
     assert run_coro(ex.delete("gone")) is True
     assert run_coro(ex.delete("running")) is False
-    with pytest.raises(httpx.HTTPStatusError):
+    with pytest.raises(ExecutorError) as exc:
         run_coro(ex.delete("boom"))
+    assert exc.value.status == 500
 
 
 def test_list_all_run_ids_paginates():

--- a/app/tests/test_executor_error_contract.py
+++ b/app/tests/test_executor_error_contract.py
@@ -1,0 +1,81 @@
+"""ports/executor.py: adapters must never leak httpx upward.
+
+Parallel to forge F7 (test_forge_error_contract): Dagu REST is HTTP, so
+network/status failures surface as ExecutorError. DuplicateRun stays the
+409 already_exists signal (now defined on the port, not the adapter).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from devcake.adapters.dagu.executor import DaguExecutor
+from devcake.ports.executor import DuplicateRun, ExecutorError
+
+
+def run_coro(c):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(c)
+    finally:
+        loop.close()
+
+
+def _executor(handler) -> DaguExecutor:
+    return DaguExecutor(
+        "http://dagu.test:8080",
+        transport=httpx.MockTransport(handler),
+        auth=("", ""),
+    )
+
+
+def test_start_network_failure_is_executor_error_not_httpx():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    with pytest.raises(ExecutorError) as exc:
+        run_coro(_executor(handler).start({"IMAGE": "x"}, "run-1"))
+    assert not isinstance(exc.value, httpx.HTTPError)
+    assert exc.value.status is None
+    assert "network" in str(exc.value).lower()
+
+
+def test_start_http_5xx_is_executor_error_with_status():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="dagu unavailable")
+
+    with pytest.raises(ExecutorError) as exc:
+        run_coro(_executor(handler).start({"IMAGE": "x"}, "run-2"))
+    assert exc.value.status == 503
+    assert "503" in str(exc.value)
+
+
+def test_start_409_remains_duplicate_run():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, json={"message": "already_exists"})
+
+    with pytest.raises(DuplicateRun):
+        run_coro(_executor(handler).start({}, "dup"))
+
+
+def test_status_network_failure_is_executor_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    with pytest.raises(ExecutorError) as exc:
+        run_coro(_executor(handler).status("run-3"))
+    assert exc.value.status is None
+
+
+def test_stop_http_error_returns_false_without_leaking_httpx():
+    """stop() is bool-success: HTTP errors become False, never httpx."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("down", request=request)
+
+    assert run_coro(_executor(handler).stop("run-4")) is False
+
+
+def test_duplicate_run_is_exported_from_ports():
+    assert issubclass(DuplicateRun, ExecutorError)

--- a/app/tests/test_messaging_error_contract.py
+++ b/app/tests/test_messaging_error_contract.py
@@ -1,0 +1,86 @@
+"""ports/messaging.py: adapters must never leak redis-py types upward.
+
+Protocol surface methods wrap redis.exceptions / OSError as MessagingError
+so domain (RunBootstrap, RunManager) never types against redis.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError
+
+from devcake.adapters.redis.messaging import Messaging
+from devcake.ports.messaging import MessagingError
+
+
+def run_coro(c):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(c)
+    finally:
+        loop.close()
+
+
+def _messaging_with_redis(redis) -> Messaging:
+    m = Messaging("redis://unused", "")
+    m.redis = redis
+    return m
+
+
+def test_create_run_user_connection_failure_is_messaging_error():
+    redis = MagicMock()
+    redis.execute_command = AsyncMock(
+        side_effect=RedisConnectionError("Connection refused"))
+    m = _messaging_with_redis(redis)
+
+    with pytest.raises(MessagingError) as exc:
+        run_coro(m.create_run_user("run-x"))
+    assert not isinstance(exc.value, RedisConnectionError)
+    assert "network" in str(exc.value).lower() or "connection" in str(exc.value).lower()
+
+
+def test_create_run_user_acl_response_error_is_messaging_error():
+    redis = MagicMock()
+    redis.execute_command = AsyncMock(
+        side_effect=ResponseError("ERR unknown command ACL"))
+    m = _messaging_with_redis(redis)
+
+    with pytest.raises(MessagingError) as exc:
+        run_coro(m.create_run_user("run-y"))
+    assert not isinstance(exc.value, ResponseError)
+
+
+def test_reply_connection_failure_is_messaging_error():
+    pipe = MagicMock()
+    pipe.xadd = MagicMock()
+    pipe.expire = MagicMock()
+    pipe.execute = AsyncMock(side_effect=RedisConnectionError("gone"))
+
+    redis = MagicMock()
+    redis.pipeline = MagicMock(return_value=pipe)
+    m = _messaging_with_redis(redis)
+
+    with pytest.raises(MessagingError):
+        run_coro(m.reply("run-z", "runspec.result", {"a": 1}))
+
+
+def test_delete_run_user_connection_failure_is_messaging_error():
+    redis = MagicMock()
+    redis.execute_command = AsyncMock(
+        side_effect=RedisConnectionError("gone"))
+    m = _messaging_with_redis(redis)
+    with pytest.raises(MessagingError):
+        run_coro(m.delete_run_user("run-teardown"))
+
+
+def test_unresolved_run_ids_connection_failure_is_messaging_error():
+    redis = MagicMock()
+    redis.xrange = AsyncMock(side_effect=RedisConnectionError("gone"))
+    m = _messaging_with_redis(redis)
+
+    with pytest.raises(MessagingError):
+        run_coro(m.unresolved_run_ids())

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -88,6 +88,7 @@ app/devcake/
     receipts.py    #   ReceiptStore — harness bake receipts (staffing, fail-closed)
     versions.py    #   HarnessVersionSource — operator-asked remote CLI latest
     claims.py      #   ClaimsNotebooks — memory `.claims/` forge write seam
+    oidc_token.py  #   OidcTokenPort — host-side OAuth refresh at runspec inject
   adapters/
     registry.py    #   PMO_SYSTEMS, make_pmo(), make_forge(), make_internal_forge(),
                    #   forges() — the ONE place that knows which adapters exist
@@ -100,6 +101,7 @@ app/devcake/
     redis/         #   MessagingPort impl — ingress + replies (09)
     claims_writer.py     # ClaimsNotebooks impl (git subprocess via adapters.git)
     registry_versions.py # HarnessVersionSource impl (npm / x.ai, operator-asked)
+    xai/           #   OidcTokenPort impl — auth.x.ai refresh (Grok CLI sessions)
   api/             # FastAPI (11, ADR-0015/0028): services.py = the
                    #   composition root (Services graph + build_services(),
                    #   called by the lifespan — importing main.py builds
@@ -123,7 +125,7 @@ app/devcake/
 
 The app boots via `uvicorn devcake.api.main:app`. `config.py`, `security.py`, and `harness.py` sit at the package root because they are cross-cutting concerns, not layer members.
 
-**Ports today:** vendor seams (`PMOPort`, `ForgePort` — ADR-0008; `InternalForgePort` — ADR-0010) and run-infrastructure seams (`ExecutorPort`, `StatePort`, `MessagingPort`, `RunFinalizer`, plus secondary `ReceiptStore`, `HarnessVersionSource`, `ClaimsNotebooks`, and the scheduled-task `CronStore` — ADR-0035). Production adapters: Linear, GitHub/GitLab/Gitea, Dagu, files (runs + receipts + cron ledger), Redis Streams, claims writer, registry versions; `MissionManager` / `FinalizerRouter` satisfy `RunFinalizer`. Wire adapters raise port-level errors (`ExecutorError`/`DuplicateRun`, `MessagingError`, `ForgeError`, `PMOTransient`) — never raw httpx/redis types. Composition root (`api/services.build_services()`, ADR-0028 — called once by the lifespan, never at import) builds adapters (incl. optional `make_internal_forge()` when Gitea admin creds are set), injects them into `RunManager` / per-instance `MissionManager`s, then `manager.set_finalizer(…)` so ingress/kill never type against the concrete orchestrator. Skill-store + per-mission repo routing (`resolve_repo` / `resolve_repo_live`) ride the same composition. All four dispatch flavors (hello, mission, steward, OAuth) call `RunBootstrap.launch` for the durable-intent-before-trigger spine (`04-orchestrator.md` §3.1).
+**Ports today:** vendor seams (`PMOPort`, `ForgePort` — ADR-0008; `InternalForgePort` — ADR-0010) and run-infrastructure seams (`ExecutorPort`, `StatePort`, `MessagingPort`, `RunFinalizer`, plus secondary `ReceiptStore`, `HarnessVersionSource`, `ClaimsNotebooks`, `OidcTokenPort`, and the scheduled-task `CronStore` — ADR-0035). Production adapters: Linear, GitHub/GitLab/Gitea, Dagu, files (runs + receipts + cron ledger), Redis Streams, claims writer, registry versions, x.ai token refresh; `MissionManager` / `FinalizerRouter` satisfy `RunFinalizer`. Wire adapters raise port-level errors (`ExecutorError`/`DuplicateRun`, `MessagingError`, `ForgeError`, `PMOTransient`) — never raw httpx/redis types. Composition root (`api/services.build_services()`, ADR-0028 — called once by the lifespan, never at import) builds adapters (incl. optional `make_internal_forge()` when Gitea admin creds are set), injects them into `RunManager` / per-instance `MissionManager`s, then `manager.set_finalizer(…)` so ingress/kill never type against the concrete orchestrator. Skill-store + per-mission repo routing (`resolve_repo` / `resolve_repo_live`) ride the same composition. All four dispatch flavors (hello, mission, steward, OAuth) call `RunBootstrap.launch` for the durable-intent-before-trigger spine (`04-orchestrator.md` §3.1).
 
 **Rule:** the domain core is testable with fakes of the ports; adapters never leak vendor types upward (normalized DTOs only, `02-domain-model.md`). Domain modules depend on **port Protocols**, not adapter packages.
 

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -80,14 +80,14 @@ app/devcake/
                    #   ForgeDescriptor, ForgeCapabilities, ForgeError,
                    #   mission_branch(instance, key) (06)
     internal_forge.py  # InternalForgePort — bundled Gitea provisioner (ADR-0010)
-    executor.py    #   ExecutorPort — start/stop/status (dagu adapter)
+    executor.py    #   ExecutorPort + ExecutorError/DuplicateRun (dagu adapter)
     state.py       #   StatePort — run-record persistence (files adapter)
-    messaging.py   #   MessagingPort — Redis Streams surface (redis adapter)
+    messaging.py   #   MessagingPort + MessagingError (redis adapter)
     finalizer.py   #   RunFinalizer — mission finalize/restore (MissionManager)
     cron.py        #   CronStore — scheduled-task fire ledger (ADR-0035)
-    claims.py      #   ClaimsNotebooks — .claims/ forge write seam (ADR-0035)
-    receipts.py    #   ReceiptStore — host bake drift-probe receipts
-    versions.py    #   HarnessVersionSource — CLI version probes
+    receipts.py    #   ReceiptStore — harness bake receipts (staffing, fail-closed)
+    versions.py    #   HarnessVersionSource — operator-asked remote CLI latest
+    claims.py      #   ClaimsNotebooks — memory `.claims/` forge write seam
   adapters/
     registry.py    #   PMO_SYSTEMS, make_pmo(), make_forge(), make_internal_forge(),
                    #   forges() — the ONE place that knows which adapters exist
@@ -95,9 +95,11 @@ app/devcake/
     gitea_issues/  #   PMOPort impl — forge-issue family (05 §9; not ForgePort)
     github/ gitlab/ gitea/  # ForgePort impls + Gitea provisioner (06, ADR-0010)
     dagu/          #   ExecutorPort impl
-    files/         #   StatePort + CronStore impls (+ runlog.py, owner_store.py,
+    files/         #   StatePort + CronStore impls (+ receipts.py, runlog.py, owner_store.py,
                    #   cron_store.py — the scheduled-task fire ledger) (10)
     redis/         #   MessagingPort impl — ingress + replies (09)
+    claims_writer.py     # ClaimsNotebooks impl (git subprocess via adapters.git)
+    registry_versions.py # HarnessVersionSource impl (npm / x.ai, operator-asked)
   api/             # FastAPI (11, ADR-0015/0028): services.py = the
                    #   composition root (Services graph + build_services(),
                    #   called by the lifespan — importing main.py builds
@@ -121,7 +123,7 @@ app/devcake/
 
 The app boots via `uvicorn devcake.api.main:app`. `config.py`, `security.py`, and `harness.py` sit at the package root because they are cross-cutting concerns, not layer members.
 
-**Ports today:** vendor seams (`PMOPort`, `ForgePort` — ADR-0008; `InternalForgePort` — ADR-0010), run-infrastructure seams (`ExecutorPort`, `StatePort`, `MessagingPort`, `RunFinalizer`), and scheduled-task / memory seams (`CronStore`, `ClaimsNotebooks` — ADR-0035). Production adapters: Linear, GitHub/GitLab/Gitea, Dagu, files (incl. cron outcome ledger), Redis Streams; `MissionManager` satisfies `RunFinalizer`. Composition root (`api/services.build_services()`, ADR-0028 — called once by the lifespan, never at import) builds adapters (incl. optional `make_internal_forge()` when Gitea admin creds are set), injects them into `RunManager` / per-instance `MissionManager`s, then `manager.set_finalizer(…)` so ingress/kill never type against the concrete orchestrator. Skill-store + per-mission repo routing (`resolve_repo` / `resolve_repo_live`) ride the same composition. All four dispatch flavors (hello, mission, steward, OAuth) call `RunBootstrap.launch` for the durable-intent-before-trigger spine (`04-orchestrator.md` §3.1).
+**Ports today:** vendor seams (`PMOPort`, `ForgePort` — ADR-0008; `InternalForgePort` — ADR-0010) and run-infrastructure seams (`ExecutorPort`, `StatePort`, `MessagingPort`, `RunFinalizer`, plus secondary `ReceiptStore`, `HarnessVersionSource`, `ClaimsNotebooks`, and the scheduled-task `CronStore` — ADR-0035). Production adapters: Linear, GitHub/GitLab/Gitea, Dagu, files (runs + receipts + cron ledger), Redis Streams, claims writer, registry versions; `MissionManager` / `FinalizerRouter` satisfy `RunFinalizer`. Wire adapters raise port-level errors (`ExecutorError`/`DuplicateRun`, `MessagingError`, `ForgeError`, `PMOTransient`) — never raw httpx/redis types. Composition root (`api/services.build_services()`, ADR-0028 — called once by the lifespan, never at import) builds adapters (incl. optional `make_internal_forge()` when Gitea admin creds are set), injects them into `RunManager` / per-instance `MissionManager`s, then `manager.set_finalizer(…)` so ingress/kill never type against the concrete orchestrator. Skill-store + per-mission repo routing (`resolve_repo` / `resolve_repo_live`) ride the same composition. All four dispatch flavors (hello, mission, steward, OAuth) call `RunBootstrap.launch` for the durable-intent-before-trigger spine (`04-orchestrator.md` §3.1).
 
 **Rule:** the domain core is testable with fakes of the ports; adapters never leak vendor types upward (normalized DTOs only, `02-domain-model.md`). Domain modules depend on **port Protocols**, not adapter packages.
 

--- a/docs/09-messaging.md
+++ b/docs/09-messaging.md
@@ -10,7 +10,7 @@
 
 Redis Streams mediate **all** Dev↔app traffic. Redis is a **transport buffer, never a source of truth**: a lost message is recoverable because artifacts also exist in Dagu run logs, and the Mission's label was never advanced (INV-3) — the step simply re-runs.
 
-The app's domain programs against **`MessagingPort`** (`ports/messaging.py`); the production adapter is `adapters/redis/messaging.py`. Per-run ACL creation is also the first step of `RunBootstrap.launch` (`04-orchestrator.md` §3.1).
+The app's domain programs against **`MessagingPort`** (`ports/messaging.py`); the production adapter is `adapters/redis/messaging.py`. Wire failures on Protocol surface methods (ACL lifecycle, reply, unresolved scan, setup) raise **`MessagingError`** — never raw `redis.exceptions`. The long-running ingress consumer still reconnects in-loop on disconnect (no `MessagingError` for transient outages). Per-run ACL creation is also the first step of `RunBootstrap.launch` (`04-orchestrator.md` §3.1).
 
 ## 1. Topology
 

--- a/docs/adr/0008-pluggable-pmo-and-forge-adapters.md
+++ b/docs/adr/0008-pluggable-pmo-and-forge-adapters.md
@@ -140,6 +140,7 @@ docs/04 §3.1). This does **not** reopen vendor pluggability decisions above.
 | `ReceiptStore` | harness bake receipts (staffing fail-closed) | `adapters/files/receipts` |
 | `HarnessVersionSource` | operator-asked remote CLI latest | `adapters/registry_versions` |
 | `ClaimsNotebooks` | memory notebook `.claims/` write | `adapters/claims_writer` |
+| `OidcTokenPort` | control-plane OAuth token refresh (host-side) | `adapters/xai` |
 | `domain/run_bootstrap.py` | deep dispatch spine shared by hello, mission, steward, OAuth | — |
 
 `RunManager` binds the finalizer via `set_finalizer` after composition (breaks

--- a/docs/adr/0008-pluggable-pmo-and-forge-adapters.md
+++ b/docs/adr/0008-pluggable-pmo-and-forge-adapters.md
@@ -133,17 +133,21 @@ docs/04 §3.1). This does **not** reopen vendor pluggability decisions above.
 
 | Port / module | Role | Production adapter |
 |---|---|---|
-| `ExecutorPort` | start/stop/status Dev runs | `adapters/dagu` |
-| `StatePort` | run-record persistence | `adapters/files` |
-| `MessagingPort` | Redis Streams ACL + ingress/reply | `adapters/redis` |
-| `RunFinalizer` | mission finalize / mapper finalize / INV-3 restore | `MissionManager` |
-| `domain/run_bootstrap.py` | deep dispatch spine shared by hello, mission, mapper, OAuth | — |
+| `ExecutorPort` | start/stop/status Dev runs; `ExecutorError` / `DuplicateRun` | `adapters/dagu` |
+| `StatePort` | run-record persistence | `adapters/files` (`run_store`) |
+| `MessagingPort` | Redis Streams ACL + ingress/reply; `MessagingError` | `adapters/redis` |
+| `RunFinalizer` | mission finalize / steward finalize / INV-3 restore | `MissionManager` / `FinalizerRouter` |
+| `ReceiptStore` | harness bake receipts (staffing fail-closed) | `adapters/files/receipts` |
+| `HarnessVersionSource` | operator-asked remote CLI latest | `adapters/registry_versions` |
+| `ClaimsNotebooks` | memory notebook `.claims/` write | `adapters/claims_writer` |
+| `domain/run_bootstrap.py` | deep dispatch spine shared by hello, mission, steward, OAuth | — |
 
 `RunManager` binds the finalizer via `set_finalizer` after composition (breaks
 the construct-time `RunManager` ↔ `MissionManager` cycle). Tests pin the
-spine and finalizer routing at `tests/test_run_bootstrap.py`. SQLite (or other)
-`StatePort` swaps remain backlog (`16-roadmap.md`) — the Protocol is the
-stable seam.
+spine and finalizer routing at `tests/test_run_bootstrap.py`. Wire adapters
+must not leak httpx/redis types upward (executor + messaging error contracts
+parallel forge F7). SQLite (or other) `StatePort` swaps remain backlog
+(`16-roadmap.md`) — the Protocol is the stable seam.
 
 ## Addendum — v0 crystallization (2026-07-13)
 


### PR DESCRIPTION
## Summary

Pre-FOSS audit + fix of secondary (non-PMO/non-forge) integration seams: Protocol honesty, Liskov-safe error surfaces, and docs zero-drift.

### Fixes

1. **ExecutorPort error contract** — `ExecutorError` / `DuplicateRun` live on `ports/executor.py`. `DaguExecutor` maps httpx network/HTTP failures to those types (never raw httpx). `stop`/`delete` stay bool-success and return `False` on wire failure.
2. **MessagingPort error contract** — `MessagingError` on Protocol surface methods (`create_run_user`, `delete_run_user`, `reply`, `delete_runspec_result`, `delete_reply_stream`, `unresolved_run_ids`, `setup`). Ingress `consume_forever` still reconnects in-loop without raising for transient disconnects.
3. **ReceiptStore Protocol honesty** — port docstring no longer claims Slice-1 fail-open; matches fail-closed staffing (`require_staffed`).
4. **Docs zero-drift** — `docs/01-architecture.md`, `docs/09-messaging.md`, ADR-0008 list ReceiptStore / HarnessVersionSource / ClaimsNotebooks and the new error types.

### Tests

- New: `test_executor_error_contract.py`, `test_messaging_error_contract.py`
- Existing: `test_dagu_executor`, staffing, run_bootstrap, structure_guards, claims, run_store (120 related tests green on Python 3.12 / `PYTHONPATH=app`)

### Environment-gated (not proven here)

- Live Redis suite (`test_messaging_live`) — needs Redis + ACL
- Docker bake / structural mount tests — needs `docker buildx bake app-test` + CI bind mounts
- npm / x.ai version lookup (`RegistryVersionSource`) — operator-asked egress

Mission: https://linear.app/fidecastro/issue/CAKE-22/pre-foss-secondary-ports-and-infrastructure-adapters-audit-fix

## Deviation

PLAN step left only a stub narrative (`PLAN_2.md`); implementation is from the mission brief + ONBOARD discoveries + live audit against the stated lens.