### PR TITLE
[CAKE-66] Forge HTTP hardening

### DIFF
--- a/app/devcake/adapters/gitea/adapter.py
+++ b/app/devcake/adapters/gitea/adapter.py
@@ -129,10 +129,16 @@ class GiteaForge:
             # access, invisible private repo) — no rate-limit carve-out on
             # self-hosted Gitea
             definitive = e.status in (401, 403, 404)
+            if e.status is None:
+                detail = "repository access failed (network)"
+            else:
+                detail = (
+                    f"repository access failed (HTTP {e.status}); the "
+                    f"token needs write:repository scope and repo access"
+                )
             return ForgeHealth(
                 ok=False, repository=repository, transient=not definitive,
-                detail=f"repository access failed (HTTP {e.status}); the "
-                       f"token needs write:repository scope and repo access")
+                detail=detail)
         can_push = bool((repo.get("permissions") or {}).get("push"))
         return ForgeHealth(
             ok=can_push, repository=repository, can_push=can_push,

--- a/app/devcake/adapters/github/adapter.py
+++ b/app/devcake/adapters/github/adapter.py
@@ -88,10 +88,14 @@ class GitHubForge:
             # repo) — except GitHub's rate-limit 403, which is transient
             definitive = e.status in (401, 403, 404) and not (
                 e.status == 403 and "rate limit" in str(e).lower())
-            hint = ("; for a fine-grained PAT, select this repository and grant "
-                    "Contents and Pull requests read/write")
+            if e.status is None:
+                detail = "repository access failed (network)"
+            else:
+                hint = ("; for a fine-grained PAT, select this repository and grant "
+                        "Contents and Pull requests read/write")
+                detail = f"repository access failed (HTTP {e.status}){hint}"
             return ForgeHealth(ok=False, repository=repository, transient=not definitive,
-                               detail=f"repository access failed (HTTP {e.status}){hint}")
+                               detail=detail)
         can_push = bool((repo.get("permissions") or {}).get("push"))
         return ForgeHealth(
             ok=can_push,

--- a/app/devcake/adapters/gitlab/adapter.py
+++ b/app/devcake/adapters/gitlab/adapter.py
@@ -97,10 +97,16 @@ class GitLabForge:
             # 401/403/404 indict the credential; anything else is transient
             definitive = e.status in (401, 403, 404) and not (
                 e.status == 403 and "rate limit" in str(e).lower())
+            if e.status is None:
+                detail = "repository access failed (network)"
+            else:
+                detail = (
+                    f"repository access failed (HTTP {e.status}); grant api and "
+                    "write_repository scopes"
+                )
             return ForgeHealth(
                 ok=False, repository=self.project, transient=not definitive,
-                detail=f"repository access failed (HTTP {e.status}); grant api and "
-                       "write_repository scopes",
+                detail=detail,
             )
         permissions = project.get("permissions") or {}
         levels = [int((permissions.get(name) or {}).get("access_level") or 0)

--- a/app/devcake/adapters/http.py
+++ b/app/devcake/adapters/http.py
@@ -15,6 +15,7 @@ adapter set's clients (`aclose_adapters`); an adapter that is simply GC'd
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 
 import httpx
@@ -52,19 +53,28 @@ async def forge_request(client: httpx.AsyncClient, method: str, url: str, *,
     three forge `_req`s let ConnectError/ReadTimeout escape raw while both
     PMO adapters wrapped correctly (the audit's first-tenant/second-tenant
     pattern). Network failures become ForgeError(status=None), which
-    health_probe's definitive-status check already reads as transient."""
+    health_probe's definitive-status check already reads as transient.
+    Success is HTTP 2xx only — 3xx raise ForgeError; non-JSON 2xx bodies
+    map through ForgeError rather than leaking json.JSONDecodeError."""
     from ..ports.forge import ForgeError
     try:
         resp = await client.request(method, url, headers=headers, **kwargs)
     except httpx.HTTPError as e:
         raise ForgeError(f"{method} {path_label} → network: {e}",
                          status=None) from e
-    if resp.status_code >= 400:
+    if resp.status_code < 200 or resp.status_code >= 300:
         raise ForgeError(f"{method} {path_label} → {resp.status_code}: "
                          f"{resp.text[:200]}", status=resp.status_code)
     if raw:                           # file_content wants bytes, not JSON
         return resp.content
-    return resp.json() if resp.text else None
+    if not resp.text:
+        return None
+    try:
+        return resp.json()
+    except json.JSONDecodeError as e:
+        raise ForgeError(
+            f"{method} {path_label} → {resp.status_code}: non-JSON body: "
+            f"{resp.text[:200]}", status=resp.status_code) from e
 
 
 def aclose_adapters(adapters) -> None:

--- a/app/tests/test_forge_error_contract.py
+++ b/app/tests/test_forge_error_contract.py
@@ -49,7 +49,8 @@ def test_network_failure_surfaces_as_forge_error_status_none(cls, url):
 @pytest.mark.parametrize("cls,url", FORGES)
 def test_health_probe_reports_network_failure_as_transient(cls, url):
     """A probe must NEVER raise to the admin UI, and status=None is not a
-    credential indictment — transient, retried."""
+    credential indictment — transient, retried. Detail must name a network
+    failure honestly — never the literal ``HTTP None``."""
     def handler(req):
         raise httpx.ReadTimeout("timed out", request=req)
 
@@ -57,6 +58,8 @@ def test_health_probe_reports_network_failure_as_transient(cls, url):
     health = run(forge.health_probe())
     assert health.ok is False
     assert health.transient is True
+    assert "HTTP None" not in health.detail
+    assert "network" in health.detail.lower()
 
 
 @pytest.mark.parametrize("cls,url", FORGES)
@@ -139,6 +142,8 @@ def test_forge_request_returns_json_and_raw_bytes():
     def handler(req):
         if req.url.path.endswith("/raw"):
             return httpx.Response(200, content=b"blob-bytes")
+        if req.url.path.endswith("/empty"):
+            return httpx.Response(200, text="")
         return httpx.Response(200, json={"ok": True})
 
     client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
@@ -146,8 +151,64 @@ def test_forge_request_returns_json_and_raw_bytes():
         body = run(forge_request(client, "GET", "http://example/j",
                                  path_label="/j"))
         assert body == {"ok": True}
+        empty = run(forge_request(client, "GET", "http://example/empty",
+                                  path_label="/empty"))
+        assert empty is None
         raw = run(forge_request(client, "GET", "http://example/raw",
                                 path_label="/raw", raw=True))
         assert raw == b"blob-bytes"
+    finally:
+        run(client.aclose())
+
+
+def test_forge_request_refuses_3xx_as_forge_error():
+    """3xx must not silently succeed — httpx follows redirects by default
+    in many setups, but a MockTransport that returns 302 must still raise
+    ForgeError with that status, never a parsed body."""
+    import json as json_mod
+
+    from devcake.adapters.http import forge_request
+
+    def handler(req):
+        return httpx.Response(
+            302, text='{"ok": false, "redirect": true}',
+            headers={"content-type": "application/json"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ForgeError) as exc:
+            run(forge_request(client, "GET", "http://example/x",
+                              path_label="/x"))
+        assert exc.value.status == 302
+        assert "302" in str(exc.value)
+    except json_mod.JSONDecodeError:
+        pytest.fail("3xx must raise ForgeError, not succeed with a body")
+    finally:
+        run(client.aclose())
+
+
+def test_forge_request_maps_non_json_2xx_to_forge_error():
+    """A 200 with a non-JSON body must become ForgeError(status=200), not
+    leak json.JSONDecodeError past the ForgeError boundary."""
+    import json as json_mod
+
+    from devcake.adapters.http import forge_request
+
+    def handler(req):
+        return httpx.Response(
+            200, text="not-json",
+            headers={"content-type": "text/plain"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ForgeError) as exc:
+            run(forge_request(client, "GET", "http://example/x",
+                              path_label="/x"))
+        assert exc.value.status == 200
+        assert not isinstance(exc.value, json_mod.JSONDecodeError)
+    except json_mod.JSONDecodeError:
+        pytest.fail("non-JSON 2xx must raise ForgeError, not JSONDecodeError")
     finally:
         run(client.aclose())

--- a/docs/06-forge-adapter.md
+++ b/docs/06-forge-adapter.md
@@ -42,7 +42,7 @@ class ForgePort(Protocol):
         # the copy-pasteable approve+merge command footer (D14, §4)
 ```
 
-All adapters raise the same `ForgeError` — callers never see forge-native or `httpx` exception types. `status` carries the HTTP code when one exists; **network / transport failures use `status=None`** (health probes treat that as transient). The wire call is ONE chokepoint: `adapters/http.forge_request` (ADR-0034; pinned by `test_forge_error_contract.py`). Adapter `_req` methods must call it rather than re-implementing the map.
+All adapters raise the same `ForgeError` — callers never see forge-native or `httpx` exception types. `status` carries the HTTP code when one exists; **network / transport failures use `status=None`** (health probes treat that as transient). Success on the wire is **HTTP 2xx only** — **3xx** raise `ForgeError` with that status (no silent redirect success); non-JSON **2xx** bodies also raise `ForgeError` (never raw `json.JSONDecodeError`). The wire call is ONE chokepoint: `adapters/http.forge_request` (ADR-0034; pinned by `test_forge_error_contract.py`). Adapter `_req` methods must call it rather than re-implementing the map.
 
 Normalized DTOs (pydantic models in `ports/forge.py`):
 
@@ -212,7 +212,7 @@ Two layers:
 | 1 | Port conformance: registered adapters implement every `ForgePort` method with signatures that match the protocol |
 | 2 | `mergeable()` maps every row of the §5 signal table (incl. the GitLab legacy fallback) **and** Gitea's boolean-only True/False/absent → True/False/None; unknown states → `None` |
 | 3 | `merge()` retries a transient GitHub 409 twice then succeeds/raises; non-retryable 405s raise; Gitea's "try again later" 405 retries inside the adapter while approvals/already-merged 405s probe then raise/absorb (§7a) |
-| 4 | Error normalization: every forge `_req` routes through `adapters/http.forge_request` → `ForgeError` only (`status=None` for network; HTTP ≥400 preserves status). Direct chokepoint + all three adapter classes pinned in `test_forge_error_contract.py` |
+| 4 | Error normalization: every forge `_req` routes through `adapters/http.forge_request` → `ForgeError` only (`status=None` for network; success is **2xx**; **3xx**/non-2xx preserve status; non-JSON 2xx map through `ForgeError`). Direct chokepoint + all three adapter classes pinned in `test_forge_error_contract.py` |
 | 5 | DTO shape parity: `get_pr_by_branch`/`pr_state` normalize GitHub/GitLab/Gitea payloads to identical `PullRequest` values; Gitea filters head client-side (no `head=` query); no PR → `None` |
 | 6 | `BranchProtection` DTO: GitHub `protected` flag; GitLab 404 → `protected=False` |
 | 7 | `api_base`: GitHub default vs GHE override; GitLab origin derived from the repo URL, explicit override wins, project path stays URL-encoded |


### PR DESCRIPTION
## Intent

Harden the shared forge wire call (`adapters/http.forge_request`) so HTTP outcomes never silently succeed or leak non-`ForgeError` exceptions, and make forge health-probe failure copy honest for network failures.

Mission: https://linear.app/fidecastro/issue/CAKE-66/forge-http-hardening

## Changes

- **`forge_request`**: success is HTTP **2xx** only (3xx raise `ForgeError` with status); non-JSON 2xx bodies map through `ForgeError` instead of leaking `json.JSONDecodeError`; empty body still → `None`; `raw=True` unchanged after the status gate.
- **GitHub / GitLab / Gitea `health_probe`**: when `ForgeError.status is None`, detail says network failure (never the literal `HTTP None`); credential-scoped copy kept when status is an int.
- **`docs/06-forge-adapter.md`**: checklist row 4 + prose match the hardened contract.
- **`test_forge_error_contract.py`**: pins 3xx refusal, non-JSON → `ForgeError`, and probe detail honesty.

## How to verify

```bash
# rebake then pytest (or hermetic docker run of app-test on buildah hosts)
./scripts/pytest_app.sh app/tests/test_forge_error_contract.py app/tests/test_connection_test.py
```

Evidence on this run (rebaked `devcake/app-test:latest`, hermetic `docker run` — host cannot create throwaway redis networks): **106 passed** across `test_forge_error_contract.py`, `test_connection_test.py`, `test_forge.py`, `test_forge_http.py`, `test_forge_runtime.py`.

## Out of scope

Forge Protocol/factory/capability redesign; PMO/Dagu/provisioner HTTP clients; live contract battery / external forge tokens; definitive vs transient status-set changes.

## Deviations

None from PLAN_1.md. Local verification used Dockerfile `--target test` + hermetic `docker run` because this agent host lacks Buildx bake and cannot create podman networks (`netavark: iptables`).