### PR TITLE
[CAKE-60] Notebook clone failures latch the notebook breaker

### DIFF
--- a/app/devcake/domain/orchestrator/finalize.py
+++ b/app/devcake/domain/orchestrator/finalize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind, Status, StatusCode
@@ -17,6 +18,31 @@ from .markers import FEED_INLINE_MAX, REPLY_MARKER
 
 log = logging.getLogger("devcake.missions")
 tracer = trace.get_tracer("devcake")
+
+# Entrypoint contract (images/common/dev_entrypoint.py): strict memory clone
+# failures prefix the detail with this shape before the clone stderr.
+_NOTEBOOK_CLONE_FAILED = re.compile(
+    r"^memory notebook (\S+) clone failed(?:\b|:)")
+
+
+def notebook_card_from_forge_auth_detail(
+        detail: str | None,
+        memory_mounts: list[dict] | None = None) -> str | None:
+    """Card name to latch for notebook-clone DEV_FORGE_AUTH, else None.
+
+    When ``memory_mounts`` is non-empty, the parsed card must appear there
+    (dispatch snapshot) — otherwise fall through to the work-repo latch.
+    """
+    m = _NOTEBOOK_CLONE_FAILED.match(detail or "")
+    if not m:
+        return None
+    card = m.group(1)
+    mounts = memory_mounts or []
+    if mounts:
+        names = {str(x.get("card") or "") for x in mounts}
+        if card not in names:
+            return None
+    return card
 
 
 def _pre_wipe(mgr, run: Run) -> bool:
@@ -283,10 +309,14 @@ def _forge_auth(mgr, run, row, detail, structured, exit_code):
     # row (classify's bare-sibling rule; the detail still names it), which
     # terminates.
     #
-    # latch only THIS run's repo (M10): a bad credential on repo A
-    # must never stop repo B's missions
+    # Latch the failing card only (M10 / ADR-0035): primary clone or push
+    # auth → run.repo_ref; strict memory-notebook clone auth → that notebook
+    # card. Never latch the work repo for a notebook-prefix failure — healthy
+    # work-repo probes would clear it while DEV_FORGE_AUTH stays uncounted.
+    target = (notebook_card_from_forge_auth_detail(detail, run.memory_mounts)
+              or run.repo_ref)
     mgr.forges.latch(
-        run.repo_ref, f"repository credential rejected in {run.run_id}")
+        target, f"repository credential rejected in {run.run_id}")
     return f"{row.error_class}: " + (detail or row.default_detail)
 
 

--- a/app/devcake/domain/orchestrator/schedule.py
+++ b/app/devcake/domain/orchestrator/schedule.py
@@ -8,6 +8,7 @@ from ...config import assignment_for
 from .. import backend_health
 from ..model import (LABEL_FAILED, LABEL_SKIP, Mission,
                      MissionType, PRIORITY_RANK, derive, find_cycles)
+from ..repo_sourcing import memory_mount_names
 from .markers import DISPATCHABLE_TYPES, decomposition_parent_ref
 
 log = logging.getLogger("devcake.missions")
@@ -116,6 +117,14 @@ async def schedule(mgr, missions: list[Mission],
                 f"{d.mission_type.value} is assigned to Dev Type "
                 f"{assignment.dev_type!r}, which does not exist — fix the "
                 f"assignment (global or this instance's override)")
+            continue
+        # ADR-0035 / CAKE-60: passenger memory notebooks bind via
+        # instance/Dev Type memory_repos. A latched notebook card must freeze
+        # every mission that binds it (same silent skip as work-repo latch).
+        if any(name in mgr.forges.breakers
+               for name in memory_mount_names(
+                   instance=mgr.instance, dev_type=dev_type,
+                   repo_ref=mission.repo)):
             continue
         if dev_type.name in mgr.breakers:
             continue  # auth breaker tripped (docs/15 §4)

--- a/app/tests/test_assignments.py
+++ b/app/tests/test_assignments.py
@@ -78,6 +78,32 @@ def test_schedule_surfaces_unassigned_mission_type(tmp_path):
     assert "unassigned" in cs.blocked_reasons["p1"]
 
 
+def test_schedule_skips_when_bound_notebook_breaker_is_latched(tmp_path):
+    """CAKE-60: passenger memory notebooks bind via instance/Dev Type
+    memory_repos. A latched notebook card must freeze those missions even
+    when the work repo's breaker is clear (docs/15 §1 DEV_FORGE_AUTH note)."""
+    mgr, dispatched = _mgr(
+        tmp_path, PMOInstance(name="eng", team_key="ENG",
+                              memory_repos=["nb"]))
+    mgr.forges.breakers["nb"] = "repository credential rejected in run-x"
+    run_coro(mgr.schedule([m("p1", "T-1")]))
+    assert dispatched == []
+
+    del mgr.forges.breakers["nb"]
+    run_coro(mgr.schedule([m("p1", "T-1")]))
+    assert dispatched == [("T-1", "ONBOARD", "judgment")]
+
+
+def test_schedule_skips_when_work_repo_breaker_is_latched(tmp_path):
+    """Control: work-repo latch still gates on mission.repo alone."""
+    mgr, dispatched = _mgr(
+        tmp_path, PMOInstance(name="eng", team_key="ENG",
+                              memory_repos=["nb"]))
+    mgr.forges.breakers["main"] = "repository credential rejected in run-y"
+    run_coro(mgr.schedule([m("p1", "T-1")]))
+    assert dispatched == []
+
+
 def test_dispatch_spec_env_uses_override_args_wholesale(tmp_path):
     """A REAL dispatch() on an overriding instance carries the OVERRIDE row's
     CLI args into the runspec — never the global row's (flags are harness-

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -586,6 +586,29 @@ def test_forge_auth_artifact_trips_repo_breaker(tmp_path):
     assert "main" in mgr.forges.breakers and not mgr.breakers
 
 
+def test_notebook_clone_forge_auth_latches_notebook_card_not_work_repo(tmp_path):
+    """CAKE-60: strict memory-notebook DEV_FORGE_AUTH must latch the notebook
+    card. Latching run.repo_ref lets healthy work-repo probes clear the
+    breaker while DEV_FORGE_AUTH stays uncounted → infinite retry."""
+    m = mission("in_progress", {"DEVCAKE"})
+    mgr, _fake, _store = make_mgr(tmp_path, m)
+    run = _run("ONBOARD", None)
+    run.repo_ref = "main"
+    run.memory_mounts = [{"card": "nb", "binding": "board", "path": "memory/nb"}]
+    error = mgr.dev_failure_error(run, {
+        "exit_code": 13,
+        "error_class": "DEV_FORGE_AUTH",
+        "error_detail": (
+            "memory notebook nb clone failed: "
+            "remote returned 403: Authentication failed"),
+    })
+    assert error.startswith("DEV_FORGE_AUTH:")
+    assert run.error_class == "DEV_FORGE_AUTH"
+    assert "nb" in mgr.forges.breakers
+    assert "main" not in mgr.forges.breakers
+    assert not mgr.breakers
+
+
 def test_stderr_403_without_error_class_does_not_trip_breaker(tmp_path):
     """A bare '403' in stderr (rate limit, URL fragment) must not halt all
     dispatch — only the Dev's structured DEV_FORGE_AUTH class may latch."""


### PR DESCRIPTION
## Intent
When a strict memory-notebook provision clone fails as structured `DEV_FORGE_AUTH`, latch the **notebook card's** forge breaker (not `run.repo_ref`). Schedule also skips missions that bind a latched notebook via `memory_repos`, so healthy work-repo probes cannot clear the latch into an infinite uncounted retry.

## Mission
https://linear.app/fidecastro/issue/CAKE-60/notebook-clone-failures-latch-the-notebook-breaker

## Changes
- `finalize._forge_auth`: parse `memory notebook <card> clone failed` detail; latch `<card>` (validated against `run.memory_mounts` when present); otherwise keep `run.repo_ref`.
- `schedule.schedule`: after resolving the Dev Type, skip when any name from `repo_sourcing.memory_mount_names` is in `forges.breakers`.
- Tests (red→green): notebook latch target, work-repo control, schedule notebook gate + work-repo control.

## How to verify
- `./scripts/pytest_app.sh` (or targeted: `test_transitions.py` forge-auth cases + `test_assignments.py` schedule breaker tests + `test_failure_taxonomy.py`)
- docs/15 already states the notebook-card latch contract; no doc edit required.

## Out of scope
- Taxonomy / uncounted rules; entrypoint artifact fields; steward passenger-memory expansion; SPA.