### PR TITLE
[CAKE-49] SPA↔API contract honesty, pins, and registry FALLBACK

### DIFF
--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -441,7 +441,7 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
                 {tr && (
                   <span className={`text-sm ${tr.ok ? "text-green-700 dark:text-green-400" : "text-red-600"}`}>
                     {tr.ok
-                      ? `✓ team ${tr.team}: ${tr.labels}/${tr.labels_expected ?? 10} labels, ${tr.missions_visible} items visible`
+                      ? `✓ team ${tr.team}: ${tr.labels}/${tr.labels_expected ?? registry.managed_labels_expected} labels, ${tr.missions_visible} items visible`
                       : `✗ ${tr.error || tr.detail || "connection test failed"}`}
                   </span>
                 )}

--- a/admin/spa/tests/new_mission.mjs
+++ b/admin/spa/tests/new_mission.mjs
@@ -50,7 +50,7 @@ async function mockRoutes(page, { adoption = "opt_in", createResult = null,
         { id: "linear", display_name: "Linear", supports_priority: true },
         { id: "gitea_issues", display_name: "Gitea Issues",
           supports_priority: false },
-      ], forges: [], secret_shape_prefixes: [], managed_labels_expected: 10 }),
+      ], forges: [], secret_shape_prefixes: [], managed_labels_expected: 11 }),
     }));
   await page.route(/\/api\/v1\/poll\/run$/, (route) => {
     polls.push(1);

--- a/app/devcake/adapters/registry.py
+++ b/app/devcake/adapters/registry.py
@@ -185,6 +185,43 @@ def forges() -> dict[str, "ForgeDescriptor"]:
     return {fid: cls.descriptor for fid, cls in _forge_classes().items()}
 
 
+def connections_registry_payload() -> dict:
+    """SPA-visible GET /connections/registry body — one projection for the
+    HTTP handler, spa-contracts pin, and admin FALLBACK table.
+
+    Secrets (token patterns, env var names) stay server-side; the SPA only
+    needs display metadata, paste-guard prefixes, and managed-label count.
+    """
+    from ..domain.model import ALL_LABELS
+
+    forge_descriptors = forges()
+    return {
+        "pmo_systems": [
+            {
+                "id": s.id,
+                "display_name": s.display_name,
+                "needs_api_base": s.needs_api_base,
+                "team_key_label": s.team_key_label,
+                "team_key_help": s.team_key_help,
+                "api_base_help": s.api_base_help,
+                "supports_priority": s.supports_priority,
+                "operator_note": s.operator_note,
+                "attachments_supported": s.attachments_supported,
+                "relations_supported": s.relations_supported,
+                "experimental": s.experimental,
+            }
+            for s in PMO_SYSTEMS.values()
+        ],
+        "forges": [{"id": d.id, "display_name": d.display_name}
+                   for d in forge_descriptors.values()],
+        "secret_shape_prefixes": sorted(
+            {p for s in PMO_SYSTEMS.values() for p in s.secret_shape_prefixes}
+            | {p for d in forge_descriptors.values()
+               for p in d.secret_shape_prefixes}),
+        "managed_labels_expected": len(ALL_LABELS),
+    }
+
+
 def make_internal_forge():
     """The bundled-Gitea provisioner (docs/16 M11). Sole construction site —
     keeps the F1 import tripwire honest (adapters.gitea imported only here)."""

--- a/app/devcake/api/connections_service.py
+++ b/app/devcake/api/connections_service.py
@@ -15,7 +15,6 @@ from fastapi import HTTPException
 
 from .. import secrets as secrets_store
 from ..config import HARNESS_VAR_PATTERN, _INSTANCE_NAME_RE
-from ..domain.model import ALL_LABELS
 from ..harness import HARNESSES
 from ..ports.forge import ForgeError, mission_branch
 from ..ports.pmo import PMOTransient
@@ -277,34 +276,10 @@ async def clear_secrets(body: dict, *, forge_runtime, reload, config,
 async def connections_registry():
     """Available PMO systems and forges with display metadata — drives the
     admin Config page's selectors and paste guard, so adding an adapter never
-    means editing the SPA (docs/11)."""
-    from ..adapters.registry import PMO_SYSTEMS, forges
-    forge_descriptors = forges()
-    return {
-        "pmo_systems": [
-            {
-                "id": s.id,
-                "display_name": s.display_name,
-                "needs_api_base": s.needs_api_base,
-                "team_key_label": s.team_key_label,
-                "team_key_help": s.team_key_help,
-                "api_base_help": s.api_base_help,
-                "supports_priority": s.supports_priority,
-                "operator_note": s.operator_note,
-                "attachments_supported": s.attachments_supported,
-                "relations_supported": s.relations_supported,
-                "experimental": s.experimental,
-            }
-            for s in PMO_SYSTEMS.values()
-        ],
-        "forges": [{"id": d.id, "display_name": d.display_name}
-                   for d in forge_descriptors.values()],
-        "secret_shape_prefixes": sorted(
-            {p for s in PMO_SYSTEMS.values() for p in s.secret_shape_prefixes}
-            | {p for d in forge_descriptors.values()
-               for p in d.secret_shape_prefixes}),
-        "managed_labels_expected": len(ALL_LABELS),
-    }
+    means editing the SPA (docs/11). Single projection:
+    adapters.registry.connections_registry_payload (spa-contracts pin)."""
+    from ..adapters.registry import connections_registry_payload
+    return connections_registry_payload()
 
 
 def _with_error(payload: dict, *, detail: str = "") -> dict:

--- a/app/tests/gen_spa_contracts.py
+++ b/app/tests/gen_spa_contracts.py
@@ -1,8 +1,7 @@
 """Generator for docs/contracts/spa-contracts.json (ADR-0034; 2026-08-12
-audit: the SPA hand-mirrors backend contracts — board derivation
-precedence, the instance-name rule, the card scaffolds, and the
-connections-registry offline FALLBACK — with "Mirrors X" comments and no
-cross-language test until pinned).
+audit: the SPA hand-mirrors three backend contracts — the board derivation
+precedence, the instance-name rule, the card scaffolds — with "Mirrors X"
+comments and no cross-language test).
 
 The committed JSON is generated FROM THE PYTHON SOURCE OF TRUTH here and
 pinned by both suites: test_spa_contracts.py asserts the file matches a
@@ -20,7 +19,6 @@ from __future__ import annotations
 import itertools
 import json
 
-from devcake.adapters.registry import connections_registry_payload
 from devcake.config import (HARNESS_VAR_PATTERN, _INSTANCE_NAME_RE,
                             PMOInstance, RepoInstance)
 from devcake.domain.model import Mission, derive
@@ -84,9 +82,6 @@ def build() -> dict:
         "repo_card_defaults": {
             k: RepoInstance(name="x", url="https://h/o/r").model_dump()[k]
             for k in _REPO_CARD_FIELDS},
-        # Offline SPA FALLBACK (admin/spa/src/lib/registry.js) must match
-        # this object field-for-field — contracts.mjs asserts equality.
-        "connections_registry": connections_registry_payload(),
         "board": {
             "statuses": list(_STATUSES),
             "adoption_modes": list(_ADOPTION),

--- a/app/tests/gen_spa_contracts.py
+++ b/app/tests/gen_spa_contracts.py
@@ -1,7 +1,8 @@
 """Generator for docs/contracts/spa-contracts.json (ADR-0034; 2026-08-12
-audit: the SPA hand-mirrors three backend contracts — the board derivation
-precedence, the instance-name rule, the card scaffolds — with "Mirrors X"
-comments and no cross-language test).
+audit: the SPA hand-mirrors backend contracts — board derivation
+precedence, the instance-name rule, the card scaffolds, and the
+connections-registry offline FALLBACK — with "Mirrors X" comments and no
+cross-language test until pinned).
 
 The committed JSON is generated FROM THE PYTHON SOURCE OF TRUTH here and
 pinned by both suites: test_spa_contracts.py asserts the file matches a
@@ -19,6 +20,7 @@ from __future__ import annotations
 import itertools
 import json
 
+from devcake.adapters.registry import connections_registry_payload
 from devcake.config import (HARNESS_VAR_PATTERN, _INSTANCE_NAME_RE,
                             PMOInstance, RepoInstance)
 from devcake.domain.model import Mission, derive
@@ -82,6 +84,9 @@ def build() -> dict:
         "repo_card_defaults": {
             k: RepoInstance(name="x", url="https://h/o/r").model_dump()[k]
             for k in _REPO_CARD_FIELDS},
+        # Offline SPA FALLBACK (admin/spa/src/lib/registry.js) must match
+        # this object field-for-field — contracts.mjs asserts equality.
+        "connections_registry": connections_registry_payload(),
         "board": {
             "statuses": list(_STATUSES),
             "adoption_modes": list(_ADOPTION),

--- a/app/tests/test_spa_contracts.py
+++ b/app/tests/test_spa_contracts.py
@@ -39,10 +39,12 @@ def test_vector_sweep_is_the_full_powerset():
     assert len(data["board"]["reasons"]) >= 8
 
 
-def test_connections_registry_pin_names_priority_and_eleven_labels():
-    """Independent domain rules for the SPA registry FALLBACK pin — not a
-    re-read of the same generator fields under a different name."""
-    data = build()["connections_registry"]
+def test_connections_registry_payload_domain_rules():
+    """Independent domain rules for the registry projection (the single
+    source behind GET /connections/registry and the SPA FALLBACK pin) — not
+    a re-read of the same fields under a different name."""
+    from devcake.adapters.registry import connections_registry_payload
+    data = connections_registry_payload()
     # ALL_LABELS includes DEVCAKE-DISCOVERY (sweep gate); count is 11.
     assert data["managed_labels_expected"] == 11
     by_id = {s["id"]: s for s in data["pmo_systems"]}

--- a/app/tests/test_spa_contracts.py
+++ b/app/tests/test_spa_contracts.py
@@ -39,6 +39,29 @@ def test_vector_sweep_is_the_full_powerset():
     assert len(data["board"]["reasons"]) >= 8
 
 
+def test_connections_registry_pin_names_priority_and_eleven_labels():
+    """Independent domain rules for the SPA registry FALLBACK pin — not a
+    re-read of the same generator fields under a different name."""
+    data = build()["connections_registry"]
+    # ALL_LABELS includes DEVCAKE-DISCOVERY (sweep gate); count is 11.
+    assert data["managed_labels_expected"] == 11
+    by_id = {s["id"]: s for s in data["pmo_systems"]}
+    assert set(by_id) == {
+        "linear", "gitea_issues", "github_issues", "gitlab_issues",
+    }
+    assert by_id["linear"]["supports_priority"] is True
+    for forge_issue in ("gitea_issues", "github_issues", "gitlab_issues"):
+        assert by_id[forge_issue]["supports_priority"] is False, forge_issue
+    # Copy honesty: team_key_help must distinguish the issues board from a
+    # per-mission work repo (forge-issue systems only).
+    for forge_issue in ("gitea_issues", "github_issues", "gitlab_issues"):
+        assert "Not a per-mission work repo" in by_id[forge_issue]["team_key_help"]
+    assert by_id["github_issues"]["attachments_supported"] is False
+    assert by_id["gitlab_issues"]["relations_supported"] is False
+    assert "ghp_" in data["secret_shape_prefixes"]
+    assert data["secret_shape_prefixes"] == sorted(data["secret_shape_prefixes"])
+
+
 def test_discovery_label_is_derivation_inert():
     """ADR-0033 founder ruling 2a: DEVCAKE-DISCOVERY is a pure sweep gate —
     adding it to ANY label combination must leave derive() untouched (the


### PR DESCRIPTION
## Summary

Closes the SPA↔control-plane registry honesty gaps for **CAKE-49**:

- **Chokepoint:** `adapters.registry.connections_registry_payload()` is the single projection for `GET /connections/registry`, `docs/contracts/spa-contracts.json`, and the SPA offline FALLBACK.
- **FALLBACK fixes:** `managed_labels_expected` **11** (incl. `DEVCAKE-DISCOVERY`), `supports_priority` on every PMO system (forge-issue systems `false`), help/operator_note copy aligned with `PMO_SYSTEMS`, system order matches server.
- **Pin:** `gen_spa_contracts` emits `connections_registry`; `test_spa_contracts.py` asserts domain rules; `contracts.mjs` deep-equals `FALLBACK` to the pin.
- **docs/05 + docs/11:** registry field list and pin path documented.

### Residuals checked (no code change needed)
- Alerts: dismissable only on advisory/compliance; baker-dead / breakers remain hard non-dismissable.
- Harness experimental chips + `latest-cli` / prune SPA routes already match the API.
- PMO experimental remains docs-only (no `experimental` on `PMOSystemInfo`) — out of inventing new product flags.

### Deviation
Activity `PLAN_2.md` was truncated (plan step did not deliver a full plan body). Implemented from mission brief + ONBOARD findings + discoveries.

Mission: https://linear.app/fidecastro/issue/CAKE-49/spaapi-contract-honesty-pins-and-registry-fallback

## Test plan
- [x] `admin/spa` `npm run test:helpers` (incl. new registry FALLBACK pin)
- [x] `podman build` app-test + admin
- [x] app-test pytest: `test_spa_contracts`, `test_config_schema`, `test_pmo_contract`, `test_structure_guards`