### PR TITLE
fix(admin): include merge_settle_minutes in repo scaffold test

### DIFF
--- a/admin/spa/tests/config_draft.mjs
+++ b/admin/spa/tests/config_draft.mjs
@@ -77,15 +77,15 @@ check("rename inside a same-length list still wins over fresh", () => {
   assert.equal(getIn(next, "cfg.pmos.0.name"), "renamed");
 });
 
-check("scaffolds carry every server-model field (pmo: 11, repo: 8)", () => {
+check("scaffolds carry every server-model field (pmo: 11, repo: 9)", () => {
   assert.deepEqual(Object.keys(newPmoCard("x", "linear")).sort(),
     ["api_base", "assignments", "discovery_routing", "intake_paused",
      "managed", "memory_repos", "name", "reference_repos", "repos",
      "system", "team_key"]);
   assert.deepEqual(Object.keys(newRepoCard("x")).sort(),
     ["api_base", "auto_merge", "auto_resolve_merge_conflicts",
-     "default_branch", "forge", "merge_retry_window_minutes", "name",
-     "url"]);
+     "default_branch", "forge", "merge_retry_window_minutes",
+     "merge_settle_minutes", "name", "url"]);
 });
 
 check("skill sources: name shape, dupes, repo-name collision", () => {


### PR DESCRIPTION
## Summary

- CI on main failed after #220: `config_draft.mjs` scaffolds check expected 8 repo fields; `newRepoCard` now carries `merge_settle_minutes` (9).
- Update the expected key list (and count in the check name).

## Test plan

- [x] `node admin/spa/tests/config_draft.mjs` — all checks passed
- [ ] CI green on this PR / main after merge