### PR TITLE
[CAKE-51] [pre-FOSS] Claims conveyor domain audit and fix

### DIFF
--- a/app/devcake/domain/claims.py
+++ b/app/devcake/domain/claims.py
@@ -1,4 +1,4 @@
-"""`.claims/` conveyor — the fast lane (PLAN_MEMORY §5).
+"""`.claims/` conveyor — the fast lane (ADR-0035 D4 / D8).
 
 The app writes one file per harvested discovery onto every memory card
 snapshotted on the run. No judgment. Failure never fails the discovering
@@ -34,8 +34,9 @@ CLAIMS_README = (
 # advisory depth cache: card → json-file count. Restart-stale until the
 # next append or list-only refresh.
 claims_depth: dict[str, int] = {}
-# health: last cap event per card (standing warning until a successful
-# under-cap write). Restart-stale; next append refreshes.
+# health: standing "refusing new leads" warning per card. Set on refuse-new;
+# cleared when listing/write shows room under cap, depth hits 0, or Clear.
+# Restart-stale until the next append or list-only refresh.
 claims_queue_capped: set[str] = set()
 
 
@@ -95,6 +96,9 @@ async def refresh_depth(notebooks: ClaimsNotebooks, card: str) -> int:
         return claims_depth.get(card, 0)
     depth = len(_json_names(names))
     claims_depth[card] = depth
+    # Empty queue cannot be refusing new leads — drop a stale standing warning.
+    if depth == 0:
+        claims_queue_capped.discard(card)
     return depth
 
 
@@ -164,15 +168,17 @@ async def _append_one_notebook(notebooks, cfg, run, entries, card, *,
         rec = claim_record(run, entry, i)
         creates[f"{CLAIMS_DIR}/{cid}.json"] = json.dumps(rec, indent=2) + "\n"
     json_creates = [p for p in creates if p.endswith(".json")]
+    n = len(json_creates)
+    # Listing proved room (or unlimited): standing capped alert is dishonest
+    # even when every entry was a file-exists dedup and nothing is committed.
+    if not cap or depth + n < cap:
+        claims_queue_capped.discard(card)
     if not creates:
         return 0
-    n = len(json_creates)
     await notebooks.commit(
         card, creates=creates, deletes=[],
         message=f"devcake:claims:v1 run={run.run_id} n={n}")
     claims_depth[card] = depth + n
-    if cap and claims_depth[card] < cap:
-        claims_queue_capped.discard(card)
     return n
 
 
@@ -187,15 +193,19 @@ async def prune_all(notebooks: ClaimsNotebooks, cards: list[str], *,
         if not notebooks.can_write(card):
             continue
         try:
-            names = _json_names(await notebooks.list_json_names(card))
-            if not names:
+            listing = await notebooks.list_json_names(card)
+            if listing is None:
                 continue
-            await notebooks.commit(
-                card, creates={},
-                deletes=[f"{CLAIMS_DIR}/{n}" for n in names],
-                message="devcake:claims:v1 prune source=clear-all")
+            names = _json_names(listing)
+            if names:
+                await notebooks.commit(
+                    card, creates={},
+                    deletes=[f"{CLAIMS_DIR}/{n}" for n in names],
+                    message="devcake:claims:v1 prune source=clear-all")
+                pruned[card] = len(names)
+            # Empty or just-wiped: advisory depth + standing cap must match disk.
             claims_depth[card] = 0
-            pruned[card] = len(names)
+            claims_queue_capped.discard(card)
         except Exception:  # noqa: BLE001 — clear must not fail the wipe
             log.exception("claims prune failed for %s", card)
             if audit:
@@ -207,7 +217,12 @@ async def prune_board(notebooks: ClaimsNotebooks, cards: list[str], *,
                       source_instance: str, source_pmo_id: str = "",
                       audit=None) -> dict[str, int]:
     """Delete `.claims/*.json` whose source matches the wiped board.
-    Leave README. Never touch paths outside `.claims/`."""
+
+    Each non-empty filter is required (AND). Instance alone wipes every
+    mission on that board; instance + pmo_id wipes one mission. OR matching
+    would cross-delete colliding numeric pmo ids across boards (N6).
+    Leave README. Never touch paths outside `.claims/`.
+    """
     pruned: dict[str, int] = {}
     for card in cards:
         if not notebooks.can_write(card):
@@ -226,14 +241,25 @@ async def prune_board(notebooks: ClaimsNotebooks, cards: list[str], *,
     return pruned
 
 
+def _claim_source_matches(rec: dict, source_instance: str,
+                          source_pmo_id: str) -> bool:
+    """True when every non-empty prune filter matches the claim meta."""
+    if not source_instance and not source_pmo_id:
+        return False
+    if source_instance and rec.get("source_instance") != source_instance:
+        return False
+    if source_pmo_id and rec.get("source_pmo_id") != source_pmo_id:
+        return False
+    return True
+
+
 async def _prune_one(notebooks, card, source_instance, source_pmo_id) -> int:
     records = await notebooks.list_claim_meta(card)
     if records is None:
         return 0
     deletes = []
     for rec in records:
-        if ((source_instance and rec.get("source_instance") == source_instance)
-                or (source_pmo_id and rec.get("source_pmo_id") == source_pmo_id)):
+        if _claim_source_matches(rec, source_instance, source_pmo_id):
             cid = rec.get("id") or ""
             if _SAFE_ID.match(str(cid)):
                 deletes.append(f"{CLAIMS_DIR}/{cid}.json")

--- a/app/tests/test_claims.py
+++ b/app/tests/test_claims.py
@@ -1,5 +1,5 @@
-"""`.claims/` conveyor (PLAN_MEMORY §5) — public seam: append_from_harvest,
-prune_board, claim_id. Fake notebooks; independent expected values."""
+"""`.claims/` conveyor (ADR-0035 D4/D8) — public seam: append_from_harvest,
+prune_board, prune_all, claim_id. Fake notebooks; independent expected values."""
 
 from __future__ import annotations
 
@@ -192,6 +192,64 @@ def test_prune_deletes_matching_source_leaves_readme_and_other_boards():
     assert ".claims/README.md" in nb.files["nb"]
 
 
+def test_prune_board_and_filters_when_both_source_fields_set():
+    """N6: colliding numeric pmo ids across boards must not cross-delete.
+
+    When both source_instance and source_pmo_id are provided, each non-empty
+    filter must match (AND). An OR match would delete the other board's claim
+    that only shares the pmo id — the same collision N6 salted claim_id for.
+    """
+    id_target = claims.claim_id("eng", "pmo-1", 2, 0)
+    id_same_pmo_other_board = claims.claim_id("cs", "pmo-1", 1, 0)
+    id_same_board_other_mission = claims.claim_id("eng", "pmo-2", 1, 0)
+    nb = FakeNotebooks(
+        writable={"nb"},
+        files={"nb": {
+            ".claims/README.md": claims.CLAIMS_README,
+            f".claims/{id_target}.json": json.dumps({
+                "id": id_target, "source_instance": "eng",
+                "source_pmo_id": "pmo-1"}),
+            f".claims/{id_same_pmo_other_board}.json": json.dumps({
+                "id": id_same_pmo_other_board, "source_instance": "cs",
+                "source_pmo_id": "pmo-1"}),
+            f".claims/{id_same_board_other_mission}.json": json.dumps({
+                "id": id_same_board_other_mission, "source_instance": "eng",
+                "source_pmo_id": "pmo-2"}),
+        }})
+    got = run_coro(claims.prune_board(
+        nb, ["nb"], source_instance="eng", source_pmo_id="pmo-1"))
+    assert got == {"nb": 1}
+    assert f".claims/{id_target}.json" not in nb.files["nb"]
+    assert f".claims/{id_same_pmo_other_board}.json" in nb.files["nb"]
+    assert f".claims/{id_same_board_other_mission}.json" in nb.files["nb"]
+
+
+def test_prune_board_instance_only_wipes_all_missions_on_that_board():
+    """Board-level prune (no source_pmo_id): every claim from that instance."""
+    id_a = claims.claim_id("eng", "pmo-1", 2, 0)
+    id_b = claims.claim_id("eng", "pmo-2", 1, 0)
+    id_other = claims.claim_id("cs", "pmo-1", 1, 0)
+    nb = FakeNotebooks(
+        writable={"nb"},
+        files={"nb": {
+            f".claims/{id_a}.json": json.dumps({
+                "id": id_a, "source_instance": "eng",
+                "source_pmo_id": "pmo-1"}),
+            f".claims/{id_b}.json": json.dumps({
+                "id": id_b, "source_instance": "eng",
+                "source_pmo_id": "pmo-2"}),
+            f".claims/{id_other}.json": json.dumps({
+                "id": id_other, "source_instance": "cs",
+                "source_pmo_id": "pmo-1"}),
+        }})
+    got = run_coro(claims.prune_board(
+        nb, ["nb"], source_instance="eng"))
+    assert got == {"nb": 2}
+    assert f".claims/{id_a}.json" not in nb.files["nb"]
+    assert f".claims/{id_b}.json" not in nb.files["nb"]
+    assert f".claims/{id_other}.json" in nb.files["nb"]
+
+
 def test_two_file_creates_do_not_share_a_path():
     """Drain-delete vs concurrent create cannot conflict: distinct files."""
     id0 = claims.claim_id("eng", "pmo-1", 2, 0)
@@ -216,7 +274,51 @@ def test_prune_all_removes_orphans_and_keeps_readme():
                 "id": id_orphan, "source_instance": "gone",
                 "source_pmo_id": "pmo-9"}),
         }})
+    claims.claims_queue_capped.add("nb")
     got = run_coro(claims.prune_all(nb, ["nb"]))
     assert got == {"nb": 2}
     assert list(nb.files["nb"]) == [".claims/README.md"]
     assert claims.claims_depth["nb"] == 0
+    # Clear emptied the queue — standing cap alert must not outlive it.
+    assert "nb" not in claims.claims_queue_capped
+
+
+def test_prune_all_empty_queue_zeros_depth_and_clears_capped():
+    """Empty on disk after Clear: still refresh advisory depth + cap flag."""
+    nb = FakeNotebooks(
+        writable={"nb"},
+        files={"nb": {".claims/README.md": claims.CLAIMS_README}})
+    claims.claims_depth["nb"] = 7
+    claims.claims_queue_capped.add("nb")
+    got = run_coro(claims.prune_all(nb, ["nb"]))
+    assert got == {}
+    assert claims.claims_depth["nb"] == 0
+    assert "nb" not in claims.claims_queue_capped
+    assert nb.files["nb"] == {".claims/README.md": claims.CLAIMS_README}
+
+
+def test_append_clears_capped_when_listing_shows_room_and_nothing_to_write():
+    """Curator drain can free the queue without an app write.
+
+    Next harvest that lists under-cap depth must drop the standing
+    claims_queue_capped warning even when every entry is a file-exists dedup
+    (no commit) — otherwise /health keeps claiming leads are refused.
+    """
+    existing_id = claims.claim_id("eng", "pmo-1", 2, 0)
+    nb = FakeNotebooks(
+        writable={"nb"},
+        files={"nb": {
+            ".claims/README.md": claims.CLAIMS_README,
+            f".claims/{existing_id}.json": json.dumps({
+                "id": existing_id, "source_instance": "eng",
+                "source_pmo_id": "pmo-1"}),
+        }})
+    cfg = AppConfig(budgets=Budgets(claims_queue_max=50))
+    claims.claims_queue_capped.add("nb")
+    claims.claims_depth["nb"] = 50  # stale post-drain
+    got = run_coro(claims.append_from_harvest(
+        nb, cfg, _run(),
+        [{"finding": "f", "evidence": "e", "scope": "s"}]))
+    assert got == {}
+    assert claims.claims_depth["nb"] == 1
+    assert "nb" not in claims.claims_queue_capped


### PR DESCRIPTION
## Intent

Audit-and-fix for the `.claims/` conveyor domain (`app/devcake/domain/claims.py`) against ADR-0035: queue caps, harvest never-fails, prune semantics, and `/health` honesty for `claims_queue_capped`.

## Fixes

1. **`prune_board` match is AND, not OR** — when both `source_instance` and `source_pmo_id` are set, every non-empty filter must match. The old OR path deleted another board’s claim that only shared a colliding numeric pmo id (the same collision N6 salts into `claim_id`).
2. **Board-level prune** (instance only, empty `source_pmo_id`) still wipes every mission on that board.
3. **`claims_queue_capped` honesty** — Clear (`prune_all`) zeros depth and clears the standing warning even when the queue was already empty; append clears the warning when listing shows room under cap (including pure file-exists dedup with no commit); `refresh_depth` clears it when depth is 0.

## Plan deviation

The PLAN step left an empty `PLAN_2.md` (transcript only). EXECUTE performed the audit against ADR-0035 / existing tests and fixed the defects found.

## How to verify

```bash
# preferred: rebake + pytest (Always Works™)
./scripts/pytest_app.sh tests/test_claims.py tests/test_claims_writer.py tests/test_memory_bindings.py tests/test_cron.py tests/test_structure_guards.py

# or: docker build --target test -t devcake/app-test:latest ./app
# then run pytest in that image with the mounts from scripts/pytest_app.sh
```

Local proof this run: `devcake/app-test:latest` built from the working tree; **2314 passed** (1 skipped; live Redis messaging tests not exercised — host lacks netavark/iptables for a scratch redis network).

## Risk

Low. Domain-only; no port Protocol change; hexagonal shape unchanged (still depends on `ClaimsNotebooks` only). `prune_board` has no production caller today (Clear uses `prune_all`); the AND fix prevents a future wire-up from cross-board deleting.

## Out of scope

Skills, blocker locator, repo routing/sourcing/mirror, orchestrator beyond harvest caller, SPA, new product features.

## Mission

https://linear.app/fidecastro/issue/CAKE-51/pre-foss-claims-conveyor-domain-audit-and-fix