### PR TITLE
[CAKE-47] [pre-FOSS] CronService scheduled-task audit

### DIFF
--- a/app/devcake/adapters/files/cron_store.py
+++ b/app/devcake/adapters/files/cron_store.py
@@ -1,8 +1,8 @@
 """Cron fire-outcome persistence: one JSON file under /data/state
-(PLAN_MEMORY §6.2). Degradation must be store-derived and restart-safe
-like the Steward's — but Steward derives from the run store because
-steward runs ARE runs, while cron fires create PMO tickets, so they
-need this tiny ledger of their own. Advisory telemetry only (INV-1):
+(ADR-0035; ports.cron.CronStore). Degradation must be store-derived and
+restart-safe like the Steward's — but Steward derives from the run store
+because steward runs ARE runs, while cron fires create PMO tickets, so
+they need this tiny ledger of their own. Advisory telemetry only (INV-1):
 wiping it re-arms automatic fires, nothing else."""
 
 from __future__ import annotations

--- a/app/devcake/domain/cron_service.py
+++ b/app/devcake/domain/cron_service.py
@@ -1,4 +1,4 @@
-"""Cron module — one verb: create a labeled ticket (PLAN_MEMORY §6).
+"""Cron module — one verb: create a labeled ticket (ADR-0035, docs/04 §1.8).
 
 Reserved `memory-curator` fans out to every Curator board (repos == [m]
 for each memory-bound card). Generic rows fire at `row.pmo`.
@@ -8,12 +8,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from ..config import (AppConfig, CronJob, MEMORY_CURATOR_CRON_ID,
                       intake_blocks_dispatch, memory_bound_names)
+from ..ports.cron import CronStore
 from . import claims as claims_mod
 from .model import LABEL_EXECUTE, LABEL_OPTIN, LABEL_PLAN, LABEL_REVIEW
 
@@ -27,7 +27,6 @@ _STAGE_LABEL = {
     "EXECUTE": LABEL_EXECUTE,
     "REVIEW": LABEL_REVIEW,
 }
-CRON_MARKER_RE = re.compile(r"`devcake:cron:v1 job=([a-z0-9_-]+)`")
 CRON_MARKER = "`devcake:cron:v1 job={id}`"
 
 
@@ -49,9 +48,9 @@ class CronUnconfigured(Exception):
 
 
 class _MemoryCronLedger:
-    """In-memory fallback with the CronStore interface — test/default
-    wiring only; production injects adapters.files.CronStore so the
-    outcome ledger survives restarts (PLAN_MEMORY §6.2)."""
+    """In-memory CronStore for tests/default wiring. Production injects
+    the file-backed adapter so the outcome ledger survives restarts
+    (ADR-0035; docs/10 cron_outcomes.json)."""
 
     def __init__(self):
         self._state: dict[str, dict] = {}
@@ -66,28 +65,32 @@ class _MemoryCronLedger:
     def outcomes(self, job_id: str) -> list[str]:
         return list(self._state.get(job_id, {}).get("outcomes") or [])
 
-    def last_fire_at(self, job_id: str):
+    def last_fire_at(self, job_id: str) -> datetime | None:
         raw = self._state.get(job_id, {}).get("last_fire_at")
         if not raw:
             return None
-        return datetime.fromisoformat(raw)
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            return None
 
 
 class CronService:
     """Single-process cadence + Run-now. One lock per job id (and, for
     memory-curator, per target board as well). Degradation and the fire
-    schedule are derived from the injected outcome ledger — restart-safe
-    when wired with the file-backed CronStore (services.py)."""
+    schedule are derived from the injected CronStore — restart-safe when
+    wired with the file-backed adapter (api/services.py)."""
 
     def __init__(self, config: AppConfig, managers: dict[str, MissionManager],
-                 claims=None, dev_types=None, store=None):
+                 claims=None, dev_types=None, store: CronStore | None = None):
         self.config = config
         self.managers = managers
         self.claims = claims
         # live Dev Type map — set M must include domain-bound notebooks
-        # (PLAN_MEMORY §6.3: "same set as I2"), not just instance lists
+        # (ADR-0035: same set as claims/memory mounts), not just instance lists
         self.dev_types = dev_types if dev_types is not None else {}
-        self.store = store if store is not None else _MemoryCronLedger()
+        self.store: CronStore = (
+            store if store is not None else _MemoryCronLedger())
         self._locks: dict[str, asyncio.Lock] = {}
         self.no_board: set[str] = set()  # memory_curator_no_board:<m>
 
@@ -117,26 +120,31 @@ class CronService:
         """Interval path — one pass per poll cycle. Elapsed-time
         semantics off the ledger's last_fire_at: one attempt per interval
         window, restart-safe, and a stalled poll cycle can't skip a whole
-        window (the old minute-multiple watermark could)."""
+        window (the old minute-multiple watermark could). Exceptions on
+        one row never kill the cycle (docs/04 §1.8)."""
         now = datetime.now(timezone.utc)
         degraded = self.degraded
         for row in list(self.config.crons):
             if not row.enabled or row.id in degraded:
                 continue
-            last = self.store.last_fire_at(row.id)
-            interval = max(row.interval_minutes, 1)
-            if last is not None and now - last < timedelta(minutes=interval):
-                continue
-            stamp = now.isoformat()
             try:
-                created = await self.fire(row.id, automatic=True)
-                self.store.record(row.id, "created" if created else "skipped",
-                                  fired_at=stamp)
-            except (CronBusy, CronUnconfigured):
-                self.store.record(row.id, "skipped", fired_at=stamp)
-            except Exception:  # noqa: BLE001 — one row must not kill the cycle
-                log.exception("cron %s automatic fire failed", row.id)
-                self.store.record(row.id, "failed", fired_at=stamp)
+                last = self.store.last_fire_at(row.id)
+                interval = max(row.interval_minutes, 1)
+                if last is not None and now - last < timedelta(minutes=interval):
+                    continue
+                stamp = now.isoformat()
+                try:
+                    created = await self.fire(row.id, automatic=True)
+                    self.store.record(
+                        row.id, "created" if created else "skipped",
+                        fired_at=stamp)
+                except (CronBusy, CronUnconfigured):
+                    self.store.record(row.id, "skipped", fired_at=stamp)
+                except Exception:  # noqa: BLE001 — one row must not kill the cycle
+                    log.exception("cron %s automatic fire failed", row.id)
+                    self.store.record(row.id, "failed", fired_at=stamp)
+            except Exception:  # noqa: BLE001 — ledger/window faults stay isolated
+                log.exception("cron %s automatic pass failed", row.id)
 
     async def fire(self, job_id: str, *, automatic: bool) -> list[dict]:
         """Create tickets. `automatic=False` is Run now (F4: no empty skip).
@@ -207,8 +215,8 @@ class CronService:
         return created
 
     async def _claims_depth(self, card: str) -> int:
-        """Skip-if-empty must be confirmed by listing (PLAN_MEMORY §6.3) —
-        the cache alone goes stale the moment a drain PR merges, and a
+        """Skip-if-empty must be confirmed by listing (ADR-0035) — the
+        cache alone goes stale the moment a drain PR merges, and a
         trusted stale >0 would fire an empty Curator ticket every interval.
         refresh_depth falls back to the cache when the listing fails."""
         if self.claims is None:
@@ -250,5 +258,3 @@ class CronService:
             mgr.instance.team_key, title, body, "normal", labels)
         log.info("cron %s created %s on %s", row.id, key, mgr.instance_name)
         return {"pmo": mgr.instance_name, "key": key, "pmo_id": pmo_id}
-
-

--- a/app/devcake/ports/__init__.py
+++ b/app/devcake/ports/__init__.py
@@ -2,8 +2,10 @@
 
 PMOPort / ForgePort (pluggable vendors — ADR-0008).
 ExecutorPort / StatePort / MessagingPort / RunFinalizer (run infrastructure).
+CronStore (scheduled-task fire ledger — ADR-0035).
 """
 
+from .cron import CronStore
 from .executor import ExecutorPort
 from .finalizer import RunFinalizer
 from .forge import ForgePort
@@ -14,6 +16,7 @@ from .state import StatePort
 from .versions import HarnessVersionSource
 
 __all__ = [
+    "CronStore",
     "ExecutorPort",
     "ForgePort",
     "MessagingPort",

--- a/app/devcake/ports/cron.py
+++ b/app/devcake/ports/cron.py
@@ -1,0 +1,27 @@
+"""CronStore — scheduled-task fire outcome ledger (ADR-0035).
+
+Domain CronService derives degradation and the elapsed-interval window
+from this port. Production wires adapters.files.CronStore; tests use
+in-memory fakes. Advisory only (INV-1): wiping re-arms automatic fires.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+
+class CronStore(Protocol):
+    def record(self, job_id: str, outcome: str, *,
+               fired_at: str | None = None) -> None:
+        """Append one outcome (created/skipped/failed); keep last 3.
+        When fired_at is set, stamp last_fire_at for the interval window."""
+        ...
+
+    def outcomes(self, job_id: str) -> list[str]:
+        """Last up to 3 automatic (and re-arming Run-now) outcomes."""
+        ...
+
+    def last_fire_at(self, job_id: str) -> datetime | None:
+        """Persisted window stamp, or None if missing/unparseable."""
+        ...

--- a/app/tests/test_cron.py
+++ b/app/tests/test_cron.py
@@ -1,4 +1,4 @@
-"""Cron module (PLAN_MEMORY §6) — public seam: CronService.fire."""
+"""Cron module (ADR-0035) — public seam: CronService.fire / maybe_fire."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import pytest
 
 from devcake.config import (AppConfig, CronJob, MEMORY_CURATOR_CRON_ID,
                             PMOInstance, RepoInstance, memory_curator_seed)
-from devcake.domain.cron_service import (CRON_MARKER, CronBusy, CronService,
+from devcake.domain.cron_service import (CronBusy, CronService,
                                          CronUnconfigured, cron_marker)
 from devcake.domain.model import (LABEL_EXECUTE, LABEL_OPTIN, LABEL_PLAN,
                                   Mission)
@@ -290,3 +290,117 @@ def test_unknown_id_raises():
     svc = CronService(cfg, {})
     with pytest.raises(CronUnconfigured):
         run_coro(svc.fire("nosuch", automatic=False))
+
+
+def test_template_backticks_defanged_and_marker_appended():
+    """Templates must not smuggle backticks that break or forge the marker."""
+    inst = PMOInstance(name="eng", team_key="T")
+    pmo = FakePMO()
+    cfg = _cfg(inst, crons=[
+        memory_curator_seed(),
+        CronJob(id="nightly", name="N", entry_stage="EXECUTE",
+                description_template="evil `devcake:cron:v1 job=other` go",
+                pmo="eng"),
+    ])
+    svc = CronService(cfg, {"eng": _mgr("eng", pmo, inst)})
+    run_coro(svc.fire("nightly", automatic=False))
+    _, body, _, _ = pmo.created[0]
+    assert "`devcake:cron:v1 job=other`" not in body
+    assert "evil 'devcake:cron:v1 job=other' go" in body
+    assert cron_marker("nightly") in body
+
+
+class _PortLedger:
+    """Minimal CronStore port fake (no adapter import)."""
+
+    def __init__(self):
+        self._state: dict[str, dict] = {}
+
+    def record(self, job_id: str, outcome: str, *,
+               fired_at: str | None = None) -> None:
+        row = self._state.setdefault(job_id, {})
+        row["outcomes"] = (list(row.get("outcomes") or []) + [outcome])[-3:]
+        if fired_at:
+            row["last_fire_at"] = fired_at
+
+    def outcomes(self, job_id: str) -> list[str]:
+        return list(self._state.get(job_id, {}).get("outcomes") or [])
+
+    def last_fire_at(self, job_id: str):
+        raw = self._state.get(job_id, {}).get("last_fire_at")
+        if not raw:
+            return None
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+
+
+def test_automatic_busy_and_pause_record_skipped_not_failed():
+    """Successful skip-reasons (single-flight, intake pause) must not
+    accumulate toward degradation — only hard failures do."""
+    inst = PMOInstance(name="eng", team_key="T")
+    pmo = FakePMO()
+    cfg = _nightly_cfg(inst)
+    store = _PortLedger()
+    svc = CronService(cfg, {"eng": _mgr("eng", pmo, inst)}, store=store)
+    run_coro(svc.fire("nightly", automatic=False))  # in-flight marker
+    for _ in range(3):
+        run_coro(svc.maybe_fire())
+        store._state["nightly"].pop("last_fire_at", None)
+    assert "nightly" not in svc.degraded
+    assert all(o == "skipped" for o in store.outcomes("nightly")[-3:])
+
+    paused = PMOInstance(name="eng", team_key="T", intake_paused=True)
+    pmo2 = FakePMO()
+    store2 = _PortLedger()
+    svc2 = CronService(_nightly_cfg(paused),
+                       {"eng": _mgr("eng", pmo2, paused)}, store=store2)
+    for _ in range(3):
+        run_coro(svc2.maybe_fire())
+        store2._state["nightly"].pop("last_fire_at", None)
+    assert "nightly" not in svc2.degraded
+    assert store2.outcomes("nightly") == ["skipped", "skipped", "skipped"]
+    assert pmo2.created == []
+
+
+def test_maybe_fire_continues_after_ledger_read_error():
+    """docs/04 poll §8: exceptions never kill the cycle — a broken
+    last_fire_at for one row must not starve later enabled rows."""
+
+    class BoomLedger(_PortLedger):
+        def last_fire_at(self, job_id: str):
+            if job_id == "broken":
+                raise RuntimeError("ledger corrupt")
+            return super().last_fire_at(job_id)
+
+    inst = PMOInstance(name="eng", team_key="T")
+    pmo = FakePMO()
+    cfg = _cfg(inst, crons=[
+        memory_curator_seed(),
+        CronJob(id="broken", name="B", entry_stage="EXECUTE",
+                description_template="x", pmo="eng", enabled=True,
+                interval_minutes=1),
+        CronJob(id="ok", name="O", entry_stage="EXECUTE",
+                description_template="y", pmo="eng", enabled=True,
+                interval_minutes=1),
+    ])
+    svc = CronService(cfg, {"eng": _mgr("eng", pmo, inst)},
+                      store=BoomLedger())
+    run_coro(svc.maybe_fire())
+    titles = [t[0] for t in pmo.created]
+    assert any(t.startswith("[cron:ok]") for t in titles)
+    assert not any(t.startswith("[cron:broken]") for t in titles)
+
+
+def test_invalid_last_fire_at_is_treated_as_due():
+    """Corrupt last_fire_at must not raise out of maybe_fire; the row is due."""
+    inst = PMOInstance(name="eng", team_key="T")
+    pmo = FakePMO()
+    cfg = _nightly_cfg(inst)
+    svc = CronService(cfg, {"eng": _mgr("eng", pmo, inst)})
+    svc.store._state["nightly"] = {
+        "last_fire_at": "not-a-timestamp", "outcomes": []}
+    run_coro(svc.maybe_fire())
+    assert len(pmo.created) == 1
+    assert pmo.created[0][0].startswith("[cron:nightly]")

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -84,6 +84,10 @@ app/devcake/
     state.py       #   StatePort — run-record persistence (files adapter)
     messaging.py   #   MessagingPort — Redis Streams surface (redis adapter)
     finalizer.py   #   RunFinalizer — mission finalize/restore (MissionManager)
+    cron.py        #   CronStore — scheduled-task fire ledger (ADR-0035)
+    claims.py      #   ClaimsNotebooks — .claims/ forge write seam (ADR-0035)
+    receipts.py    #   ReceiptStore — host bake drift-probe receipts
+    versions.py    #   HarnessVersionSource — CLI version probes
   adapters/
     registry.py    #   PMO_SYSTEMS, make_pmo(), make_forge(), make_internal_forge(),
                    #   forges() — the ONE place that knows which adapters exist
@@ -91,7 +95,7 @@ app/devcake/
     gitea_issues/  #   PMOPort impl — forge-issue family (05 §9; not ForgePort)
     github/ gitlab/ gitea/  # ForgePort impls + Gitea provisioner (06, ADR-0010)
     dagu/          #   ExecutorPort impl
-    files/         #   StatePort impl (+ runlog.py, owner_store.py,
+    files/         #   StatePort + CronStore impls (+ runlog.py, owner_store.py,
                    #   cron_store.py — the scheduled-task fire ledger) (10)
     redis/         #   MessagingPort impl — ingress + replies (09)
   api/             # FastAPI (11, ADR-0015/0028): services.py = the
@@ -117,7 +121,7 @@ app/devcake/
 
 The app boots via `uvicorn devcake.api.main:app`. `config.py`, `security.py`, and `harness.py` sit at the package root because they are cross-cutting concerns, not layer members.
 
-**Ports today:** vendor seams (`PMOPort`, `ForgePort` — ADR-0008; `InternalForgePort` — ADR-0010) and run-infrastructure seams (`ExecutorPort`, `StatePort`, `MessagingPort`, `RunFinalizer`). Production adapters: Linear, GitHub/GitLab/Gitea, Dagu, files, Redis Streams; `MissionManager` satisfies `RunFinalizer`. Composition root (`api/services.build_services()`, ADR-0028 — called once by the lifespan, never at import) builds adapters (incl. optional `make_internal_forge()` when Gitea admin creds are set), injects them into `RunManager` / per-instance `MissionManager`s, then `manager.set_finalizer(…)` so ingress/kill never type against the concrete orchestrator. Skill-store + per-mission repo routing (`resolve_repo` / `resolve_repo_live`) ride the same composition. All four dispatch flavors (hello, mission, steward, OAuth) call `RunBootstrap.launch` for the durable-intent-before-trigger spine (`04-orchestrator.md` §3.1).
+**Ports today:** vendor seams (`PMOPort`, `ForgePort` — ADR-0008; `InternalForgePort` — ADR-0010), run-infrastructure seams (`ExecutorPort`, `StatePort`, `MessagingPort`, `RunFinalizer`), and scheduled-task / memory seams (`CronStore`, `ClaimsNotebooks` — ADR-0035). Production adapters: Linear, GitHub/GitLab/Gitea, Dagu, files (incl. cron outcome ledger), Redis Streams; `MissionManager` satisfies `RunFinalizer`. Composition root (`api/services.build_services()`, ADR-0028 — called once by the lifespan, never at import) builds adapters (incl. optional `make_internal_forge()` when Gitea admin creds are set), injects them into `RunManager` / per-instance `MissionManager`s, then `manager.set_finalizer(…)` so ingress/kill never type against the concrete orchestrator. Skill-store + per-mission repo routing (`resolve_repo` / `resolve_repo_live`) ride the same composition. All four dispatch flavors (hello, mission, steward, OAuth) call `RunBootstrap.launch` for the durable-intent-before-trigger spine (`04-orchestrator.md` §3.1).
 
 **Rule:** the domain core is testable with fakes of the ports; adapters never leak vendor types upward (normalized DTOs only, `02-domain-model.md`). Domain modules depend on **port Protocols**, not adapter packages.
 


### PR DESCRIPTION
## Intent

Pre-FOSS audit of domain **CronService** (one-verb labeled-ticket creation / scheduled tasks) against ADR-0035 and docs/04 poll §1.8. Fix proven defects only; no new product features.

Mission: https://linear.app/fidecastro/issue/CAKE-47/pre-foss-cronservice-scheduled-task-audit

## Findings fixed

1. **Hexagonal gap** — domain duck-typed the outcome ledger with no `ports/*` Protocol while production injects `adapters.files.CronStore`. Added `ports.cron.CronStore`; domain types `store` against it; in-memory ledger remains the default test/wiring fallback.
2. **Cycle isolation** — `maybe_fire` evaluated `last_fire_at` / the interval window *outside* the per-row exception fence, so a single ledger read failure aborted later enabled rows despite docs/04 (“Exceptions never kill the cycle”). Outer per-row try now isolates ledger/window faults.
3. **Liskov** — `_MemoryCronLedger.last_fire_at` raised `ValueError` on corrupt ISO timestamps; file `CronStore` returns `None`. Memory ledger now matches.
4. **Hygiene** — removed unused `CRON_MARKER_RE`; comments point at ADR-0035 / docs/04 instead of PLAN_MEMORY-only anchors.
5. **Coverage** — public-seam tests for template defang, skip-vs-fail degradation (busy / intake pause), cycle isolation, and invalid `last_fire_at` treated as due.

## Confirmed correct (no code change)

- Labels: `DEVCAKE` + stage; ONBOARD opt-in only; memory-curator forces EXECUTE
- Marker + defang + `{timestamp}`
- Single-flight, intake pause, elapsed-interval window
- Degradation ledger (3 automatic failures), Run-now re-arms on ticket create, restart-safe with file store
- memory-curator fan-out, empty-claims automatic skip, listing-over-stale-cache, `no_board` warnings

## How to verify

```bash
./scripts/pytest_app.sh app/tests/test_cron.py app/tests/test_structure_guards.py
# or host Python 3.12:
PYTHONPATH=app python -m pytest app/tests/test_cron.py app/tests/test_structure_guards.py -q
```

Local evidence this run: `PYTHONPATH=app python3.12 -m pytest app/tests/test_cron.py app/tests/test_structure_guards.py -q` → **26 passed**; `ruff check` on touched paths clean. Full `docker buildx bake app-test` was unavailable on the agent host (Podman buildx without bake); CI rebakes.

## Out of scope

STEWARD, SPA, `adapters/files/cron_store.py` internals beyond the port contract, claims conveyor beyond depth listing, new cron product features.

## Risk

Low — domain cadence only; ledger semantics unchanged except corrupt-timestamp and cycle isolation hardening. No migration.