### PR TITLE
[CAKE-38] [pre-FOSS] GUI secret store + transcript redaction audit and fix

### DIFF
--- a/app/devcake/adapters/gitea/provision.py
+++ b/app/devcake/adapters/gitea/provision.py
@@ -670,11 +670,11 @@ class GiteaProvisioner:
     # ── secret storage (0600, two-level path → auto-redaction scan) ─────────
 
     def _store(self, name: str, data: dict) -> None:
-        d = _secrets_dir()
-        d.mkdir(parents=True, exist_ok=True)
-        path = d / name
-        path.write_text(json.dumps(data))
-        path.chmod(0o600)
+        """Atomic 0600 JSON under internal_forge/; invalidates the redaction
+        scan so a just-minted token is disk-scanned before the next redact
+        (same contract as secrets._atomic_write — CAKE-38)."""
+        from ...secrets import write_system_secret_json
+        write_system_secret_json("internal_forge", name, data)
 
     def _load(self, name: str) -> dict | None:
         path = _secrets_dir() / name

--- a/app/devcake/adapters/registry.py
+++ b/app/devcake/adapters/registry.py
@@ -131,28 +131,25 @@ def make_pmo(inst) -> PMOPort:
     if inst.system not in PMO_SYSTEMS:
         raise ValueError(f"unknown PMO system {inst.system!r} — registered: "
                          f"{sorted(PMO_SYSTEMS)}")
+    # Factory registration is the redaction line for unusual key shapes under
+    # the 16-char disk-scan floor (store write + register_all cover the rest).
+    # Every system registers under the same pmo_key:{name} scheme.
+    from ..security import register_runtime_secret
+    if inst.api_key:
+        register_runtime_secret(f"pmo_key:{inst.name}", inst.api_key)
     if inst.system == "linear":
         from .linear import LinearAdapter
         return LinearAdapter(inst.api_key, instance=inst.name)
     if inst.system == "gitea_issues":
         from .gitea_issues import GiteaIssuesAdapter
-        from ..security import register_runtime_secret
-        if inst.api_key:
-            register_runtime_secret(f"pmo_key:{inst.name}", inst.api_key)
         return GiteaIssuesAdapter(
             inst.api_base, inst.api_key, inst.team_key, instance=inst.name)
     if inst.system == "github_issues":
         from .github_issues import GitHubIssuesAdapter
-        from ..security import register_runtime_secret
-        if inst.api_key:
-            register_runtime_secret(f"pmo_key:{inst.name}", inst.api_key)
         return GitHubIssuesAdapter(
             inst.api_base, inst.api_key, inst.team_key, instance=inst.name)
     if inst.system == "gitlab_issues":
         from .gitlab_issues import GitLabIssuesAdapter
-        from ..security import register_runtime_secret
-        if inst.api_key:
-            register_runtime_secret(f"pmo_key:{inst.name}", inst.api_key)
         return GitLabIssuesAdapter(
             inst.api_base, inst.api_key, inst.team_key, instance=inst.name)
     raise AssertionError("unreachable")  # registry and constructors in sync
@@ -188,12 +185,20 @@ def make_internal_forge():
 def make_gitea_adapter(url: str, token: str, reviewer_token: str | None = None):
     """Construct a Gitea ForgePort with EXPLICIT tokens (not env-resolved) —
     the app-side adapter for an internal-forge mission repo. Registers the
-    tokens for redaction like make_forge does."""
+    tokens for redaction like make_forge does.
+
+    Keys are content-addressed (sha256 prefix), not token[:6]: Gitea PATs are
+    40-hex and concurrent mission tokens can share a 6-char prefix — a
+    prefix key would overwrite in _runtime_secrets and eventually drop older
+    values out of the prior list (CAKE-38).
+    """
+    import hashlib
     from .gitea import GiteaForge
     from ..security import register_runtime_secret
     for v in (token, reviewer_token):
         if v:
-            register_runtime_secret(f"forge_token:gitea:{v[:6]}", v)
+            digest = hashlib.sha256(v.encode()).hexdigest()[:16]
+            register_runtime_secret(f"forge_token:gitea:{digest}", v)
     return GiteaForge(url, token, reviewer_token)
 
 

--- a/app/devcake/secrets.py
+++ b/app/devcake/secrets.py
@@ -195,6 +195,25 @@ _RESERVED_SECRET_DIRS = frozenset({
 })
 
 
+def write_system_secret_json(subdir: str, filename: str, data: dict) -> Path:
+    """Atomic 0600 JSON under /data/secrets/{subdir}/{filename}.
+
+    For system-managed reserved dirs (internal_forge, …) that share the
+    redaction glob. Same write choke point as connection/harness secrets —
+    invalidates the redaction scan cache. Path components are validated so
+    callers cannot escape the secrets root.
+    """
+    if subdir not in _RESERVED_SECRET_DIRS:
+        raise ValueError(f"not a system secret dir: {subdir!r}")
+    base = os.path.basename(filename or "")
+    if (not base or base != filename or base in (".", "..")
+            or "/" in base or "\\" in base):
+        raise ValueError(f"invalid system secret filename {filename!r}")
+    path = _root() / subdir / base
+    _atomic_write(path, data)
+    return path
+
+
 def require_credential_ref(dev_type: str, filename: str) -> None:
     """Path components only — refuse reserved dirs and traversal."""
     if (not dev_type or dev_type in _RESERVED_SECRET_DIRS

--- a/app/tests/test_security.py
+++ b/app/tests/test_security.py
@@ -331,3 +331,97 @@ def test_profile_secret_snapshots_are_covered_by_the_redaction_glob(tmp_path, mo
          "harness": {"ANTHROPIC_API_KEY": value + "-h"}}))
     out = security.redact(f"transcript {value} and {value}-h end")
     assert value not in out and MASK in out
+
+
+def test_make_gitea_adapter_registers_tokens_without_prefix_collision():
+    """CAKE-38: registration keys must not be token[:6] — Gitea PATs that
+    share a 6-hex prefix would overwrite each other in _runtime_secrets and
+    eventually drop out of the prior list (cap 64), unmasking live mission
+    tokens. Content-addressed (or otherwise unique-per-value) keys keep every
+    concurrent token redacted."""
+    from devcake.adapters.registry import make_gitea_adapter
+    from devcake.security import register_runtime_secret, unregister_runtime_secret
+    import devcake.security as sec
+
+    # 40-char hex-like tokens sharing the first 6 chars (realistic Gitea shape)
+    tokens = [f"aaaaaa{i:034d}" for i in range(70)]
+    try:
+        for tok in tokens:
+            make_gitea_adapter("http://gitea:3000/devcake-internal/m.git",
+                              tok, None)
+        first, last = tokens[0], tokens[-1]
+        out = redact(f"leak {first} and {last}")
+        assert first not in out and last not in out
+        assert MASK in out
+    finally:
+        sec._runtime_secrets.clear()
+        sec._runtime_secret_priors.clear()
+
+
+def test_make_pmo_registers_api_key_for_every_system(tmp_path, monkeypatch):
+    """CAKE-38: every make_pmo path must register_runtime_secret the instance
+    key. Linear historically skipped factory registration and relied only on
+    store write + pattern match — unusual key shapes under the 16-char disk
+    scan floor then had no factory-side redaction line."""
+    import json as _json
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake.adapters.registry import PMO_SYSTEMS, make_pmo
+    from devcake.config import PMOInstance
+    from devcake.security import unregister_runtime_secret
+
+    # 12 chars: above redact's 8-char floor, below disk-scan's 16-char floor —
+    # only runtime registration (factory or register_all) can mask it.
+    secret = "short-pmo-k1"
+    assert 8 <= len(secret) < 16
+    for system in sorted(PMO_SYSTEMS):
+        # instance names: ^[a-z][a-z0-9]{0,11}$
+        inst_name = ("linear" if system == "linear"
+                     else system.replace("_", "")[:12])
+        # direct disk write — skip secrets.write_* so conn: keys are absent
+        conn = tmp_path / "secrets" / "connections"
+        conn.mkdir(parents=True, exist_ok=True)
+        (conn / f"pmo-{inst_name}.json").write_text(
+            _json.dumps({"api_key": secret}))
+        inst = PMOInstance(
+            name=inst_name, system=system, team_key="T",
+            api_base="http://example.test" if system != "linear" else None)
+        try:
+            make_pmo(inst)
+            out = redact(f"pmo leak {secret}")
+            assert secret not in out, f"{system} did not register api_key"
+            assert MASK in out
+        finally:
+            unregister_runtime_secret(f"pmo_key:{inst_name}")
+
+
+def test_internal_forge_store_invalidates_scan_and_is_0600(tmp_path, monkeypatch):
+    """CAKE-38: internal_forge token files share the redaction glob. A plain
+    write_text+chmod is not atomic (default umask window) and used to skip
+    invalidate_secret_scan — a just-minted token could miss the disk-scan
+    half of redaction until some other store write flushed the cache.
+    Runtime register covers mint, but load-from-disk / cold scan must see
+    the file immediately too."""
+    import json as _json
+    import stat
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake.adapters.gitea.provision import GiteaProvisioner
+    from devcake import security
+
+    monkeypatch.setattr(security, "_SECRETS_DIR", tmp_path / "secrets")
+    security.invalidate_secret_scan()
+    security.redact("warm the known-values cache")  # populate empty result
+
+    prov = GiteaProvisioner(url="http://gitea:3000", admin_user="a",
+                            admin_password="p")
+    token = "just-minted-internal-token-abcdef"
+    prov._store("service.json", {"app_token": token, "reviewer_token": ""})
+
+    path = tmp_path / "secrets" / "internal_forge" / "service.json"
+    assert path.is_file()
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert _json.loads(path.read_text())["app_token"] == token
+    # no leftover tmp from a non-atomic writer
+    assert list((tmp_path / "secrets" / "internal_forge").glob("*.tmp")) == []
+    # disk scan half: without invalidate this stays unmasked after cache warm
+    out = security.redact(f"transcript {token} end")
+    assert token not in out and MASK in out

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -364,10 +364,21 @@ values and token patterns with `«REDACTED»` (`app/devcake/security.py`):
 - **Registry contributions** — every registered PMO/forge adapter’s
   `secret_env_vars` / `token_patterns` (configured or not). Superset tripwire in
   `app/tests/test_security.py`.
+- **GUI secret store (disk + write/boot registration)** — every long-ish
+  string value (≥16 chars) under `/data/secrets/*/*` is scanned; every store
+  write also `register_runtime_secret`s the value, and boot calls
+  `secrets.register_all()` so values under the 16-char scan floor stay exact-
+  match masked (ADR-0011). System-managed files under `internal_forge/` use
+  the same atomic write + scan-invalidation choke point.
 - **Gitea internal tokens** — 40 hex; patterns would mask git SHAs. Value
-  registration only (`register_runtime_secret` + `/data/secrets/internal_forge/`).
-- **Runtime registry** — per-run Redis ACL password; empty after app restart
-  (inbound envelope scrub still covers the dominant echo path).
+  registration only (`register_runtime_secret` at mint/load + the disk scan
+  of `/data/secrets/internal_forge/`). Factory registration for explicit
+  Gitea adapter tokens is content-addressed (not a token prefix) so concurrent
+  mission PATs cannot collide in the runtime map.
+- **Runtime registry** — per-run Redis ACL password (empty after app restart
+  until the next run mints one) plus the write/boot/factory registrations
+  above. Inbound envelope scrub still covers the dominant Redis-password
+  echo path.
 
 Redaction matters **because Devs hold secrets**. It is the last line of defense
 for **app-mediated** posts to PMO systems and forges, not a substitute for zone C.


### PR DESCRIPTION
## Summary

Pre-FOSS audit of the GUI-only secret store and app-mediated transcript redaction against `docs/14-security.md` §§4/7 and ADR-0011.

**Held (no change):** never-echo GET/status; presence-and-timestamp secrets-check/inventory (no value-derived fingerprints); write-time + boot `register_all`; scan-cache invalidation on GUI store writes; `redact()` at feed/finalize/forge/audit choke points.

**Fixed:**
1. **`make_gitea_adapter` registration keys** — content-addressed (sha256) instead of `token[:6]`, so concurrent internal-forge PATs that share a 6-hex prefix cannot overwrite each other and eventually drop out of the prior list.
2. **`make_pmo` for Linear** — factory now registers `pmo_key:{name}` like every other PMO system (short non-pattern keys under the 16-char disk floor had no construction-time redaction line).
3. **Internal-forge `_store`** — atomic 0600 write via new `secrets.write_system_secret_json` (invalidates redaction scan) instead of `write_text` + late `chmod`.
4. **`docs/14` §7** — honestly lists GUI store disk scan + write/boot registration and the content-addressed factory keys.

**Deviation:** PLAN step uploaded only a stub; EXECUTE re-audited from the mission brief + ONBOARD baseline (same situation as prior CAKE PLAN stubs).

## Mission

https://linear.app/fidecastro/issue/CAKE-38/pre-foss-gui-secret-store-transcript-redaction-audit-and-fix

## Test plan

- [x] New TDD tests in `test_security.py` (prefix collision, make_pmo all systems, internal_forge store 0600+invalidate)
- [x] Related suite green in `devcake/app-test` image (116 tests: security, secrets_store, secret_reload_lock, hygiene, internal_forge_provision, agnosticism, forge_runtime, connection_test, default_board)
- [ ] CI `ci.yml` green on this PR