### PR TITLE
[CAKE-12] FOSS entry surfaces: README, tutorials, positioning, AGENTS contradictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ into `.env`, optionally bakes, then runs compose. Control ports bind
 2. [Tutorial 2 — daily operations](docs/tutorials/02-operating-devcake.md)
 3. [Tutorial 3 — MCP plugins](docs/tutorials/03-mcp-plugins.md)
 4. Fresh empty volume drill: [operator-drill](docs/tutorials/operator-drill.md)
+5. Pre-v1 host wipe-and-re-onboard: [host-refresh](docs/tutorials/host-refresh.md)
 
 After upgrades or changes under `app/`, `admin/`, or `images/`:
 
@@ -246,18 +247,30 @@ More detail: [`AGENTS.md`](AGENTS.md) · [`docs/13-deployment.md`](docs/13-deplo
 
 ## Verify
 
+Primary local unit path (always rebakes `app-test` so the image matches the
+tree; prefers Docker Buildx bake and falls back to a plain Dockerfile build
+where bake is unavailable — e.g. podman/buildah hosts, see
+`scripts/lib/bake_app_test.sh`):
+
 ```bash
-# Unit suite only (always rebuilds app-test so the image matches the tree).
-# Prefers Docker Buildx bake; falls back to Dockerfile --target test when bake
-# is missing (e.g. podman/buildah hosts — see scripts/lib/bake_app_test.sh):
 ./scripts/pytest_app.sh
+```
 
-# CI-shaped bake (requires real Docker Buildx — not buildah's buildx shim):
+CI-shaped proof on a full Docker Engine (real Buildx — not buildah's shim)
+matches [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — bake group
+`ci`, then Redis + pytest in `app-test`, then the dispatch smoke. The bake
+line CI uses is:
+
+```bash
 docker buildx bake -f docker-bake.hcl -f docker-bake.ci.hcl ci
+```
 
-# Local suite (healthy stack already up; pin gate + ruff + pytest + forge/PMO
-# contracts + dispatch-hello). Not a full GHA clone (no npm/pip-audit; no
-# control-plane rebake). Mixed-version live stack prints a warning banner:
+Full local suite when the stack is up (pin gate + ruff + pytest + forge/PMO
+contract batteries + dispatch-hello smoke). Not a full GHA clone (no
+npm/pip-audit, no control-plane rebake); a mixed-version live stack prints a
+warning banner:
+
+```bash
 ./scripts/ci_suite.sh
 ```
 

--- a/docs/17-positioning.md
+++ b/docs/17-positioning.md
@@ -3,15 +3,18 @@
 > **Audience:** anyone writing outward-facing words about this project — README,
 > website, pitch, launch post. The README is the applied version of this doc;
 > the full argument it compresses is [`19-thesis.md`](19-thesis.md).
-> **Status:** adopted at v0 close; last revised 2026-08-11 — §1, §1c, §6.
+> **Status:** adopted — normative for outward copy.
 > **Aligned with the product security contract**
 > in [`14-security.md`](14-security.md). Outward copy must not claim a stronger
-> posture than `14`.
+> posture than `14`. Ship history and backlog live in
+> [`16-roadmap.md`](16-roadmap.md).
 
 ## 1. The core insight
 
 DevCake is a **meta-harness** — a CLI agent orchestrator. It does not replace
-Claude Code, Grok Build, or Codex; it **staffs** them. Those tools are model
+Claude Code, Grok Build, Codex, or the other registry harnesses; it **staffs**
+them (examples, not an exclusive roster — full launch-supported set in
+[`08-harness-templates.md`](08-harness-templates.md)). Those tools are model
 harnesses: one session between a model and its tools. DevCake is the outer
 envelope that turns board work into sequenced, isolated, accountable harness
 runs — swap the workers without changing the control plane.
@@ -68,9 +71,11 @@ both lists recognizable within the first minute.
 
 **Use DevCake when:**
 
-- Your team already runs real work through a task board (Linear in-tree today)
-  and the board has discipline: tickets are written to be picked up, and
-  labels mean things.
+- Your team already runs real work through a task board (**Linear** and
+  **Gitea Issues** are launch-supported; **GitHub Issues** and **GitLab
+  Issues** are experimental — [`05-pmo-adapter.md`](05-pmo-adapter.md)) and
+  the board has discipline: tickets are written to be picked up, and labels
+  mean things.
 - One adult operator can own a dedicated machine and the trust envelope that
   comes with it — team membership, branch protection, credentials, backups
   ([`18-operator-contract.md`](18-operator-contract.md)).
@@ -146,20 +151,22 @@ multi-tenant sandbox, and receipts do not make agents injection-proof
 > tight.
 
 **Two minutes (engineers):** the thirty-second pitch, then:
-> Under the hood it's deliberately boring: your PMO system (Linear in v0) is
-> the single source of truth, and labels form the state machine — triage, plan,
-> execute, review. Each step runs as a disposable Docker container wrapping a
-> real coding harness — Claude Code, Grok Build, or Codex — using the
-> subscription or API credentials you provide. Dagu holds `docker.sock` on a
-> dedicated host; that is intentional, not an accident (`14`). There are no
-> persistent per-Mission leases or checkouts: a crashed agent holds nothing,
-> while process-local locks only serialize dispatch and maintenance. A human
-> edit to a ticket always beats an in-flight agent. "Done"
-> means *merged* — never before. Everything is traced in OpenTelemetry down to
-> token counts; a large test suite pins behavioral invariants. The security
-> contract is adult-operator: prompt injection is in scope of “ticket writers
-> are trusted,” and the real supply-chain defense is branch protection and
-> human merge. One Bake + compose brings up the stack on loopback.
+> Under the hood it's deliberately boring: your PMO system (Linear and Gitea
+> Issues launch-supported; GitHub/GitLab Issues experimental) is the single
+> source of truth, and labels form the state machine — triage, plan, execute,
+> review. Each step runs as a disposable Docker container wrapping a real
+> coding harness from the registry — Claude Code, Grok Build, Codex, Pi,
+> OpenCode, Qwen Code — using the subscription or API credentials you provide.
+> Dagu holds `docker.sock` on a dedicated host; that is intentional, not an
+> accident (`14`). There are no persistent per-Mission leases or checkouts: a
+> crashed agent holds nothing, while process-local locks only serialize
+> dispatch and maintenance. A human edit to a ticket always beats an in-flight
+> agent. "Done" means *merged* — never before. Everything is traced in
+> OpenTelemetry down to token counts; a large test suite pins behavioral
+> invariants. The security contract is adult-operator: prompt injection is in
+> scope of “ticket writers are trusted,” and the real supply-chain defense is
+> branch protection and human merge. One Bake + compose brings up the stack on
+> loopback (images are Bake-only — compose never builds them).
 
 ## 3. Message house
 
@@ -168,7 +175,7 @@ multi-tenant sandbox, and receipts do not make agents injection-proof
 | **Roof (motto)** | *Your board is the interface.* (board-native day-to-day Mission work — and you own the trust envelope) |
 | **Pillar 1 — Board-native Mission work** | Your task board is the day-to-day Mission interface. Labels are the controls; tickets are the conversations; your merge (or auto-merge) is the deploy button. The admin UI remains the configuration and operations surface. |
 | **Pillar 2 — Autonomy with receipts** | Every step posts transcript + token bill. Traced and audited. REVIEW is always a pipeline stage; formal forge approval uses the **reviewer token** when configured. “Done” never lies about merge. |
-| **Pillar 3 — Your box, your rules** | Self-hosted on a **dedicated** machine; you own the trust envelope — team membership, branch protection, the merge button, backups (`18`). Mix Claude/Grok/Codex per role. Control plane does not ship your secrets to us; agents with open egress can still exfiltrate if injected — defend the supply chain (`14`). |
+| **Pillar 3 — Your box, your rules** | Self-hosted on a **dedicated** machine; you own the trust envelope — team membership, branch protection, the merge button, backups (`18`). Mix registry harnesses per role (Claude, Grok, Codex, and the rest of the launch-supported roster). Control plane does not ship your secrets to us; agents with open egress can still exfiltrate if injected — defend the supply chain (`14`). |
 | **Foundation** | Verified, not vibed: acceptance path tickets → PRs, GitHub, GitLab, and Gitea, invariant tests, redaction of app-mediated posts. Security contract in `14`. |
 
 ## 4. Tone guide

--- a/docs/19-thesis.md
+++ b/docs/19-thesis.md
@@ -4,8 +4,8 @@
 > a skeptical practitioner, a potential contributor, a researcher.
 > [`17-positioning.md`](17-positioning.md) is the compressed voice of this
 > document; the README is the applied version of `17`.
-> **Status:** adopted 2026-07-28 (first version) — expected to evolve with
-> evidence (§2, §7).
+> **Status:** adopted — normative thesis; evidence labels in §0 and falsifiers
+> in §7 evolve with field data (history in [`16-roadmap.md`](16-roadmap.md)).
 > **Security:** aligned with [`14-security.md`](14-security.md) — nothing here
 > claims a stronger posture, and every autonomy claim inherits the trust
 > clauses of `17` §1a.

--- a/docs/tutorials/01-first-mission.md
+++ b/docs/tutorials/01-first-mission.md
@@ -64,7 +64,9 @@ Open **http://localhost:8080** (loopback; admin user/password from `.env`).
 
 Labels `DEVCAKE-*` appear on the team after a successful PMO connection.
 
-## Step 2 — Meet the seven pages
+## Step 2 — Meet the admin pages
+
+Six top-level sidebar items (Adapters expands to two pages — seven surfaces total):
 
 - **Overview** — masthead answer sentence, Let's get baking checklist, alerts, Needs Human Action, stats, In the oven, recent runs, quick links. Service health = **sidebar** dots.
 - **Missions** — pipeline strip (stage counts) + grouped mission list of the poll snapshot; **Poll now**; row MoreMenu (Park/Retry/…); drawer Send guidance + Stop run.

--- a/docs/tutorials/02-operating-devcake.md
+++ b/docs/tutorials/02-operating-devcake.md
@@ -1,6 +1,7 @@
 # Tutorial 2 — Operating DevCake Day to Day
 
-Your board is the interface — you operate work **through Linear**, not a chat
+Your board is the interface — you operate work **through the PMO** (Linear or
+Gitea Issues launch-supported; GitHub/GitLab Issues experimental), not a chat
 UI. Labels and statuses are the control surface; DevCake reads them as
 instructions and reports back the same way. The admin panel is for config,
 health, secrets, and runs — keep it on **localhost** (or SSH tunnel); it is

--- a/docs/tutorials/03-mcp-plugins.md
+++ b/docs/tutorials/03-mcp-plugins.md
@@ -12,10 +12,11 @@ Type fields on the Config page:
   design (`../14-security.md` §2 Zone B).
 
 Worked example throughout: **devcake-logs-mcp**, a log-platform connector
-(Datadog / AWS CloudWatch Logs). The companion is **not yet published** at a
-fixed public URL — substitute your operator's `OWNER/REPO` (and pin a release
-tag) when you install it. Backend-specific detail (key scopes, IAM
-permissions, query dialects) lives in that plugin repo's README, not here.
+(Datadog / AWS CloudWatch Logs). Treat it as a **pattern**, not a guaranteed
+public install: the official companion may be private or unpublished. Substitute
+an `OWNER/REPO` (and pin a release tag) for a plugin git URL **you** control.
+Backend-specific detail (key scopes, IAM permissions, query dialects) lives in
+that plugin repo's README, not here.
 
 ## 1. Declare the secret names
 
@@ -53,10 +54,10 @@ Mechanics worth knowing (`../07-dev-runtime.md` §5, `../08-harness-templates.md
   entrypoint shell — values never enter config.
 - **Pin a release tag** (`@v0.1.0`) — runs must not float with a moving
   branch.
-- Register with `python -m <module>` (or an absolute path):
-  `pip install --user` puts console scripts in `~/.local/bin`, which is
-  NOT on `PATH` in the claude/codex Dev images.
-- When the plugin repo goes public, drop `${LOGS_MCP_GIT_TOKEN}@` from the
+- Register with `python -m <module>` or the installed console script:
+  `pip install --user` lands scripts in `~/.local/bin`, which is **on**
+  `PATH` in every registry harness image (ADR-0023 toolchain floor).
+- When the plugin repo is public, drop `${LOGS_MCP_GIT_TOKEN}@` from the
   install line and delete that secret.
 
 ## 3. Save and verify


### PR DESCRIPTION
## Summary

FOSS entry-surface honesty pass (docs only) for CAKE-12:

- **Clone identity:** README Quickstart and Tutorial 1 use `<this-repo-url>` instead of the 404 `github.com/fidecastro/devcake` remote.
- **MCP tutorial:** Tutorial 3 is a worked **pattern** with operator-supplied `OWNER/REPO`; no public `devcake-logs-mcp` install promise. PATH note aligned with ADR-0023.
- **Residuals:** docs/17 two-minute pitch and fit lists match launch-supported Linear + Gitea Issues, experimental forge-issue PMOs, and the full registry harness roster.
- **Admin inventory:** Tutorial 1 sidebar description matches six top-level nav items (Adapters = two pages).
- **Timelessness:** positioning/thesis status headers no longer carry PR-changelog dates; history points at docs/16.
- **AGENTS.md:** unchanged — already defers security to docs/14 and forbids compose-build of DevCake images.

## Verification

- `rg 'fidecastro/devcake'` empty on in-scope entry surfaces
- 59 relative markdown links from entry surfaces resolve
- Scope: 6 files under README / tutorials / docs/17 / docs/19

## Mission

https://linear.app/fidecastro/issue/CAKE-12/foss-entry-surfaces-readme-tutorials-positioning-agents-contradictions