### PR TITLE
[CAKE-72] Clear-runs route ratchet sees nested statements

### DIFF
--- a/app/devcake/api/clear.py
+++ b/app/devcake/api/clear.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+from opentelemetry import trace
 
 from ..adapters.dagu import DaguExecutor
 from ..adapters.files import RunLogStore, RunStore
@@ -22,6 +23,10 @@ from ..domain import failure_taxonomy
 from ..telemetry import OO_ORG, OO_URL
 
 log = logging.getLogger("devcake.clear")
+
+# ProxyTracer (api/poll.py precedent): resolves the real provider per span
+# start, so module scope needs no telemetry install.
+tracer = trace.get_tracer("devcake")
 
 DATA_DIR = Path(os.environ.get("DEVCAKE_DATA_DIR", "/data"))
 STATE_DIR = DATA_DIR / "state"
@@ -384,3 +389,63 @@ async def clear_all(
                       "notebooks (notes stay; board claims pruned)",
                       "repo mirrors"],
     }
+
+
+async def run_clear_runs(
+    *,
+    store: RunStore,
+    executor: DaguExecutor,
+    messaging: Messaging,
+    runlog: RunLogStore | None,
+    internal_forge,
+    run_manager,
+    claims,
+    config,
+    poll_lock,
+    dispatch_lock,
+    missions_cache,
+    managers: dict,
+    shared_backend_degraded: dict,
+) -> dict[str, Any]:
+    """HTTP clear-runs request body (ADR-0015): locks, wipe, advisory clears.
+
+    Owns the orchestration formerly inlined in ``main.clear_runs`` so the
+    route stays a ≤4-statement forward. Wipe semantics stay in ``clear_all``;
+    lock order is load-bearing (poll_rt.lock → dispatch_lock).
+    """
+    with tracer.start_as_current_span("system.clear_runs") as span:
+        # Serialize the wipe against EVERY dispatch path (audit D5 #2/#8 +
+        # re-audit #0/#6). Two locks, acquired in a fixed order:
+        #   • poll_rt.lock stops the periodic poll cycle (and force-poll) —
+        #     the poll loop takes it at cycle start, so no cycle runs.
+        #   • bootstrap.dispatch_lock is the true chokepoint: EVERY dispatch
+        #     flavor (poll, oauth, steward "run now", hello) creates its ACL
+        #     user + container inside RunBootstrap.launch under this lock.
+        #     poll_rt.lock alone missed the three non-poll paths, so the
+        #     ACL/SIGTERM race D3 targeted was still reachable — this closes it.
+        # Order poll_rt.lock → dispatch_lock matches the poll loop's own order
+        # (run_cycle holds poll_rt.lock, then launch takes dispatch_lock), so
+        # there is no lock-ordering inversion / deadlock.
+        async with poll_lock, dispatch_lock:
+            result = await clear_all(
+                store, executor, messaging, runlog,
+                internal_forge=internal_forge,
+                run_manager=run_manager,
+                claims=claims, config=config)
+        missions_cache.clear()
+        for mgr in managers.values():
+            mgr._grace.clear()
+            mgr._grace_next.clear()
+        # ADR-0018: the backend-degraded map IS run history, so "start fresh"
+        # legitimately forgets it — and clearing it now avoids throttling with
+        # zero evidence until the next poll cycle recomputes.
+        shared_backend_degraded.clear()
+        # auth breakers stay — they reflect live credential health, not run history
+        span.set_attribute(
+            "devcake.clear.runs_deleted",
+            int((result.get("local") or {}).get("runs_deleted") or 0))
+        span.set_attribute(
+            "devcake.clear.dagu_deleted",
+            int((result.get("dagu") or {}).get("deleted") or 0))
+        span.set_attribute("devcake.clear.ok", bool(result.get("ok")))
+        return result

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -22,9 +22,7 @@ import logging
 import os
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
-from opentelemetry import trace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
 from ..ports.executor import DuplicateRun
@@ -48,10 +46,6 @@ from .services import Services, _log_task_death, build_services
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
 log = logging.getLogger("devcake")
-
-# ProxyTracer (api/poll.py precedent): resolves the real provider per span
-# start, so module scope needs no telemetry install
-tracer = trace.get_tracer("devcake")
 
 services: Services | None = None
 
@@ -329,12 +323,10 @@ async def export_runs_csv(mission_key: str | None = None,
 
 @app.get("/api/v1/runs/{run_id}")
 async def get_run(run_id: str):
-    from .runs_service import run_detail
+    from .runs_service import get_run_response
     s = svc()
-    if (run := s.store.get(run_id)) is None:
-        raise HTTPException(404)
-    return run_detail(run, s.config.cost_inputs,
-                      missions_cache=s.poll_rt.missions_cache)
+    return get_run_response(run_id, s.store, s.config.cost_inputs,
+                            missions_cache=s.poll_rt.missions_cache)
 
 
 TERMINAL_STATES = {"finished", "failed", "timed_out", "orphaned"}
@@ -436,30 +428,19 @@ async def stop_run_route(run_id: str):
 @app.get("/api/v1/runs/{run_id}/log")
 async def get_run_log(run_id: str, tail: int | None = None):
     """Condensed harness output relayed live by the Dev (docs/11 §2a)."""
+    from .runs_service import get_run_log_response
     s = svc()
-    if s.store.get(run_id) is None:
-        raise HTTPException(404)
-    _seq, text = s.runlog.read(run_id, tail)
-    return PlainTextResponse(text)
+    return get_run_log_response(run_id, s.store, s.runlog, tail)
 
 
 @app.get("/api/v1/runs/{run_id}/log/stream")
 async def stream_run_log(run_id: str):
     """SSE follow: replays the stored log, then live lines until the run ends.
     X-Accel-Buffering disables nginx proxy buffering for this response."""
+    from .runs_service import stream_run_log_response
     s = svc()
-    if s.store.get(run_id) is None:
-        raise HTTPException(404)
-
-    def is_terminal() -> bool:
-        r = s.store.get(run_id)
-        return r is None or r.state in TERMINAL_STATES
-
-    return StreamingResponse(
-        s.runlog.stream(run_id, is_terminal),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-    )
+    return stream_run_log_response(
+        run_id, s.store, s.runlog, terminal_states=TERMINAL_STATES)
 
 
 @app.post("/api/v1/system/stop-runs")
@@ -478,42 +459,18 @@ async def clear_runs():
     Config, secrets, and everything in the PMO/forge are untouched (INV-1).
     In-flight Devs are stopped first. See docs/11 §3 and docs/10 §5.
     """
-    from .clear import clear_all
+    from .clear import run_clear_runs
     s = svc()
-    with tracer.start_as_current_span("system.clear_runs") as span:
-        # Serialize the wipe against EVERY dispatch path (audit D5 #2/#8 +
-        # re-audit #0/#6). Two locks, acquired in a fixed order:
-        #   • poll_rt.lock stops the periodic poll cycle (and force-poll) —
-        #     the poll loop takes it at cycle start, so no cycle runs.
-        #   • bootstrap.dispatch_lock is the true chokepoint: EVERY dispatch
-        #     flavor (poll, oauth, steward "run now", hello) creates its ACL
-        #     user + container inside RunBootstrap.launch under this lock.
-        #     poll_rt.lock alone missed the three non-poll paths, so the
-        #     ACL/SIGTERM race D3 targeted was still reachable — this closes it.
-        # Order poll_rt.lock → dispatch_lock matches the poll loop's own order
-        # (run_cycle holds poll_rt.lock, then launch takes dispatch_lock), so
-        # there is no lock-ordering inversion / deadlock.
-        async with s.poll_rt.lock, s.manager.bootstrap.dispatch_lock:
-            result = await clear_all(s.store, s.executor, s.messaging, s.runlog,
-                                     internal_forge=s.internal_forge,
-                                     run_manager=s.manager,
-                                     claims=s.claims, config=s.config)
-        s.poll_rt.missions_cache.clear()
-        for mgr in s.managers.values():
-            mgr._grace.clear()
-            mgr._grace_next.clear()
-        # ADR-0018: the backend-degraded map IS run history, so "start fresh"
-        # legitimately forgets it — and clearing it now avoids throttling with
-        # zero evidence until the next poll cycle recomputes.
-        s.shared_backend_degraded.clear()
-        # auth breakers stay — they reflect live credential health, not run history
-        span.set_attribute("devcake.clear.runs_deleted",
-                           int((result.get("local") or {}).get("runs_deleted") or 0))
-        span.set_attribute("devcake.clear.dagu_deleted",
-                           int((result.get("dagu") or {}).get("deleted") or 0))
-        span.set_attribute("devcake.clear.ok", bool(result.get("ok")))
-        return result
-
+    return await run_clear_runs(
+        store=s.store, executor=s.executor, messaging=s.messaging,
+        runlog=s.runlog, internal_forge=s.internal_forge,
+        run_manager=s.manager, claims=s.claims, config=s.config,
+        poll_lock=s.poll_rt.lock,
+        dispatch_lock=s.manager.bootstrap.dispatch_lock,
+        missions_cache=s.poll_rt.missions_cache,
+        managers=s.managers,
+        shared_backend_degraded=s.shared_backend_degraded,
+    )
 
 # ── Config CRUD (docs/11 §1; writes validate once here, hot-apply next cycle) ──
 

--- a/app/devcake/api/runs_service.py
+++ b/app/devcake/api/runs_service.py
@@ -20,7 +20,7 @@ import io
 from datetime import date, datetime, timedelta, timezone
 
 from fastapi import HTTPException
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, StreamingResponse
 
 from ..config import CostInputs
 from ..domain import costing
@@ -312,6 +312,45 @@ def run_detail(run: Run, cost_inputs: CostInputs,
     body["harness_version"] = _blank(run.harness_version)
     body["mission_url"] = _mission_url_of(run, missions_cache)
     return body
+
+
+def get_run_response(run_id: str, store, cost_inputs: CostInputs,
+                     missions_cache: list[dict] | None = None) -> dict:
+    """GET /runs/{id} body — 404 when missing (ADR-0015 thin route)."""
+    if (run := store.get(run_id)) is None:
+        raise HTTPException(404)
+    return run_detail(run, cost_inputs, missions_cache=missions_cache)
+
+
+def get_run_log_response(run_id: str, store, runlog,
+                         tail: int | None = None) -> PlainTextResponse:
+    """GET /runs/{id}/log body — 404 when the run record is gone."""
+    if store.get(run_id) is None:
+        raise HTTPException(404)
+    _seq, text = runlog.read(run_id, tail)
+    return PlainTextResponse(text)
+
+
+def stream_run_log_response(
+    run_id: str,
+    store,
+    runlog,
+    *,
+    terminal_states: set[str] | frozenset[str],
+) -> StreamingResponse:
+    """GET /runs/{id}/log/stream SSE body — 404 when the run record is gone."""
+    if store.get(run_id) is None:
+        raise HTTPException(404)
+
+    def is_terminal() -> bool:
+        r = store.get(run_id)
+        return r is None or r.state in terminal_states
+
+    return StreamingResponse(
+        runlog.stream(run_id, is_terminal),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 # CSV export (docs/11): the WHOLE filtered set, flat regardless of the page's

--- a/app/tests/test_clear.py
+++ b/app/tests/test_clear.py
@@ -469,3 +469,66 @@ def test_clear_all_without_run_manager_still_wipes(monkeypatch):
 
     out = run_coro(clear_mod.clear_all(None, None, None))
     assert out["stopped"]["skipped"] == "no run_manager"
+
+
+def test_run_clear_runs_acquires_locks_then_clears_advisories(monkeypatch):
+    """Public clear-runs entrypoint: poll→dispatch lock order, then advisory
+    clears (missions cache, grace maps, backend-degraded). Wipe body is
+    clear_all — this test owns the route-orchestration seam only."""
+    import devcake.api.clear as clear_mod
+
+    order: list[str] = []
+
+    class _Lock:
+        def __init__(self, name: str):
+            self.name = name
+
+        async def __aenter__(self):
+            order.append(f"enter:{self.name}")
+            return self
+
+        async def __aexit__(self, *exc):
+            order.append(f"exit:{self.name}")
+            return False
+
+    class _Grace:
+        def __init__(self, name: str):
+            self.name = name
+            self.cleared = 0
+
+        def clear(self):
+            self.cleared += 1
+            order.append(f"clear:{self.name}")
+
+    async def fake_clear_all(*args, **kwargs):
+        order.append("clear_all")
+        return {"ok": True, "local": {"runs_deleted": 3},
+                "dagu": {"deleted": 2}}
+
+    monkeypatch.setattr(clear_mod, "clear_all", fake_clear_all)
+
+    poll_lock = _Lock("poll")
+    dispatch_lock = _Lock("dispatch")
+    missions_cache = _Grace("missions")
+    grace = _Grace("grace")
+    grace_next = _Grace("grace_next")
+    degraded = _Grace("degraded")
+    managers = {"eng": SimpleNamespace(_grace=grace, _grace_next=grace_next)}
+
+    out = run_coro(clear_mod.run_clear_runs(
+        store=None, executor=None, messaging=None, runlog=None,
+        internal_forge=None, run_manager=None, claims=None, config=None,
+        poll_lock=poll_lock, dispatch_lock=dispatch_lock,
+        missions_cache=missions_cache, managers=managers,
+        shared_backend_degraded=degraded,
+    ))
+
+    assert out["ok"] is True
+    assert order[:3] == ["enter:poll", "enter:dispatch", "clear_all"]
+    # both locks released before advisory clears (async with exits after body)
+    assert order.index("exit:dispatch") < order.index("clear:missions")
+    assert order.index("exit:poll") < order.index("clear:missions")
+    assert grace.cleared == 1 and grace_next.cleared == 1
+    assert missions_cache.cleared == 1 and degraded.cleared == 1
+    # unlock order is LIFO for `async with a, b`
+    assert order.index("exit:dispatch") < order.index("exit:poll")

--- a/app/tests/test_runs_service.py
+++ b/app/tests/test_runs_service.py
@@ -11,8 +11,9 @@ from fastapi import HTTPException
 
 from devcake.adapters.files.run_store import RunStore
 from devcake.config import CostInputs, ModelRate
-from devcake.api.runs_service import (list_runs_response, run_detail,
-                                      runs_csv_response)
+from devcake.api.runs_service import (get_run_log_response, get_run_response,
+                                      list_runs_response, run_detail,
+                                      runs_csv_response, stream_run_log_response)
 from devcake.domain.run import Run
 
 T0 = datetime(2026, 8, 1, 12, 0, tzinfo=timezone.utc)
@@ -332,6 +333,45 @@ def test_rows_and_detail_never_leak_prompts_results_or_notes(tmp_path):
         assert banned not in detail
     assert detail["cost_usd_estimated"] == 5.60
     assert detail["input_tokens"] == 1_000_000
+
+
+def test_get_run_response_404_when_missing(tmp_path):
+    store = _store(tmp_path, [])
+    with pytest.raises(HTTPException) as ei:
+        get_run_response("missing", store, CostInputs())
+    assert ei.value.status_code == 404
+
+
+def test_get_run_response_returns_detail(tmp_path):
+    store = _store(tmp_path, [_run(1, tr=GROK_TR)])
+    body = get_run_response("A-1-1-EXECUTE-ZZZZZZ", store, CostInputs())
+    assert body["run_id"] == "A-1-1-EXECUTE-ZZZZZZ"
+    assert body["input_tokens"] == 1_000_000
+
+
+def test_get_run_log_response_404_when_missing(tmp_path):
+    store = _store(tmp_path, [])
+
+    class _Log:
+        def read(self, run_id, tail=None):
+            raise AssertionError("read must not run for missing run")
+
+    with pytest.raises(HTTPException) as ei:
+        get_run_log_response("missing", store, _Log())
+    assert ei.value.status_code == 404
+
+
+def test_stream_run_log_response_404_when_missing(tmp_path):
+    store = _store(tmp_path, [])
+
+    class _Log:
+        def stream(self, run_id, is_terminal):
+            raise AssertionError("stream must not run for missing run")
+
+    with pytest.raises(HTTPException) as ei:
+        stream_run_log_response(
+            "missing", store, _Log(), terminal_states={"finished"})
+    assert ei.value.status_code == 404
 
 
 # ── CSV export (docs/11: the Runs ⋯ menu's spreadsheet) ──────────────────────

--- a/app/tests/test_structure_guards.py
+++ b/app/tests/test_structure_guards.py
@@ -5,7 +5,9 @@ executable after it — no module-level ``MissionManager.<attr> = ...`` bindings
 (the old façade mechanism) and no module-level ``def`` below the class.
 
 C6 rule: ``api/main.py`` is composition root + route forwards — every
-``@app.<verb>`` route body is ≤ 4 statements (docstring excluded). Endpoint
+``@app.<verb>`` route body is ≤ 4 statements (docstring excluded), counted
+**recursively** through compound bodies (``with``/``async with``/``try``/
+``if``/nested ``def``) so a single wrapper cannot hide work. Endpoint
 behavior lives in ``api/`` service modules. The allowlist below is the
 residual thick body at close-out; it may SHRINK, never grow — a new
 endpoint that needs more than a forward gets a service module.
@@ -23,8 +25,8 @@ MANAGER = (Path(__file__).parents[1] / "devcake" / "domain" / "orchestrator"
 MAIN = Path(__file__).parents[1] / "devcake" / "api" / "main.py"
 
 # Residual bodies allowed in main.py (C6 close-out; shrink opportunistically).
-# Only ``run_steward`` still exceeds 4 statements; everything else forwards
-# to a service module or is already a short forward (≤4). May SHRINK, never grow.
+# Only ``run_steward`` still exceeds 4 under the nesting-aware counter.
+# May SHRINK, never grow — do not add names that already satisfy ≤4.
 ROUTE_BODY_ALLOWLIST = {
     "run_steward",
 }
@@ -47,13 +49,78 @@ def test_manager_has_no_post_class_bindings():
         "the façade: " + "; ".join(offenders))
 
 
-def _is_route(node) -> bool:
+def _strip_docstring(body: list) -> list:
+    if (body and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)):
+        return body[1:]
+    return body
+
+
+def _count_statements(stmts: list) -> int:
+    """Recursive statement count for ADR-0015 route bodies.
+
+    Each statement counts once. Compound bodies (``If``/``For``/``While``/
+    ``With``/``AsyncWith``/``Try``/``Match``) contribute their nested
+    statements too. Nested ``def``/``async def``/``class`` inside a route
+    contribute their bodies (docstring stripped) so a local helper cannot
+    hide work either.
+    """
+    total = 0
+    for stmt in stmts:
+        total += 1
+        if isinstance(stmt, (ast.If, ast.For, ast.AsyncFor, ast.While)):
+            total += _count_statements(stmt.body)
+            total += _count_statements(stmt.orelse)
+        elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+            total += _count_statements(stmt.body)
+        elif isinstance(stmt, ast.Try):
+            total += _count_statements(stmt.body)
+            for handler in stmt.handlers:
+                total += _count_statements(handler.body)
+            total += _count_statements(stmt.orelse)
+            total += _count_statements(stmt.finalbody)
+        elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            total += _count_statements(_strip_docstring(stmt.body))
+        elif isinstance(stmt, ast.Match):
+            for case in stmt.cases:
+                total += _count_statements(case.body)
+    return total
+
+
+def _app_aliases(tree: ast.AST) -> set[str]:
+    """Names bound to the FastAPI app object (``app`` plus simple aliases).
+
+    Recognizes ``api = app`` / ``api: FastAPI = app`` so ``@api.post(...)``
+    still counts as a route. Does not chase import graphs.
+    """
+    aliases = {"app"}
+    for node in tree.body:
+        value = None
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            value = node.value
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            value = node.value
+            targets = [node.target]
+        if value is None:
+            continue
+        if isinstance(value, ast.Name) and value.id in aliases:
+            for tgt in targets:
+                if isinstance(tgt, ast.Name):
+                    aliases.add(tgt.id)
+    return aliases
+
+
+def _is_route(node, app_names: set[str] | None = None) -> bool:
+    names = app_names if app_names is not None else {"app"}
     for dec in node.decorator_list:
         call = dec if isinstance(dec, ast.Call) else None
         target = call.func if call else dec
         if (isinstance(target, ast.Attribute)
                 and isinstance(target.value, ast.Name)
-                and target.value.id == "app"):
+                and target.value.id in names):
             return True
     return False
 
@@ -107,21 +174,59 @@ def test_lifespan_never_awaits_mirror_warmup():
         "warm-up must ride a background task, never boot")
 
 
+def test_count_statements_sees_with_wrapped_bodies():
+    """Nesting hole proof: top-level length ≤4 must not hide a thick ``with``.
+
+    Independent literals — five nested assigns inside one ``with`` → count 6
+    (the ``with`` plus each body stmt), not 1.
+    """
+    tree = ast.parse(
+        "async def route():\n"
+        "    with span:\n"
+        "        a = 1\n"
+        "        b = 2\n"
+        "        c = 3\n"
+        "        d = 4\n"
+        "        e = 5\n"
+    )
+    fn = tree.body[0]
+    body = _strip_docstring(fn.body)
+    assert len(body) == 1, "fixture must be a single top-level with"
+    assert _count_statements(body) == 6
+    assert _count_statements(body) > 4
+
+
+def test_is_route_recognizes_app_name_aliases():
+    tree = ast.parse(
+        "app = FastAPI()\n"
+        "api = app\n"
+        "@api.post('/x')\n"
+        "async def aliased():\n"
+        "    return 1\n"
+        "@app.get('/y')\n"
+        "async def plain():\n"
+        "    return 1\n"
+    )
+    aliases = _app_aliases(tree)
+    assert aliases == {"app", "api"}
+    by_name = {n.name: n for n in tree.body
+               if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    assert _is_route(by_name["aliased"], aliases)
+    assert _is_route(by_name["plain"], aliases)
+
+
 def test_main_route_bodies_stay_thin():
     tree = ast.parse(MAIN.read_text())
+    aliases = _app_aliases(tree)
     offenders = []
     for node in tree.body:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        if not _is_route(node) or node.name in ROUTE_BODY_ALLOWLIST:
+        if not _is_route(node, aliases) or node.name in ROUTE_BODY_ALLOWLIST:
             continue
-        body = node.body
-        if (body and isinstance(body[0], ast.Expr)
-                and isinstance(body[0].value, ast.Constant)
-                and isinstance(body[0].value.value, str)):
-            body = body[1:]                       # docstring doesn't count
-        if len(body) > 4:
-            offenders.append(f"{node.name} ({len(body)} statements)")
+        n = _count_statements(_strip_docstring(node.body))
+        if n > 4:
+            offenders.append(f"{node.name} ({n} statements)")
     assert not offenders, (
         "main.py route bodies grew past 4 statements — move the behavior to "
         "an api/ service module (ADR-0015 Decision 3): " + "; ".join(offenders))

--- a/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
+++ b/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
@@ -18,11 +18,11 @@
 
 > **Amended by ADR-0028 (2026-08-04):** Decision 3's "main.py is composition
 > root" still governs *where routes live* and the ≤4-statement forward ratchet
-> (guard-tested residual count is authority — seven, not the C6 draft's nine).
-> **Object-graph construction** moved to `api/services.build_services()`;
-> `main.py` is wiring + route forwards only. Read ADR-0028 for the factory
-> seam; do not treat Decision 3 alone as current law on *where* dependencies
-> are built.
+> (guard-tested residual count is authority — currently only `run_steward`;
+> earlier drafts claimed nine then seven). **Object-graph construction** moved
+> to `api/services.build_services()`; `main.py` is wiring + route forwards
+> only. Read ADR-0028 for the factory seam; do not treat Decision 3 alone as
+> current law on *where* dependencies are built.
 
 ## Decision 1 — the manager is DI container + advisory state + verbs
 
@@ -66,15 +66,15 @@ Endpoint behavior lives in `api/` application-service modules (the
 as forwards with **unchanged coroutine names and signatures** — tests call
 them directly (`app_main.save_profile(...)`), so the forward layer is the
 API's stable test seam. No `APIRouter`: it would be a second routing idiom for
-zero behavior. Every `@app.<verb>` body is ≤ 4 statements, AST-guarded with an
-allowlist that may only shrink, never grow. It holds **seven** read-side
-residuals — `dispatch_hello` (CI fixture), the `run_mapper`/`oauth` trio,
-and `get_run_log`/`stream_run_log`/`clear_runs` — not the single-entry end
-state an earlier draft imagined. (The C6 close-out counted nine; `list_runs`
-and `get_run` were since forwarded — the ratchet shrank and this prose
-lagged until the 2026-08 truth sweep.) The guard test
-(`test_structure_guards.py`) is the source of truth. Poll machinery lives in `api/poll.py` as `PollRuntime`; health probes
-in `api/health.py`.
+zero behavior. Every `@app.<verb>` body is ≤ 4 statements, counted
+**recursively** through compound bodies (`with`/`async with`/`try`/`if`/
+nested `def`) and AST-guarded with an allowlist that may only shrink, never
+grow. The live allowlist holds only `run_steward`; earlier residuals
+(`dispatch_hello`, oauth/mapper trio, `get_run`/`get_run_log`/
+`stream_run_log`/`clear_runs`) are thin forwards into service modules. The
+guard test (`test_structure_guards.py`) is the source of truth — including
+app-object name aliases (`api = app` then `@api.post`). Poll machinery lives
+in `api/poll.py` as `PollRuntime`; health probes in `api/health.py`.
 
 ## Decision 4 — module-public functions are the sanctioned test seam
 


### PR DESCRIPTION
## Intent

Close the ADR-0015 ≤4-statement `api/main.py` ratchet hole where `clear_runs` hid ~14 behavioral statements inside a single `with` tracer span (top-level count = 3). Move that orchestration behind `api/clear.run_clear_runs`, teach the structure guard to count nested statements and recognize FastAPI app name aliases, and keep `ROUTE_BODY_ALLOWLIST` from growing (still only `run_steward`).

## Mission

https://linear.app/fidecastro/issue/CAKE-72/clear-runs-route-ratchet-sees-nested-statements

## What changed

- **Guard (TDD first):** recursive `_count_statements` over `with`/`try`/`if`/nested `def`; `_app_aliases` so `@api.post` still counts; honest allowlist comment; fixture proving the nesting hole.
- **Service chokepoint:** `run_clear_runs` owns locks (poll → dispatch), `clear_all`, missions/grace/backend-degraded clears, and span attributes.
- **Thin routes:** `main.clear_runs` is a ≤4 forward; collateral `get_run` / `get_run_log` / `stream_run_log` (5/5/7 under the new counter) forwarded into `runs_service` so the allowlist did not grow.
- **Docs:** ADR-0015 Decision 3 residual list matches the live allowlist + nesting-aware rule.

## Deviation from plan

Chose **full recursive statement counting** and thinned the three collateral run routes in this PR (plan allowed either that or a With-only counter). Wipe semantics / INV-1 / lock order unchanged.

## How to verify

```bash
./scripts/pytest_app.sh tests/test_structure_guards.py tests/test_clear.py tests/test_runs_service.py -q
```

Local evidence before push: red named `clear_runs (14)` (+ get_run/get_run_log/stream_run_log); green **57 passed** on those suites (+ cycle_lock_wiring) in a fresh `app-test` image.

## Out of scope

- Extracting `run_steward`
- Wipe-completeness residuals (profiles.json, Redis ACL SAVE, wipe-generation fence)