### PR TITLE
[CAKE-85] Pin the cross-container mirrors

### DIFF
--- a/app/devcake/domain/repo_mirror.py
+++ b/app/devcake/domain/repo_mirror.py
@@ -34,12 +34,13 @@ log = logging.getLogger("devcake.mirror")
 SYNC_CONCURRENCY = 4     # git subprocesses, not HTTP probes — lower than the
 #                          forge sweep's PROBE_CONCURRENCY on purpose
 
-# Auth wording that latches the per-repo forge breaker. Mirrors the Dev-side
-# clone_error_class (workspace/clone.py) MINUS "repository not found": on the
-# sync path a 404 is a deleted/renamed repo — an operator config problem —
-# and the breaker's remediation copy says "update the token", which would
-# mislead. Everything unrecognized is transient (fail toward retry; the
-# breaker is the sharp edge — docs/15 §4 asymmetry).
+# Auth wording that latches the per-repo forge breaker. Pinned mirror of the
+# Dev-side clone_error_class markers (workspace/clone.py) MINUS
+# "repository not found": on the sync path a 404 is a deleted/renamed repo —
+# an operator config problem — and the breaker's remediation copy says
+# "update the token", which would mislead. Everything unrecognized is
+# transient (fail toward retry; the breaker is the sharp edge — docs/15 §4
+# asymmetry). Guard: app/tests/test_mirror_auth_markers_pin.py (ADR-0034).
 _AUTH_MARKERS = ("authentication failed", "could not read username",
                  "could not read password", "invalid credentials",
                  "returned error: 403", "returned error: 401",

--- a/app/tests/test_argv_forge_dialect_gone.py
+++ b/app/tests/test_argv_forge_dialect_gone.py
@@ -1,0 +1,42 @@
+"""argv.forge_dialect is a dead duplicate of dev_entrypoint.forge_dialect
+(ADR-0034). The entrypoint defines and calls its own; it never imports
+forge_dialect from argv. This ratchet keeps the dead symbol from returning.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_REPO = _HERE.parents[2]
+
+ARGV = Path("/srv/images/common/devcake_dev/harness/argv.py")
+if not ARGV.exists():
+    ARGV = _REPO / "images" / "common" / "devcake_dev" / "harness" / "argv.py"
+
+ENTRYPOINT = Path("/srv/images/common/dev_entrypoint.py")
+if not ENTRYPOINT.exists():
+    ENTRYPOINT = _REPO / "images" / "common" / "dev_entrypoint.py"
+
+
+def test_argv_does_not_define_forge_dialect():
+    assert ARGV.exists(), (
+        f"mount missing — pytest must bind images/common → /srv/images/common "
+        f"(or run against the checkout); looked for {ARGV}"
+    )
+    tree = ast.parse(ARGV.read_text())
+    names = {n.name for n in tree.body if isinstance(n, ast.FunctionDef)}
+    assert "forge_dialect" not in names, (
+        "images/common/devcake_dev/harness/argv.py still defines "
+        "forge_dialect — dead duplicate of dev_entrypoint.forge_dialect; "
+        "delete it (CAKE-85 / ADR-0034)"
+    )
+
+
+def test_entrypoint_still_defines_forge_dialect():
+    assert ENTRYPOINT.exists(), f"missing {ENTRYPOINT}"
+    tree = ast.parse(ENTRYPOINT.read_text())
+    names = {n.name for n in tree.body if isinstance(n, ast.FunctionDef)}
+    assert "forge_dialect" in names, (
+        "dev_entrypoint.forge_dialect vanished — that is the live chokepoint"
+    )

--- a/app/tests/test_mirror_auth_markers_pin.py
+++ b/app/tests/test_mirror_auth_markers_pin.py
@@ -1,0 +1,114 @@
+"""App repo_mirror._AUTH_MARKERS ↔ Dev clone_error_class auth_markers pin
+(ADR-0034). Cross-runtime copies cannot share an import; this ratchet
+compares the production tuples field-by-field so drift turns red.
+
+Authoritative relation (repo_mirror.py): app markers == Dev markers minus
+"repository not found" — on the mirror sync path a 404 is config/delete,
+not a token failure, so the breaker must not latch as auth.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from devcake.domain import repo_mirror as _repo_mirror
+from devcake.domain.repo_mirror import sync_error_class
+
+_HERE = Path(__file__).resolve()
+_REPO = _HERE.parents[2]
+
+CLONE = Path("/srv/images/common/devcake_dev/workspace/clone.py")
+if not CLONE.exists():
+    CLONE = _REPO / "images" / "common" / "devcake_dev" / "workspace" / "clone.py"
+
+REPO_MIRROR = Path(_repo_mirror.__file__)
+
+_REPO_NOT_FOUND = "repository not found"
+
+
+def _tuple_literals(path: Path, *, assign_name: str | None = None,
+                    in_function: str | None = None) -> tuple[str, ...]:
+    assert path.exists(), (
+        f"mount missing — pytest must bind images/common → /srv/images/common "
+        f"(or run against the checkout); looked for {path}"
+    )
+    tree = ast.parse(path.read_text())
+    nodes = tree.body
+    if in_function:
+        fn = next(
+            (n for n in tree.body
+             if isinstance(n, ast.FunctionDef) and n.name == in_function),
+            None,
+        )
+        assert fn is not None, f"{path} lost function {in_function}"
+        nodes = fn.body
+    for node in nodes:
+        if not isinstance(node, ast.Assign):
+            continue
+        if assign_name is not None:
+            if not any(isinstance(t, ast.Name) and t.id == assign_name
+                       for t in node.targets):
+                continue
+        if not isinstance(node.value, ast.Tuple):
+            continue
+        vals = []
+        for elt in node.value.elts:
+            assert isinstance(elt, ast.Constant) and isinstance(elt.value, str), (
+                f"unexpected marker element in {path}: {ast.dump(elt)}"
+            )
+            vals.append(elt.value)
+        return tuple(vals)
+    raise AssertionError(
+        f"no string-tuple assign "
+        f"{assign_name or '(any)'} found in {path}"
+        + (f"::{in_function}" if in_function else "")
+    )
+
+
+def _extract_clone_error_class(path: Path):
+    """Load the pure clone_error_class function without importing the module
+    (clone.py pulls subprocess / workspace helpers at module level)."""
+    tree = ast.parse(path.read_text())
+    keep = [n for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name == "clone_error_class"]
+    assert keep, f"{path} lost clone_error_class"
+    ns: dict = {}
+    exec(compile(ast.Module(body=keep, type_ignores=[]),  # noqa: S102
+                 str(path), "exec"), ns)
+    return ns["clone_error_class"]
+
+
+def test_auth_markers_app_is_dev_minus_repository_not_found():
+    app = _tuple_literals(REPO_MIRROR, assign_name="_AUTH_MARKERS")
+    dev = _tuple_literals(CLONE, assign_name="auth_markers",
+                          in_function="clone_error_class")
+    assert set(app) == set(dev) - {_REPO_NOT_FOUND}, (
+        f"auth-marker drift: app={sorted(app)!r} "
+        f"dev={sorted(dev)!r} — expected app == dev - {{{_REPO_NOT_FOUND!r}}}"
+    )
+    assert _REPO_NOT_FOUND in set(dev)
+    assert _REPO_NOT_FOUND not in set(app)
+
+
+def test_auth_marker_asymmetry_on_shared_stderr_vectors():
+    """Both sides agree on credential wording; only Dev treats a missing
+    repo as auth (app keeps it transient — breaker copy would mislead)."""
+    clone_error_class = _extract_clone_error_class(CLONE)
+    agree_auth = (
+        "remote: Authentication failed",
+        "fatal: could not read Username for 'https://example.com'",
+        "fatal: could not read Password for 'https://example.com'",
+        "remote: Invalid credentials",
+        "remote: Write access to repository not granted",
+        "The requested URL returned error: 403",
+        "The requested URL returned error: 401",
+    )
+    for stderr in agree_auth:
+        assert sync_error_class(stderr) == "auth", stderr
+        assert clone_error_class(stderr) == "DEV_FORGE_AUTH", stderr
+
+    assert sync_error_class("ERROR: Repository not found.") == "transient"
+    assert clone_error_class("ERROR: Repository not found.") == "DEV_FORGE_AUTH"
+
+    assert sync_error_class("fatal: unable to access") == "transient"
+    assert clone_error_class("fatal: unable to access") == "DEV_FORGE"

--- a/app/tests/test_safe_activity_relpath_pin.py
+++ b/app/tests/test_safe_activity_relpath_pin.py
@@ -1,0 +1,76 @@
+"""App safe_activity_relpath ↔ Dev _safe_activity_relpath pin (ADR-0034).
+
+Cross-runtime copies (app process vs Dev image) cannot share an import; this
+ratchet runs one shared input vector through both production functions so
+zip-slip behavior drift turns red.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from devcake.domain.orchestrator.activity_payload import safe_activity_relpath
+
+_HERE = Path(__file__).resolve()
+_REPO = _HERE.parents[2]
+
+ACTIVITY = Path("/srv/images/common/devcake_dev/workspace/activity.py")
+if not ACTIVITY.exists():
+    ACTIVITY = (_REPO / "images" / "common" / "devcake_dev"
+                / "workspace" / "activity.py")
+
+
+def _load_container_safe_relpath():
+    assert ACTIVITY.exists(), (
+        f"mount missing — pytest must bind images/common → /srv/images/common "
+        f"(or run against the checkout); looked for {ACTIVITY}"
+    )
+    tree = ast.parse(ACTIVITY.read_text())
+    keep = [n for n in tree.body
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_safe_activity_relpath"]
+    assert keep, f"{ACTIVITY} lost _safe_activity_relpath"
+    ns: dict = {}
+    exec(compile(ast.Module(body=keep, type_ignores=[]),  # noqa: S102
+                 str(ACTIVITY), "exec"), ns)
+    return ns["_safe_activity_relpath"]
+
+
+# Shared vectors: happy paths, empties, abs/~, .., nested .., backslash,
+# depth > 20, segment > 200, "." segments, trailing slashes.
+_VECTORS: tuple[str | object, ...] = (
+    "a/b.md",
+    "ok.md",
+    "dir/sub/file.txt",
+    "",
+    None,
+    123,
+    "/abs",
+    "/abs/nested",
+    "~",
+    "~/secret",
+    "..",
+    "../evil",
+    "a/../../x",
+    "a/../b",
+    "a\\b\\c.md",
+    "a/./b/./c.md",
+    "a/b/",
+    "a//b///c.md",
+    "/".join(f"d{i}" for i in range(21)),
+    "a/" + ("x" * 201),
+    "a/" + ("x" * 200),
+    ".",
+    "./.",
+    " ",
+)
+
+
+def test_safe_activity_relpath_parity_on_shared_vectors():
+    container = _load_container_safe_relpath()
+    for raw in _VECTORS:
+        assert safe_activity_relpath(raw) == container(raw), (  # type: ignore[arg-type]
+            f"zip-slip path drift on {raw!r}: "
+            f"app={safe_activity_relpath(raw)!r} "
+            f"container={container(raw)!r}"  # type: ignore[arg-type]
+        )

--- a/images/common/devcake_dev/harness/argv.py
+++ b/images/common/devcake_dev/harness/argv.py
@@ -20,17 +20,6 @@ def resume_specs() -> dict[str, ResumeSpec]:
 RESUME_SPECS: dict[str, ResumeSpec] = resume_specs()
 
 
-def forge_dialect(env: dict) -> tuple:
-    """(clone_user, git_name, git_email, cli_token_envs) for the clone
-    bootstrap. Values come from the app's ForgeDescriptor via spec_env
-    (docs/06, docs/07). App and images deploy in lockstep (docs/13 §8), so
-    every var is always present — a KeyError here means a mismatched build
-    and should crash the run loudly."""
-    cli_envs = [e for e in env.get("DEVCAKE_FORGE_CLI_ENVS", "").split(",") if e]
-    return (env["DEVCAKE_CLONE_USER"], env["DEVCAKE_GIT_NAME"],
-            env["DEVCAKE_GIT_EMAIL"], cli_envs)
-
-
 def cli_version(harness: str, *, timeout: float = 5.0) -> str:
     """First line of `<cli> --version` in this container. Empty on unknown
     harness, missing binary, or timeout — never raises into provision."""

--- a/images/common/devcake_dev/workspace/activity.py
+++ b/images/common/devcake_dev/workspace/activity.py
@@ -9,8 +9,10 @@ import subprocess
 import sys
 
 def _safe_activity_relpath(path: str):
-    """Mirror of the app's safe_activity_relpath: reject zip-slip / absolute
-    / empty paths. Returns a posix-relative string or None."""
+    """Pinned mirror of app safe_activity_relpath (activity_payload.py):
+    reject zip-slip / absolute / empty paths. Returns a posix-relative
+    string or None. Guard: app/tests/test_safe_activity_relpath_pin.py
+    (ADR-0034)."""
     if not path or not isinstance(path, str):
         return None
     raw = path.replace("\\", "/").strip()

--- a/images/common/devcake_dev/workspace/clone.py
+++ b/images/common/devcake_dev/workspace/clone.py
@@ -89,7 +89,11 @@ def _clone_siblings(entries, *, dest_parent, dest_by, label, rel_prefix,
 def clone_error_class(stderr: str) -> str:
     """DEV_FORGE_AUTH only on git's credential wording — a bare "403"/"401"
     can be a rate limit or an incidental URL fragment, and DEV_FORGE_AUTH
-    latches the app's global forge breaker."""
+    latches the app's global forge breaker.
+
+    auth_markers are the Dev half of the app repo_mirror._AUTH_MARKERS pin
+    (app omits "repository not found" — sync-path asymmetry). Guard:
+    app/tests/test_mirror_auth_markers_pin.py (ADR-0034)."""
     lowered = stderr.lower()
     auth_markers = ("returned error: 403", "returned error: 401",
                     "authentication failed", "repository not found",


### PR DESCRIPTION
## Intent
Close three ADR-0034 cross-container mirror gaps in one PR: pin app↔Dev auth markers and zip-slip path helpers, and delete the dead `argv.forge_dialect` duplicate.

## Mission
https://linear.app/fidecastro/issue/CAKE-85/pin-the-cross-container-mirrors

## What changed
- **Auth markers pin** (`test_mirror_auth_markers_pin.py`): AST-extracts `repo_mirror._AUTH_MARKERS` and Dev `clone_error_class` markers; asserts app == Dev minus `"repository not found"` (intentional sync-path asymmetry). Shared stderr vectors document agree-auth + the 404 asymmetry.
- **Zip-slip path pin** (`test_safe_activity_relpath_pin.py`): shared input vector through app `safe_activity_relpath` and container `_safe_activity_relpath`.
- **Dead duplicate** (`test_argv_forge_dialect_gone.py` + delete): remove unused `forge_dialect` from `harness/argv.py`; live copy stays on `dev_entrypoint`.
- Comment hygiene names the pin guards (ADR-0034 corollary 4).

## How to verify
```bash
./scripts/pytest_app.sh tests/test_mirror_auth_markers_pin.py tests/test_safe_activity_relpath_pin.py tests/test_argv_forge_dialect_gone.py tests/test_repo_mirror.py tests/test_activity_zip.py tests/test_entrypoint_render.py
```
Observed locally (app-test via Dockerfile `--target test` fallback; images bind-mounted): **162 passed**.

## Deviations
- Also named the pin on the Dev `clone_error_class` docstring (plan only required app/`_safe_activity_relpath` comments).
- Host has no `docker buildx bake`; Dev `images` group not rebaked locally — argv delete is tree-truth; next images bake drops the dead symbol from tags.

## Out of scope
- Unifying `HARNESS_AUTH_MARKERS` / `DISTINCTIVE_AUTH_MARKERS` in `fault.py`
- Merging app and container path helpers into one package
- Changing breaker latch semantics or zip-slip limits