### PR TITLE
[CAKE-48] Control-plane API structure, auth, and docs/11 REST alignment

### DIFF
--- a/app/tests/test_structure_guards.py
+++ b/app/tests/test_structure_guards.py
@@ -7,23 +7,26 @@ executable after it — no module-level ``MissionManager.<attr> = ...`` bindings
 C6 rule: ``api/main.py`` is composition root + route forwards — every
 ``@app.<verb>`` route body is ≤ 4 statements (docstring excluded). Endpoint
 behavior lives in ``api/`` service modules. The allowlist below is the
-residual read-side surface at close-out; it may SHRINK, never grow — a new
+residual thick body at close-out; it may SHRINK, never grow — a new
 endpoint that needs more than a forward gets a service module.
+
+Also pins ``docs/11-admin-panel.md`` §1 REST table against the live
+``main.py`` route list (method + path skeletons).
 """
 
 import ast
+import re
 from pathlib import Path
 
 MANAGER = (Path(__file__).parents[1] / "devcake" / "domain" / "orchestrator"
            / "manager.py")
 MAIN = Path(__file__).parents[1] / "devcake" / "api" / "main.py"
 
-# Residual bodies allowed in main.py (C6 close-out; shrink opportunistically):
-# the CI fixture, the steward/OAuth trio, and the small read-side runs/log/
-# clear endpoints. Everything else forwards to a service module.
+# Residual bodies allowed in main.py (C6 close-out; shrink opportunistically).
+# Only ``run_steward`` still exceeds 4 statements; everything else forwards
+# to a service module or is already a short forward (≤4). May SHRINK, never grow.
 ROUTE_BODY_ALLOWLIST = {
-    "dispatch_hello", "run_steward", "oauth_start", "oauth_status",
-    "clear_runs", "get_run_log", "stream_run_log",
+    "run_steward",
 }
 
 
@@ -122,6 +125,73 @@ def test_main_route_bodies_stay_thin():
     assert not offenders, (
         "main.py route bodies grew past 4 statements — move the behavior to "
         "an api/ service module (ADR-0015 Decision 3): " + "; ".join(offenders))
+
+
+# ── docs/11 §1 REST table ↔ main.py route inventory ─────────────────────────
+
+# Host checkout: repo/app/tests → repo/docs; container: /srv/tests → /srv/docs
+# (pytest_app.sh binds docs at /srv/docs).
+_DOC_ROOTS = [Path(__file__).parents[2], Path(__file__).parents[1]]
+DOCS_11 = next(
+    (r / "docs" / "11-admin-panel.md" for r in _DOC_ROOTS
+     if (r / "docs" / "11-admin-panel.md").exists()),
+    _DOC_ROOTS[0] / "docs" / "11-admin-panel.md",
+)
+
+
+def _skeleton(path: str) -> str:
+    """Normalize `/api/v1/foo/{name:path}` / `{VAR}` → `/api/v1/foo/{}`."""
+    path = path.split("?")[0].lower()
+    return re.sub(r"\{[^}]+\}", "{}", path)
+
+
+def _main_route_skeletons() -> set[tuple[str, str]]:
+    out: set[tuple[str, str]] = set()
+    for m in re.finditer(
+        r'@app\.(get|post|put|patch|delete)\("([^"]+)"\)', MAIN.read_text()
+    ):
+        out.add((m.group(1).upper(), _skeleton(m.group(2))))
+    return out
+
+
+def _docs11_rest_skeletons() -> set[tuple[str, str]]:
+    """Parse Method+path cells from docs/11 §1 (before the next ## heading)."""
+    text = DOCS_11.read_text()
+    sec = re.search(r"(## 1[^\n]*\n)(.*?)(\n## )", text, re.S)
+    assert sec is not None, "docs/11 §1 heading not found"
+    out: set[tuple[str, str]] = set()
+    cell_re = re.compile(
+        r"`((?:GET|POST|PUT|PATCH|DELETE)"
+        r"(?:\s*[·•/]\s*(?:GET|POST|PUT|PATCH|DELETE))*)"
+        r"\s+(/api/v1/[^`]+)`"
+    )
+    for m in cell_re.finditer(sec.group(2)):
+        methods = re.findall(r"GET|POST|PUT|PATCH|DELETE", m.group(1))
+        skel = _skeleton(m.group(2))
+        for method in methods:
+            out.add((method, skel))
+    return out
+
+
+def test_docs11_rest_table_covers_every_main_route():
+    """Contributor REST inventory must not silently drop live control-plane
+    paths (CAKE-48). Compare method + path *skeletons* so `{job_id}` vs
+    `{id}` / `{VAR}` vs `{var}` / `{name:path}` vs `{name}` stay notation-
+    only, not inventory holes. Both directions: missing rows and ghost rows.
+    """
+    code = _main_route_skeletons()
+    docs = _docs11_rest_skeletons()
+    missing = sorted(code - docs)
+    ghosts = sorted(docs - code)
+    assert not missing, (
+        "docs/11 §1 REST table missing live main.py routes: "
+        + ", ".join(f"{m} {p}" for m, p in missing)
+    )
+    assert not ghosts, (
+        "docs/11 §1 REST table lists paths absent from main.py: "
+        + ", ".join(f"{m} {p}" for m, p in ghosts)
+    )
+    assert len(code) >= 70, f"unexpectedly small main.py surface ({len(code)})"
 
 
 # ── ADR-0028: the composition root is a factory, not an import side effect ───

--- a/docs/11-admin-panel.md
+++ b/docs/11-admin-panel.md
@@ -16,6 +16,9 @@ Simple but beautiful: a static SPA (React + Vite + Tailwind, `admin/spa/`) serve
 
 ## 1. REST API contract (`/api/v1`)
 
+Full control-plane inventory (source of truth: `app/devcake/api/main.py`;
+pin: `test_docs11_rest_table_covers_every_main_route`). Auth posture: §6.
+
 | Method + path | Purpose |
 |---|---|
 | `GET /api/v1/health` | Full component health (below) |
@@ -55,7 +58,7 @@ Simple but beautiful: a static SPA (React + Vite + Tailwind, `admin/spa/`) serve
 | `POST /api/v1/system/clear-runs` | Operator wipe: stop **and drain** in-flight Devs (wait for container exit, capped just past Dagu's 30 s SIGTERM grace — the later ACL sweep must never race a live Dev), delete local run records + audit log + profiles breadcrumb, wipe per-run workspace dirs, purge Dagu run history, delete OpenObserve log/trace streams, trim Redis ingress / reply streams / `dev-*` ACL users, **delete every `activity-*` repo on the internal Gitea** (ADR-0014 D4 — the PMO stays the source of truth; repo git history, incl. pre-edit feed states, is lost; the `activity-` prefix is reserved — never hand-create repos with it in `devcake-repos`, the sweep would delete them), prune memory-notebook `.claims/*.json` (notes stay). Config + secrets + PMO + operator repos + skill-store + work repos + notebook notes untouched (`10-persistence.md` §5; full step list in §4) |
 | `POST /api/v1/steward/run` | Manually dispatch a Relations Steward run (`03-mission-lifecycle.md` §4b). Works regardless of the `enabled` toggle and of steward degradation (which govern only the interval service); **honors intake pause** (global master or that instance's switch) — 422 while paused. Also 422 without a valid `dev_type` / unusable workspace, 409 while a steward run is active |
 | `GET /api/v1/cron` | List cron rows from live config (reserved `memory-curator` always present) |
-| `POST /api/v1/cron/{id}/run` | Fire a scheduled task now (instant). 422 unknown; 409 in-flight (generic rows); 200 `{created: [{pmo, key}]}` — the Memory Curator fan-out returns an empty `created` when every board is busy/paused/absent. Memory Curator Run-now bypasses skip-if-empty (F4) |
+| `POST /api/v1/cron/{job_id}/run` | Fire a scheduled task now (instant). 422 unknown; 409 in-flight (generic rows); 200 `{created: [{pmo, key}]}` — the Memory Curator fan-out returns an empty `created` when every board is busy/paused/absent. Memory Curator Run-now bypasses skip-if-empty (F4) |
 | `GET /api/v1/profiles` | Config profile rows (ADR-0013): counts + presence only, plus the last-applied breadcrumb and the divergence boolean. Never a secret value |
 | `GET /api/v1/profiles/{name}` | One profile: metadata, full section A, a secrets **presence map**, and the apply-preview `diff` vs current settings |
 | `POST /api/v1/profiles` | Save-current-as: snapshots the live settings + secret values under `{"name": …}`. 409 on collision unless `overwrite: true`; warnings name configured instances whose secret is missing from the snapshot |


### PR DESCRIPTION
## Intent

Lock the control-plane HTTP surface so `docs/11` §1, ADR-0028 structure guards, and auth posture stay aligned with live `api/main.py` — without building OIDC/SSO.

## Mission

https://linear.app/fidecastro/issue/CAKE-48/control-plane-api-structure-auth-and-docs11-rest-alignment

## What changed

- **Inventory pin:** `test_docs11_rest_table_covers_every_main_route` compares every `@app` route in `main.py` to `docs/11-admin-panel.md` §1 (method + path skeletons). Both missing and ghost rows fail.
- **Allowlist shrink (ADR-0015/0028):** `ROUTE_BODY_ALLOWLIST` now only `run_steward` (the sole body still >4 statements). Thin handlers (`dispatch_hello`, OAuth, clear/log) left the allowlist.
- **Docs:** cron Run-now path param `{id}` → `{job_id}` to match code; short §1 note that the table is the full inventory.

## Deviation from plan

The three known REST-table gaps (`GET|POST …/harnesses/{template}/latest-cli`, `POST …/harness/prune`) were **already present on `main`** (landed in #199). Full inventory diff found no other missing skeletons — only the cron param-name notation. Auth middleware matched the contract (only `GET /api/v1/health/live` public; Basic + `X-DevCake-Request: 1` on mutations); **no production auth change**. `docs/14` claims already match — untouched.

## How to verify

```bash
./scripts/pytest_app.sh app/tests/test_structure_guards.py app/tests/test_api_auth.py app/tests/test_api_surface.py -q
```

Observed locally (app-test image + bind-mounted tree; redis network unavailable on this host, but these suites do not need it): **143 passed**.

## Risk / rollout

Docs + structure-guard tests only. No run-path / image bake required for deploy.

## Out of scope

OIDC/SSO; Admin SPA DESIGN; SPA registry FALLBACK pin.