### PR TITLE
[CAKE-56] Fix the image-prune route (POST /api/v1/harness/prune)

### DIFF
--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -783,7 +783,7 @@ async def test_forge(name: str):
 
 @app.post("/api/v1/harness/prune")
 async def request_harness_prune():
-    return bake_status_mod.request_prune(dev_types=svc().config.dev_types)
+    return bake_status_mod.request_prune(dev_types=svc().dev_types)
 
 
 # ── internal-forge repos + skill store (M11, docs/16) — bodies in

--- a/app/tests/test_bake_status.py
+++ b/app/tests/test_bake_status.py
@@ -104,6 +104,42 @@ def test_prune_request_also_drops_a_fresh_keep_set_order(tmp_path, monkeypatch):
     assert (tmp_path / bs.PRUNE_REQUEST_NAME).is_file()
 
 
+def test_harness_prune_http_route_returns_ok(tmp_path, monkeypatch):
+    """POST /api/v1/harness/prune must read Dev Types from services, not AppConfig.
+
+    Regression: the route used svc().config.dev_types (AttributeError → 500).
+    Dev Types live on Services as svc().dev_types.
+    """
+    import json
+
+    import pytest
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from fakes import make_services
+    from devcake import bake_status as bs
+    from devcake.api import main as app_main
+    from devcake.config import AppConfig, DevType
+
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    dts = {"d": DevType(name="d", harness_template="grok-build")}
+    monkeypatch.setattr(app_main, "services", make_services(
+        config=AppConfig(), dev_types=dts))
+
+    probe = FastAPI()
+    probe.add_api_route(
+        "/api/v1/harness/prune", app_main.request_harness_prune, methods=["POST"])
+    response = TestClient(probe).post("/api/v1/harness/prune")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "requested": True}
+    assert (tmp_path / bs.PRUNE_REQUEST_NAME).is_file()
+    keep = tmp_path / "harness_keep_set.json"
+    assert keep.is_file()
+    assert json.loads(keep.read_text())["pins"][0]["template"] == "grok-build"
+
+
 def test_baker_transition_fires_on_edges_only():
     from devcake.bake_status import baker_transition
 


### PR DESCRIPTION
## Intent
`POST /api/v1/harness/prune` always returned 500 because the route read `svc().config.dev_types`. `AppConfig` has no `dev_types` field — Dev Types live on `Services` as `svc().dev_types`. This PR points the handler at the correct object and adds an HTTP behavior test.

## Mission
https://linear.app/fidecastro/issue/CAKE-56/fix-the-image-prune-route-post-apiv1harnessprune

## Change
- `app/devcake/api/main.py`: `request_harness_prune` → `bake_status.request_prune(dev_types=svc().dev_types)`
- `app/tests/test_bake_status.py`: `test_harness_prune_http_route_returns_ok` exercises the HTTP route (FastAPI probe + `make_services`), asserts 200/`{"ok": true, "requested": true}` and prune request + keep-set side effects

## How to verify
1. Red→green confirmed: before the fix, the new test raised `AttributeError: 'AppConfig' object has no attribute 'dev_types'`.
2. Fresh `app-test` bake + full suite: **2504 passed**, 1 skipped.
3. Live prune against a running stack: **not available** in this agent environment (no compose plugin / no `.env` / nothing listening on :8000).

## Out of scope
Admin SPA prune button, baker prune execution, keep-set semantics, docs churn, other harness routes.