### PR TITLE
fix(forge): URL-encode # in get_pr_by_branch queries

### DIFF
--- a/app/devcake/adapters/github/adapter.py
+++ b/app/devcake/adapters/github/adapter.py
@@ -104,9 +104,17 @@ class GitHubForge:
         )
 
     async def get_pr_by_branch(self, branch: str) -> Optional[PullRequest]:
-        """Newest PR (any state) whose head is the given branch."""
+        """Newest PR (any state) whose head is the given branch.
+
+        Branch names from forge-issue PMO keys carry ``#`` (``owner/repo#N``).
+        Percent-encode the head value so ``#`` is not treated as a URL
+        fragment — otherwise GitHub never sees the filter and merge_sweep
+        cannot complete after a merge.
+        """
+        from urllib.parse import quote
+        head = quote(f"{self.owner}:{branch}", safe="")
         prs = await self._req(
-            "GET", f"/pulls?head={self.owner}:{branch}&state=all&sort=created&direction=desc")
+            "GET", f"/pulls?head={head}&state=all&sort=created&direction=desc")
         if not prs:
             return None
         pr = prs[0]

--- a/app/devcake/adapters/gitlab/adapter.py
+++ b/app/devcake/adapters/gitlab/adapter.py
@@ -114,7 +114,11 @@ class GitLabForge:
         )
 
     async def get_pr_by_branch(self, branch: str) -> Optional[PullRequest]:
-        mrs = await self._req("GET", f"/merge_requests?source_branch={branch}"
+        # Percent-encode so `#` in forge-issue branch names is not a URL
+        # fragment (same trap as GitHub's `head=` filter).
+        from urllib.parse import quote
+        source = quote(branch, safe="")
+        mrs = await self._req("GET", f"/merge_requests?source_branch={source}"
                                      f"&order_by=created_at&sort=desc")
         if not mrs:
             return None

--- a/app/tests/test_forge.py
+++ b/app/tests/test_forge.py
@@ -218,6 +218,43 @@ def test_get_pr_by_branch_shape_parity():
     assert run_coro(stub_req(gl(), []).get_pr_by_branch("x")) is None
 
 
+def test_get_pr_by_branch_encodes_hash_in_query():
+    """Forge-issue mission keys mint branches with `#` (owner/repo#N). An
+    unescaped `#` is a URL fragment — the forge never sees the head /
+    source_branch filter, so merge_sweep cannot complete after a merge."""
+    from urllib.parse import quote
+
+    branch = "devcake/DEVCAKEMEM-fidecastro/devcake-memories#3"
+
+    seen: list[str] = []
+    g = gh()
+
+    async def gh_req(method, path, **kw):
+        seen.append(path)
+        return [GH_PR_MERGED_ITEM]
+
+    g._req = gh_req
+    pr = run_coro(g.get_pr_by_branch(branch))
+    assert pr is not None and pr.number == 9
+    assert len(seen) == 1
+    assert f"head={quote(f'o:{branch}', safe='')}" in seen[0]
+    assert "#" not in seen[0]
+
+    seen.clear()
+    l = gl()
+
+    async def gl_req(method, path, **kw):
+        seen.append(path)
+        return [GL_MR_MERGED]
+
+    l._req = gl_req
+    mr = run_coro(l.get_pr_by_branch(branch))
+    assert mr is not None and mr.number == 9
+    assert len(seen) == 1
+    assert f"source_branch={quote(branch, safe='')}" in seen[0]
+    assert "#" not in seen[0]
+
+
 def test_pr_state_shape_parity():
     s = run_coro(stub_req(gh(), {"number": 8, "html_url": "u", "state": "closed",
                                  "merged": True}).pr_state(8))


### PR DESCRIPTION
## Summary
- Percent-encode branch names in GitHub `head=` and GitLab `source_branch=` PR lookups so `#` from forge-issue mission keys (`owner/repo#N`) is not treated as a URL fragment.
- Without this, merge_sweep gets an empty PR list after auto/human merge and never calls `complete_merged` → GitHub Issues stay open with `DEVCAKE-MERGE` (observed on `fidecastro/devcake-memories#3`).
- After deploying locally, merge_sweep found PR #4 via the encoded query and closed issue #3.

## Test plan
- [x] `test_get_pr_by_branch_encodes_hash_in_query` (red → green)
- [x] Full `./scripts/pytest_app.sh` — 2357 passed
- [x] Bake `app` + restart; logs show `%23` in `pulls?head=…`
- [x] Issue `fidecastro/devcake-memories#3` closed by DevCake complete path