### PR TITLE
[CAKE-77] Delivery merge_sha goes through ForgePort

### DIFF
--- a/app/devcake/domain/orchestrator/deliver.py
+++ b/app/devcake/domain/orchestrator/deliver.py
@@ -85,12 +85,13 @@ async def _deliver_core(mgr, repo_ref, mission_key, pmo_id, pmo_kind, pr
         if forge is None:
             return False
         state = await forge.pr_state(pr.number)
-        # the fresh pr_state read is the best source (all adapters normalize
-        # it onto the DTO now); the raw-payload probe is a legacy fallback —
-        # on GitLab it always misses (no /pulls route) and zips at "main"
-        merge_sha = (state.merge_commit_sha
-                     or getattr(pr, "merge_commit_sha", None)
-                     or await _merge_sha(forge, pr.number))
+        # Fresh pr_state is the sole SHA source (all adapters normalize
+        # merge_commit_sha onto the DTO). Missing SHA → default branch name.
+        merge_sha = (
+            state.merge_commit_sha
+            or getattr(pr, "merge_commit_sha", None)
+            or "main"
+        )
         files = [f for f in await forge.pr_files(pr.number)
                  if f.status != "removed"]
         cap = mgr._attachment_cap()
@@ -125,16 +126,6 @@ async def _deliver_core(mgr, repo_ref, mission_key, pmo_id, pmo_kind, pr
         except Exception:
             log.exception("could not post the delivery-failure notice")
         return False
-
-
-async def _merge_sha(forge, pr_number: int) -> str:
-    """Best-effort merge commit sha via a direct PR read (adapters that don't
-    surface it on the DTO expose it on the raw payload)."""
-    try:
-        raw = await forge._req("GET", f"/pulls/{pr_number}")
-        return raw.get("merge_commit_sha") or "main"
-    except Exception:  # noqa: BLE001 — best-effort probe per docstring: any failure falls back to zipping at the "main" ref
-        return "main"
 
 
 async def _build_zip(forge, files: list[PRFile], ref: str,

--- a/app/devcake/ports/forge.py
+++ b/app/devcake/ports/forge.py
@@ -64,8 +64,8 @@ class PullRequest(BaseModel):
     state: Literal["open", "closed"]
     merged: bool = False
     # the merge commit once merged (deliverable zip ref); None before the
-    # merge or when the vendor omits it — callers fall back to a direct
-    # PR read, then to the default branch (deliver._merge_sha)
+    # merge or when the vendor omits it — callers fall back to the default
+    # branch name "main" (DTO fields only; no adapter-private probe)
     merge_commit_sha: Optional[str] = None
 
 

--- a/app/tests/test_repo_routing.py
+++ b/app/tests/test_repo_routing.py
@@ -431,7 +431,9 @@ def test_internal_zip_delivery(tmp_path, monkeypatch):
 
     class FakeForge:
         async def pr_state(self, n):
-            return PullRequest(number=n, url="http://gitea/pr/1", state="closed", merged=True)
+            return PullRequest(number=n, url="http://gitea/pr/1",
+                               state="closed", merged=True,
+                               merge_commit_sha="abc123")
         async def pr_files(self, n):
             return [PRFile(path="report/REPORT.md", status="added"),
                     PRFile(path="report/data.bin", status="added"),
@@ -439,8 +441,6 @@ def test_internal_zip_delivery(tmp_path, monkeypatch):
         async def file_content(self, path, ref):
             return {"report/REPORT.md": b"# report",
                     "report/data.bin": b"\x00\x01\x02"}[path]
-        async def _req(self, method, path):
-            return {"merge_commit_sha": "abc123"}
 
     class RT:
         internal = {"linear-t-1"}
@@ -501,13 +501,12 @@ def _mission_delivery_setup(tmp_path, feed_body):
     class FakeForge:
         async def pr_state(self, n):
             return PullRequest(number=n, url="http://gitea/pr/1",
-                               state="closed", merged=True)
+                               state="closed", merged=True,
+                               merge_commit_sha="abc123")
         async def pr_files(self, n):
             return [PRFile(path="a.txt", status="added")]
         async def file_content(self, path, ref):
             return b"data"
-        async def _req(self, method, path):
-            return {"merge_commit_sha": "abc123"}
 
     class RT:
         internal = {"linear-t-1"}
@@ -574,13 +573,12 @@ def test_external_zip_delivery_gated_by_toggle(tmp_path):
     class FakeForge:
         async def pr_state(self, n):
             return PullRequest(number=n, url="http://gh/pr/1",
-                               state="closed", merged=True)
+                               state="closed", merged=True,
+                               merge_commit_sha="deadbeef")
         async def pr_files(self, n):
             return [PRFile(path="src/a.py", status="added")]
         async def file_content(self, path, ref):
             return b"print(1)\n"
-        async def _req(self, method, path):
-            return {"merge_commit_sha": "deadbeef"}
 
     class RT:
         internal = set()          # external — not in forges.internal
@@ -639,13 +637,12 @@ def test_external_mission_zip_respects_toggle(tmp_path):
     class FakeForge:
         async def pr_state(self, n):
             return PullRequest(number=n, url="http://gh/pr/1",
-                               state="closed", merged=True)
+                               state="closed", merged=True,
+                               merge_commit_sha="abc")
         async def pr_files(self, n):
             return [PRFile(path="a.txt", status="added")]
         async def file_content(self, path, ref):
             return b"data"
-        async def _req(self, method, path):
-            return {"merge_commit_sha": "abc"}
 
     class RT:
         internal = set()
@@ -670,6 +667,147 @@ def test_external_mission_zip_respects_toggle(tmp_path):
     cfg.attach_merged_changeset_to_pmo = True
     run_coro(mgr.deliver_internal_zip_for_mission(m, pr))
     assert "T-1-deliverable.zip" in uploaded
+
+
+def test_deliver_zip_ref_from_pr_state_merge_commit_sha(tmp_path):
+    """CAKE-77: deliver pins the zip to PullRequest.merge_commit_sha from
+    pr_state — never via adapter-private forge._req."""
+    from devcake.ports.forge import PRFile, PullRequest
+    from fakes import make_mission_manager
+    from devcake.adapters.files.run_store import RunStore
+
+    uploaded = {}
+    seen_refs: list[str] = []
+    req_calls: list[tuple[str, str]] = []
+
+    class FakePMO:
+        async def upload_attachment(self, pmo_id, name, data):
+            uploaded[name] = data
+            return f"https://pmo/{name}"
+
+        def capabilities(self):
+            from devcake.ports.pmo import PMOCapabilities
+            return PMOCapabilities(attachment_max_bytes=10 * 1024 * 1024,
+                                   relations_supported=True)
+
+    class FakeForge:
+        async def pr_state(self, n):
+            return PullRequest(number=n, url="http://gitea/pr/1",
+                               state="closed", merged=True,
+                               merge_commit_sha="deadbeef")
+
+        async def pr_files(self, n):
+            return [PRFile(path="a.txt", status="added")]
+
+        async def file_content(self, path, ref):
+            seen_refs.append(ref)
+            return b"data"
+
+        async def _req(self, method, path):
+            # Reach-through detector: recording beats raising — a swallowed
+            # exception would still yield the "main" fallback and hide the leak.
+            req_calls.append((method, path))
+            return {"merge_commit_sha": "should-not-be-used"}
+
+    class RT:
+        internal = {"linear-t-1"}
+
+        def get(self, name):
+            return FakeForge()
+
+    mgr = make_mission_manager(
+        pmo=FakePMO(), forge_runtime=RT(),
+        runs=type("Runs", (), {"store": RunStore(tmp_path / "runs")})(),
+    )
+    feed = []
+
+    async def _feed(pmo_id, kind, md):
+        feed.append(md)
+
+    mgr._feed = _feed
+    mgr._attachment_cap = lambda: 10 * 1024 * 1024
+
+    run = _run("linear-t-1")
+    run.mission_pmo_id = "p1"
+    run.mission_key = "T-1"
+    run.finalized_steps = []
+    pr = PullRequest(number=1, url="http://gitea/pr/1",
+                     state="closed", merged=True)
+    run_coro(mgr.deliver_internal_zip(run, pr))
+
+    assert "T-1-deliverable.zip" in uploaded
+    assert seen_refs == ["deadbeef"]
+    assert req_calls == []
+
+
+def test_deliver_zip_ref_falls_back_to_main_without_req(tmp_path):
+    """CAKE-77: when neither pr_state nor the inbound PR carries
+    merge_commit_sha, the zip ref is the default branch name — still with
+    no forge._req reach-through."""
+    from devcake.ports.forge import PRFile, PullRequest
+    from fakes import make_mission_manager
+    from devcake.adapters.files.run_store import RunStore
+
+    uploaded = {}
+    seen_refs: list[str] = []
+    req_calls: list[tuple[str, str]] = []
+
+    class FakePMO:
+        async def upload_attachment(self, pmo_id, name, data):
+            uploaded[name] = data
+            return f"https://pmo/{name}"
+
+        def capabilities(self):
+            from devcake.ports.pmo import PMOCapabilities
+            return PMOCapabilities(attachment_max_bytes=10 * 1024 * 1024,
+                                   relations_supported=True)
+
+    class FakeForge:
+        async def pr_state(self, n):
+            return PullRequest(number=n, url="http://gitea/pr/1",
+                               state="closed", merged=True,
+                               merge_commit_sha=None)
+
+        async def pr_files(self, n):
+            return [PRFile(path="a.txt", status="added")]
+
+        async def file_content(self, path, ref):
+            seen_refs.append(ref)
+            return b"data"
+
+        async def _req(self, method, path):
+            req_calls.append((method, path))
+            return {"merge_commit_sha": "should-not-be-used"}
+
+    class RT:
+        internal = {"linear-t-1"}
+
+        def get(self, name):
+            return FakeForge()
+
+    mgr = make_mission_manager(
+        pmo=FakePMO(), forge_runtime=RT(),
+        runs=type("Runs", (), {"store": RunStore(tmp_path / "runs")})(),
+    )
+    feed = []
+
+    async def _feed(pmo_id, kind, md):
+        feed.append(md)
+
+    mgr._feed = _feed
+    mgr._attachment_cap = lambda: 10 * 1024 * 1024
+
+    run = _run("linear-t-1")
+    run.mission_pmo_id = "p1"
+    run.mission_key = "T-1"
+    run.finalized_steps = []
+    pr = PullRequest(number=1, url="http://gitea/pr/1",
+                     state="closed", merged=True)
+    run_coro(mgr.deliver_internal_zip(run, pr))
+
+    assert "T-1-deliverable.zip" in uploaded
+    assert seen_refs == ["main"]
+    assert req_calls == []
 
 
 def test_onboard_runspec_carries_extra_repo_read_tokens(tmp_path, monkeypatch):

--- a/scripts/contract_tests_forge.py
+++ b/scripts/contract_tests_forge.py
@@ -206,12 +206,9 @@ async def run_battery(inst: RepoInstance, fixture) -> None:
     check("10", "approval_footer renders", pr.url in footer)
 
     # 11 — pr_files lists the merged change set (deliverable packaging)
-    merge_sha = None
-    try:
-        raw = await forge._req("GET", f"/pulls/{n}")
-        merge_sha = raw.get("merge_commit_sha")
-    except Exception:
-        pass
+    # merge SHA comes from ForgePort.pr_state (same path deliver uses)
+    state_after = await forge.pr_state(n)
+    merge_sha = state_after.merge_commit_sha
     files = await forge.pr_files(n)
     check("11", "pr_files lists changed files",
           any(f.path == "out.bin" for f in files), f"{[f.path for f in files]}")


### PR DESCRIPTION
## Intent

Stop delivery from resolving the deliverable zip ref via adapter-private `forge._req("GET", "/pulls/{n}")`. Pin the zip to `PullRequest.merge_commit_sha` from `ForgePort.pr_state` (then the inbound PR DTO), else the default branch name `"main"`.

Mission: https://linear.app/fidecastro/issue/CAKE-77/delivery-merge-sha-goes-through-forgeport

## What changed

- **`deliver.py`**: deleted `_merge_sha`; SHA resolution is DTO-only.
- **`ports/forge.py`**: comment updated — fallback is `"main"`, not a private PR read.
- **`test_repo_routing.py`**: port-seam tests that prove `file_content` gets the SHA from `pr_state` and that `_req` is never touched (including the missing-SHA → `"main"` path); existing FakeForges carry SHA on `pr_state` and drop `_req` stubs.
- **`scripts/contract_tests_forge.py`**: checks 11–12 read `merge_commit_sha` from `pr_state` instead of `/pulls/` `_req`.

No new `ForgePort` method. No adapter `pr_state` mapping changes.

## How to verify

```bash
PYTHONPATH=app python3.12 -m pytest app/tests/test_repo_routing.py -q
# or
./scripts/pytest_app.sh app/tests/test_repo_routing.py -q
```

Evidence from this run: host `PYTHONPATH=app` and fresh `docker build -f app/Dockerfile --target test` → `docker run … pytest tests/test_repo_routing.py` both **26 passed**.

## Risk / rollout

Behavior change only when `pr_state` / inbound PR omit `merge_commit_sha`: previously a GitHub/Gitea-dialect `_req` could still recover the SHA; now the zip pins to `"main"` (same as the old GitLab miss path). All three adapters already populate the field on `pr_state`.

## Out of scope

- ForgePort / factory redesign
- Expanding GitHub `get_pr_by_branch` list payloads with `merge_commit_sha`
- Live Gitea contract battery (hermetic honesty fix only)