### PR TITLE
[CAKE-59] A failed notebook clone is unlistable, not empty

### DIFF
--- a/app/devcake/adapters/claims_writer.py
+++ b/app/devcake/adapters/claims_writer.py
@@ -158,7 +158,17 @@ class ClaimsWriter:
             raise RuntimeError(
                 f"claims notebook clone failed though {want} exists: "
                 f"{detail}")
-        # Reachable remote with no heads / no default-branch ref —
+        if heads:
+            # Populated remote without the configured branch: almost
+            # certainly a misconfigured default_branch — reading it as a
+            # confidently empty notebook is the exact failure this helper
+            # exists to prevent. Bootstrap is the no-heads case below.
+            have = ", ".join(sorted(h.removeprefix("refs/heads/")
+                                    for h in heads)[:5])
+            raise RuntimeError(
+                f"claims notebook unlistable: remote has no {want} "
+                f"(branches: {have}) — check the card's default_branch")
+        # Reachable remote with no heads at all (fresh bare repo) —
         # empty-init so the first commit can push the branch.
         dest.mkdir(parents=True)
         for args in (["init", "-b", branch],

--- a/app/devcake/adapters/claims_writer.py
+++ b/app/devcake/adapters/claims_writer.py
@@ -130,13 +130,40 @@ class ClaimsWriter:
             ["clone", "--depth", "1", "--branch", branch, url, str(dest)],
             env=env)
         if r.returncode != 0:
-            # empty remote (no default branch yet) — init a local checkout
-            shutil.rmtree(dest, ignore_errors=True)
-            dest.mkdir(parents=True)
-            for args in (["init", "-b", branch],
-                         ["remote", "add", "origin", url]):
-                await self._run(args, cwd=dest, env=env)
+            await self._empty_or_unlistable(dest, url=url, branch=branch,
+                                            env=env, clone=r)
         return dest
+
+    async def _empty_or_unlistable(self, dest: Path, *, url: str,
+                                   branch: str, env: dict,
+                                   clone) -> None:
+        """After a failed `clone --branch`, distinguish genuine empty
+        remotes (empty-init) from outages (raise → unlistable)."""
+        probe = await self.git(["ls-remote", "--heads", url], env=env)
+        shutil.rmtree(dest, ignore_errors=True)
+        if probe.returncode != 0:
+            detail = (probe.stderr or probe.stdout or clone.stderr
+                      or clone.stdout or "")[-400:]
+            raise RuntimeError(
+                f"claims notebook unlistable (clone+ls-remote failed): "
+                f"{detail}")
+        heads = {
+            line.split("\t", 1)[-1].strip()
+            for line in (probe.stdout or "").splitlines()
+            if line.strip()
+        }
+        want = f"refs/heads/{branch}"
+        if want in heads:
+            detail = (clone.stderr or clone.stdout or "")[-400:]
+            raise RuntimeError(
+                f"claims notebook clone failed though {want} exists: "
+                f"{detail}")
+        # Reachable remote with no heads / no default-branch ref —
+        # empty-init so the first commit can push the branch.
+        dest.mkdir(parents=True)
+        for args in (["init", "-b", branch],
+                     ["remote", "add", "origin", url]):
+            await self._run(args, cwd=dest, env=env)
 
     async def _with_tree(self, card, *, write: bool):
         inst = self._inst(card)

--- a/app/devcake/ports/claims.py
+++ b/app/devcake/ports/claims.py
@@ -11,14 +11,16 @@ from typing import Protocol
 
 class ClaimsNotebooks(Protocol):
     async def list_json_names(self, card: str) -> list[str] | None:
-        """`*.json` filenames under `.claims/` (no path prefix). None if
-        the notebook cannot be listed (missing card, no credentials)."""
+        """`*.json` filenames under `.claims/` (no path prefix).
+        `[]` only when checkout succeeds and `.claims/` has no JSON.
+        None if unlistable (missing card, clone/ls-remote failure)."""
         ...
 
     async def snapshot(self, card: str) -> dict | None:
         """`{json_names: [...], has_readme: bool}` in ONE checkout — the
-        append path's listing + README presence probe. None if the
-        notebook cannot be read."""
+        append path's listing + README presence probe. None if unlistable
+        (including clone failure); definite-empty only after a successful
+        checkout."""
         ...
 
     async def list_claim_meta(self, card: str) -> list[dict] | None:

--- a/app/tests/test_claims_writer.py
+++ b/app/tests/test_claims_writer.py
@@ -15,7 +15,8 @@ from pathlib import Path
 import pytest
 
 from devcake.config import AppConfig, RepoInstance
-from devcake.adapters.claims_writer import make_claims_writer
+from devcake.adapters.claims_writer import ClaimsWriter, make_claims_writer
+from devcake.adapters.git import GitResult
 
 
 def run_coro(c):
@@ -24,6 +25,10 @@ def run_coro(c):
         return loop.run_until_complete(c)
     finally:
         loop.close()
+
+
+def _git_result(rc=0, stdout="", stderr=""):
+    return GitResult(rc, stdout, stderr)
 
 
 @pytest.fixture
@@ -214,3 +219,87 @@ def test_commit_retries_once_after_push_race(tmp_path, tokens):
     snap = run_coro(w.snapshot("nb"))
     assert snap == {"json_names": ["aa11bb22cc33dd44.json"],
                     "has_readme": False}
+
+
+def test_clone_failure_returns_unlistable_not_empty(tokens):
+    """Auth/network/missing-repo clone failure must surface as None
+    (unlistable), never definite-empty from a local empty-init tree."""
+    tokens[("nb", "token")] = "bad-token"
+    card = RepoInstance(name="nb", forge="github",
+                        url="https://github.com/acme/notes",
+                        default_branch="main")
+
+    async def failing_git(args, cwd=None, env=None):
+        # clone + ls-remote fail (outage). init/remote succeed so that
+        # today's buggy empty-init path would still produce a tree —
+        # without the fix, reads would return []/False instead of None.
+        if args[:1] == ["clone"]:
+            return _git_result(128, stderr="Authentication failed")
+        if args[:2] == ["ls-remote", "--heads"]:
+            return _git_result(128, stderr="Could not read from remote")
+        if args[:1] == ["init"] or args[:2] == ["remote", "add"]:
+            return _git_result(0)
+        return _git_result(1, stderr=f"unexpected git {args!r}")
+
+    w = ClaimsWriter(_cfg(card), git=failing_git)
+    assert run_coro(w.list_json_names("nb")) is None
+    assert run_coro(w.snapshot("nb")) is None
+    assert run_coro(w.has_readme("nb")) is None
+    assert run_coro(w.list_claim_meta("nb")) is None
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="no git binary")
+def test_genuine_empty_remote_empty_inits_and_first_commit_works(
+        tmp_path, tokens):
+    """Clone --branch fails on a reachable remote with no heads, but
+    ls-remote succeeds empty → definite-empty reads + first push OK."""
+    origin = tmp_path / "origin.git"
+    env = {"PATH": "/usr/local/bin:/usr/bin:/bin",
+           "HOME": str(tmp_path), "GIT_TERMINAL_PROMPT": "0",
+           "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@x",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@x"}
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)],
+                   check=True, capture_output=True, env=env)
+    # No commits → no heads. Clone --branch fails; ls-remote --heads is empty.
+    url = "file://localhost" + str(origin)
+    tokens[("nb", "token")] = "unused-for-local"
+    card = RepoInstance(name="nb", forge="github", url=url,
+                        default_branch="main")
+    w = make_claims_writer(_cfg(card), internal_forge=None)
+
+    assert run_coro(w.list_json_names("nb")) == []
+    assert run_coro(w.has_readme("nb")) is False
+    assert run_coro(w.snapshot("nb")) == {"json_names": [], "has_readme": False}
+    assert run_coro(w.list_claim_meta("nb")) == []
+
+    run_coro(w.commit(
+        "nb",
+        creates={".claims/aabbccddeeff0011.json": "{}\n"},
+        deletes=[],
+        message="devcake:claims:v1 run=r1 n=1"))
+    assert run_coro(w.list_json_names("nb")) == ["aabbccddeeff0011.json"]
+
+
+def test_default_branch_exists_but_clone_fails_is_unlistable(tokens):
+    """ls-remote shows refs/heads/<default> yet clone failed → None.
+    Must not empty-init over a remote that already has the branch."""
+    tokens[("nb", "token")] = "tok"
+    card = RepoInstance(name="nb", forge="github",
+                        url="https://github.com/acme/notes",
+                        default_branch="main")
+
+    async def flaky_clone_git(args, cwd=None, env=None):
+        if args[:1] == ["clone"]:
+            return _git_result(128, stderr="early EOF / transient")
+        if args[:2] == ["ls-remote", "--heads"]:
+            return _git_result(
+                0, stdout="abc123\trefs/heads/main\ndef456\trefs/heads/dev\n")
+        if args[:1] == ["init"] or args[:2] == ["remote", "add"]:
+            return _git_result(0)
+        return _git_result(1, stderr=f"unexpected git {args!r}")
+
+    w = ClaimsWriter(_cfg(card), git=flaky_clone_git)
+    assert run_coro(w.list_json_names("nb")) is None
+    assert run_coro(w.snapshot("nb")) is None
+    assert run_coro(w.has_readme("nb")) is None
+    assert run_coro(w.list_claim_meta("nb")) is None

--- a/app/tests/test_claims_writer.py
+++ b/app/tests/test_claims_writer.py
@@ -303,3 +303,29 @@ def test_default_branch_exists_but_clone_fails_is_unlistable(tokens):
     assert run_coro(w.snapshot("nb")) is None
     assert run_coro(w.has_readme("nb")) is None
     assert run_coro(w.list_claim_meta("nb")) is None
+
+
+def test_branch_missing_on_populated_remote_is_unlistable(tokens):
+    """ls-remote shows other heads but not the configured branch → None.
+    A typo'd default_branch must never read as a confidently empty
+    notebook; empty-init is reserved for a remote with no heads at all."""
+    tokens[("nb", "token")] = "tok"
+    card = RepoInstance(name="nb", forge="github",
+                        url="https://github.com/acme/notes",
+                        default_branch="main")
+
+    async def wrong_branch_git(args, cwd=None, env=None):
+        if args[:1] == ["clone"]:
+            return _git_result(128, stderr="Remote branch main not found")
+        if args[:2] == ["ls-remote", "--heads"]:
+            return _git_result(
+                0, stdout="abc123\trefs/heads/master\ndef456\trefs/heads/dev\n")
+        if args[:1] == ["init"] or args[:2] == ["remote", "add"]:
+            return _git_result(0)
+        return _git_result(1, stderr=f"unexpected git {args!r}")
+
+    w = ClaimsWriter(_cfg(card), git=wrong_branch_git)
+    assert run_coro(w.list_json_names("nb")) is None
+    assert run_coro(w.snapshot("nb")) is None
+    assert run_coro(w.has_readme("nb")) is None
+    assert run_coro(w.list_claim_meta("nb")) is None

--- a/docs/adr/0035-memory-notebooks-claims-conveyor-and-scheduled-tasks.md
+++ b/docs/adr/0035-memory-notebooks-claims-conveyor-and-scheduled-tasks.md
@@ -69,6 +69,9 @@ seeded by the app.
    notebook, refuse-new-never-evict. Conveyor failure never fails the
    discovering run. The writer is forge-neutral (clone+commit+push with
    the card's write token, one push-race retry) — never a Dev token.
+   List/snapshot return `None` when the notebook cannot be cloned or
+   listed (including clone failure); definite empty (`[]` / no README)
+   is only when checkout succeeds and `.claims/` has no JSON.
    The app reads/writes ONLY under `.claims/`; note bodies stay
    app-blind (wipe test: delete every note, replay the same Dev
    outputs, the mission loop is unchanged).


### PR DESCRIPTION
## Intent

`ClaimsWriter._checkout` treated any nonzero `git clone` exit as empty-remote init, so `list_json_names` / `snapshot` / `has_readme` / `list_claim_meta` returned definite-empty (`[]` / `False`) during forge/network outages instead of **`None` (unlistable)** required by `ports/claims.py`. Domain `claims_list_failed` and depth/capped-alert bookkeeping only fire on `None`, so outages looked like empty boards.

**Fix:** after a failed `clone --depth 1 --branch`, probe `git ls-remote --heads`:
- ls-remote fails → raise → unlistable (`None`)
- default branch exists on remote but clone still failed → raise → unlistable
- reachable remote with no heads / no default-branch ref → keep empty-init (first push can create the branch)

## Mission

https://linear.app/fidecastro/issue/CAKE-59/a-failed-notebook-clone-is-unlistable-not-empty

## How to verify

```bash
./scripts/pytest_app.sh app/tests/test_claims_writer.py app/tests/test_claims.py
# or, after bake app-test:
docker run --rm localhost/devcake/app-test:latest python -m pytest tests/test_claims_writer.py tests/test_claims.py -v
```

New tests cover: clone+ls-remote outage → `None`; genuine empty bare remote → `[]` + first commit; default branch present but clone fails → `None`. Existing round-trip and push-race regressions stay green.

## Risk / rollout

Adapter-only behavior change at the claims checkout chokepoint. No schema/API migration. Write path for brand-new empty notebooks unchanged.

## Out of scope

Repo mirror / provision clone failure paths; SPA/health copy; `_with_tree` / commit-retry refactors.