### PR TITLE
[CAKE-78] Grok OAuth refresh leaves the event loop

### DIFF
--- a/app/devcake/domain/grok_oauth.py
+++ b/app/devcake/domain/grok_oauth.py
@@ -27,7 +27,6 @@ log = logging.getLogger("devcake.grok_oauth")
 # Refresh slightly early so an access token never expires mid-boot.
 EXPIRY_SLACK_S = 120.0
 DEFAULT_TOKEN_URL = "https://auth.x.ai/oauth2/token"
-GROK_AUTH_FILENAME = "grok-auth.json"
 
 
 class CredentialRefreshError(Exception):

--- a/app/devcake/domain/runs.py
+++ b/app/devcake/domain/runs.py
@@ -9,6 +9,7 @@ RunBootstrap; this module owns ingress, kill, and hello-specific fields.
 
 from __future__ import annotations
 
+import asyncio
 import hmac
 import logging
 import os
@@ -262,7 +263,9 @@ class RunManager:
             refresh_err: str | None = None
             if run.state in ("dispatched", "running"):
                 try:
-                    secret = self._runspec_secret(run)
+                    # Host-side Grok OAuth refresh (flock + sync httpx) must
+                    # not monopolize the event loop during runspec.get.
+                    secret = await asyncio.to_thread(self._runspec_secret, run)
                 except Exception as e:  # noqa: BLE001 — narrowed to CredentialRefreshError below; other types re-raise
                     # Fail closed at inject: host-side Grok OAuth refresh.
                     from .grok_oauth import CredentialRefreshError

--- a/app/tests/test_grok_oauth.py
+++ b/app/tests/test_grok_oauth.py
@@ -194,3 +194,88 @@ def test_ensure_fresh_lock_serializes_second_refresh(tmp_path):
     once()
     once()
     assert state["n"] == 1
+
+
+def test_runspec_get_oauth_refresh_does_not_block_event_loop(
+        tmp_path, monkeypatch):
+    """runspec.get must leave the asyncio loop free while host Grok OAuth
+    refresh blocks (flock + sync token POST). A concurrent probe on the
+    same loop must complete before the blocking refresh returns."""
+    import asyncio
+
+    from devcake.adapters.files.run_store import RunStore
+    from devcake.config import AppConfig, DevType, PMOInstance, RepoInstance
+    from devcake.domain.run import Run
+    from devcake.domain.runs import RunManager
+    from fakes import FakeForgeRuntime, make_mission_manager
+
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import secrets as secrets_store
+    secrets_store.write_connection_secret(
+        "repo", "main", "token", "ghp_write_token_for_tests_0001")
+
+    now = time.time()
+    auth_path = tmp_path / "secrets" / "main-dev" / "grok-auth.json"
+    auth_path.parent.mkdir(parents=True)
+    auth_path.write_text(_cli_file(exp_unix=now - 60, refresh="rt-block"))
+
+    order: list[str] = []
+    block_s = 0.35
+
+    class BlockingPort:
+        def refresh(self, *, refresh_token, client_id=None, token_url="",
+                    timeout=15.0):
+            assert refresh_token == "rt-block"
+            time.sleep(block_s)
+            order.append("refresh_return")
+            return TokenRefreshResult(
+                access_token=_jwt(int(now + 9000), iat=int(now)),
+                refresh_token="rt-new",
+                expires_in=9000.0,
+            )
+
+    cfg = AppConfig()
+    cfg.repos = [RepoInstance(name="main", url="https://github.com/o/r")]
+    mission_mgr = make_mission_manager(
+        config=cfg,
+        instance=PMOInstance(name="linear", team_key="DEV", repos=["main"]),
+        forge_runtime=FakeForgeRuntime(object(), inst=cfg.repos[0]),
+        dev_types={
+            "main-dev": DevType(name="main-dev", harness_template="grok-build"),
+        },
+    )
+    mission_mgr.oidc_tokens = BlockingPort()
+
+    replies: list[tuple] = []
+
+    class FakeMessaging:
+        async def reply(self, run_id, kind, payload):
+            replies.append((kind, payload))
+
+        async def delete_runspec_result(self, rid):
+            pass
+
+    store = RunStore(tmp_path / "runs")
+    manager = RunManager(store, FakeMessaging(), executor=None,
+                         finalizer=mission_mgr)
+    run = Run(run_id="T-1-1-EXECUTE-AAAAAA", mission_key="T-1",
+              mission_type="EXECUTE", dev_type="main-dev", seq=1,
+              repo_ref="main", state="dispatched")
+    store.save(run)
+
+    async def probe():
+        await asyncio.sleep(0.05)
+        order.append("probe")
+
+    async def exercise():
+        await asyncio.gather(
+            manager.handle(run.run_id, "runspec.get", {}),
+            probe(),
+        )
+
+    asyncio.new_event_loop().run_until_complete(exercise())
+
+    assert replies and replies[-1][0] == "runspec.result"
+    assert "probe" in order and "refresh_return" in order
+    assert order.index("probe") < order.index("refresh_return"), (
+        f"event loop starved during OAuth refresh; order={order}")


### PR DESCRIPTION
## Intent

Host-side Grok OAuth refresh (`fcntl.flock` + sync `httpx` via `OidcTokenPort.refresh`) ran inline on the asyncio event loop during `runspec.get`, freezing the control plane for the token HTTP wait. This PR offloads that blocking secret build with `asyncio.to_thread` and deletes the unused `GROK_AUTH_FILENAME` constant.

Mission: https://linear.app/fidecastro/issue/CAKE-78/grok-oauth-refresh-leaves-the-event-loop

## What changed

- `RunManager._handle_inner` (`runspec.get`): `await asyncio.to_thread(self._runspec_secret, run)` so flock + token refresh run in a worker thread; `CredentialRefreshError` fail-closed mapping unchanged.
- `domain/grok_oauth.py`: remove unused `GROK_AUTH_FILENAME` (dispatch already compares the literal `"grok-auth.json"`).
- Test-first probe: concurrent coroutine must complete before a blocking fake refresh returns.

## How to verify

```bash
./scripts/pytest_app.sh tests/test_grok_oauth.py tests/test_harness.py
# or: PYTHONPATH=app python3.12 -m pytest app/tests/test_grok_oauth.py app/tests/test_harness.py -q
```

Observed: 35 passed (fresh `devcake/app-test` image + local PYTHONPATH=app).

## Out of scope

Async `OidcTokenPort` / `httpx.AsyncClient`; making `_credential_spec` / `runspec_secret_payload` async; replacing flock with an asyncio lock.