### PR TITLE
[CAKE-64] One owner for the run timeout

### DIFF
--- a/app/tests/test_repo_structural.py
+++ b/app/tests/test_repo_structural.py
@@ -211,3 +211,26 @@ def test_exit_handler_reclaims_workspace_ownership():
     assert w["host"] == {"NetworkMode": "none"}
     assert w["auto_remove"] is True
     assert h["timeout_sec"] > 0
+
+
+def test_dag_timeout_clears_max_legal_app_timeout():
+    """docs/13 §4 + docs/04 §5: app watchdog owns the kill. DAG timeout_sec
+    is belt-and-suspenders only and must clear every legal
+    AppConfig.dev_timeout_minutes (Field le) plus the documented 30-minute
+    margin — otherwise Dagu aborts first for long legal settings."""
+    from annotated_types import Le
+    from devcake.config import AppConfig
+
+    field = AppConfig.model_fields["dev_timeout_minutes"]
+    le_values = [m.le for m in field.metadata if isinstance(m, Le)]
+    assert le_values, "dev_timeout_minutes must carry a Field le= constraint"
+    field_le_minutes = le_values[0]
+
+    timeout_sec = _dag()["timeout_sec"]
+    # Independent expected rule: docs/13 §4 margin is the literal 30 minutes.
+    min_belt = (field_le_minutes + 30) * 60
+    assert timeout_sec >= min_belt, (
+        f"DAG timeout_sec={timeout_sec} must be >= "
+        f"(dev_timeout_minutes.le={field_le_minutes} + 30) * 60 "
+        f"= {min_belt} so the app watchdog owns the kill"
+    )

--- a/dagu/dags/dev-run.yaml
+++ b/dagu/dags/dev-run.yaml
@@ -28,7 +28,7 @@
 # bump past that fix, move Memory/NanoCPUs/PidsLimit up one level into
 # `host:` and delete this note. docs/13 §4 carries the same reminder.
 
-timeout_sec: 9000               # 150 min belt-and-suspenders; the app watchdog kills at 120
+timeout_sec: 88200              # (max legal app timeout 1440 + 30) * 60; app owns the kill (docs/13 §4)
 max_clean_up_time_sec: 30       # grace between SIGTERM and SIGKILL on stop
 retry_policy:
   limit: 0                      # Dagu must NOT auto-retry: DevCake owns attempt counting

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -192,7 +192,7 @@ Empty or `change-me*` bootstrap passwords refuse app boot unless
 ```yaml
 # dev-run: one run = two dependent Dev containers (ADR-0025). Only non-secret
 # params; everything else via runspec.get. $DEVCAKE_WS_HOST is dagu-service env.
-timeout_sec: 9000               # 150 min belt-and-suspenders; the app watchdog kills at 120
+timeout_sec: 88200              # (max legal app timeout 1440 + 30) * 60; app owns the kill (docs/13 §4)
 max_clean_up_time_sec: 30       # grace between SIGTERM and SIGKILL on stop
 retry_policy:
   limit: 0                      # Dagu must NOT auto-retry: DevCake owns attempt counting


### PR DESCRIPTION
## Intent

Restore the documented single-owner contract: the **app watchdog** always owns the wall-clock kill. Dagu’s DAG-level `timeout_sec` is belt-and-suspenders only and must never fire first for any legal `dev_timeout_minutes`.

## Context

Mission: [CAKE-64](https://linear.app/fidecastro/issue/CAKE-64/one-owner-for-the-run-timeout)

`AppConfig.dev_timeout_minutes` allows up to **1440** minutes while `dagu/dags/dev-run.yaml` hard-coded `timeout_sec: 9000` (150 min). For any legal setting above 150 min, Dagu aborted first — contradicting docs/04 §5 and docs/13 §4.

**Decision (plan):** raise the DAG belt to `(1440 + 30) × 60 = 88200`; do **not** cap the Field ceiling.

## Changes

- `dagu/dags/dev-run.yaml`: `timeout_sec: 88200` with formula comment
- `docs/13-deployment.md`: numeric example updated to match
- `app/tests/test_repo_structural.py`: lockstep test — live Field `le` + live DAG `timeout_sec` vs docs/13’s literal 30-minute margin

## How to verify

```bash
./scripts/pytest_app.sh tests/test_repo_structural.py::test_dag_timeout_clears_max_legal_app_timeout
# or the full structural module
./scripts/pytest_app.sh tests/test_repo_structural.py
```

## Out of scope

- Cap/`le=` changes on `dev_timeout_minutes`
- Per-run dynamic Dagu timeouts
- Watchdog / reconcile dead-status spelling drift