### PR TITLE
[CAKE-45] [pre-FOSS] Steward cadence and STEWARD ops audit

### DIFF
--- a/app/devcake/domain/orchestrator/steward.py
+++ b/app/devcake/domain/orchestrator/steward.py
@@ -130,10 +130,12 @@ async def _launch_steward(mgr, dev_type: DevType, *, duty: str,
 
 async def dispatch_steward(mgr, dev_type: DevType, missions: list[Mission],
                            context_stale=frozenset(),
-                           context_omit=frozenset()) -> Run:
+                           context_omit=frozenset()) -> Run | None:
     """Dispatch the RELATIONS steward: a Dev whose only job is proposing
     missing blocked-by edges. No PMO writes at dispatch (no status, no
-    labels) — finalize_steward validates and applies whatever it proposes."""
+    labels) — finalize_steward validates and applies whatever it proposes.
+    Returns None when the shared launch chokepoint skips (unstaffed /
+    unusable workspace base) — same contract as discovery."""
     from ...prompts import STEWARD_MISSION_CAP, steward_prompt
     eligible = [m for m in missions
                 if m.pmo_kind == "issue" and m.status not in ("done", "canceled")
@@ -340,12 +342,13 @@ async def apply_steward_edges(mgr, edges: list) -> tuple[int, int]:
 async def apply_discovery_routes(mgr, run: Run, routes: list) -> tuple[int, int]:
     """The Dev is advisory; the app is the gatekeeper (the
     apply_steward_edges precedent, ADR-0033 D5). Validate every route
-    against the LIVE board and feed-counted budgets, copy finding text from
-    the source run record — verbatim transport is structural, steward text
-    never lands beyond its one-line "because" — deliver one marked comment
-    per recipient, receipt a batch only when it was *dispositioned*
-    (delivered, or deliberately routed nowhere / a terminal reject), and
-    drop the sweep-gate label once a source has nothing pending.
+    against the LIVE board and delivery markers (posted − receipted
+    arithmetic), copy finding text from the source run record — verbatim
+    transport is structural, steward text never lands beyond its one-line
+    "because" — deliver one marked comment per recipient, receipt a batch
+    only when it was *dispositioned* (delivered, or deliberately routed
+    nowhere / a terminal reject), and drop the sweep-gate label once a
+    source has nothing pending.
     Transient holds (unreadable feed, failed post, routing toggle off)
     write no ``to=-`` — the sweep re-drives. A recipient past the
     full-read page ceiling is NOT transient (feeds only grow): terminal

--- a/app/devcake/domain/steward_service.py
+++ b/app/devcake/domain/steward_service.py
@@ -210,8 +210,12 @@ class StewardService:
                           >= self.config.concurrency.global_max):
                         outcome = "concurrency_deferred"
                     else:
+                        # same gate honesty as relations / run_now: stale and
+                        # omit ride into launch so mounts and mirror_repos
+                        # match what `_context_gate` just decided
                         run = await mgr.dispatch_steward_discovery(
-                            dt, fam, pending)
+                            dt, fam, pending, context_stale=ctx_stale,
+                            context_omit=ctx_omit)
                         if run is None:
                             outcome = "dispatch_skipped"   # workspace/empty
                         else:

--- a/app/tests/test_discovery_trigger.py
+++ b/app/tests/test_discovery_trigger.py
@@ -37,8 +37,8 @@ def _svc_setup(tmp_path, *, src_feed_bodies=(), routing=True):
     svc = StewardService(AppConfig(), {"steward": dt}, mgr)
     calls = []
 
-    async def fake_dispatch(dt_, fam, pending):
-        calls.append((sorted(fam.by_id), dict(pending)))
+    async def fake_dispatch(dt_, fam, pending, **kw):
+        calls.append((sorted(fam.by_id), dict(pending), kw))
         return object()   # a dispatched run
     mgr.dispatch_steward_discovery = fake_dispatch
     return pmo, mgr, svc, calls, [src, other]
@@ -49,7 +49,7 @@ def test_dispatches_one_family_and_clears_served(tmp_path):
     mgr._discoveries_pending.add("src")
     run_coro(svc.maybe_dispatch_discovery(missions))
     assert len(calls) == 1
-    fam_ids, pending = calls[0]
+    fam_ids, pending, _kw = calls[0]
     assert "src" in fam_ids
     assert pending == {"src": [(2, 1)]}
     assert mgr._discoveries_pending == set()
@@ -164,7 +164,7 @@ def test_discovery_and_relations_share_one_lock(tmp_path):
     rel = []
     gate = asyncio.Event()
 
-    async def slow_disc(dt_, fam, pending):
+    async def slow_disc(dt_, fam, pending, **kw):
         calls.append("d")
         await gate.wait()
         return object()
@@ -188,6 +188,50 @@ def test_discovery_and_relations_share_one_lock(tmp_path):
 
     run_coro(both())
     assert "d" in calls
+
+
+def test_discovery_forwards_context_stale_and_omit(tmp_path):
+    """PLAN_MEMORY §3.5 / ADR-0033 gate honesty: the discovery lane shares
+    `_context_gate` with relations and Run-now. Stale/omit sets must ride
+    into dispatch so launch marks memory mounts and drops omitted cards —
+    computing them then discarding them left discovery mounts dishonest
+    relative to the gate that just ran."""
+    pmo, mgr, svc, calls, missions = _svc_setup(tmp_path)
+    seen: list[dict] = []
+
+    async def fake_dispatch(dt_, fam, pending, **kw):
+        seen.append(kw)
+        calls.append(1)
+        return object()
+
+    async def gate(dt, repo, extra=()):
+        return True, {}, {"mem-notebook"}, {"skillcard"}
+
+    mgr.dispatch_steward_discovery = fake_dispatch
+    svc._context_gate = gate
+    mgr._discoveries_pending.add("src")
+    run_coro(svc.maybe_dispatch_discovery(missions))
+    assert calls == [1]
+    assert seen[0]["context_stale"] == {"mem-notebook"}
+    assert seen[0]["context_omit"] == {"skillcard"}
+
+
+def test_degraded_skips_discovery_and_retains_pending(tmp_path):
+    """Shared degradation (3 consecutive dead STEWARD runs) backs off the
+    discovery lane too — pending stays for the sweep/kick after a human
+    Run-now success clears the condition. Mirrors relations' degraded_skip."""
+    from devcake.domain.run import Run
+    pmo, mgr, svc, calls, missions = _svc_setup(tmp_path)
+    for i, st in enumerate(("failed", "timed_out", "orphaned"), start=1):
+        mgr.runs.store.save(Run(
+            run_id=f"TEAM-{i}-STEWARD-XXXXXX", mission_key="TEAM",
+            mission_type="STEWARD", dev_type="steward", seq=i, state=st,
+            error=f"dead-{i}"))
+    assert svc.degraded()
+    mgr._discoveries_pending.add("src")
+    run_coro(svc.maybe_dispatch_discovery(missions))
+    assert calls == []
+    assert mgr._discoveries_pending == {"src"}
 
 
 def test_harvest_notify_seam_is_best_effort(tmp_path):


### PR DESCRIPTION
## Summary

Skeptical audit of STEWARD cadence (`StewardService`) and STEWARD ops (`orchestrator/steward.py`) for CAKE-45, then the minimal sound fix.

### Finding fixed

**Discovery lane dropped context gate results.** Relations periodic and Run-now pass `_context_gate`’s `context_stale` / `context_omit` into launch so memory mounts and `mirror_repos` stay honest (PLAN_MEMORY §3.5). The discovery path computed the same sets after widening `ensure_fresh` to family repos, then called `dispatch_steward_discovery` without them — default empty frozensets — so a non-strict open gate could mark cards stale/omit while the discovery launch still mounted them as fresh. Discovery now forwards the sets like the other two callers.

### Also (no behavior change)

- Pin: three consecutive dead STEWARD runs skip discovery and retain `_discoveries_pending` (shared degradation).
- `dispatch_steward` annotated `Run | None` (matches unstaffed / unusable workspace skip).
- `apply_discovery_routes` docstring: “feed-counted budgets” → delivery-marker / pending arithmetic (ADR-0033 addendum 14).

### Audit outcome (no code change)

Lock sharing, watermark-after-success, Run-now-when-degraded, one-family pending batch, intake / `discovery_routing` gates, launch chokepoint, relations edge gatekeeping, and discovery route apply (verbatim transport, terminal rejects, receipt holds) already match ADR-0033 D3/5/6/11 and docs/03 §4b / docs/04 segment 6.

### Deviation

PLAN step left only a truncated stub (`PLAN_2.md`). EXECUTE re-audited the live surface from the mission brief + code and fixed what the evidence supported.

### Tests

- `test_discovery_forwards_context_stale_and_omit` (red→green)
- `test_degraded_skips_discovery_and_retains_pending`
- Full steward + discovery trigger + structure-guard adjacent: 116 passed on Python 3.12 (`PYTHONPATH=app`). Host bake unavailable (Podman `buildx bake -f` unsupported); CI rebakes `app-test`.

Mission: https://linear.app/fidecastro/issue/CAKE-45/pre-foss-steward-cadence-and-steward-ops-audit