### PR TITLE
[CAKE-58] Scheduled tickets use the real priority vocabulary

### DIFF
--- a/app/devcake/domain/cron_service.py
+++ b/app/devcake/domain/cron_service.py
@@ -255,6 +255,6 @@ class CronService:
             labels.add(_STAGE_LABEL[stage])
         await mgr.pmo.ensure_labels(mgr.instance.team_key, labels)
         key, pmo_id = await mgr.pmo.create_mission(
-            mgr.instance.team_key, title, body, "normal", labels)
+            mgr.instance.team_key, title, body, "medium", labels)
         log.info("cron %s created %s on %s", row.id, key, mgr.instance_name)
         return {"pmo": mgr.instance_name, "key": key, "pmo_id": pmo_id}

--- a/app/tests/test_cron.py
+++ b/app/tests/test_cron.py
@@ -13,7 +13,8 @@ from devcake.config import (AppConfig, CronJob, MEMORY_CURATOR_CRON_ID,
 from devcake.domain.cron_service import (CronBusy, CronService,
                                          CronUnconfigured, cron_marker)
 from devcake.domain.model import (LABEL_EXECUTE, LABEL_OPTIN, LABEL_PLAN,
-                                  Mission)
+                                  PRIORITY_RANK, Mission)
+
 
 
 def run_coro(c):
@@ -38,15 +39,24 @@ class FakePMO:
 
     async def create_mission(self, team_ref, title, description, priority,
                              label_names, parent_ref=None):
+        if priority not in PRIORITY_RANK:
+            raise ValueError(f"illegal priority {priority!r}")
         key = f"T-{len(self.created) + 1}"
         pid = f"id-{key}"
-        self.created.append((title, description, set(label_names), key))
+        self.created.append((title, description, set(label_names), key, priority))
         self.missions.append(Mission(
             pmo_id=pid, pmo_kind="issue", key=key, title=title,
-            description=description, status="backlog",
+            description=description, status="backlog", priority=priority,
             labels=set(label_names),
             updated_at=datetime.now(timezone.utc)))
         return key, pid
+
+
+
+def test_fake_pmo_refuses_illegal_priority():
+    pmo = FakePMO()
+    with pytest.raises(ValueError, match="illegal priority 'normal'"):
+        run_coro(pmo.create_mission("T", "t", "d", "normal", set()))
 
 
 def _cfg(*pmos, crons=None, memory=None):
@@ -55,6 +65,7 @@ def _cfg(*pmos, crons=None, memory=None):
     rows = list(pmos)
     jobs = list(crons) if crons is not None else [memory_curator_seed()]
     return AppConfig(pmos=rows, repos=repos, crons=jobs)
+
 
 
 def _mgr(name, pmo, inst):
@@ -76,15 +87,16 @@ def test_generic_execute_labels_and_onboard_has_no_stage_label():
     svc = CronService(cfg, {"eng": _mgr("eng", pmo, inst)})
     got = run_coro(svc.fire("nightly", automatic=False))
     assert got[0]["key"] == "T-1"
-    title, body, labels, _ = pmo.created[0]
+    title, body, labels, _, priority = pmo.created[0]
     assert title.startswith("[cron:nightly]")
     assert LABEL_OPTIN in labels and LABEL_EXECUTE in labels
     assert cron_marker("nightly") in body
     assert "{timestamp}" not in body
+    assert priority == "medium"
     pmo.created.clear()
     pmo.missions.clear()
     run_coro(svc.fire("onboard", automatic=False))
-    _, _, labels, _ = pmo.created[0]
+    _, _, labels, _, _ = pmo.created[0]
     assert labels == {LABEL_OPTIN}
     assert "DEVCAKE-ONBOARD" not in labels
 
@@ -132,7 +144,8 @@ def test_memory_curator_skips_empty_automatic_run_now_does_not():
     assert pmo.created == []
     got = run_coro(svc.fire(MEMORY_CURATOR_CRON_ID, automatic=False))
     assert got[0]["pmo"] == "cur"
-    _, body, labels, _ = pmo.created[0]
+    _, body, labels, _, _ = pmo.created[0]
+
     assert LABEL_EXECUTE in labels
     assert cron_marker(MEMORY_CURATOR_CRON_ID) in body
 
@@ -304,10 +317,11 @@ def test_template_backticks_defanged_and_marker_appended():
     ])
     svc = CronService(cfg, {"eng": _mgr("eng", pmo, inst)})
     run_coro(svc.fire("nightly", automatic=False))
-    _, body, _, _ = pmo.created[0]
+    _, body, _, _, _ = pmo.created[0]
     assert "`devcake:cron:v1 job=other`" not in body
     assert "evil 'devcake:cron:v1 job=other' go" in body
     assert cron_marker("nightly") in body
+
 
 
 class _PortLedger:

--- a/app/tests/test_mission_create.py
+++ b/app/tests/test_mission_create.py
@@ -16,7 +16,8 @@ from fastapi import HTTPException
 
 from devcake.api import mission_actions
 from devcake.api.mission_actions import create_mission
-from devcake.domain.model import MissionRef
+from devcake.domain.model import MissionRef, PRIORITY_RANK
+
 
 
 def run_coro(c):
@@ -43,6 +44,8 @@ class CreatePMO:
 
     async def create_mission(self, team_ref, title, description, priority,
                              label_names, parent_ref=None):
+        if priority not in PRIORITY_RANK:
+            raise ValueError(f"illegal priority {priority!r}")
         self.created.append((team_ref, title, description, priority,
                              set(label_names)))
         return "DEV-9", "pmo-new"

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -13,7 +13,9 @@ from devcake.config import AppConfig, DevType
 from devcake.ports.forge import ForgeError, PullRequest
 from devcake.domain.orchestrator import MissionManager
 from devcake.domain.orchestrator import decomposition, review, transitions
-from devcake.domain.model import Activity, ActivityEntry, Mission, MissionType
+from devcake.domain.model import (Activity, ActivityEntry, Mission, MissionType,
+                                  PRIORITY_RANK)
+
 from devcake.adapters.files.run_store import RunStore
 from devcake.domain.run import Run
 from devcake.domain import backend_health
@@ -112,6 +114,8 @@ class FakePMO:
 
     async def create_mission(self, team_ref, title, description, priority,
                              label_names, parent_ref=None):
+        if priority not in PRIORITY_RANK:
+            raise ValueError(f"illegal priority {priority!r}")
         self.created.append((title, parent_ref))
         key, pmo_id = f"T-{len(self.created) + 1}", f"id-{len(self.created)}"
         self.all_missions.append(Mission(
@@ -121,6 +125,7 @@ class FakePMO:
             parent_ref=parent_ref,
         ))
         return key, pmo_id
+
 
     async def list_all(self, team_ref):
         return list(self.all_missions)


### PR DESCRIPTION
## Intent
Fix cron scheduled-ticket creation so it passes a docs/02 priority (`medium`) into `PMOPort.create_mission` instead of the illegal string `normal`, which made Linear's adapter KeyError on bare dict subscript. Harden create_mission test FakePMOs so they refuse out-of-vocabulary priorities and cannot green-light this class of bug again.

## Mission
https://linear.app/fidecastro/issue/CAKE-58/scheduled-tickets-use-the-real-priority-vocabulary

## Changes
- `CronService._create_ticket`: `"normal"` → `"medium"`
- `test_cron.FakePMO.create_mission`: reject priorities not in `PRIORITY_RANK`, record priority, assert fire path uses `"medium"`
- Same refusal fence on `test_transitions.FakePMO` and `test_mission_create.CreatePMO`

## How to verify
```bash
./scripts/pytest_app.sh app/tests/test_cron.py app/tests/test_transitions.py app/tests/test_mission_create.py
# or against a fresh app-test image:
docker run --rm --entrypoint python localhost/devcake/app-test:latest -m pytest tests/test_cron.py tests/test_transitions.py tests/test_mission_create.py -q
rg '"normal"' app/devcake/   # should be empty
```

## Risk / rollout
Low: one literal change on the cron create path; default priority matches docs/02. No adapter or SPA changes.

## Out of scope
Adapter priority maps, SPA priority UI, shared FakePMO module, cron labels/stages/markers.