### PR TITLE
[CAKE-42] [pre-FOSS] CI workflows and local pytest/ci scripts honesty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
-# DevCake CI — Bake control-plane images (GHA BuildKit cache) + pytest +
-# minimal compose hello-dispatch smoke. Compose never builds; see docker-bake.hcl.
+# DevCake PR/main CI (model-free proof path). Compose never builds; see docker-bake.hcl.
+#
+# Matrix (single job): pin gate → admin npm helper tests + npm audit → Bake
+# group `ci` (app, app-test, admin, hello; load:true, sbom:false) → Redis →
+# ruff → pip-audit → pytest on fresh app-test → compose bring-up with
+# CI_COMPOSE_WITH_GITEA=1 → hello dispatch smoke → forge/PMO contract
+# batteries against bundled Gitea. Permissions: contents:read only (no
+# packages:write). No SBOM/provenance on this path — those are publish-only
+# (docker-publish.yml). Does not run scripts/acceptance.py (token-gated).
 name: CI
 
 on:
@@ -124,8 +131,8 @@ jobs:
           docker rm -f devcake-ci-redis 2>/dev/null || true
           docker network rm devcake_control 2>/dev/null || true
 
-      # Minimal compose (no Gitea) + hard readiness — scripts/ci_compose_for_dispatch.sh
-      # then real Dagu → hello → Redis → finalize (scripts/ci_dispatch_hello.sh).
+      # Compose for dispatch + contract batteries (Gitea on via CI_COMPOSE_WITH_GITEA=1).
+      # scripts/ci_compose_for_dispatch.sh then hello smoke + forge/PMO batteries.
       - name: Compose stack for dispatch smoke
         run: |
           set -euo pipefail

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,5 +1,8 @@
 # Bake Dev harness images (shared base stage) with GHA BuildKit cache.
 # Heavy job — runs when harness paths change (PR and main) or on dispatch.
+# Proves layer presence + harness CLI pins + hello redis-import only.
+# Full Dagu→hello→finalize dispatch smoke is ci.yml, not this workflow.
+# No SBOM/provenance (publish-only); permissions: contents:read.
 name: Docker images
 
 on:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,7 @@
-# Optional publish of DevCake images to GHCR (manual).
+# Optional publish of DevCake images to GHCR (manual workflow_dispatch only).
 # Images: ghcr.io/<owner>/devcake/<name>:<sha12> and :latest
+# SBOM + provenance are enabled on this bake only — there is no committed
+# tree-wide SBOM artifact process; PR CI keeps sbom/provenance false.
 name: Docker publish
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,12 @@ copy voice, evidence loop). Read it before touching the SPA. Iron rules:
 | Change type | Minimum proof |
 |---|---|
 | Docker / Bake / Compose | `docker buildx bake …` succeeds **and** `docker compose up -d` + healthchecks pass |
-| App / API | **`docker buildx bake app-test`** (or `scripts/pytest_app.sh`) **then** pytest in that image, **or** `PYTHONPATH=app` on Python **3.12** against the working tree; **and** bake/restart prod `app` when the run path changed |
+| App / API | **`./scripts/pytest_app.sh`** (always rebuilds `app-test` via Bake or Dockerfile `--target test`, then pytest), **or** `docker buildx bake app-test` then pytest in that image, **or** `PYTHONPATH=app` on Python **3.12** against the working tree; **and** bake/restart prod `app` when the run path changed |
 | Admin SPA | `bake admin` **and** load UI / nginx-health |
 | Dev harness / entrypoint | `bake images` (or affected target) **and** smoke CLI + import entrypoint |
 | Docs-only | No runtime required; still re-read for accuracy |
 
-**Stale `app-test` trap:** the `devcake/app-test` image **COPY**s `app/devcake` and `app/tests` at bake time. Re-running pytest on an old `devcake/app-test:latest` grades the last bake, not your working tree — a silent false green. Always rebake after `app/` edits, or use `PYTHONPATH=app` on 3.12, or `./scripts/pytest_app.sh` (always bakes first). CI rebakes on every run; local agent loops often forget.
+**Stale `app-test` trap:** the `devcake/app-test` image **COPY**s `app/devcake` and `app/tests` at bake time. Re-running pytest on an old `devcake/app-test:latest` grades the last bake, not your working tree — a silent false green. Always rebake after `app/` edits, or use `PYTHONPATH=app` on 3.12, or `./scripts/pytest_app.sh` (always rebuilds first via `scripts/lib/bake_app_test.sh`: Docker Buildx bake when available, else `docker build -f app/Dockerfile --target test`). CI rebakes on every run; local agent loops often forget.
 
 Never claim done from "build succeeded" alone when the user-facing path is run/up. Name anything still unproven.
 
@@ -130,13 +130,13 @@ docker buildx bake -f docker-bake.hcl -f docker-bake.ci.hcl all
 
 | Workflow | When | What |
 |---|---|---|
-| `ci.yml` | every PR + `main` | Bake group `ci` → ruff → Redis + `app-test` pytest → minimal compose (no Gitea) via `scripts/ci_compose_for_dispatch.sh` → `scripts/ci_dispatch_hello.sh` |
-| `docker-images.yml` | `images/**` changes + `main` + manual | Bake group `images` → harness CLI smoke + hello redis-import smoke (layer only; full dispatch is `ci.yml`) |
-| `docker-publish.yml` | **manual** (`workflow_dispatch`) | Bake `all` + push to GHCR (`ghcr.io/<owner>/devcake/<name>`) |
+| `ci.yml` | every PR + `main` | Pin gate → admin npm checks → bake group `ci` (sbom:false) → ruff → pip-audit → Redis + fresh `app-test` pytest → compose via `scripts/ci_compose_for_dispatch.sh` **with Gitea** (`CI_COMPOSE_WITH_GITEA=1`) → `scripts/ci_dispatch_hello.sh` → forge/PMO contract batteries. Permissions: `contents: read` only. |
+| `docker-images.yml` | `images/**` changes + `main` + manual | Bake group `images` → harness CLI smoke + hello redis-import smoke (layer only; full dispatch is `ci.yml`). No SBOM. |
+| `docker-publish.yml` | **manual** (`workflow_dispatch`) | Bake `all` + push to GHCR (`ghcr.io/<owner>/devcake/<name>`); `packages: write`; SBOM + provenance on this bake only — not a tree-wide SBOM program. |
 
-**Local unit path:** `./scripts/pytest_app.sh` (always rebakes `app-test`, then pytest).  
-**Local full suite:** `scripts/ci_suite.sh` — pin gate + bake app-test + pytest + Gitea forge battery + dispatch smoke.  
-**Clean-room dispatch compose:** `scripts/ci_compose_for_dispatch.sh` (minimal services; set `CI_COMPOSE_WRITE_ENV=1` only when you intend to overwrite `.env`).
+**Local unit path:** `./scripts/pytest_app.sh` — always rebuilds `app-test` (Buildx bake preferred; Dockerfile `--target test` fallback when bake is missing, e.g. buildah), then pytest.  
+**Local suite:** `scripts/ci_suite.sh` — pin gate + rebuild app-test + ruff + pytest + forge/PMO contracts + dispatch-hello; requires a **healthy stack already up**; not a full GHA clone (no npm/pip-audit, no control-plane rebake); mixed-version live stack prints a loud banner and is not tree evidence.  
+**Clean-room dispatch compose:** `scripts/ci_compose_for_dispatch.sh` (default without Gitea; set `CI_COMPOSE_WITH_GITEA=1` for contracts). `CI_COMPOSE_WRITE_ENV=1` / `GITHUB_ACTIONS=true` **overwrites `.env`**.
 
 ### Do
 

--- a/README.md
+++ b/README.md
@@ -244,16 +244,22 @@ More detail: [`AGENTS.md`](AGENTS.md) · [`docs/13-deployment.md`](docs/13-deplo
 ## Verify
 
 ```bash
-# Unit suite only (always rebakes app-test so the image matches the tree):
+# Unit suite only (always rebuilds app-test so the image matches the tree).
+# Prefers Docker Buildx bake; falls back to Dockerfile --target test when bake
+# is missing (e.g. podman/buildah hosts — see scripts/lib/bake_app_test.sh):
 ./scripts/pytest_app.sh
 
-# CI-shaped bake (Docker): see .github/workflows/ci.yml
+# CI-shaped bake (requires real Docker Buildx — not buildah's buildx shim):
 docker buildx bake -f docker-bake.hcl -f docker-bake.ci.hcl ci
 
-# Full local suite (stack up; forge battery + dispatch-hello smoke):
+# Local suite (healthy stack already up; pin gate + ruff + pytest + forge/PMO
+# contracts + dispatch-hello). Not a full GHA clone (no npm/pip-audit; no
+# control-plane rebake). Mixed-version live stack prints a warning banner:
 ./scripts/ci_suite.sh
 ```
 
+PR CI (`.github/workflows/ci.yml`) also runs pin gate, npm checks, pip-audit,
+compose with Gitea, and contract batteries — see `docs/13-deployment.md` §6.
 Token-spending golden path (optional, real models/forges):
 `scripts/acceptance.py` — including internal-forge / Gitea lanes when configured.
 

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -279,7 +279,25 @@ DAG's `name:` keys (ADR-0025), with the human-readable run id format of
 
 **Cache:** opt-in local `.buildx-cache/` — `BAKE_LOCAL_CACHE=1 docker buildx bake …` (needs a docker-container builder or the containerd image store; the default `docker` driver cannot export cache, so plain `bake all` works everywhere without it). CI: `docker buildx bake -f docker-bake.hcl -f docker-bake.ci.hcl …` for GitHub Actions `type=gha` cache.
 
-**GitHub Actions:** `.github/workflows/ci.yml` bakes group `ci` + pytest on every PR; `docker-images.yml` bakes harnesses when `images/**` changes; `docker-publish.yml` (manual) pushes all images to GHCR.
+**Bake prerequisite:** full matrix targets (`ci`, `images`, `all`, control-plane) need real **Docker Buildx bake**. On hosts where `docker` is Podman and `docker buildx` is Buildah, `bake` is missing and `-f` may be rejected — only the **app-test unit path** has a fallback (`scripts/lib/bake_app_test.sh` → `docker build -f app/Dockerfile --target test`). Admin/hello/harness builds still need Docker Buildx (or GHA).
+
+**GitHub Actions (what green means):**
+
+| Workflow | Permissions | What it proves | What it does not |
+|---|---|---|---|
+| `ci.yml` (every PR + `main`) | `contents: read` | Pin gate; admin npm helper tests + audit; bake group `ci` (**sbom: false**, **provenance: false**); ruff; pip-audit; pytest on tree-fresh `app-test`; compose with **Gitea on** (`CI_COMPOSE_WITH_GITEA=1`); hello dispatch smoke; forge + PMO contract batteries (bundled Gitea, no external tokens) | Token-spending `scripts/acceptance.py`; full harness matrix; SBOM attestation |
+| `docker-images.yml` (path-filtered / manual) | `contents: read` | Bake group `images`; harness CLI pin smoke; hello redis-import (layer only) | Full dispatch (that is `ci.yml`); SBOM |
+| `docker-publish.yml` (**manual** only) | `contents: read` + `packages: write` | Bake `all` + push GHCR; **sbom: true** + **provenance: true** on that bake | Not an automatic publish; not a committed tree-wide SBOM artifact program |
+
+**Local scripts (model-free):**
+
+| Script | Role |
+|---|---|
+| `./scripts/pytest_app.sh` | Always rebuilds `app-test` then pytest (+ throwaway Redis if compose is down) |
+| `scripts/ci_suite.sh` | Pin gate → app-test rebuild → ruff → pytest → forge/PMO contracts → dispatch-hello; **stack must already be healthy**; mixed-version banner if live app ≠ local tag (warn, not fail) |
+| `scripts/ci_compose_for_dispatch.sh` | Clean-room compose for smoke/contracts; default without Gitea; `CI_COMPOSE_WITH_GITEA=1` for batteries. `CI_COMPOSE_WRITE_ENV=1` overwrites `.env` |
+| `scripts/ci_dispatch_hello.sh` | Dagu → hello → Redis → finalize only (no bake) |
+
 | Image | Bake target | Context / Dockerfile target | Default tag |
 |---|---|---|---|
 | `devcake/app` | `app` → `runtime` | `./app` | `devcake/app:${TAG}` |

--- a/scripts/ci_compose_for_dispatch.sh
+++ b/scripts/ci_compose_for_dispatch.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
-# Bring up the minimal compose set for hello dispatch smoke (no Gitea).
+# Bring up the compose set for hello dispatch smoke (and optional contracts).
 # Used by GHA ci.yml and optionally for local clean-room proof.
 #
-# Service set (transitive deps for app + Dagu spawning hello):
+# Default service set is WITHOUT Gitea (dispatch-only):
 #   fluentbit  — redis/dagu depend_on + fluentd log driver
 #   openobserve — app depends_on service_started
 #   otel-collector — hello OTLP export target
 #   redis, dagu, app, admin
+# Set CI_COMPOSE_WITH_GITEA=1 to add bundled Gitea (as ci.yml does for the
+# forge + PMO contract-battery lane). Off by default for a minimal smoke.
+#
+# FOOTGUN: CI_COMPOSE_WRITE_ENV=1 or GITHUB_ACTIONS=true OVERWRITES ./.env
+# with synthetic CI credentials. Never set WRITE_ENV on a developer machine
+# that has a real .env you care about.
 #
 # Third-party pull resilience (no registry credentials):
 #   - Skip services whose digest-pinned image is already local (GHA unit-test

--- a/scripts/ci_dispatch_hello.sh
+++ b/scripts/ci_dispatch_hello.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Stub-harness smoke: full dispatch pipeline (Dagu → container → Redis → finalize).
-# Preconditions: compose stack up (app + admin + redis + dagu + …), hello image
-# baked as devcake/dev-hello:${DEVCAKE_TAG:-latest}, ADMIN_* credentials set.
+# Preconditions: compose stack up and healthy (app + admin + redis + dagu + …);
+# hello image present as devcake/dev-hello:${DEVCAKE_TAG:-latest}; ADMIN_* set.
+# This script does not bake or compose-up — bring the stack with
+# scripts/ci_compose_for_dispatch.sh (or ./up.sh) first.
 # Used by scripts/ci_suite.sh and .github/workflows/ci.yml.
 set -euo pipefail
 

--- a/scripts/ci_suite.sh
+++ b/scripts/ci_suite.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
-# DevCake CI suite (docs/16 M7): deterministic, model-free, ~1 minute.
-# Requires the compose stack running + Bake images present.
-# Real-model acceptance is scripts/acceptance.py.
+# DevCake model-free local suite — not a full clone of GHA ci.yml.
+#
+# Preconditions (fail late if missing):
+#   - healthy compose stack already up (app + redis + dagu + … + gitea for
+#     contracts); use scripts/ci_compose_for_dispatch.sh with
+#     CI_COMPOSE_WITH_GITEA=1 for a clean-room bring-up
+#   - hello image present as devcake/dev-hello:${DEVCAKE_TAG:-latest}
+#   - ADMIN_* / REDIS_PASSWORD in .env (or environment)
+#
+# Steps: pin gate → app-test rebuild (tree) → ruff → pytest → forge/PMO
+# contracts (live app) → dispatch-hello. Mixed-version is warn-not-fail
+# (banner only): unit lanes grade the tree; dispatch/contracts grade the
+# live stack. Does NOT: npm helper tests, npm audit, pip-audit, rebake
+# prod app/admin/hello, or write SBOM.
+#
+# App-test rebuild: scripts/lib/bake_app_test.sh (Buildx bake preferred;
+# Dockerfile --target test fallback on buildah/podman).
+# Token-spending acceptance: scripts/acceptance.py (not this script).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -43,8 +58,8 @@ mixed_version_banner() {
 echo "── digest-pin gate (ISSUES #29)"
 python3 scripts/check_image_pins.py
 
-echo "── bake app-test (prod image has no pytest; DEVCAKE_TAG=${DEVCAKE_TAG:-latest} lockstep)"
-docker buildx bake -f docker-bake.hcl app-test
+echo "── rebuild app-test (prod image has no pytest; DEVCAKE_TAG=${DEVCAKE_TAG:-latest} lockstep)"
+bash scripts/lib/bake_app_test.sh
 mixed_version_banner
 
 echo "── ruff (syntax / undefined names / blanket-except policy, docs/15 §7)"

--- a/scripts/lib/bake_app_test.sh
+++ b/scripts/lib/bake_app_test.sh
@@ -22,14 +22,16 @@ export DEVCAKE_TAG="$TAG"
 
 echo "── ensure app-test → devcake/app-test:${TAG}"
 
-# No mandatory `-f docker-bake.hcl`: the default file in the repo root is that
-# HCL, and buildah's buildx rejects `-f` even when bake itself is absent.
-if docker buildx bake app-test; then
-  echo "── app-test via: docker buildx bake app-test"
+# `-f docker-bake.hcl` is mandatory: without it, bake's default-file lookup
+# also merges docker-compose.yml, whose `:?` interpolations hard-fail on a
+# fresh clone with no .env. (On podman, buildah's buildx shim fails with or
+# without `-f`, so the fallback below still triggers there either way.)
+if docker buildx bake -f docker-bake.hcl app-test; then
+  echo "── app-test via: docker buildx bake -f docker-bake.hcl app-test"
   exit 0
 fi
 
-echo "── docker buildx bake unavailable or failed; fallback: docker build --target test"
+echo "── bake failed (CLI missing or bake error); fallback: docker build --target test"
 # Match docker-bake.hcl target "app-test" (context ./app, Dockerfile target test).
 if docker build -f app/Dockerfile --target test \
   -t "devcake/app-test:${TAG}" \

--- a/scripts/lib/bake_app_test.sh
+++ b/scripts/lib/bake_app_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Chokepoint: tree-fresh devcake/app-test:${DEVCAKE_TAG:-latest}.
+#
+# Prefer Docker Buildx bake (real Docker Engine + Buildx). When bake is missing
+# or rejects the CLI (e.g. podman/buildah's buildx shim: no `bake` subcommand,
+# and `-f` is an "unknown shorthand flag"), fall back to the same image the
+# bake target builds:
+#   docker build -f app/Dockerfile --target test -t devcake/app-test:$TAG ./app
+#
+# Logs which path ran so a green unit suite is never misread as "full bake
+# matrix green." Does NOT build admin/hello/harnesses.
+#
+# Callers: scripts/pytest_app.sh, scripts/ci_suite.sh. GHA uses docker/bake-action
+# (real Buildx) and does not need this helper.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TAG="${DEVCAKE_TAG:-latest}"
+export DEVCAKE_TAG="$TAG"
+
+echo "── ensure app-test → devcake/app-test:${TAG}"
+
+# No mandatory `-f docker-bake.hcl`: the default file in the repo root is that
+# HCL, and buildah's buildx rejects `-f` even when bake itself is absent.
+if docker buildx bake app-test; then
+  echo "── app-test via: docker buildx bake app-test"
+  exit 0
+fi
+
+echo "── docker buildx bake unavailable or failed; fallback: docker build --target test"
+# Match docker-bake.hcl target "app-test" (context ./app, Dockerfile target test).
+if docker build -f app/Dockerfile --target test \
+  -t "devcake/app-test:${TAG}" \
+  ./app; then
+  echo "── app-test via: docker build -f app/Dockerfile --target test"
+  exit 0
+fi
+
+echo "ERROR: could not build devcake/app-test:${TAG} (bake and Dockerfile fallback both failed)" >&2
+exit 1

--- a/scripts/pytest_app.sh
+++ b/scripts/pytest_app.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Always-fresh unit suite: rebake app-test (COPY'd tree) then pytest.
+# Always-fresh unit suite: rebuild app-test (COPY'd tree) then pytest.
 # Avoids the stale-image false green when app/ or tests/ changed since last bake.
+# Uses scripts/lib/bake_app_test.sh: Docker Buildx bake when available, else
+# `docker build -f app/Dockerfile --target test` (podman/buildah hosts).
 # For the full local suite (forge battery + dispatch smoke) use ci_suite.sh.
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -20,8 +22,8 @@ if [[ -f .env ]]; then
   done < <(grep -E '^REDIS_PASSWORD=' .env || true)
 fi
 
-echo "── bake app-test (ensures image matches working tree)"
-docker buildx bake -f docker-bake.hcl app-test
+# Always rebuild before pytest (stale COPY'd image = silent false green).
+bash scripts/lib/bake_app_test.sh
 
 TAG="${DEVCAKE_TAG:-latest}"
 NET_ARGS=()


### PR DESCRIPTION
## Summary

Makes the model-free proof path (GHA CI + local scripts) honest about what it grades, how it rebakes, and what fails on non-Docker-Buildx hosts.

### Changes

1. **`scripts/lib/bake_app_test.sh`** — shared chokepoint for tree-fresh `devcake/app-test`:
   - Prefer `docker buildx bake app-test` (no mandatory `-f`; default HCL in repo root)
   - Fallback: `docker build -f app/Dockerfile --target test -t devcake/app-test:$TAG ./app`
   - Logs which path ran; fails loud if both fail
   - Wired into `pytest_app.sh` and `ci_suite.sh`

2. **Script header honesty** — `ci_compose_for_dispatch.sh` (default without Gitea; opt-in for contracts; loud `.env` overwrite footgun), `ci_suite.sh` (not a full GHA clone; stack must be healthy), `pytest_app.sh`, `ci_dispatch_hello.sh`.

3. **Workflow comments** — `ci.yml` matrix includes Gitea + contracts, contents:read, no SBOM; `docker-publish.yml` SBOM publish-only; `docker-images.yml` layer/CLI smoke only.

4. **Docs** — fixed AGENTS “no Gitea” row; expanded `docs/13-deployment.md` §6 and README Verify for permissions, SBOM, local script map, Buildx prerequisite/fallback.

### Mission

https://linear.app/fidecastro/issue/CAKE-42/pre-foss-ci-workflows-and-local-pytestci-scripts-honesty

### Residuals

- **Live-pending:** full `ci_suite.sh` on a deployed stack; GHA green on this PR.
- **Token-gated:** `scripts/acceptance.py`.
- **Host-gated:** full bake matrix still needs Docker Buildx; only app-test unit path has Dockerfile fallback. On hosts without container bridge networking (e.g. netavark missing iptables), `pytest_app.sh`’s throwaway Redis network may fail — use host-network Redis or a real compose network.
- **SBOM:** publish-bake attestation only; no tree-wide SBOM program.

### Proof (this run)

- Pin gate: green
- `bake_app_test.sh` on podman/buildah: bake rejected → fallback `docker build --target test` tagged `devcake/app-test:latest`
- Pytest via that image (host-network Redis substitute): **2327 passed, 1 skipped**