### PR TITLE
[CAKE-20] [pre-FOSS] PMOPort and PMO adapters audit + fix

### DIFF
--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -148,7 +148,16 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
     <>
       <Section id="pmo" title="PMO connections"
         description="The PMO teams DevCake watches, and how missions are adopted."
-        help={`One instance per team. Supported: ${registry.pmo_systems.map((s) => s.display_name).join(", ")}. Instance names prefix branches and run ids (MYTEAM-DEV-17).`}
+        help={(() => {
+          const systems = registry.pmo_systems || [];
+          const launch = systems.filter((s) => !s.experimental).map((s) => s.display_name);
+          const exp = systems.filter((s) => s.experimental).map((s) => s.display_name);
+          const bits = [];
+          if (launch.length) bits.push(`Launch-supported: ${launch.join(", ")}`);
+          if (exp.length) bits.push(`Experimental (in-tree, not launch-supported): ${exp.join(", ")}`);
+          bits.push("Instance names prefix branches and run ids (MYTEAM-DEV-17).");
+          return `One instance per team. ${bits.join(". ")}`;
+        })()}
         actions={
           <MoreMenu label="More PMO actions" items={[
             { label: CLEAR_SECRETS_ENTRY.menuLabel, danger: true,
@@ -313,7 +322,9 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
                     aria-label="PMO system"
                   >
                     {(registry.pmo_systems || []).map((s) => (
-                      <option key={s.id} value={s.id}>{s.display_name}</option>
+                      <option key={s.id} value={s.id}>
+                        {s.display_name}{s.experimental ? " (experimental)" : ""}
+                      </option>
                     ))}
                   </select>
                 </Field>

--- a/admin/spa/src/lib/registry.js
+++ b/admin/spa/src/lib/registry.js
@@ -17,6 +17,7 @@ const FALLBACK = {
       operator_note: "",
       attachments_supported: true,
       relations_supported: true,
+      experimental: false,
     },
     {
       id: "gitea_issues",
@@ -30,6 +31,7 @@ const FALLBACK = {
       operator_note: "",
       attachments_supported: true,
       relations_supported: true,
+      experimental: false,
     },
     {
       id: "gitlab_issues",
@@ -41,9 +43,10 @@ const FALLBACK = {
       api_base_help:
         "GitLab origin from the app container. gitlab.com: https://gitlab.com. Self-hosted: https://gitlab.example.com",
       operator_note:
-        "Blocked-by issue links need GitLab Premium (or self-hosted EE). DevCake probes the live token.",
+        "Experimental (not launch-supported). Blocked-by issue links need GitLab Premium (or self-hosted EE). DevCake probes the live token.",
       attachments_supported: true,
       relations_supported: false,
+      experimental: true,
     },
     {
       id: "github_issues",
@@ -55,9 +58,10 @@ const FALLBACK = {
       api_base_help:
         "GitHub API origin. github.com: leave empty or https://api.github.com. GitHub Enterprise: https://ghe.example.com/api/v3",
       operator_note:
-        "GitHub's public API cannot attach files to issues. Transcripts live in the activity repo; the ticket comment is a short pointer.",
+        "Experimental (not launch-supported). GitHub's public API cannot attach files to issues. Transcripts live in the activity repo; the ticket comment is a short pointer.",
       attachments_supported: false,
       relations_supported: true,
+      experimental: true,
     },
   ],
   forges: [

--- a/app/devcake/adapters/gitea_issues/adapter.py
+++ b/app/devcake/adapters/gitea_issues/adapter.py
@@ -431,6 +431,7 @@ class GiteaIssuesAdapter:
         return found
 
     async def children_of(self, ref: MissionRef) -> list[Mission]:
+        self._require_issue(ref)
         # Issue-only: no project children. Decomposition uses markers + relations.
         return []
 
@@ -767,4 +768,6 @@ class GiteaIssuesAdapter:
             attachment_max_bytes=50 * 1024 * 1024,
             native_label_swap_atomic=True,  # PUT full label set
             relations_supported=True,
+            attachments_supported=True,
+            global_ids=False,  # issue numbers collide across Gitea instances
         )

--- a/app/devcake/adapters/github_issues/adapter.py
+++ b/app/devcake/adapters/github_issues/adapter.py
@@ -258,6 +258,8 @@ class GitHubIssuesAdapter:
         )
 
     async def children_of(self, ref: MissionRef) -> list[Mission]:
+        self._require_issue(ref)
+        # Issue-only: no project children. Decomposition uses markers + relations.
         return []
 
     async def post_feed(self, ref: MissionRef, markdown: str) -> None:

--- a/app/devcake/adapters/gitlab_issues/adapter.py
+++ b/app/devcake/adapters/gitlab_issues/adapter.py
@@ -543,6 +543,9 @@ class GitLabIssuesAdapter:
             raise PMOTransient(f"gitlab_issues download network: {e}") from e
         except AssetUrlError as e:
             raise RuntimeError(f"gitlab_issues download refused: {e}") from e
+        if resp.status_code in (429, 500, 502, 503, 504):
+            raise PMOTransient(
+                f"gitlab_issues download → {resp.status_code}")
         if resp.status_code >= 400:
             raise RuntimeError(
                 f"gitlab_issues download → {resp.status_code}: {resp.text[:200]}")

--- a/app/devcake/adapters/gitlab_issues/adapter.py
+++ b/app/devcake/adapters/gitlab_issues/adapter.py
@@ -334,6 +334,8 @@ class GitLabIssuesAdapter:
         return found
 
     async def children_of(self, ref: MissionRef) -> list[Mission]:
+        self._require_issue(ref)
+        # Issue-only: no project children. Decomposition uses markers + relations.
         return []
 
     async def post_feed(self, ref: MissionRef, markdown: str) -> None:

--- a/app/devcake/adapters/linear/adapter.py
+++ b/app/devcake/adapters/linear/adapter.py
@@ -955,9 +955,17 @@ class LinearAdapter:
             except AssetUrlError as e:
                 raise RuntimeError(
                     f"linear download redirect refused: {e}") from e
+            except httpx.HTTPError as e:
+                raise PMOTransient(f"linear download network: {e}") from e
             except RuntimeError:
                 raise RuntimeError("linear download: too many redirects")
-            resp.raise_for_status()
+            if resp.status_code in (429, 500, 502, 503, 504):
+                raise PMOTransient(
+                    f"linear download → {resp.status_code}")
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"linear download → {resp.status_code}: "
+                    f"{(resp.text or '')[:200]}")
             try:
                 return enforce_download_byte_cap(
                     resp.content,

--- a/app/devcake/adapters/linear/adapter.py
+++ b/app/devcake/adapters/linear/adapter.py
@@ -919,9 +919,18 @@ class LinearAdapter:
                                          transport=self._transport) as client:
                 resp = await client.put(uf["uploadUrl"], content=data,
                                         headers=headers)
-                resp.raise_for_status()
         except httpx.HTTPError as e:
             raise PMOTransient(f"linear upload network: {e}") from e
+        # Status map mirrors download_asset: only 429/5xx are retryable.
+        # Do not wrap raise_for_status() in HTTPError → PMOTransient —
+        # HTTPStatusError ⊆ HTTPError and permanent 4xx would be retried.
+        if resp.status_code in (429, 500, 502, 503, 504):
+            raise PMOTransient(
+                f"linear upload → {resp.status_code}")
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"linear upload → {resp.status_code}: "
+                f"{(resp.text or '')[:200]}")
         return uf["assetUrl"]
 
     async def download_asset(self, url: str) -> bytes:

--- a/app/devcake/adapters/registry.py
+++ b/app/devcake/adapters/registry.py
@@ -36,6 +36,12 @@ class PMOSystemInfo(BaseModel):
     operator_note: str = ""
     attachments_supported: bool = True
     relations_supported: bool = True
+    # Launch vs experimental honesty (docs/05 §9.7–9.8, docs/16). False =
+    # launch-supported (Linear, Gitea Issues). True = in-tree but not
+    # launch-supported (GitHub/GitLab Issues). SPA select + help copy read
+    # this; it is NOT a second code path — adapters still implement full
+    # PMOPort.
+    experimental: bool = False
 
 
 PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
@@ -89,11 +95,13 @@ PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
         supports_priority=False,
         attachments_supported=False,
         relations_supported=True,
+        experimental=True,
         operator_note=(
-            "GitHub's public API cannot attach files to issues. Transcripts, "
-            "plans, and other deliverables still land in the mission's "
-            "activity repo; the ticket comment carries a short reference. "
-            "This is a GitHub limitation, not a DevCake setting."
+            "Experimental (not launch-supported). GitHub's public API cannot "
+            "attach files to issues. Transcripts, plans, and other "
+            "deliverables still land in the mission's activity repo; the "
+            "ticket comment carries a short reference. Attachment limit is "
+            "a GitHub API gap, not a DevCake setting."
         ),
     ),
     "gitlab_issues": PMOSystemInfo(
@@ -115,12 +123,14 @@ PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
         supports_priority=False,
         attachments_supported=True,
         relations_supported=False,
+        experimental=True,
         operator_note=(
-            "Blocked-by issue links need GitLab Premium (or self-hosted EE). "
-            "DevCake probes the live token — Free boards will not write "
-            "decomposition traffic-control edges, and child missions will "
-            "not block each other. File attachments work. This is a GitLab "
-            "license limit, not a DevCake setting."
+            "Experimental (not launch-supported). Blocked-by issue links "
+            "need GitLab Premium (or self-hosted EE). DevCake probes the "
+            "live token — Free boards will not write decomposition "
+            "traffic-control edges, and child missions will not block each "
+            "other. File attachments work. Relations limit is a GitLab "
+            "license gap, not a DevCake setting."
         ),
     ),
 }

--- a/app/devcake/api/connections_service.py
+++ b/app/devcake/api/connections_service.py
@@ -293,6 +293,7 @@ async def connections_registry():
                 "operator_note": s.operator_note,
                 "attachments_supported": s.attachments_supported,
                 "relations_supported": s.relations_supported,
+                "experimental": s.experimental,
             }
             for s in PMO_SYSTEMS.values()
         ],

--- a/app/tests/test_config_schema.py
+++ b/app/tests/test_config_schema.py
@@ -427,6 +427,32 @@ def test_registry_payload_carries_operator_notes():
     assert by_id["linear"]["operator_note"] == ""
 
 
+def test_registry_marks_github_and_gitlab_issues_experimental():
+    """Launch vs experimental is registry metadata (not docs-only).
+
+    Linear + Gitea Issues are launch-supported; GitHub/GitLab Issues stay
+    experimental until the live contract battery graduates them (docs/05 §9.7–9.8,
+    docs/16). The SPA select and operator_note ride this flag.
+    """
+    import asyncio
+    from devcake.adapters.registry import PMO_SYSTEMS
+    from devcake.api.connections_service import connections_registry
+
+    assert PMO_SYSTEMS["linear"].experimental is False
+    assert PMO_SYSTEMS["gitea_issues"].experimental is False
+    assert PMO_SYSTEMS["github_issues"].experimental is True
+    assert PMO_SYSTEMS["gitlab_issues"].experimental is True
+    assert "experimental" in PMO_SYSTEMS["github_issues"].operator_note.lower()
+    assert "experimental" in PMO_SYSTEMS["gitlab_issues"].operator_note.lower()
+
+    payload = asyncio.new_event_loop().run_until_complete(connections_registry())
+    by_id = {s["id"]: s for s in payload["pmo_systems"]}
+    assert by_id["linear"]["experimental"] is False
+    assert by_id["gitea_issues"]["experimental"] is False
+    assert by_id["github_issues"]["experimental"] is True
+    assert by_id["gitlab_issues"]["experimental"] is True
+
+
 def test_stale_put_bodies_rejected_not_dropped():
     """pydantic ignores unknown keys, so without the guard a stale client's
     PUT would silently lose the edit instead of failing."""

--- a/app/tests/test_gitea_issues_contract.py
+++ b/app/tests/test_gitea_issues_contract.py
@@ -365,6 +365,8 @@ def test_capabilities_issue_only():
     assert caps.projects_supported is False
     assert caps.relations_supported is True
     assert caps.native_label_swap_atomic is True
+    assert caps.attachments_supported is True
+    assert caps.global_ids is False
 
 
 def test_project_ref_get_raises():
@@ -555,8 +557,10 @@ def test_download_asset_allows_same_host_redirect():
 
 
 @pytest.mark.parametrize("op", [
+    lambda pmo: pmo.get(MissionRef("9", "project")),
     lambda pmo: pmo.get_activity(MissionRef("9", "project"), full=True),
     lambda pmo: pmo.get_activity(MissionRef("9", "project")),
+    lambda pmo: pmo.children_of(MissionRef("9", "project")),
     lambda pmo: pmo.post_feed(MissionRef("9", "project"), "hi"),
     lambda pmo: pmo.set_status(MissionRef("9", "project"), "done"),
     lambda pmo: pmo.swap_labels(MissionRef("9", "project"), set(), {"X"}),
@@ -567,7 +571,8 @@ def test_project_ref_operations_raise_never_fabricate_or_noop(op):
     """projects_supported=False: a project ref is a caller bug (2026-08-12
     audit F1). The old adapter fabricated a Mission for get_activity and
     silently no-opped every write — success reported, no labels swapped, the
-    misroute invisible forever. All seven now raise the permanent family."""
+    misroute invisible forever. Every method raises the permanent family,
+    including children_of (must not return [])."""
     router = Router()
     pmo = make_pmo(router)
     with pytest.raises(RuntimeError, match="projects are not supported"):

--- a/app/tests/test_github_issues_contract.py
+++ b/app/tests/test_github_issues_contract.py
@@ -291,6 +291,14 @@ def test_project_ref_raises():
         run(make_pmo().get(MissionRef("1", "project")))
 
 
+def test_children_of_project_ref_raises_never_empty_list():
+    """projects_supported=False: children_of must not silently return [] on a
+    project ref (port F1 — every method raises the permanent family)."""
+    with pytest.raises(RuntimeError, match="projects are not supported"):
+        run(make_pmo().children_of(MissionRef("1", "project")))
+    assert run(make_pmo().children_of(MissionRef("1", "issue"))) == []
+
+
 def test_mixed_case_managed_label_normalizes_and_can_be_swapped():
     """GitHub folds case. A human `Devcake-Plan` must not wedge the stage."""
     r = Router()

--- a/app/tests/test_gitlab_issues_contract.py
+++ b/app/tests/test_gitlab_issues_contract.py
@@ -389,6 +389,42 @@ def test_upload_and_download_round_trip():
     assert r.notes[1] == []  # feed chokepoint posts the note, not upload
 
 
+def test_download_asset_maps_http_status_to_domain_errors():
+    """Port Liskov: download 429/5xx are retryable (PMOTransient); other ≥400
+    permanent. Mirrors upload_attachment / gitea_issues download mapping."""
+    url = ("https://gitlab.com/api/v4/projects/o%2Fr/"
+           "uploads/abc123/plan.md")
+
+    def handler_5xx(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="upstream down")
+
+    pmo = GitLabIssuesAdapter(
+        "https://gitlab.com", "tok", "o/r",
+        transport=httpx.MockTransport(handler_5xx))
+    with pytest.raises(PMOTransient, match="download"):
+        run(pmo.download_asset(url))
+
+    def handler_429(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, text="slow down")
+
+    pmo = GitLabIssuesAdapter(
+        "https://gitlab.com", "tok", "o/r",
+        transport=httpx.MockTransport(handler_429))
+    with pytest.raises(PMOTransient, match="download"):
+        run(pmo.download_asset(url))
+
+    def handler_4xx(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="forbidden")
+
+    pmo = GitLabIssuesAdapter(
+        "https://gitlab.com", "tok", "o/r",
+        transport=httpx.MockTransport(handler_4xx))
+    with pytest.raises(RuntimeError, match="download") as ei:
+        run(pmo.download_asset(url))
+    assert not isinstance(ei.value, PMOTransient)
+    assert not isinstance(ei.value, httpx.HTTPError)
+
+
 def test_download_asset_refuses_evil_host():
     pmo = make_pmo()
     with pytest.raises(RuntimeError, match="refused"):

--- a/app/tests/test_gitlab_issues_contract.py
+++ b/app/tests/test_gitlab_issues_contract.py
@@ -359,6 +359,15 @@ def test_project_ref_get_raises():
         run(pmo.get(MissionRef("1", "project")))
 
 
+def test_children_of_project_ref_raises_never_empty_list():
+    """projects_supported=False: children_of must not silently return [] on a
+    project ref (port F1 — every method raises the permanent family)."""
+    pmo = make_pmo()
+    with pytest.raises(RuntimeError, match="projects are not supported"):
+        run(pmo.children_of(MissionRef("1", "project")))
+    assert run(pmo.children_of(MissionRef("1", "issue"))) == []
+
+
 def test_429_is_pmo_transient():
     def handler(req: httpx.Request) -> httpx.Response:
         return httpx.Response(429, text="slow down")

--- a/app/tests/test_linear_download_asset.py
+++ b/app/tests/test_linear_download_asset.py
@@ -76,3 +76,28 @@ def test_download_asset_refuses_oversized_body():
         "C", (), {"attachment_max_bytes": 40})()
     with pytest.raises(RuntimeError, match="refused"):
         run(a.download_asset("https://uploads.linear.app/team/big.bin"))
+
+
+def test_download_asset_maps_http_status_to_domain_errors():
+    """Port Liskov: httpx status/network failures must not escape the adapter
+    — only PMOTransient (retryable) or permanent RuntimeError."""
+    from devcake.ports.pmo import PMOTransient
+
+    def handler_5xx(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="upstream down")
+
+    a = LinearAdapter(
+        api_key="lin_api_test_key_xxxxxxxxxxxx",
+        transport=httpx.MockTransport(handler_5xx))
+    with pytest.raises(PMOTransient, match="download"):
+        run(a.download_asset("https://uploads.linear.app/team/x.bin"))
+
+    def handler_4xx(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="forbidden")
+
+    a = LinearAdapter(
+        api_key="lin_api_test_key_xxxxxxxxxxxx",
+        transport=httpx.MockTransport(handler_4xx))
+    with pytest.raises(RuntimeError, match="download") as ei:
+        run(a.download_asset("https://uploads.linear.app/team/x.bin"))
+    assert not isinstance(ei.value, httpx.HTTPError)

--- a/app/tests/test_linear_download_asset.py
+++ b/app/tests/test_linear_download_asset.py
@@ -101,3 +101,54 @@ def test_download_asset_maps_http_status_to_domain_errors():
     with pytest.raises(RuntimeError, match="download") as ei:
         run(a.download_asset("https://uploads.linear.app/team/x.bin"))
     assert not isinstance(ei.value, httpx.HTTPError)
+
+
+async def _file_upload_gql(query, variables=None):
+    """Canned fileUpload mutation so tests can drive only the PUT status map."""
+    _ = query, variables
+    return {
+        "fileUpload": {
+            "success": True,
+            "uploadFile": {
+                "uploadUrl": "https://uploads.linear.app/put",
+                "assetUrl": "https://uploads.linear.app/asset/x",
+                "headers": [{"key": "Upload-Key", "value": "v"}],
+            },
+        },
+    }
+
+
+def test_upload_attachment_maps_http_status_to_domain_errors():
+    """Port Liskov: permanent PUT 4xx must not become PMOTransient via
+    raise_for_status() + blanket HTTPError (HTTPStatusError ⊆ HTTPError).
+    Retryable 429/5xx → PMOTransient; other ≥400 → permanent RuntimeError."""
+    from devcake.ports.pmo import PMOTransient
+
+    def put_status(code: int, text: str = ""):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "PUT"
+            return httpx.Response(code, text=text or f"status {code}")
+        return handler
+
+    a = LinearAdapter(
+        api_key="lin_api_test_key_xxxxxxxxxxxx",
+        transport=httpx.MockTransport(put_status(403, "forbidden")))
+    a._gql = _file_upload_gql  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="upload") as ei:
+        run(a.upload_attachment("issue-id", "plan.md", b"# plan"))
+    assert not isinstance(ei.value, PMOTransient)
+    assert not isinstance(ei.value, httpx.HTTPError)
+
+    a = LinearAdapter(
+        api_key="lin_api_test_key_xxxxxxxxxxxx",
+        transport=httpx.MockTransport(put_status(503, "upstream down")))
+    a._gql = _file_upload_gql  # type: ignore[method-assign]
+    with pytest.raises(PMOTransient, match="upload"):
+        run(a.upload_attachment("issue-id", "plan.md", b"# plan"))
+
+    a = LinearAdapter(
+        api_key="lin_api_test_key_xxxxxxxxxxxx",
+        transport=httpx.MockTransport(put_status(429, "slow down")))
+    a._gql = _file_upload_gql  # type: ignore[method-assign]
+    with pytest.raises(PMOTransient, match="upload"):
+        run(a.upload_attachment("issue-id", "plan.md", b"# plan"))

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -94,13 +94,14 @@ class PMOHealth(BaseModel):        # neutral connection-probe result — replace
     detail: str = ""
 
 class PMOCapabilities(BaseModel):
-    projects_supported: bool          # Linear: True
+    projects_supported: bool          # Linear: True; forge-issue: False
     project_labels_supported: bool    # Linear: True (project labels since 2025-06)
     attachment_max_bytes: int
     native_label_swap_atomic: bool    # Linear: True via issueUpdate(labelIds)
-    relations_supported: bool = False # write support latched on create_relation; False until a blocking-link POST succeeds
-    attachments_supported: bool = True  # official file-upload API
-    attachments_supported: bool = True  # official file-upload API; false skips upload + contract rows 8/13
+    relations_supported: bool = False # write support; GitLab Free latches False on 403
+    attachments_supported: bool = True  # official file-upload API; False → feed multipart (GitHub)
+    comment_max_chars: int | None = None  # GitHub Issues: 65536; None = no extra cap
+    global_ids: bool = False          # Linear UUIDs True; forge-issue numbers False
 ```
 
 `/health` and `POST /api/v1/connections/pmo/{name}/test` consume `health_probe` (the public port method) instead of reaching into adapter internals. Two deliberate behavior changes from the pre-port era: the managed-label count is the **intersection with `ALL_LABELS`** (a `DEVCAKE-CUSTOM-EXTRA` label no longer inflates it, as the old `startswith("DEVCAKE")` check did), and the test endpoint's response now carries `labels_expected` alongside `labels`.
@@ -109,10 +110,10 @@ class PMOCapabilities(BaseModel):
 
 `app/devcake/adapters/registry.py` is the single place that knows which PMO systems exist and how to construct them. The domain never imports it — `api/main.py` builds adapters here and injects them (`01-architecture.md` §3).
 
-- **`PMO_SYSTEMS: dict[str, PMOSystemInfo]`** — registry metadata per system: `id`, `display_name`, `secret_env_vars`, `token_patterns` (regex sources), `secret_shape_prefixes`. (There is no `api_key_env_default` field — schema v4 stores secret VALUES in the GUI store.) The secret fields feed `security.redact` (`14-security.md` §7) and the admin SPA's paste guard — every registered system contributes its token shapes **whether configured or not**, so switching adapters never opens a redaction gap. Linear's entry: env names for redaction `LINEAR_API_KEY`, patterns `lin_api_…`/`lin_oauth_…`, prefixes `lin_api_`/`lin_oauth_`.
-- **`make_pmo(inst) -> PMOPort`** constructs one adapter for a single `PMOInstance` (`inst`); the composition root builds **one manager/adapter per** configured entry in `config.pmos` (0..N). An unregistered `inst.system` raises.
+- **`PMO_SYSTEMS: dict[str, PMOSystemInfo]`** — registry metadata per system: `id`, `display_name`, `secret_env_vars`, `token_patterns` (regex sources), `secret_shape_prefixes`, capability residual flags (`attachments_supported`, `relations_supported`, `supports_priority`), `operator_note`, and **`experimental`** (launch vs experimental honesty — `True` for GitHub Issues and GitLab Issues; `False` for Linear and Gitea Issues). (There is no `api_key_env_default` field — schema v4 stores secret VALUES in the GUI store.) The secret fields feed `security.redact` (`14-security.md` §7) and the admin SPA's paste guard — every registered system contributes its token shapes **whether configured or not**, so switching adapters never opens a redaction gap. Linear's entry: env names for redaction `LINEAR_API_KEY`, patterns `lin_api_…`/`lin_oauth_…`, prefixes `lin_api_`/`lin_oauth_`.
+- **`make_pmo(inst) -> PMOPort`** constructs one adapter for a single `PMOInstance` (`inst`); the composition root builds **one manager/adapter per** configured entry in `config.pmos` (0..N). An unregistered `inst.system` raises. Non-Linear systems register the GUI-stored API key via `register_runtime_secret` so exact-match redaction covers pasted tokens without a shape pattern.
 - **`PMOInstance.system` is validated against `PMO_SYSTEMS`** at config-load/PUT time (pydantic field validator), so a typo'd system name is a 422, not a boot crash.
-- **`GET /api/v1/connections/registry`** exposes the registered PMO systems and forges (display names, default env-var names, merged `secret_shape_prefixes`, `managed_labels_expected`) — the admin Config page's selectors and paste guard are driven from it, so adding an adapter never means editing the SPA (`11-admin-panel.md`).
+- **`GET /api/v1/connections/registry`** exposes the registered PMO systems and forges (display names, capability residual flags, `operator_note`, `experimental`, merged `secret_shape_prefixes`, `managed_labels_expected`) — the admin PMO page's selectors, experimental suffix, and paste guard are driven from it, so adding an adapter never means editing the SPA (`11-admin-panel.md`).
 - **Hot reload:** a successful config `PUT` calls `reload_connections()` — the PMO (and forge) adapters are rebuilt from the saved config, the orchestrator is repointed, and `ensure_labels` is re-run for the (possibly new) team. Label bootstrap is otherwise startup-only; without the re-ensure, a hot-swapped `team_key` would run unlabeled until restart.
 
 The registry also carries the forge side (`forges()` / `make_forge`, `06-forge-adapter.md`); the shapes mirror each other.
@@ -310,13 +311,13 @@ Expect all rows **PASS** (1–5, 5b, 8–14 when `relations_supported`). Same sc
 
 **GHA `ci.yml` note:** the minimal dispatch compose has no Gitea, so the PMO live battery stays in **local `ci_suite.sh`** (full stack), not the PR-minimal job — same as the forge contract battery today.
 
-### 9.6 Path to GitHub / GitLab Issues
+### 9.6 GitHub / GitLab Issues — experimental in-tree
 
-Same forge-issue profile (issue-only, label stages, open→backlog, markdown comments, dependency/links). New package per vendor; do **not** grow a shared Issues Port until a second forge-issue adapter exists. Live gate: same `scripts/contract_tests_pmo.py` once the system is registered.
+GitHub Issues and GitLab Issues ship as **experimental** forge-issue adapters (same profile: issue-only, label stages, open→backlog, markdown comments, dependency/links). They are **not** launch-supported until the live `scripts/contract_tests_pmo.py` battery graduates them (docs/16). Registry `PMOSystemInfo.experimental=True` and `operator_note` keep the admin SPA honest; do not present them as equal to Linear / Gitea Issues. Shared cancel footer lives in `adapters/forge_issue.py` (not a second Issues Port).
 
 ### 9.7 GitLab Issues (`gitlab_issues`) — experimental
 
-**Experimental** (in-tree, not launch-supported) as of 2026-08-15. `team_key` is `path_with_namespace` (two or more segments). `api_base` defaults to `https://gitlab.com`. Auth: `PRIVATE-TOKEN` (`glpat-…`).
+**Experimental** (in-tree, not launch-supported) as of 2026-08-15 — registry `experimental=True`. `team_key` is `path_with_namespace` (two or more segments). `api_base` defaults to `https://gitlab.com`. Auth: `PRIVATE-TOKEN` (`glpat-…`).
 
 | Need | Measured |
 |---|---|
@@ -330,7 +331,7 @@ Same forge-issue profile (issue-only, label stages, open→backlog, markdown com
 
 ### 9.8 GitHub Issues (`github_issues`) — experimental
 
-**Experimental** (in-tree, not launch-supported) as of 2026-08-15. `team_key` is `owner/repo`. `api_base` defaults to `https://api.github.com`. Auth: `Authorization: Bearer` (`ghp_` / `github_pat_`).
+**Experimental** (in-tree, not launch-supported) as of 2026-08-15 — registry `experimental=True`. `team_key` is `owner/repo`. `api_base` defaults to `https://api.github.com`. Auth: `Authorization: Bearer` (`ghp_` / `github_pat_`).
 
 | Need | Measured |
 |---|---|

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -895,14 +895,15 @@ and not sufficient). Launch-supported PMOs remain Linear + Gitea Issues.
 
 | Kind | Names | Registry id | Gate / status |
 |---|---|---|---|
-| PMO | GitHub Issues, GitLab Issues | `github_issues`, `gitlab_issues` | **experimental** — live `contract_tests_pmo.py`: row 12 never skippable; row 8/13 skip iff `attachments_supported` is false; row 10 matches row 14 (`relations_supported`, probed from the live token — not hardcoded). No blanket “documented capability skip”. |
+| PMO | GitHub Issues, GitLab Issues | `github_issues`, `gitlab_issues` | **experimental** — `PMOSystemInfo.experimental=True` in the adapter registry (admin SPA select suffix + operator_note). Live `contract_tests_pmo.py`: row 12 never skippable; row 8/13 skip iff `attachments_supported` is false; row 10 matches row 14 (`relations_supported`, probed from the live token — not hardcoded). No blanket “documented capability skip”. |
 | Platform | `HarnessDialect` + registry-as-id-source + `aim()` | — | shipped for all six house templates |
 | Harness | Pi, OpenCode, Qwen Code | `pi`, `opencode`, `qwen-code` | **launch-supported** (dialect + Bake + aim + captures; resume still off until a capture pair) |
 
 Copy the `gitea_issues` profile (docs/05 §9): issue-only, `open→backlog`,
 `DEVCAKE-*` labels, `team_key=owner/repo`, `global_ids=False`. Separate
-packages — do **not** add issue methods to `ForgePort`. Do **not** extract a
-shared Issues port until the second forge-issue adapter exists (§9.6).
+packages — do **not** add issue methods to `ForgePort`. Cancel footer is
+shared via `adapters/forge_issue.py`; still do **not** invent a second
+Issues Port abstraction beyond that chokepoint (docs/05 §9.6).
 
 H1 lives in `images/common/devcake_dev/harness/` (Dev hexagon). Do not add
 `ports/harness.py` on the app. `app/devcake/harness.py` stays image / creds /

--- a/docs/adr/0008-pluggable-pmo-and-forge-adapters.md
+++ b/docs/adr/0008-pluggable-pmo-and-forge-adapters.md
@@ -50,12 +50,15 @@ instance, eventually — without touching the core.
 3. **Adapter registry + hot reload.** `adapters/registry.py` is the single
    place that knows which PMO systems and forges exist (`PMO_SYSTEMS`,
    `make_pmo`, `make_forge`, `forges()`), including each adapter's secret env
-   vars, token regexes, and paste-guard prefixes. Config `system`/`forge`
-   fields are open strings validated against the registry (an unknown value
-   422s exactly like the old `Literal`s). A config PUT calls
-   `reload_connections()`: both adapters rebuild, and managed labels are
-   re-ensured for the (possibly new) team. `GET /api/v1/connections/registry`
-   feeds the admin SPA, so adding an adapter never edits the UI.
+   vars, token regexes, paste-guard prefixes, capability residual flags, and
+   launch-vs-experimental labeling (`PMOSystemInfo.experimental` — in-tree
+   GitHub/GitLab Issues are experimental; Linear + Gitea Issues are not).
+   Config `system`/`forge` fields are open strings validated against the
+   registry (an unknown value 422s exactly like the old `Literal`s). A config
+   PUT calls `reload_connections()`: both adapters rebuild, and managed
+   labels are re-ensured for the (possibly new) team.
+   `GET /api/v1/connections/registry` feeds the admin SPA, so adding an
+   adapter never edits the UI.
 
 4. **`ForgeDescriptor` owns the dev-side dialect.** Everything forge-specific
    that is not an API call — PR/MR CLI instructions, clone auth user, git


### PR DESCRIPTION
## Summary

Pre-FOSS audit + fix of the `PMOPort` seam (CAKE-20 / CAKE-4 part 1/4).

### Round 1 (prior)
- **Experimental labeling honesty:** `PMOSystemInfo.experimental` on the registry; `True` for `github_issues` / `gitlab_issues`, `False` for Linear + Gitea Issues. Projected on `GET /api/v1/connections/registry`; SPA FALLBACK + system select suffix + help copy. `operator_note` leads with Experimental.
- **Port F1 / project refs:** forge-issue `children_of` raises on project-kind refs.
- **Linear `download_asset`:** 429/5xx → `PMOTransient`; other ≥400 → permanent `RuntimeError`.
- **Gitea capabilities:** explicit `attachments_supported=True` / `global_ids=False`.
- **Docs:** `docs/05`, `docs/16`, ADR-0008.

### Round 2 (REVIEW R1/R2/R3)
- **R1 Linear `upload_attachment`:** no longer maps permanent 4xx to `PMOTransient` via `raise_for_status()` + blanket `HTTPError`. Status split mirrors download: network → `PMOTransient`; 429/5xx → `PMOTransient`; other ≥400 → `RuntimeError`.
- **R2 GitLab `download_asset`:** 429/5xx → `PMOTransient` (was all ≥400 permanent); mirrors GitLab upload / Gitea download.
- **R3 residual:** remaining PMO asset paths already correct (Gitea up/down, GitLab upload, GitHub unsupported raises, Linear download).

### Live contract battery

**Not executed** — no operator tokens / stack for live rows:

- `DEVCAKE_CONTRACT_INSTANCE` / `DEVCAKE_CONTRACT_SYSTEM`+`TOKEN`+`TEAM` unset for Linear / GitHub Issues / GitLab Issues
- Default `GITEA_ADMIN_*` CI lane needs full compose stack (`ci_suite.sh`)
- All rows of `scripts/contract_tests_pmo.py` remain **operator-token-gated** (or Gitea-admin-gated)

### Tests

- `PYTHONPATH=app` pytest (3.12): focused PMO suite **245 passed** after R1/R2 (including new status-map tests)
- Host lacks `docker buildx bake`; CI rebakes `app-test`

## Mission

https://linear.app/fidecastro/issue/CAKE-20/pre-foss-pmoport-and-pmo-adapters-audit-fix