### PR TITLE
[CAKE-50] Admin SPA DESIGN.md compliance, dead paths, and residual UX defects

### DIFF
--- a/admin/spa/package.json
+++ b/admin/spa/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "check:ui": "node tests/run.mjs",
-    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs && node tests/config_draft.mjs && node tests/contracts.mjs && node tests/req_seq.mjs && node tests/mission_identity.mjs && node tests/alerts.mjs"
+    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs && node tests/config_draft.mjs && node tests/contracts.mjs && node tests/req_seq.mjs && node tests/mission_identity.mjs && node tests/alerts.mjs && node tests/design_tokens.mjs"
   },
   "dependencies": {
     "@fontsource-variable/bricolage-grotesque": "^5.2.10",

--- a/admin/spa/src/components/Alert.jsx
+++ b/admin/spa/src/components/Alert.jsx
@@ -3,9 +3,10 @@ import { Info, TriangleAlert, OctagonAlert, ChevronRight, ExternalLink, X } from
 
 const STYLES = {
   info: {
-    box: "border-sky-200 bg-sky-50 text-sky-900 dark:border-sky-900 dark:bg-sky-950/60 dark:text-sky-200",
+    // quiet informational — neutral register, not a second brand accent
+    box: "border-neutral-200 bg-neutral-50 text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900/60 dark:text-neutral-200",
     icon: Info,
-    iconCls: "text-sky-500 dark:text-sky-400",
+    iconCls: "text-neutral-500 dark:text-neutral-400",
   },
   warning: {
     box: "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950/60 dark:text-amber-200",

--- a/admin/spa/src/components/MissionDrawer.jsx
+++ b/admin/spa/src/components/MissionDrawer.jsx
@@ -129,7 +129,7 @@ export default function MissionDrawer({ mission, multiPmo, syncing, rows, adopti
               {syncing && (
                 <span
                   title="Waiting for the next poll cycle to confirm the last change"
-                  className="rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-medium text-blue-800 dark:bg-blue-950 dark:text-blue-300"
+                  className="rounded-full bg-accent-100 px-2 py-0.5 text-[10px] font-medium text-accent-800 dark:bg-accent-950 dark:text-accent-300"
                 >
                   syncing…
                 </span>

--- a/admin/spa/src/components/MissionRow.jsx
+++ b/admin/spa/src/components/MissionRow.jsx
@@ -84,7 +84,7 @@ export default function MissionRow({ row, multiPmo, syncing, sectionReason, onOp
       {syncing && (
         <span
           title="Waiting for the next poll cycle to confirm this change"
-          className="shrink-0 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-medium text-blue-800 dark:bg-blue-950 dark:text-blue-300"
+          className="shrink-0 rounded-full bg-accent-100 px-2 py-0.5 text-[10px] font-medium text-accent-800 dark:bg-accent-950 dark:text-accent-300"
         >
           syncing…
         </span>

--- a/admin/spa/src/components/RunTerminal.jsx
+++ b/admin/spa/src/components/RunTerminal.jsx
@@ -64,13 +64,13 @@ export default function RunTerminal({ run, onClose }) {
       className="flex h-[75vh] max-w-5xl flex-col overflow-hidden">
         <div className="flex items-center gap-2 border-b border-neutral-800 bg-neutral-900 px-4 py-2.5">
           <span className="h-3 w-3 rounded-full bg-red-500" />
-          <span className="h-3 w-3 rounded-full bg-yellow-500" />
+          <span className="h-3 w-3 rounded-full bg-amber-400" />
           <span className="h-3 w-3 rounded-full bg-green-500" />
           <span className="ml-3 truncate font-mono text-xs text-neutral-300">
             {run.run_id}
           </span>
           <span className={`rounded px-1.5 py-0.5 text-xs ${
-            live ? "bg-blue-900 text-blue-200" : "bg-neutral-800 text-neutral-400"}`}>
+            live ? "bg-accent-900 text-accent-200" : "bg-neutral-800 text-neutral-400"}`}>
             {live ? "live" : run.state}
           </span>
           {(run.memory_mounts || []).length > 0 && (

--- a/admin/spa/src/components/StatusDot.jsx
+++ b/admin/spa/src/components/StatusDot.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 
 // Status dot. Preferred API: state ∈ ok | running | broken | unknown
-// (the Runs-table color code — green / pulsing blue / red / grey).
-// Legacy API: ok = true | false | undefined (sidebar services — no blue).
+// (the Runs-table color code — green / pulsing accent / red / grey).
+// Legacy API: ok = true | false | undefined (sidebar services — no running).
 const STATE_CLS = {
   ok: "bg-green-500",
-  running: "bg-blue-500 animate-pulse",
+  running: "bg-accent-500 animate-pulse",
   broken: "bg-red-500",
   unknown: "bg-neutral-400",
 };

--- a/admin/spa/src/components/StatusPill.jsx
+++ b/admin/spa/src/components/StatusPill.jsx
@@ -13,14 +13,14 @@ export default function StatusPill({ state, verdict }) {
       ? "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300"
       : FAILED.includes(state)
         ? "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300"
-        : "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300";
+        : "bg-accent-100 text-accent-800 dark:bg-accent-950 dark:text-accent-300";
   const dot = flagged
     ? "bg-amber-500"
     : state === "finished"
       ? "bg-green-500"
       : FAILED.includes(state)
         ? "bg-red-500"
-        : "bg-blue-500 animate-pulse";
+        : "bg-accent-500 animate-pulse";
   return (
     <span title={flagged ? verdict : undefined}
       className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}>

--- a/admin/spa/src/pages/OverviewPage.jsx
+++ b/admin/spa/src/pages/OverviewPage.jsx
@@ -324,7 +324,7 @@ function NeedsHumanPanel({ merge, attention }) {
             <span
               className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
                 r.kind === "merge"
-                  ? "bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300"
+                  ? "bg-accent-100 text-accent-800 dark:bg-accent-950 dark:text-accent-300"
                   : "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300"
               }`}
             >
@@ -444,7 +444,7 @@ export default function OverviewPage({
         </Stat>
         <Stat icon={Bot} label="Devs">
           {/* the Dev fleet in the Runs-table color code (founder decision):
-              green available · blue running · red broken (breaker latched
+              green available · accent running · red broken (breaker latched
               or no credentials). Service health lives in the sidebar. */}
           {devTypes === null ? (
             <span className="font-display text-2xl font-extrabold tracking-tight">—</span>

--- a/admin/spa/src/pages/ReposPage.jsx
+++ b/admin/spa/src/pages/ReposPage.jsx
@@ -49,24 +49,30 @@ function InternalReposSection({ onClear, onClearAll, refreshKey }) {
       )}
       {data.repos.length > 0 && (
       <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead className="text-left text-neutral-500">
-            <tr><th className="py-1 pr-3">Mission</th><th className="pr-3">Repo</th>
-              <th className="pr-3">Size</th><th className="pr-3">Open PRs</th><th></th></tr>
+        <table className="w-full min-w-[32rem] text-sm">
+          <thead className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+            <tr>
+              <th className="py-1 pr-3 text-left font-medium">Mission</th>
+              <th className="pr-3 text-left font-medium">Repo</th>
+              <th className="pr-3 text-left font-medium">Size</th>
+              <th className="pr-3 text-left font-medium">Open PRs</th>
+              <th className="text-right font-medium"><span className="sr-only">Actions</span></th>
+            </tr>
           </thead>
           <tbody>
             {data.repos.map((r) => (
-              <tr key={r.name} className="border-t border-neutral-200 dark:border-neutral-800">
-                <td className="py-1.5 pr-3 font-mono">{r.mission_key}</td>
+              <tr key={r.name}
+                className="border-t border-neutral-100 hover:bg-stone-50 dark:border-neutral-800 dark:hover:bg-neutral-900">
+                <td className="py-1.5 pr-3 font-mono text-xs">{r.mission_key}</td>
                 <td className="pr-3">
-                  <a className="text-accent-600 hover:underline" href={r.html_url}
+                  <a className="text-accent-600 hover:underline dark:text-accent-300" href={r.html_url}
                     target="_blank" rel="noreferrer">{r.name}</a>
                 </td>
-                <td className="pr-3">{Math.round(r.size_kb)} KB</td>
-                <td className="pr-3">{r.open_prs}</td>
+                <td className="pr-3 tabular-nums">{Math.round(r.size_kb)} KB</td>
+                <td className="pr-3 tabular-nums">{r.open_prs}</td>
                 <td className="text-right">
-                  <Button kind="danger-ghost" icon={Trash2}
-                    onClick={() => onClear(r.name)}>Clear</Button>
+                  <Button kind="danger-ghost" size="sm" icon={Trash2}
+                    onClick={() => onClear(r.name)}>Clear data</Button>
                 </td>
               </tr>
             ))}

--- a/admin/spa/tests/design_tokens.mjs
+++ b/admin/spa/tests/design_tokens.mjs
@@ -1,0 +1,57 @@
+// DESIGN.md §1: components use only the @theme registers (accent / neutral /
+// surfaces / amber / red / green) plus the documented light-mode stone hover
+// idiom. Stock Tailwind blue/sky/yellow/… families are residual palette drift
+// — they are not retuned in index.css @theme and read as a second brand accent.
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcRoot = join(here, "../src");
+
+// Families not listed in DESIGN.md §1 and not part of the Runs-table stone
+// hover idiom. Numeric suffix required so prose comments ("blue running") can
+// still name the concept without tripping the guard until classes are gone.
+const OFF_PALETTE = /\b(?:blue|sky|yellow|purple|indigo|cyan|teal|violet|fuchsia|rose|orange)-[0-9]{2,3}\b/g;
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else if (/\.(js|jsx)$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+let failed = 0;
+const check = (name, fn) => {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.log(`  ✗ ${name}: ${e.message}`);
+  }
+};
+
+check("no off-palette Tailwind color families in SPA components", () => {
+  const hits = [];
+  for (const file of walk(srcRoot)) {
+    const text = readFileSync(file, "utf8");
+    const rel = relative(join(here, ".."), file);
+    for (const m of text.matchAll(OFF_PALETTE)) {
+      const line = text.slice(0, m.index).split("\n").length;
+      hits.push(`${rel}:${line}: ${m[0]}`);
+    }
+  }
+  assert.equal(hits.length, 0,
+    `off-palette classes (DESIGN.md §1):\n  ${hits.join("\n  ")}`);
+});
+
+if (failed) {
+  console.error(`design_tokens.mjs: ${failed} check(s) failed`);
+  process.exit(1);
+}
+console.log("design_tokens.mjs: all checks passed");

--- a/admin/spa/tests/run.mjs
+++ b/admin/spa/tests/run.mjs
@@ -23,6 +23,8 @@ const SUITES = [
   "contracts.mjs",
   "req_seq.mjs",
   "mission_identity.mjs",
+  "alerts.mjs",
+  "design_tokens.mjs",
   "settings.mjs",
   "tasks.mjs",
   "hierarchy.mjs",


### PR DESCRIPTION
## Summary

Audit and residual DESIGN.md compliance fixes for the admin SPA (CAKE-50) — no visual redesign.

### Findings fixed

1. **Off-palette color families (DESIGN §1)** — stock Tailwind `blue-*` / `sky-*` / `yellow-*` used for running/info/status chrome while `@theme` only retunes accent/neutral/amber/surfaces. Retuned:
   - `StatusPill` / `StatusDot` running → accent (active/current, same register as StageGlyph “current”)
   - Mission row/drawer `syncing…` → accent
   - `Alert` info → neutral (quiet informational, not a second brand accent)
   - Overview “merge” badge → accent (vs amber “attention”)
   - Run terminal: live badge → accent; window chrome middle dot → amber (on-register)

2. **Internal forge table (DESIGN §2 tables + §7 copy)** — thead lacked the Runs-table idiom (uppercase tracking, dark twin, hover rows, mono ids); row action was bare **Clear** → **Clear data**.

3. **Guard** — `admin/spa/tests/design_tokens.mjs` fails on off-palette families; wired into `npm run test:helpers` and `check:ui` pure-node list.

### Re-verified clean (no change)

- No live `window.confirm` / `prompt` / `alert`
- No raw hex outside `index.css`
- Config one-section routing; Repos/PMO under Adapters
- MoreMenu hierarchy (intentional one-item Clear-secrets menus kept)
- Draft vs InstantZone semantics

### Verification

| Check | Result |
|---|---|
| `npm --prefix admin/spa run test:helpers` | pass (incl. design_tokens) |
| `npm --prefix admin/spa run build` | pass |
| Admin image build (`docker build -f admin/Dockerfile`) | pass (podman; `docker buildx bake` unavailable in this harness) |
| Admin container static serve + `/nginx-health` | 200 with basic auth |
| `npm run check:ui` | **not run** — no live backend / compose plugin on this host |

Mission: https://linear.app/fidecastro/issue/CAKE-50/admin-spa-designmd-compliance-dead-paths-and-residual-ux-defects