### PR TITLE
[CAKE-52] [pre-FOSS] Skills assembly domain audit and fix

### DIFF
--- a/app/devcake/domain/skills.py
+++ b/app/devcake/domain/skills.py
@@ -1,16 +1,20 @@
 """SkillService — the skill store's domain seam (docs/16 skill store v1).
 
 Skills are standard Claude Code skills (`<name>/SKILL.md` + optional
-supporting files). Two sources, store-first:
+supporting files). Three sources, store-first for flat names:
 - the operator-editable `skill-store` repo on the bundled Gitea (read via
-  the InternalForgePort — F1: domain never imports adapters), and
+  the InternalForgePort — F1: domain never imports adapters),
 - the bundled copies under app/devcake/skills/ (the seed content), which
-  keep built-in skills working when the internal forge is disabled or down.
+  keep built-in skills working when the internal forge is disabled or down,
+- and external `<source>/<skill>` names from dedicated `skill_sources`
+  connections (ADR-0016 addendum 2; read via RepoCache, never repo cards).
 
 Skills are additive: every failure here degrades to a warning, never a
 refused run. Size caps are enforced from the tree listing's blob sizes
 BEFORE any download — an oversized store file must never be pulled into
-the shared control-plane process (review finding, 2026-07-17).
+the shared control-plane process (review finding, 2026-07-17). A skill
+whose SKILL.md is file-cap dropped is skipped entirely (no helpers-only
+payload — ADR-0016 Decision 4 / Required soft-force honesty).
 """
 
 from __future__ import annotations
@@ -620,7 +624,14 @@ class SkillService:
     async def _collect(self, name: str, sized: list[tuple[str, int]],
                        total: int, fetch) -> tuple[list[dict], int, list[str]]:
         """One skill's files within the caps: sizes are checked BEFORE
-        fetch; a store exception propagates (payload_for falls back)."""
+        fetch; a store exception propagates (payload_for falls back).
+
+        SKILL.md is required: if it is present in the sized tree and
+        over MAX_FILE_BYTES, return empty — do not ship helpers alone
+        (ADR-0016 Decision 4: size-capped skills must not appear as
+        shipped for Required soft-force). Total-cap mid-skill still
+        keeps SKILL.md and drops later helpers.
+        """
         entry: list[dict] = []
         used = 0
         warns: list[str] = []
@@ -634,6 +645,10 @@ class SkillService:
             if _over_file_cap(size):
                 warns.append(f"skill {name!r}: {path} exceeds "
                              f"{MAX_FILE_BYTES} bytes — skipped")
+                if path == anchor:
+                    # Manifest unusable → whole skill unusable; stop
+                    # before fetching any helpers.
+                    return [], 0, warns
                 continue
             if total + used + size > MAX_TOTAL_BYTES:
                 warns.append(f"skills payload cap ({MAX_TOTAL_BYTES} bytes) "

--- a/app/devcake/domain/skills.py
+++ b/app/devcake/domain/skills.py
@@ -77,8 +77,9 @@ class SkillInfo(BaseModel):
     # shipped in the app image: re-seeds at boot, so it can be edited but
     # never deleted — the UI offers delete only when this is False
     builtin: bool = False
-    # external skills only (ADR-0016 addendum): the repo card the skill is
-    # served from — read-only by construction (save/delete refuse `/`)
+    # external skills only (ADR-0016 addendum 2): the skill_sources
+    # connection name the skill is served from — read-only by construction
+    # (save/delete refuse `/`)
     origin: str = ""
 
 
@@ -97,9 +98,9 @@ class SkillService:
         self._tree: list[dict] | None = None      # [{path, size}]
         self._file_bytes: dict[str, bytes] = {}
 
-    def _card(self, name: str):
-        """The named skill SOURCE (dedicated connection — 2026-08-14
-        ruling; repo cards are never consulted for skills)."""
+    def _skill_source(self, name: str):
+        """The named skill SOURCE (dedicated `skill_sources` connection —
+        2026-08-14 ruling; repo cards are never consulted for skills)."""
         for r in (self.config.skill_sources if self.config is not None else []):
             if r.name == name:
                 return r
@@ -162,7 +163,9 @@ class SkillService:
                 "detail": "internal forge disabled (GITEA_ADMIN_PASSWORD unset)",
                 "html_url": ""}
         try:
-            paths = {t["path"] for t in await self._store_tree()}
+            sizes = {t["path"]: int(t.get("size") or 0)
+                     for t in await self._store_tree()}
+            paths = set(sizes)
             builtin_names = set(self._builtin_skills())
             names = sorted(
                 n for n in {p.split("/", 1)[0] for p in paths if "/" in p}
@@ -171,13 +174,25 @@ class SkillService:
             async def _one(name: str) -> SkillInfo:
                 # parallel per skill: sequential Gitea file GETs were the
                 # catalog's load-time cost when many skills live in the store
-                text = (await self._store_file(f"{name}/SKILL.md")
+                n_files = sum(1 for p in paths if p.startswith(f"{name}/"))
+                md_path = f"{name}/SKILL.md"
+                # size gate BEFORE the read (same class as external_infos):
+                # an oversized store SKILL.md must not be pulled into memory
+                if _over_file_cap(sizes.get(md_path, 0)):
+                    return SkillInfo(
+                        name=name,
+                        description=f"(SKILL.md exceeds the "
+                                    f"{MAX_FILE_BYTES}-byte cap — "
+                                    f"not read)",
+                        source="store", files=n_files,
+                        builtin=name in builtin_names)
+                text = (await self._store_file(md_path)
                         ).decode("utf-8", errors="replace")
                 return SkillInfo(
                     name=name,
                     description=str(parse_frontmatter(text).get("description", "")),
                     source="store",
-                    files=sum(1 for p in paths if p.startswith(f"{name}/")),
+                    files=n_files,
                     builtin=name in builtin_names)
 
             skills = list(await asyncio.gather(*(_one(n) for n in names)))
@@ -202,9 +217,9 @@ class SkillService:
 
     async def get_skill(self, name: str) -> dict:
         """Admin View: full skill tree as UTF-8 text files (store-first when
-        the forge is up, bundled fallback; `<card>/<skill>` reads the repo
-        mirror). Raises SkillStoreError 404/422. Paths are relative to the
-        skill dir (SKILL.md, not name/SKILL.md)."""
+        the forge is up, bundled fallback; `<source>/<skill>` reads the
+        skill-source mirror). Raises SkillStoreError 404/422. Paths are
+        relative to the skill dir (SKILL.md, not name/SKILL.md)."""
         if "/" in (name or ""):
             return await self._get_external(name)
         if not re.fullmatch(SKILL_NAME_RE, name or ""):
@@ -214,24 +229,34 @@ class SkillService:
         if self.forge is not None:
             try:
                 tree = await self._store_tree()
-                paths = sorted(
-                    t["path"] for t in tree
+                sized = sorted(
+                    (t["path"], int(t.get("size") or 0)) for t in tree
                     if t["path"].startswith(f"{name}/"))
-                if f"{name}/SKILL.md" in paths:
-                    blobs = await asyncio.gather(
-                        *(self._store_file(p) for p in paths))
+                if f"{name}/SKILL.md" in {p for p, _ in sized}:
+                    # ONE capped read path (same class as external View):
+                    # sizes-before-fetch + MAX_FILE_BYTES/MAX_TOTAL_BYTES;
+                    # skipped files surface as warnings.
+                    entry, _used, warns = await self._collect(
+                        name, sized, 0, self._store_file)
+                    if not entry:
+                        raise SkillStoreError(
+                            404, warns[0] if warns
+                            else f"skill {name!r} not found")
                     files = [{
-                        "path": p[len(name) + 1:],
-                        "content": data.decode("utf-8", errors="replace"),
-                    } for p, data in zip(paths, blobs, strict=True)]
+                        "path": e["path"][len(name) + 1:],
+                        "content": base64.b64decode(e["content_b64"]).decode(
+                            "utf-8", errors="replace"),
+                    } for e in entry]
                     skill_md = next(
-                        f["content"] for f in files if f["path"] == "SKILL.md")
+                        (f["content"] for f in files
+                         if f["path"] == "SKILL.md"), "")
                     return {
                         "name": name,
                         "description": str(
                             parse_frontmatter(skill_md).get("description", "")),
                         "source": "store",
                         "builtin": name in builtin,
+                        "warnings": warns,
                         "files": files,
                     }
             except SkillStoreError:
@@ -260,15 +285,16 @@ class SkillService:
             }
         raise SkillStoreError(404, f"skill {name!r} not found")
 
-    # ── external reads (ADR-0016 addendum: repo-card mirror, read-only) ──────
+    # ── external reads (ADR-0016 addendum 2: skill-source mirror, read-only) ─
 
     async def _get_external(self, name: str) -> dict:
-        card, _, skill = name.partition("/")
-        if not (re.fullmatch(r"[a-z][a-z0-9]{0,11}", card)
+        source, _, skill = name.partition("/")
+        if not (re.fullmatch(r"[a-z][a-z0-9]{0,11}", source)
                 and re.fullmatch(SKILL_NAME_RE, skill)):
             raise SkillStoreError(422, f"invalid skill name {name!r}")
-        if self._card(card) is None or self.repo_cache is None:
-            raise SkillStoreError(404, f"repo card {card!r} not configured")
+        if self._skill_source(source) is None or self.repo_cache is None:
+            raise SkillStoreError(
+                404, f"skill source {source!r} not configured")
         # ONE capped read path (audit 2026-08-13: the first cut re-read every
         # blob here UNCAPPED — a large third-party file on default_branch
         # could OOM the shared app, the exact class the store forbids). The
@@ -287,52 +313,52 @@ class SkillService:
         return {"name": name,
                 "description": str(
                     parse_frontmatter(skill_md).get("description", "")),
-                "source": "external", "builtin": False, "origin": card,
+                "source": "external", "builtin": False, "origin": source,
                 "warnings": warns, "files": files}
 
     async def external_infos(self, referenced: list[str]) -> list[SkillInfo]:
-        """Catalog rows for the repo cards that Dev Types reference via
-        `<card>/<skill>` names — EVERY skill in those cards' trees (so the
-        operator can discover what else a card offers), best-effort: an
-        unsynced or unreadable mirror contributes nothing (the Dev-Type
+        """Catalog rows for the skill sources that Dev Types reference via
+        `<source>/<skill>` names — EVERY skill in those sources' trees (so
+        the operator can discover what else a source offers), best-effort:
+        an unsynced or unreadable mirror contributes nothing (the Dev-Type
         chips still render unknown names with the stale chip)."""
         out: list[SkillInfo] = []
-        cards = sorted({n.split("/", 1)[0] for n in referenced if "/" in n})
-        for card in cards:
-            inst = self._card(card)
+        sources = sorted({n.split("/", 1)[0] for n in referenced if "/" in n})
+        for source in sources:
+            inst = self._skill_source(source)
             if inst is None or self.repo_cache is None:
                 continue
             try:
-                sha = await self.repo_cache.tree_head(card)
+                sha = await self.repo_cache.tree_head(source)
                 if sha is None:
                     continue
                 tree = await self.repo_cache.read_skill_tree(
-                    card, inst.subdir, sha)
+                    source, inst.subdir, sha)
                 for skill, rels in sorted(tree.items()):
                     # size gate BEFORE the read (audit 2026-08-13): the
-                    # catalog renders every referenced card — an oversized
+                    # catalog renders every referenced source — an oversized
                     # third-party SKILL.md must not be pulled into memory
                     if _over_file_cap(rels.get("SKILL.md", 0)):
                         out.append(SkillInfo(
-                            name=f"{card}/{skill}",
+                            name=f"{source}/{skill}",
                             description=f"(SKILL.md exceeds the "
                                         f"{MAX_FILE_BYTES}-byte cap — "
                                         f"not read)",
                             source="external", files=len(rels),
-                            builtin=False, origin=card))
+                            builtin=False, origin=source))
                         continue
                     md = await self.repo_cache.read_skill_file(
-                        card, inst.subdir, sha, skill, "SKILL.md")
+                        source, inst.subdir, sha, skill, "SKILL.md")
                     desc = str(parse_frontmatter(
                         (md or b"").decode("utf-8", errors="replace")
                     ).get("description", ""))
                     out.append(SkillInfo(
-                        name=f"{card}/{skill}", description=desc,
+                        name=f"{source}/{skill}", description=desc,
                         source="external", files=len(rels), builtin=False,
-                        origin=card))
+                        origin=source))
             except Exception as e:  # noqa: BLE001 — the catalog is advisory; a broken mirror never takes the Skills page down
-                log.warning("external skill listing for card %r failed: %s",
-                            card, e)
+                log.warning("external skill listing for source %r failed: %s",
+                            source, e)
         return out
 
     # ── authoring (admin UI: create / import / delete — docs/11) ────────────
@@ -471,10 +497,13 @@ class SkillService:
 
     async def payload_for(self, names: list[str]) -> tuple[list[dict], list[str]]:
         """([{name, files: [{path, content_b64}]}], warnings) for the runspec.
-        Store-first per skill; bundled fallback; a skill missing from both is
-        skipped with a warning — never a refused run. Paths are repo-relative
-        POSIX including the skill dir (entrypoint writes them under
-        $HOME/<skills_dir>/<path>, per the harness registry).
+        Store-first per skill; bundled fallback only when the skill is absent
+        from the store tree or a store *read* fails — never when the store
+        listed the skill but every file was dropped by a size cap (that would
+        silently re-ship an older bundled override). A skill missing from
+        both is skipped with a warning — never a refused run. Paths are
+        repo-relative POSIX including the skill dir (entrypoint writes them
+        under $HOME/<skills_dir>/<path>, per the harness registry).
 
         Caps run against sizes from the tree/stat BEFORE any content read;
         once MAX_TOTAL_BYTES is exhausted the remaining skills are dropped
@@ -492,11 +521,12 @@ class SkillService:
         builtin = self._builtin_skills()
         total = 0
         for idx, name in enumerate(names):
-            external = "/" in name        # <card>/<skill> — structurally
+            external = "/" in name        # <source>/<skill> — structurally
             #                               disjoint from store/builtin names
             in_store = (not external and bool(store_index)
                         and f"{name}/SKILL.md" in store_index)
             entry, size_used = [], 0
+            store_read_failed = False
             if external:
                 try:
                     entry, size_used, warns = await self._collect_external(
@@ -517,8 +547,14 @@ class SkillService:
                     warnings.append(f"skill {name!r}: store read failed ({e}) "
                                     "— trying the bundled copy")
                     entry, size_used, warns = [], 0, []
+                    store_read_failed = True
                 warnings.extend(warns)
-            if not entry and not external and name in builtin:
+            # Builtin only when the skill is not listed in the store (or the
+            # store is down so in_store is False), or a store read threw.
+            # Cap drops on a listed store skill stay empty — no silent
+            # re-ship of the older bundled override.
+            if (not entry and not external and name in builtin
+                    and (not in_store or store_read_failed)):
                 sized = [(f.relative_to(self.builtin_dir).as_posix(),
                           f.stat().st_size) for f in builtin[name]]
 
@@ -545,28 +581,28 @@ class SkillService:
 
     async def _collect_external(self, name: str, total: int
                                 ) -> tuple[list[dict], int, list[str]]:
-        """One `<card>/<skill>` skill from the repo-card mirror (ADR-0016
-        addendum): pin the sha, list sized blobs (mirror-side filters already
-        dropped symlink modes and hostile dir names), rebase payload paths to
-        the BASENAME dir — so `install_skills` and harness discovery stay
-        untouched — and run the same `_collect` caps. Deliberately uncached:
-        the dispatch gate just proved the mirror fresh, and this read pins
-        one sha so a concurrent fetch cannot tear it."""
-        card, _, skill = name.partition("/")
-        inst = self._card(card)
+        """One `<source>/<skill>` skill from a skill-source mirror (ADR-0016
+        addendum 2): pin the sha, list sized blobs (mirror-side filters
+        already dropped symlink modes and hostile dir names), rebase payload
+        paths to the BASENAME dir — so `install_skills` and harness discovery
+        stay untouched — and run the same `_collect` caps. Deliberately
+        uncached: the dispatch gate just proved the mirror fresh, and this
+        read pins one sha so a concurrent fetch cannot tear it."""
+        source, _, skill = name.partition("/")
+        inst = self._skill_source(source)
         if self.repo_cache is None or inst is None:
-            return [], 0, [f"skill {name!r}: repo card {card!r} is not "
+            return [], 0, [f"skill {name!r}: skill source {source!r} is not "
                            "configured — skipped"]
-        sha = await self.repo_cache.tree_head(card)
+        sha = await self.repo_cache.tree_head(source)
         if sha is None:
-            return [], 0, [f"skill {name!r}: mirror for {card!r} has no "
+            return [], 0, [f"skill {name!r}: mirror for {source!r} has no "
                            "readable head — skipped"]
         tree = await self.repo_cache.read_skill_tree(
-            card, inst.subdir, sha)
+            source, inst.subdir, sha)
         files = tree.get(skill)
         if not files:
-            where = f"{card}:{inst.subdir}" if inst.subdir \
-                else card
+            where = f"{source}:{inst.subdir}" if inst.subdir \
+                else source
             return [], 0, [f"skill {name!r}: no {skill}/SKILL.md under "
                            f"{where} — skipped"]
         sized = [(f"{skill}/{rel}", int(size))
@@ -574,7 +610,7 @@ class SkillService:
 
         async def _read(path: str) -> bytes:
             data = await self.repo_cache.read_skill_file(
-                card, inst.subdir, sha, skill, path[len(skill) + 1:])
+                source, inst.subdir, sha, skill, path[len(skill) + 1:])
             if data is None:
                 raise SkillStoreError(502, f"mirror read failed: {path}")
             return data

--- a/app/tests/test_skills.py
+++ b/app/tests/test_skills.py
@@ -313,6 +313,25 @@ def test_payload_store_present_does_not_silently_ship_builtin(tmp_path):
     assert not any(s.get("name") == "tdd" for s in payload)
 
 
+def test_payload_store_oversize_skill_md_ships_nothing(tmp_path):
+    """ADR-0016 Decision 4: a size-capped skill is skipped entirely.
+    Per-file cap on SKILL.md must not leave a helpers-only payload entry
+    (that would still count as shipped for Required soft-force)."""
+    from devcake.domain import skills as skills_mod
+    huge = b"x" * (skills_mod.MAX_FILE_BYTES + 1)
+    forge = _FakeForge({
+        "tdd/SKILL.md": huge,
+        "tdd/helper.md": b"small helper",
+    })
+    svc = skills_mod.SkillService(
+        internal_forge=forge, builtin_dir=_builtin_tree(tmp_path))
+    payload, warnings = _run(svc.payload_for(["tdd"]))
+    assert payload == []
+    assert any("SKILL.md" in w and "exceeds" in w for w in warnings)
+    assert "tdd/helper.md" not in forge.file_calls
+    assert "tdd/SKILL.md" not in forge.file_calls
+
+
 def test_payload_store_read_failure_still_falls_back_to_builtin(tmp_path):
     """I/O failure on a store skill (not a cap drop) still tries the
     bundled copy — additive, same contract as store-down."""
@@ -366,6 +385,25 @@ def test_get_skill_store_caps_before_download(tmp_path):
     assert got["source"] == "store"
     assert any("huge.bin" in w for w in got["warnings"])
     assert forge.file_calls == ["tdd/SKILL.md"]
+
+
+def test_get_skill_store_oversize_skill_md_is_not_found(tmp_path):
+    """View must not return a skill body without SKILL.md when the
+    manifest itself is file-cap dropped (helpers alone are not a skill)."""
+    from devcake.domain import skills as skills_mod
+    from devcake.domain.skills import SkillStoreError
+    huge = b"x" * (skills_mod.MAX_FILE_BYTES + 1)
+    forge = _FakeForge({
+        "tdd/SKILL.md": huge,
+        "tdd/helper.md": b"small helper",
+    })
+    svc = skills_mod.SkillService(
+        internal_forge=forge, builtin_dir=tmp_path / "none")
+    with pytest.raises(SkillStoreError) as e:
+        _run(svc.get_skill("tdd"))
+    assert e.value.status == 404
+    assert "exceeds" in str(e.value)
+    assert forge.file_calls == []
 
 
 # ── authoring: compose / import-validate / save / delete (admin UI flow) ─────
@@ -804,6 +842,21 @@ def test_payload_external_caps_apply_before_reading(tmp_path):
     assert {f["path"] for f in payload[0]["files"]} == {"tdd/SKILL.md"}
     assert any("huge.bin" in w for w in warnings)
     assert ("myrepo", "tdd", "huge.bin") not in mirror.reads
+
+
+def test_payload_external_oversize_skill_md_ships_nothing(tmp_path):
+    """Same ADR-0016 Decision 4 honesty as store: oversized SKILL.md must
+    not ship helpers-only for an external skill (one _collect pipe)."""
+    from devcake.domain import skills as skills_mod
+    svc, mirror = _ext_svc(tmp_path)
+    mirror.trees[("myrepo", "")] = {"tdd": {
+        "SKILL.md": skills_mod.MAX_FILE_BYTES + 1, "helper.md": 12}}
+    mirror.files[("myrepo", "tdd", "helper.md")] = b"small helper"
+    payload, warnings = _run(svc.payload_for(["myrepo/tdd"]))
+    assert payload == []
+    assert any("SKILL.md" in w and "exceeds" in w for w in warnings)
+    assert ("myrepo", "tdd", "helper.md") not in mirror.reads
+    assert ("myrepo", "tdd", "SKILL.md") not in mirror.reads
 
 
 def test_payload_external_respects_source_subdir(tmp_path):

--- a/app/tests/test_skills.py
+++ b/app/tests/test_skills.py
@@ -30,8 +30,8 @@ def test_devtype_skills_accepts_valid_names_and_dedupes():
 
 @pytest.mark.parametrize("bad", [
     "", "UPPER", "has space", "-leading-hyphen", "a" * 65, "dot.name",
-    # external `<card>/<skill>` shape violations (ADR-0016 addendum): one
-    # slash max, prefix in repo-card shape (starts alpha, no hyphens, ≤12)
+    # external `<source>/<skill>` shape violations (ADR-0016 addendum 2):
+    # one slash max, prefix instance-shaped (starts alpha, no hyphens, ≤12)
     "a/b/c", "SL/ash", "1x/skill", "has-hyphen/skill", "toolongcardxx/skill",
     "/ash", "sl/",
 ])
@@ -41,8 +41,8 @@ def test_devtype_skills_rejects_bad_names(bad):
 
 
 def test_devtype_external_skill_names_and_basename_collisions():
-    """`<card>/<skill>` selects from an external repo card (ADR-0016
-    addendum). Basenames must be unique across the selection — the payload
+    """`<source>/<skill>` selects from a dedicated skill source (ADR-0016
+    addendum 2). Basenames must be unique across the selection — the payload
     flattens external paths to the basename dir."""
     dt = _dt(skills=["sl/ash", "tdd"], skills_required=["sl/ash"])
     assert dt.skills == ["sl/ash", "tdd"]
@@ -294,6 +294,78 @@ def test_payload_oversized_file_skipped_without_fetching(tmp_path):
     # the cap must be enforced from the tree's size field BEFORE download —
     # an oversized store file must never be pulled into app memory
     assert forge.file_calls == ["big/SKILL.md"]
+
+
+def test_payload_store_present_does_not_silently_ship_builtin(tmp_path):
+    """Store-first: when the skill is IN the store but every file is
+    dropped by the size cap, do not fall through to the bundled copy —
+    that would silently re-ship an older override the operator replaced."""
+    from devcake.domain import skills as skills_mod
+    huge = b"x" * (skills_mod.MAX_FILE_BYTES + 1)
+    forge = _FakeForge({"tdd/SKILL.md": huge})
+    svc = skills_mod.SkillService(
+        internal_forge=forge, builtin_dir=_builtin_tree(tmp_path))
+    payload, warnings = _run(svc.payload_for(["tdd"]))
+    assert payload == []
+    assert any("exceeds" in w for w in warnings)
+    assert forge.file_calls == []
+    # builtin must not be consulted as a silent replacement
+    assert not any(s.get("name") == "tdd" for s in payload)
+
+
+def test_payload_store_read_failure_still_falls_back_to_builtin(tmp_path):
+    """I/O failure on a store skill (not a cap drop) still tries the
+    bundled copy — additive, same contract as store-down."""
+    from devcake.domain.skills import SkillService
+
+    class _BoomOnFile(_FakeForge):
+        async def skill_store_file(self, path):
+            self.file_calls.append(path)
+            raise RuntimeError("blob 500")
+
+    forge = _BoomOnFile({"tdd/SKILL.md": b"---\nname: tdd\n---\nSTORE\n"})
+    svc = SkillService(internal_forge=forge,
+                       builtin_dir=_builtin_tree(tmp_path))
+    payload, warnings = _run(svc.payload_for(["tdd"]))
+    assert b"Test-first" in _b64(payload, "tdd", "tdd/SKILL.md")
+    assert any("store read failed" in w for w in warnings)
+
+
+def test_list_skills_store_skips_oversized_manifest_without_reading(tmp_path):
+    """Catalog must not pull an oversized store SKILL.md into memory —
+    same audit class as external_infos (2026-08-13)."""
+    from devcake.domain import skills as skills_mod
+    huge = b"x" * (skills_mod.MAX_FILE_BYTES + 1)
+    forge = _FakeForge({
+        "big/SKILL.md": huge,
+        "ok/SKILL.md": b"---\ndescription: Fine\n---\n",
+    })
+    svc = skills_mod.SkillService(
+        internal_forge=forge, builtin_dir=tmp_path / "none")
+    skills, store = _run(svc.list_skills())
+    assert store["ok"] is True
+    by_name = {s.name: s for s in skills}
+    assert by_name["ok"].description == "Fine"
+    assert by_name["big"].description.startswith("(SKILL.md exceeds")
+    assert "big/SKILL.md" not in forge.file_calls
+    assert "ok/SKILL.md" in forge.file_calls
+
+
+def test_get_skill_store_caps_before_download(tmp_path):
+    """Admin View for store skills must ride size gates before fetch —
+    external already does; store was the remaining uncapped path."""
+    from devcake.domain import skills as skills_mod
+    forge = _FakeForge({
+        "tdd/SKILL.md": b"---\nname: tdd\ndescription: D\n---\nbody",
+        "tdd/huge.bin": b"x" * (skills_mod.MAX_FILE_BYTES + 1),
+    })
+    svc = skills_mod.SkillService(
+        internal_forge=forge, builtin_dir=tmp_path / "none")
+    got = _run(svc.get_skill("tdd"))
+    assert [f["path"] for f in got["files"]] == ["SKILL.md"]
+    assert got["source"] == "store"
+    assert any("huge.bin" in w for w in got["warnings"])
+    assert forge.file_calls == ["tdd/SKILL.md"]
 
 
 # ── authoring: compose / import-validate / save / delete (admin UI flow) ─────
@@ -652,16 +724,16 @@ def test_payload_ships_skill_md_first_under_mid_skill_cap(tmp_path):
     assert any("cap" in w for w in warnings)
 
 
-# ── external skills: `<card>/<skill>` from the repo-card mirror ──────────────
-# (ADR-0016 addendum: no second cache — the ADR-0024 mirror's read-side)
+# ── external skills: `<source>/<skill>` from a skill-source mirror ───────────
+# (ADR-0016 addendum 2: dedicated skill_sources; ADR-0024 mirror read-side)
 
 class _FakeMirror:
-    """RepoCache read-side stub: fixed head, one tree per (card, subdir)."""
+    """RepoCache read-side stub: fixed head, one tree per (source, subdir)."""
 
     def __init__(self, trees=None, head="abc123", files=None):
-        self.trees = trees or {}     # (card, subdir) -> {skill: {rel: size}}
+        self.trees = trees or {}     # (source, subdir) -> {skill: {rel: size}}
         self.head = head             # None = unreadable mirror
-        self.files = files or {}     # (card, skill, rel) -> bytes
+        self.files = files or {}     # (source, skill, rel) -> bytes
         self.reads: list[tuple] = []
 
     async def tree_head(self, name):
@@ -712,10 +784,11 @@ def test_payload_external_never_falls_back_to_store_or_builtin(tmp_path):
     assert any("no tdd/SKILL.md" in w for w in warnings)
 
 
-def test_payload_external_unconfigured_card_and_dead_mirror_warn(tmp_path):
+def test_payload_external_unconfigured_source_and_dead_mirror_warn(tmp_path):
     svc, mirror = _ext_svc(tmp_path)
     payload, warnings = _run(svc.payload_for(["ghost/tdd"]))
-    assert payload == [] and any("not configured" in w for w in warnings)
+    assert payload == []
+    assert any("skill source" in w and "not configured" in w for w in warnings)
     svc2, _m = _ext_svc(tmp_path / "b", head=None)
     payload, warnings = _run(svc2.payload_for(["myrepo/tdd"]))
     assert payload == [] and any("no readable head" in w for w in warnings)
@@ -755,12 +828,16 @@ def test_get_skill_external_reads_the_mirror_and_stays_read_only(tmp_path):
     with pytest.raises(SkillStoreError) as e:
         _run(svc.get_skill("myrepo/none"))
     assert e.value.status == 404
+    with pytest.raises(SkillStoreError) as e2:
+        _run(svc.get_skill("ghost/tdd"))
+    assert e2.value.status == 404
+    assert "skill source" in str(e2.value)
     # read-only BY CONSTRUCTION: authoring names refuse the slash
     with pytest.raises(SkillStoreError):
         _run(svc.delete_skill("myrepo/tdd"))
 
 
-def test_external_infos_lists_every_skill_in_referenced_cards(tmp_path):
+def test_external_infos_lists_every_skill_in_referenced_sources(tmp_path):
     svc, mirror = _ext_svc(tmp_path)
     mirror.trees[("myrepo", "")] = {
         "tdd": {"SKILL.md": 5}, "review": {"SKILL.md": 5, "extra.md": 3}}
@@ -794,7 +871,7 @@ def test_get_skill_external_caps_ride_the_one_collect_pipe(tmp_path):
 
 def test_external_infos_skips_oversized_manifests_without_reading(tmp_path):
     """Same audit class for the catalog: an oversized SKILL.md on a
-    referenced card gets a placeholder description, never a fetch."""
+    referenced skill source gets a placeholder description, never a fetch."""
     from devcake.domain import skills as skills_mod
     svc, mirror = _ext_svc(tmp_path)
     mirror.trees[("myrepo", "")] = {

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -369,11 +369,14 @@ until that run exists, field evidence below stays operator-self-reported.
   Dev Types (`judgment` / `implementer` / `steward`); registry `skills_dir`
   snapshotted onto the Run. Normative ADR + `app/devcake/skills/README.md`.
   **External skill repos SHIPPED 2026-08-13** (ADR-0016 addendum, founder
-  ruling "just a forge adapter"): `<card>/<skill>` names serve read-only
-  from the card's ADR-0024 mirror (no second cache), fail-closed via the
-  existing gate's needed-set union, payload paths flattened so the
-  container contract is untouched, `Run.skill_repo_heads` provenance,
-  private repos via card tokens day one.
+  ruling "just a forge adapter"), then **dedicated skill sources SHIPPED
+  2026-08-14** (addendum 2 — supersedes the repo-card source design):
+  `<source>/<skill>` names serve read-only from `AppConfig.skill_sources`
+  via the ADR-0024 mirror (no second cache), fail-closed via the existing
+  gate's needed-set union (`context_sourcing_strict`), payload paths
+  flattened so the container contract is untouched, `Run.skill_repo_heads`
+  provenance, read tokens under the `skill:` secret scope. Managed on the
+  Skills page; `RepoInstance.skills_subdir` is gone.
   **built**.
 - **Admin skill/prompt Markdown View** (PR #45, post-ADR-0016): skill and
   prompt View render as Markdown in the SPA. **built**.
@@ -678,10 +681,6 @@ the v0.2 trailer list).
   batteries; live GitLab MRs are field-reported (Field evidence above),
   but the two-forges-in-one-instance demo and the token-spending golden
   paths remain **⏳**.
-- **Dedicated skill sources (2026-08-14)**: external skills moved off
-  repo cards onto their own `skill_sources` connections (ADR-0016
-  addendum 2) — the `skills_subdir` facet is gone; the Skills page
-  manages sources; read tokens ride the new `skill:` secret scope. **⏳**
 - **Memory + Cron (PLAN_MEMORY)**: schema, sourcing, claims conveyor,
   merge guard, CronService, and admin surfaces are in the tree. **Not
   called shipped** until the throwaway-box A/B has receipts


### PR DESCRIPTION
## Intent

Skeptical audit and fix of the skills assembly domain seam (`SkillService` / skill store) for real bugs, contract drift, and ADR-0016 honesty — without reopening orchestrator/SPA/product scope.

## Mission

- Key: [CAKE-52](https://linear.app/fidecastro/issue/CAKE-52/pre-foss-skills-assembly-domain-audit-and-fix)
- Origin: CAKE-19 decomposition part 2/4
- Round 2 (post-REVIEW reject): fix SKILL.md file-cap honesty at `_collect` so helpers-only payloads never count as shipped.

## Changes

1. **Store-present no silent builtin re-ship** — when a skill is listed in the store tree but every file is dropped by size caps, do **not** fall through to the bundled copy (that silently re-shipped an older operator override). Builtin fallback remains for store-down and store *read* I/O failures.
2. **Store list/View size gates** — `list_skills` and store-path `get_skill` enforce `MAX_FILE_BYTES` (and View rides `_collect` caps) before download, matching the external-skill audit class (2026-08-13).
3. **SKILL.md file-cap honesty (REVIEW must-fix)** — if `name/SKILL.md` is present in the sized tree and exceeds `MAX_FILE_BYTES`, `_collect` returns an **empty** entry + warning and does **not** fetch helpers. Prevents helpers-only payload entries that still counted as shipped for Required soft-force (ADR-0016 Decision 4). Same chokepoint serves store payload, external payload, and store/external View. Total-cap mid-skill still keeps SKILL.md and drops later helpers.
4. **Terminology residue** — operator-facing errors/warnings and domain comments now say **skill source** (ADR-0016 addendum 2); `_card` → `_skill_source`. Module docstring lists three sources (store / builtin / external).
5. **docs/16** — dedicated `skill_sources` moved to the shipped section; residual ⏳ removed (sources are live in-tree).

## How to verify

```bash
PYTHONPATH=app python3.12 -m pytest app/tests/test_skills.py -q
# full CI path:
./scripts/pytest_app.sh   # rebakes app-test when Docker Bake is available
```

New public-seam tests:
- `test_payload_store_oversize_skill_md_ships_nothing`
- `test_payload_external_oversize_skill_md_ships_nothing`
- `test_get_skill_store_oversize_skill_md_is_not_found`

Local EXECUTE evidence (this round): **73** skills tests passed on Python 3.12 with `PYTHONPATH=app`; structure-guard suite green except host-env `fastapi` missing for the bare-import check (CI image has full deps).

## Risk / rollout

- Behavior change: a store skill that is only cap-dropped no longer ships the older builtin. Additive still holds (warn + skip).
- Behavior change: oversize `SKILL.md` no longer ships helpers-only; skill is fully skipped / View 404s with the exceeds warning.
- Store `get_skill` may return `warnings` (like external View) when helper files are skipped.
- Error string change: `repo card X not configured` → `skill source X not configured` (operators/logs only).

## Out of scope

Claims conveyor, blocker locator, repo routing/mirror, orchestrator prompt assembly beyond this seam, SPA UI work, new product features.