### PR TITLE
[CAKE-67] Gitea adapter robustness

### DIFF
--- a/app/devcake/adapters/gitea/adapter.py
+++ b/app/devcake/adapters/gitea/adapter.py
@@ -146,18 +146,15 @@ class GiteaForge:
         IGNORES a `head` query param (live-verified) — filter client-side,
         paginating so a busy repo (>50 PRs) doesn't hide our PR beyond page 1
         (review finding #10)."""
-        matching: list[dict] = []
-        page = 1
-        while page <= 20:                # bound: 1000 PRs is plenty of headroom
-            batch = await self._req(
-                "GET", f"/pulls?state=all&sort=recentupdate&limit=50&page={page}")
-            if not batch:
-                break
-            matching.extend(p for p in batch
-                            if ((p.get("head") or {}).get("ref")) == branch)
-            if len(batch) < 50:
-                break
-            page += 1
+        from .._toolkit import paginate_rest
+        raw, _ = await paginate_rest(
+            lambda page: self._req(
+                "GET",
+                f"/pulls?state=all&sort=recentupdate&limit=50&page={page}"),
+            page_size=50, max_pages=20,
+            what="gitea get_pr_by_branch", on_ceiling="warn")
+        matching = [p for p in raw
+                    if ((p.get("head") or {}).get("ref")) == branch]
         if not matching:
             return None
         pr = max(matching, key=lambda p: p.get("number", 0))
@@ -252,22 +249,17 @@ class GiteaForge:
 
     async def pr_files(self, pr_number: int) -> list[PRFile]:
         """Changed files across the PR (paginated — large changesets)."""
-        out: list[PRFile] = []
-        page = 1
-        while True:
-            batch = await self._req(
-                "GET", f"/pulls/{pr_number}/files?limit=50&page={page}")
-            if not batch:
-                break
-            for f in batch:
-                out.append(PRFile(path=f.get("filename", ""),
-                                  status=f.get("status", "modified"),
-                                  additions=int(f.get("additions") or 0),
-                                  deletions=int(f.get("deletions") or 0)))
-            if len(batch) < 50:
-                break
-            page += 1
-        return out
+        from .._toolkit import paginate_rest
+        raw, _ = await paginate_rest(
+            lambda page: self._req(
+                "GET", f"/pulls/{pr_number}/files?limit=50&page={page}"),
+            page_size=50, max_pages=40,
+            what=f"gitea pr_files #{pr_number}", on_ceiling="warn")
+        return [PRFile(path=f.get("filename", ""),
+                       status=f.get("status", "modified"),
+                       additions=int(f.get("additions") or 0),
+                       deletions=int(f.get("deletions") or 0))
+                for f in raw]
 
     async def file_content(self, path: str, ref: str) -> bytes:
         """Raw bytes of a file at a ref (base64-safe — non-code deliverables

--- a/app/devcake/adapters/gitea/provision.py
+++ b/app/devcake/adapters/gitea/provision.py
@@ -212,8 +212,10 @@ class GiteaProvisioner:
             "GET", f"/repos/{owner_repo}/branch_protections/main",
             tolerate=(404,))
         if existing is None:
+            # 409 only: concurrent create race. 403/422 must fail loud —
+            # silent protect-skip left required_approvals unenforceable.
             await self._req("POST", f"/repos/{owner_repo}/branch_protections",
-                            tolerate=(403, 409, 422), json=desired)
+                            tolerate=(409,), json=desired)
             existing = await self._req(
                 "GET", f"/repos/{owner_repo}/branch_protections/main",
                 tolerate=(404,))
@@ -221,7 +223,6 @@ class GiteaProvisioner:
                 existing.get("approvals_whitelist_username") or []):
             await self._req(
                 "PATCH", f"/repos/{owner_repo}/branch_protections/main",
-                tolerate=(403, 404, 422),
                 json={"enable_approvals_whitelist": True,
                       "approvals_whitelist_username": [REVIEWER_USER]})
 
@@ -557,30 +558,31 @@ class GiteaProvisioner:
             username=ACTIVITY_RO_USER, token=token)
 
     async def list_activity_repos(self) -> list[InternalRepo]:
-        """Every activity-* repo in OPERATOR_ORG — PAGINATED (unlike the
-        legacy list_repos limit=50 read; activity repos will exceed a page),
-        prefix-filtered so operator repos and the skill-store never appear."""
-        repos, page = [], 1
-        while True:
-            batch = await self._req(
+        """Every activity-* repo in OPERATOR_ORG — paginated via
+        paginate_rest, prefix-filtered so operator repos and the skill-store
+        never appear."""
+        from .._toolkit import paginate_rest
+        batch, _ = await paginate_rest(
+            lambda page: self._req(
                 "GET", f"/orgs/{OPERATOR_ORG}/repos?limit=50&page={page}",
-                tolerate=(404,)) or []
-            for r in batch:
-                name = r.get("name") or ""
-                if not name.startswith(ACTIVITY_PREFIX):
-                    continue
-                # activity-{instance}-{key}: mission key = after the first
-                # hyphen past the instance (the admin-surface idiom)
-                stem = name[len(ACTIVITY_PREFIX):]
-                repos.append(InternalRepo(
-                    name=name, mission_key=stem.split("-", 1)[-1],
-                    html_url=f"{self.public_url}/{OPERATOR_ORG}/{name}",
-                    clone_url=f"{self.url}/{OPERATOR_ORG}/{name}.git",
-                    size_kb=int(r.get("size") or 0),
-                    updated_at=r.get("updated_at") or ""))
-            if len(batch) < 50:
-                return repos
-            page += 1
+                tolerate=(404,)) or [],
+            page_size=50, max_pages=40,
+            what="gitea list_activity_repos", on_ceiling="warn")
+        repos = []
+        for r in batch:
+            name = r.get("name") or ""
+            if not name.startswith(ACTIVITY_PREFIX):
+                continue
+            # activity-{instance}-{key}: mission key = after the first
+            # hyphen past the instance (the admin-surface idiom)
+            stem = name[len(ACTIVITY_PREFIX):]
+            repos.append(InternalRepo(
+                name=name, mission_key=stem.split("-", 1)[-1],
+                html_url=f"{self.public_url}/{OPERATOR_ORG}/{name}",
+                clone_url=f"{self.url}/{OPERATOR_ORG}/{name}.git",
+                size_kb=int(r.get("size") or 0),
+                updated_at=r.get("updated_at") or ""))
+        return repos
 
     async def delete_activity_repo(self, repo_name: str) -> None:
         """Clear-sweep delete. Belt-and-braces: refuses non-activity names
@@ -626,15 +628,18 @@ class GiteaProvisioner:
     # ── admin surface ────────────────────────────────────────────────────────
 
     async def list_repos(self) -> list[InternalRepo]:
-        repos = await self._req("GET", f"/orgs/{ORG}/repos?limit=50") or []
+        from .._toolkit import paginate_rest
+        repos, _ = await paginate_rest(
+            lambda page: self._req(
+                "GET", f"/orgs/{ORG}/repos?limit=50&page={page}") or [],
+            page_size=50, max_pages=40,
+            what="gitea list_repos", on_ceiling="warn")
         out = []
         for r in repos:
-            html = r.get("html_url", "")
-            # rewrite the in-container ROOT_URL host to the operator-facing one
             out.append(InternalRepo(
                 name=r["name"],
                 mission_key=r["name"].split("-", 1)[-1].upper(),
-                html_url=html,
+                html_url=r.get("html_url", ""),
                 clone_url=f"{self.url}/{ORG}/{r['name']}.git",
                 size_kb=int(r.get("size") or 0),
                 open_prs=int(r.get("open_pr_counter") or 0),

--- a/app/tests/test_forge.py
+++ b/app/tests/test_forge.py
@@ -405,6 +405,67 @@ def test_gitea_get_pr_by_branch_no_server_head_filter():
     assert "state=all" in seen[0]
 
 
+def test_gitea_get_pr_by_branch_finds_match_beyond_page_one():
+    """Busy repos (>50 PRs) hide the mission branch past page 1 — the
+    adapter must walk pages and still return the newest matching PR."""
+    target = "devcake/DEV-page2"
+    page1 = [
+        {"number": i, "html_url": f"https://gt/{i}", "state": "open",
+         "merged": False, "head": {"ref": f"noise-{i}"}}
+        for i in range(1, 51)
+    ]
+    page2 = [
+        {"number": 51, "html_url": "https://gt/51", "state": "closed",
+         "merged": True, "head": {"ref": target}},
+        {"number": 52, "html_url": "https://gt/52", "state": "open",
+         "merged": False, "head": {"ref": "other"}},
+    ]
+    pages = {1: page1, 2: page2}
+    forge = gt()
+
+    async def _req(method, path, **kw):
+        assert "page=" in path
+        page = int(path.split("page=")[-1].split("&")[0])
+        return pages.get(page, [])
+
+    forge._req = _req
+    pr = run_coro(forge.get_pr_by_branch(target))
+    assert pr is not None
+    assert pr.number == 51
+    assert pr.merged is True
+    assert pr.state == "closed"
+
+
+def test_gitea_pr_files_concatenates_across_pages():
+    """Large changesets span pages — pr_files must return every path."""
+    from devcake.ports.forge import PRFile
+
+    page1 = [
+        {"filename": f"f{i}.py", "status": "modified",
+         "additions": 1, "deletions": 0}
+        for i in range(50)
+    ]
+    page2 = [
+        {"filename": "tail.py", "status": "added",
+         "additions": 3, "deletions": 1},
+    ]
+    pages = {1: page1, 2: page2}
+    forge = gt()
+
+    async def _req(method, path, **kw):
+        assert "/pulls/9/files" in path
+        page = int(path.split("page=")[-1].split("&")[0])
+        return pages.get(page, [])
+
+    forge._req = _req
+    files = run_coro(forge.pr_files(9))
+    assert len(files) == 51
+    assert files[0] == PRFile(path="f0.py", status="modified",
+                              additions=1, deletions=0)
+    assert files[-1] == PRFile(path="tail.py", status="added",
+                               additions=3, deletions=1)
+
+
 def test_get_pr_by_branch_encodes_hash_in_query():
     """Forge-issue mission keys mint branches with `#` (owner/repo#N). An
     unescaped `#` is a URL fragment — the forge never sees the head /

--- a/app/tests/test_internal_forge_provision.py
+++ b/app/tests/test_internal_forge_provision.py
@@ -403,6 +403,53 @@ def test_adopt_repairs_stripped_whitelist(tmp_path, monkeypatch):
     assert patched and patched[0]["approvals_whitelist_username"] == ["devcake-reviewer"]
 
 
+def test_ensure_protection_post_403_fails_loud(tmp_path, monkeypatch):
+    """Branch-protection create must not swallow 403 — provisioning that
+    silently ships without protection leaves merges forever-broken."""
+
+    def handler(request):
+        path = request.url.path
+        if request.method == "GET" and path.endswith("branch_protections/main"):
+            return httpx.Response(404, json={})
+        if request.method == "POST" and path.endswith("/branch_protections"):
+            return httpx.Response(403, json={"message": "forbidden"})
+        if request.method == "POST" and path.endswith("/tokens"):
+            return httpx.Response(201, json={"sha1": "tok-1234"})
+        return httpx.Response(201, json={})
+
+    prov = _prov(handler, tmp_path, monkeypatch)
+    with pytest.raises(RuntimeError) as e:
+        run_coro(prov.ensure_mission_repo("linear", "T-prot"))
+    assert "403" in str(e.value)
+    assert "branch_protections" in str(e.value)
+
+
+def test_ensure_protection_patch_422_fails_loud(tmp_path, monkeypatch):
+    """Repair PATCH of a stripped whitelist must fail loud on 422."""
+
+    def handler(request):
+        path = request.url.path
+        if request.method == "GET" and "/repos/devcake-repos/taken" in path \
+                and "branch_protections" not in path:
+            return httpx.Response(200, json={"name": "taken"})
+        if path.endswith("branch_protections/main"):
+            if request.method == "PATCH":
+                return httpx.Response(422, json={"message": "invalid"})
+            return httpx.Response(200, json={
+                "branch_name": "main", "required_approvals": 1,
+                "enable_approvals_whitelist": True,
+                "approvals_whitelist_username": []})
+        if request.method == "POST" and path.endswith("/tokens"):
+            return httpx.Response(201, json={"sha1": "tok-1234"})
+        return httpx.Response(201, json={})
+
+    prov = _prov(handler, tmp_path, monkeypatch)
+    with pytest.raises(RuntimeError) as e:
+        run_coro(prov.create_operator_repo("taken"))
+    assert "422" in str(e.value)
+    assert "branch_protections" in str(e.value)
+
+
 # ── activity repos (ADR-0014 D4) ─────────────────────────────────────────────
 
 import hashlib
@@ -587,6 +634,31 @@ def test_list_activity_repos_prefix_filter_paginated(tmp_path, monkeypatch):
     assert [r.name for r in repos] == ["activity-linear-t-1",
                                       "activity-linear-t-2"]
     assert repos[0].mission_key == "t-1"
+
+
+def test_list_repos_walks_past_first_page(tmp_path, monkeypatch):
+    """Mission-org list_repos must not stop at limit=50 — page 2+ repos
+    remain visible to the admin Repositories surface."""
+    page1 = [{"name": f"linear-t-{i}", "html_url": f"http://gitea/r{i}",
+              "size": 1, "open_pr_counter": 0, "updated_at": "2026-08-01"}
+             for i in range(1, 51)]
+    page2 = [{"name": "linear-t-51", "html_url": "http://gitea/r51",
+              "size": 2, "open_pr_counter": 1, "updated_at": "2026-08-02"}]
+    pages = {1: page1, 2: page2}
+    seen_pages = []
+
+    def handler(request):
+        assert request.url.path == "/api/v1/orgs/devcake-internal/repos"
+        page = int(request.url.params.get("page", "1"))
+        seen_pages.append(page)
+        return httpx.Response(200, json=pages.get(page, []))
+
+    prov = _prov(handler, tmp_path, monkeypatch)
+    repos = run_coro(prov.list_repos())
+    assert [r.name for r in repos] == [f"linear-t-{i}" for i in range(1, 52)]
+    assert repos[-1].mission_key == "T-51"
+    assert repos[-1].open_prs == 1
+    assert seen_pages == [1, 2]
 
 
 def test_delete_activity_repo_guarded(tmp_path, monkeypatch):


### PR DESCRIPTION
## Intent

Consume REVIEW_LEDGER medium/small Gitea forge findings in one PR: real REST pagination via `_toolkit.paginate_rest`, loud branch-protection create/repair failures, honest multi-page `list_repos`, and deletion of the stale `html_url` ROOT_URL rewrite comment.

Mission: https://linear.app/fidecastro/issue/CAKE-67/gitea-adapter-robustness

## Changes

- `GiteaForge.get_pr_by_branch` / `pr_files` — hand-rolled loops → `paginate_rest` (max_pages 20 / 40, page_size 50, `on_ceiling=warn`)
- `GiteaProvisioner.list_repos` — paginate past the first 50; drop stale rewrite comment (body still assigns `html_url` unchanged)
- `GiteaProvisioner.list_activity_repos` — same chokepoint; prefix filter preserved
- `_ensure_protection` — no longer tolerates 403/422 on POST/PATCH (POST keeps 409 for concurrent-create race only); GET still tolerates 404

## How to verify

```bash
./scripts/pytest_app.sh tests/test_internal_forge_provision.py tests/test_forge.py
# or PYTHONPATH=app python3.12 -m pytest app/tests/test_internal_forge_provision.py app/tests/test_forge.py -q
```

Local proof on this agent host: rebuilt `devcake/app-test` then 98/98 on touched suites; full image suite 2511 passed (1 Redis-dependent clear-body failure — host cannot create throwaway Redis network). CI is the merge gate for Redis live + full compose.

## Risk / rollout

Gitea-only adapter/provisioner behavior. Loud protection failures will surface provisioning errors that previously left repos unprotected — intentional fail-loud. No Protocol/registry changes; no GitHub/GitLab edits.

## Out of scope

ForgePort redesign, live contract battery, inventing `html_url` rewrite behavior.