### PR TITLE
[CAKE-71] Dispatch sorts survive naive timestamps

### DIFF
--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -6,7 +6,7 @@ import base64
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 from opentelemetry import trace
@@ -54,7 +54,7 @@ def resolve_repo(mgr, mission: Mission, all_runs: list | None = None):
         (r for r in all_runs
          if r.mission_pmo_id == mission.pmo_id and mgr._run_is_ours(r)
          and r.mission_type != "STEWARD"),
-        key=lambda r: r.created_at, reverse=True)
+        key=lambda r: aware(r.created_at), reverse=True)
     return resolve_repo(mission, mgr.instance,
                         set(mgr.forges.instances), history)
 
@@ -187,8 +187,7 @@ async def resolve_blocker_work(
                 if getattr(r, "pmo_ref", "") in res.accepted_pmo_refs]
         runs_sorted = sorted(
             runs,
-            key=lambda r: getattr(r, "created_at", None) or datetime.min.replace(
-                tzinfo=timezone.utc),
+            key=lambda r: aware(r.created_at),
             reverse=True)
         repo_ref = next((r.repo_ref for r in runs_sorted if r.repo_ref), None)
         if not repo_ref:

--- a/app/tests/test_blocker_work.py
+++ b/app/tests/test_blocker_work.py
@@ -294,6 +294,27 @@ def test_resolve_blocker_work_unmountable_skipped(tmp_path):
     assert any("unavailable" in s for s in skips)
 
 
+def test_resolve_blocker_work_sorts_mixed_naive_aware_created_at(tmp_path):
+    """Naive + aware Run.created_at must not TypeError the blocker sort;
+    newest wall-clock after aware() (naive treated as UTC) wins the mount."""
+    a = _mission("a", "T-A", status="done")
+    b = _mission("b", "T-B", blocked_by=["a"])
+    older = _run(
+        "a", "T-A", "repo-older",
+        created=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
+    newer = _run(
+        "a", "T-A", "repo-newer",
+        created=datetime(2026, 1, 2, 12, 0, 0))  # naive
+    newer.run_id = "LINEAR-T-A-2-EXECUTE-BBBBBB"
+    mgr = make_mission_manager(tmp_path, pmo=BlockerPMO({"a": a, "b": b}),
+                               internal_forge=_ROInternal())
+    entries, skips, _notes = run_coro(
+        dispatch.resolve_blocker_work(
+            mgr, b, "primary", [older, newer]))
+    assert entries == [{"repo_ref": "repo-newer", "mission_key": "T-A"}]
+    assert skips == []
+
+
 def test_blocker_repos_note_lists_paths(tmp_path):
     mgr = make_mission_manager(tmp_path)
     note = dispatch._blocker_repos_note(

--- a/app/tests/test_repo_routing.py
+++ b/app/tests/test_repo_routing.py
@@ -270,6 +270,45 @@ def test_resolve_repo_history_assembly(tmp_path):
     assert name == "beta" and reason is None      # sticky = newest repo_ref
 
 
+def test_resolve_repo_sticky_survives_mixed_naive_aware_created_at(tmp_path):
+    """Sticky history sort must not TypeError on mixed naive/aware created_at;
+    newest after aware() (naive as UTC) wins."""
+    from fakes import FakeForgeRuntime, make_mission_manager
+    from devcake.adapters.files.run_store import RunStore
+    import devcake.domain.repo_routing as rr
+
+    store = RunStore(tmp_path / "runs")
+    older = _run("alpha")
+    older.mission_pmo_id = "p1"
+    older.pmo_ref = "linear"
+    older.created_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    newer = _run("beta", seq=2)
+    newer.mission_pmo_id = "p1"
+    newer.pmo_ref = "linear"
+    newer.created_at = datetime(2026, 1, 2, 12, 0, 0)  # naive
+    store.save(older)
+    store.save(newer)
+
+    fr = FakeForgeRuntime(object())
+    fr._inst.name = "main"
+    mgr = make_mission_manager(
+        instance=INST,
+        forge_runtime=fr,
+        runs=type("Runs", (), {"store": store})(),
+    )
+    orig = rr.resolve_repo
+
+    def spy(mission, instance, names, history):
+        return orig(mission, instance, {"alpha", "beta"}, history)
+
+    rr.resolve_repo = spy
+    try:
+        name, reason = dispatch.resolve_repo(mgr, _m())
+    finally:
+        rr.resolve_repo = orig
+    assert name == "beta" and reason is None
+
+
 def test_internal_repo_naming_and_port_helper():
     """The internal-repo naming convention lives on the PORT (domain may
     derive it to detect prior internal routing across restarts) — not in the


### PR DESCRIPTION
## Intent

Two run-history sorts in `dispatch.py` compared raw `Run.created_at`. A mix of naive and aware datetimes raised `TypeError` and degraded the poll segment. Both sorts now normalize through `domain.run.aware`; the dead `datetime.min` fallback on the blocker-work sort is removed (`Run.created_at` is always set).

## Mission

https://linear.app/fidecastro/issue/CAKE-71/dispatch-sorts-survive-naive-timestamps

## How to verify

```bash
./scripts/pytest_app.sh app/tests/test_blocker_work.py app/tests/test_repo_routing.py
```

(or rebake `app-test` then pytest those modules). New mixed naive/aware tests must pass; existing blocker-work / repo-routing suites stay green.

## Risk / rollout

Pure domain sort fix on an existing chokepoint. No config, schema, or API change.

## Out of scope

- Reworking `backend_health._aware` or merging it with `run.aware`
- Scanning every other sort in the codebase
- Docs updates