### PR TITLE
[CAKE-57] Settings export accepts named profiles

### DIFF
--- a/app/devcake/api/settings_transfer.py
+++ b/app/devcake/api/settings_transfer.py
@@ -63,13 +63,25 @@ def bundle_filename() -> str:
 
 async def export_settings_body(body: dict, *, config, dev_types,
                                skill_service) -> PlainTextResponse:
-    sections = body.get("sections") or {}
+    raw_sections = body.get("sections")
+    if raw_sections is None:
+        sections: dict = {}
+    elif not isinstance(raw_sections, dict):
+        raise HTTPException(422, "sections must be an object")
+    else:
+        sections = raw_sections
     inc_cfg = bool(sections.get("config"))
     inc_sec = bool(sections.get("secrets"))
     inc_env = bool(sections.get("setup_env"))
     if not (inc_cfg or inc_sec or inc_env):
         raise HTTPException(422, "select at least one section to export")
-    enc = body.get("encryption") or {}
+    raw_enc = body.get("encryption")
+    if raw_enc is None:
+        enc: dict = {}
+    elif not isinstance(raw_enc, dict):
+        raise HTTPException(422, "encryption must be an object")
+    else:
+        enc = raw_enc
     passphrase = None
     if inc_sec or inc_env:
         mode = enc.get("mode")
@@ -86,6 +98,7 @@ async def export_settings_body(body: dict, *, config, dev_types,
             raise HTTPException(422, "exports containing secrets or setup "
                                      "values require an encryption choice")
     source = body.get("source") or "current"
+    profile_name: str | None = None
     if source == "current":
         skill_payloads = None
         if inc_cfg and body.get("include_skills"):
@@ -96,18 +109,24 @@ async def export_settings_body(body: dict, *, config, dev_types,
             include_config=inc_cfg, include_secrets=inc_sec,
             include_credential_files=inc_sec and bool(body.get("include_credential_files")),
             include_setup_env=inc_env, skill_payloads=skill_payloads)
-    else:
-        name = str((source or {}).get("profile") or "")
+    elif isinstance(source, dict):
+        raw_profile = source.get("profile")
+        if not isinstance(raw_profile, str) or not raw_profile:
+            raise HTTPException(
+                422,
+                "source must be \"current\" or {\"profile\": \"<name>\"}")
+        profile_name = raw_profile
         if inc_env:
             raise HTTPException(422, "profiles never hold setup values — "
                                      "export setup_env from current settings")
         try:
-            stored = profiles_store.read_profile(name)
+            stored = profiles_store.read_profile(profile_name)
         except BundleError as e:
             raise HTTPException(e.status, str(e))
         for want, key in ((inc_cfg, "config"), (inc_sec, "secrets")):
             if want and key not in stored:
-                raise HTTPException(422, f"profile {name!r} has no {key} section")
+                raise HTTPException(
+                    422, f"profile {profile_name!r} has no {key} section")
         bundle = {k: v for k, v in stored.items() if k != "name"}
         bundle["sections"] = [s for s in ("config", "secrets")
                               if (s == "config" and inc_cfg) or (s == "secrets" and inc_sec)]
@@ -115,12 +134,16 @@ async def export_settings_body(body: dict, *, config, dev_types,
             bundle.pop("config", None)
         if not inc_sec:
             bundle.pop("secrets", None)
+    else:
+        raise HTTPException(
+            422,
+            "source must be \"current\" or {\"profile\": \"<name>\"}")
     if (inc_sec or inc_env) and passphrase is None:
         bundle["plaintext_secrets"] = True
     if passphrase is not None:
         bundle = protect_bundle(bundle, passphrase)
     audit_event("settings_exported",
-                f"source={'current' if source == 'current' else source.get('profile')} "
+                f"source={'current' if source == 'current' else profile_name} "
                 f"sections={'+'.join(bundle.get('sections') or [])} "
                 f"encrypted={passphrase is not None}")
     return PlainTextResponse(

--- a/app/tests/test_settings_transfer.py
+++ b/app/tests/test_settings_transfer.py
@@ -132,6 +132,30 @@ def test_export_from_profile_source(monkeypatch, tmp_path):
     assert e.value.status_code == 404
 
 
+@pytest.mark.parametrize("body,needle", [
+    ({"source": "myprofile", "sections": {"config": True}}, "source"),
+    ({"source": ["current"], "sections": {"config": True}}, "source"),
+    ({"source": "current", "sections": "config"}, "sections"),
+    ({"sections": ALL, "encryption": "passphrase"}, "encryption"),
+    ({"source": {"profile": ""}, "sections": {"config": True}}, "source"),
+    ({"source": {"name": "base"}, "sections": {"config": True}}, "source"),
+])
+def test_export_rejects_bad_body_shapes_with_422(monkeypatch, tmp_path, body, needle):
+    """Bad request shapes must be 422, never AttributeError / 500.
+
+    Contract: source is omit/\"current\" or {\"profile\": \"<name>\"};
+    sections and encryption (when present) must be objects.
+    Bare-string profile names are not accepted as shorthand.
+    """
+    from fastapi import HTTPException
+    app_main, *_ = _wire_app(monkeypatch, tmp_path)
+    with pytest.raises(HTTPException) as e:
+        run_coro(app_main.export_settings(body))
+    assert e.value.status_code == 422
+    assert needle in str(e.value.detail).lower()
+    assert "AttributeError" not in str(e.value.detail)
+
+
 # ── preview + import ─────────────────────────────────────────────────────────
 
 def test_preview_needs_passphrase_then_no_values(monkeypatch, tmp_path):


### PR DESCRIPTION
## Intent

`POST /api/v1/settings/export` validates request body shapes and returns **422** on bad input instead of AttributeError / **500**. Named-profile export already worked for `{"source": {"profile": "<name>"}}`; bare strings like `"myprofile"` (and non-object `sections` / `encryption`) now fail honestly.

## Context

Mission: [CAKE-57](https://linear.app/fidecastro/issue/CAKE-57/settings-export-accepts-named-profiles)

Consumes REVIEW_LEDGER findings (from mission text): calling `.get` on a string `source` / `sections` / `encryption` 500'd. Contract unchanged — do **not** accept bare-string profile shorthand.

## How to verify

```bash
./scripts/pytest_app.sh app/tests/test_settings_transfer.py
# observed here: 20 passed (fresh app-test bake; redis scratch net unavailable — ran docker run --network none against baked image)
```

## Risk / rollout

API-only validation gate in `export_settings_body`. SPA already sends legal shapes. No migration.

## Out of scope

- Admin SPA / ExportDialog
- Import/preview validation beyond existing gates
- Accepting `"source": "<profile>"` as new sugar