### PR TITLE
[CAKE-62] Resume really resumes when an entrypoint script exists

### DIFF
--- a/app/tests/test_dev_entrypoint.py
+++ b/app/tests/test_dev_entrypoint.py
@@ -80,12 +80,62 @@ def test_override_without_a_script_is_refused():
             model="stub-model", extra=(), script="", override=True)
 
 
-def _composed_launch():
-    import os
-    os.environ.setdefault("DEVCAKE_RUN_ID", "T-LAUNCH")
-    os.environ.setdefault("REDIS_URL", "redis://127.0.0.1:6399/0")
-    os.environ.setdefault("REDIS_USER", "t")
-    os.environ.setdefault("REDIS_PASSWORD", "t")
+# ── CAKE-62: resume through composed_launch (session_id) ─────────────────────
+
+
+def test_additive_prelude_with_session_id_execs_resume_argv():
+    """MCP/entrypoint prelude must wrap resume dialect argv, not fresh argv."""
+    import shlex
+
+    launch = _composed_launch()
+    resume = _harness_resume_argv()
+    prompt = "NUDGE"
+    sid = "SID"
+    script = "claude mcp add x -- y"
+    got = launch(
+        "grok-build", prompt, plan_mode=False, model="stub-model",
+        extra=(), script=script, override=False, session_id=sid)
+    expected_resume = resume(
+        "grok-build", sid, prompt, model="stub-model")
+    fresh = launch(
+        "grok-build", prompt, plan_mode=False, model="stub-model",
+        extra=(), script=script, override=False)
+    assert got[:4] == ["bash", "--noprofile", "--norc", "-c"]
+    quoted = " ".join(shlex.quote(p) for p in expected_resume)
+    assert got[-1] == f"{script}\nexec {quoted}\n"
+    # must not equal a fresh argv composition (no -r SID)
+    assert got != fresh
+    assert f"-r {shlex.quote(sid)}" not in fresh[-1]
+    assert "-r" in got[-1] and sid in got[-1]
+
+
+def test_empty_script_with_session_id_equals_harness_resume_argv():
+    launch = _composed_launch()
+    resume = _harness_resume_argv()
+    prompt = "NUDGE"
+    sid = "SID"
+    got = launch(
+        "grok-build", prompt, plan_mode=False, model="stub-model",
+        extra=(), script="", override=False, session_id=sid)
+    assert got == resume(
+        "grok-build", sid, prompt, model="stub-model")
+
+
+def test_override_with_session_id_still_uses_only_operator_script():
+    """Under override the opaque script is the process; session_id is ignored."""
+    launch = _composed_launch()
+    script = "my-cli --serve"
+    got = launch(
+        "grok-build", "NUDGE", plan_mode=False, model="stub-model",
+        extra=(), script=script, override=True, session_id="SID")
+    assert got[:4] == ["bash", "--noprofile", "--norc", "-c"]
+    assert got[-1] == script
+    assert "grok" not in got[-1]
+    assert "-r" not in got[-1]
+    assert "SID" not in got[-1]
+
+
+def _images_common_root() -> Path:
     roots = [
         Path(__file__).resolve().parents[2] / "images" / "common",
         Path("/srv/images/common"),
@@ -94,5 +144,21 @@ def _composed_launch():
     assert root is not None, "images/common missing"
     if str(root) not in sys.path:
         sys.path.insert(0, str(root))
+    return root
+
+
+def _composed_launch():
+    import os
+    os.environ.setdefault("DEVCAKE_RUN_ID", "T-LAUNCH")
+    os.environ.setdefault("REDIS_URL", "redis://127.0.0.1:6399/0")
+    os.environ.setdefault("REDIS_USER", "t")
+    os.environ.setdefault("REDIS_PASSWORD", "t")
+    _images_common_root()
     from devcake_dev.harness.launch import composed_launch
     return composed_launch
+
+
+def _harness_resume_argv():
+    _images_common_root()
+    from devcake_dev.harness.argv import harness_resume_argv
+    return harness_resume_argv

--- a/docs/07-dev-runtime.md
+++ b/docs/07-dev-runtime.md
@@ -284,7 +284,7 @@ unchanged and bounds the whole loop.
 |---|---|
 | `domain.fault` | ADR-0018 harness fault classification; container-produced `(exit_code, error_class)` pairs in `PRODUCED` (pure) |
 | `harness.dialect` / `dialects` | Fail-closed `HarnessDialect` registry — argv / render / parse / fault / session id; unknown id → `ValueError` (docs/16 H1) |
-| `harness.launch` | Single `composed_launch` chokepoint (dialect argv ± operator script / override) |
+| `harness.launch` | Single `composed_launch` chokepoint (dialect argv / resume argv ± operator script / override) |
 | `harness.aim` | Backend adaptor (docs/08 §8): base URL → env / extra argv / files — not fault classification |
 | `harness.continuation` | ADR-0022 continuation policy, nudges, session chains, token-report merge, terminal evidence (pure) |
 | `harness.render` / `tokens` / `argv` | Live relay, stream dumps, CLI argv (+ resume dialects, `RESUME_SPECS`) |

--- a/images/common/dev_entrypoint.py
+++ b/images/common/dev_entrypoint.py
@@ -940,21 +940,23 @@ def harness_main() -> None:
                         if cont_cfg.max_continuations > 0 else "")
                      + f"\n\n---\n\n{result_text}",
                      bad_output_reason=reason)
-            if decision.action == "resume":
+            # Override scripts are opaque — DevCake cannot inject dialect
+            # resume flags. Degrade to the fresh arm (same honesty as
+            # "resume unavailable → fresh") so mode/tokens stay truthful.
+            relaunch = decision.action
+            if relaunch == "resume" and override:
+                relaunch = "fresh"
+            if relaunch == "resume":
                 mode = "resume"
                 inv_prompt = resume_nudge_prompt(
                     mission_type, legal, attempt=cont.used,
                     budget=cont_cfg.max_continuations, stray_note=note)
-                if override or script:
-                    os.environ["DEVCAKE_PROMPT"] = inv_prompt
-                    cmd = composed_launch(
-                        harness, inv_prompt, plan_mode=False, model=model,
-                        extra=extra, script=script, override=override)
-                else:
-                    cmd = harness_resume_argv(
-                        harness, last_sid(chains), inv_prompt,
-                        model=model, extra=extra)
-            if decision.action == "fresh" or cmd is None:
+                os.environ["DEVCAKE_PROMPT"] = inv_prompt
+                cmd = composed_launch(
+                    harness, inv_prompt, plan_mode=False, model=model,
+                    extra=extra, script=script, override=False,
+                    session_id=last_sid(chains))
+            if relaunch == "fresh" or cmd is None:
                 # `cmd is None` is defensive only: a harness in RESUME_SPECS
                 # always has a builder arm — degrade to fresh, never crash
                 mode = "fresh"

--- a/images/common/devcake_dev/harness/launch.py
+++ b/images/common/devcake_dev/harness/launch.py
@@ -3,6 +3,8 @@
 Default: aim() has already written env/files; an operator script is
 additive (MCP add, PATH) and then the dialect argv is exec'd.
 override=True: dialect argv is not used — the operator script is the process.
+session_id set (and not override): resume dialect argv, then the same
+additive-prelude wrap as a fresh launch.
 
 Prod entrypoint and the hermetic probe call this one function.
 """
@@ -24,6 +26,7 @@ def composed_launch(
     script: str = "",
     override: bool = False,
     out_dir=None,
+    session_id: str | None = None,
 ) -> list[str]:
     body = (script or "").strip()
     if override:
@@ -32,9 +35,19 @@ def composed_launch(
                 "override_harness_adapter is set but the entrypoint "
                 "script is empty")
         return ["bash", "--noprofile", "--norc", "-c", body]
-    dialect_argv = get_dialect(template).argv(
-        prompt, plan_mode=plan_mode, model=model,
-        extra=list(extra), out_dir=out_dir)
+    dialect = get_dialect(template)
+    if session_id:
+        # Plan never continues — no plan_mode on resume (ADR-0022).
+        dialect_argv = dialect.resume_argv(
+            session_id, prompt, model=model,
+            extra=list(extra), out_dir=out_dir)
+        if dialect_argv is None:
+            raise ValueError(
+                f"harness {template!r} has no resume dialect")
+    else:
+        dialect_argv = dialect.argv(
+            prompt, plan_mode=plan_mode, model=model,
+            extra=list(extra), out_dir=out_dir)
     if not body:
         return dialect_argv
     quoted = " ".join(shlex.quote(p) for p in dialect_argv)


### PR DESCRIPTION
## Intent

When ADR-0022 continuation chooses `action == "resume"` and a Dev Type entrypoint/MCP prelude is present, relaunch through `composed_launch(..., session_id=…)` so the process actually gets **resume dialect argv** (session id in flags), not a fresh `dialect.argv` while `mode` stayed `"resume"`.

## Mission

https://linear.app/fidecastro/issue/CAKE-62/resume-really-resumes-when-an-entrypoint-script-exists

## Change

- **`composed_launch`**: optional `session_id` builds `resume_argv` then applies the same additive-prelude wrap as a fresh launch; override still ignores dialect argv (and sid).
- **`dev_entrypoint` resume arm**: always routes non-override resume through the chokepoint with `session_id`. **Override + resume** degrades to the existing fresh arm so mode/token/transcript merge stay honest (opaque script cannot take `--resume` / `-r`).
- **Tests** (red→green): prelude+sid, empty+sid equals `harness_resume_argv`, override+sid ignores sid.
- **docs/07**: one-line honesty on the launch chokepoint row.

## How to verify

```bash
./scripts/pytest_app.sh
# or targeted:
# pytest tests/test_dev_entrypoint.py tests/test_entrypoint_continuation.py
```

Local evidence this run: rebuilt `devcake/app-test`, full suite **2506 passed, 1 skipped**.

## Out of scope

- New env contracts for override scripts to self-resume
- Changing `RESUME_SPECS` / capture fixtures
- Live multi-continuation container bake of all harness images (unit/chokepoint bar per plan)