### PR TITLE
[CAKE-86] One OTel attribute vocabulary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
             -v "${{ github.workspace }}/images/Dockerfile:/srv/images.Dockerfile:ro" \
             -v "${{ github.workspace }}/docs:/srv/docs:ro" \
             -v "${{ github.workspace }}/admin/spa/src/lib/registry_fallback.json:/srv/admin-registry-fallback.json:ro" \
+            -v "${{ github.workspace }}/admin/spa/src/pages/RunsPage.jsx:/srv/admin-runs-page.jsx:ro" \
             -v "${{ github.workspace }}/scripts:/srv/repo-scripts:ro" \
             -v "${{ github.workspace }}/up.sh:/srv/up.sh:ro" \
             -w /srv \

--- a/app/devcake/telemetry/attributes.py
+++ b/app/devcake/telemetry/attributes.py
@@ -1,0 +1,85 @@
+"""Authoritative ``devcake.*`` OTel attribute vocabulary (docs/12 §3, CAKE-86).
+
+Data-only chokepoint: every ``span.set_attribute("devcake.…")`` name that is
+queryable or cross-span (alerts, dashboards, SPA, aggregation docs) must appear
+in ``ATTRIBUTES``. OpenObserve flattens dots to underscores — use ``oo_field``.
+
+Span home constants pin the documented carriers for attrs that dashboards and
+alerts filter on; they are not an SDK import surface.
+"""
+
+from __future__ import annotations
+
+# Normative names exactly as set_attribute keys (dots, not OO underscores).
+ATTRIBUTES: frozenset[str] = frozenset({
+    # Identity / correlation
+    "devcake.mission.key",
+    "devcake.mission.type",
+    "devcake.dev_type",
+    "devcake.harness",
+    "devcake.cli_version",
+    "devcake.run.id",
+    "devcake.run.attempt",
+    "devcake.instance",
+    "devcake.pmo.id",
+    "devcake.repo",
+    "devcake.kind",
+    # Tokens / cost (home: run.finalize)
+    "devcake.tokens.input",
+    "devcake.tokens.output",
+    "devcake.tokens.total",
+    "devcake.tokens.cache_read",
+    "devcake.tokens.cache_write",
+    "devcake.tokens.reasoning",
+    "devcake.cost.usd",
+    "devcake.cost.usd_estimated",
+    "devcake.cost.rate_card",
+    # Outcomes / verdicts
+    "devcake.outcome",
+    "devcake.verdict",
+    "devcake.cause",
+    "devcake.reason",
+    "devcake.kill.reason",
+    "devcake.merge.verdict",
+    # Poll cycle counts
+    "devcake.poll.cycle",
+    "devcake.missions.seen",
+    "devcake.missions.candidates",
+    "devcake.missions.dispatched",
+    # Continuations (ADR-0022)
+    "devcake.continuation",
+    "devcake.continuations",
+    # Audit / breaker / poison
+    "devcake.audit.action",
+    "devcake.audit.detail",
+    "devcake.breaker",
+    "devcake.poison.entries",
+    # Steward / discoveries
+    "devcake.steward.duty",
+    "devcake.steward.edges_created",
+    "devcake.steward.edges_rejected",
+    "devcake.steward.routes_delivered",
+    "devcake.steward.routes_rejected",
+    "devcake.discoveries.harvested",
+    # Clear-runs / baker / sweep
+    "devcake.clear.runs_deleted",
+    "devcake.clear.dagu_deleted",
+    "devcake.clear.ok",
+    "devcake.baker.cause",
+    "devcake.baker.detail",
+    "devcake.baker.state",
+    "devcake.children",
+})
+
+TOKEN_ATTRS: frozenset[str] = frozenset(
+    name for name in ATTRIBUTES if name.startswith("devcake.tokens.")
+)
+
+# Dashboard / alert home spans (pinned; emitters already match).
+COST_HOME_SPAN = "run.finalize"
+PMO_TRANSIENT_SPAN = "poll.instance"
+
+
+def oo_field(name: str) -> str:
+    """OpenObserve SQL column: dots → underscores (devcake.run.id → devcake_run_id)."""
+    return name.replace(".", "_")

--- a/app/tests/test_otel_attribute_vocabulary.py
+++ b/app/tests/test_otel_attribute_vocabulary.py
@@ -1,0 +1,258 @@
+"""One OTel attribute vocabulary — pin docs / emitters / OO SQL / SPA (CAKE-86).
+
+``devcake.telemetry.attributes`` is the authoritative registry (ADR-0034).
+This suite is the pinned mirror: drift between the five surfaces turns red.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from devcake.telemetry.attributes import (
+    ATTRIBUTES,
+    COST_HOME_SPAN,
+    PMO_TRANSIENT_SPAN,
+    TOKEN_ATTRS,
+    oo_field,
+)
+
+# Host checkout: repo/app/tests → repo/… ; container binds under /srv/…
+_REPO = Path(__file__).resolve().parents[2]
+_CANDIDATES = {
+    "docs12": [
+        Path("/srv/docs/12-observability.md"),
+        _REPO / "docs" / "12-observability.md",
+    ],
+    "docs15": [
+        Path("/srv/docs/15-errors-and-retries.md"),
+        _REPO / "docs" / "15-errors-and-retries.md",
+    ],
+    "provision": [
+        Path("/srv/repo-scripts/provision_oo.py"),
+        _REPO / "scripts" / "provision_oo.py",
+    ],
+    "runs_page": [
+        Path("/srv/admin-runs-page.jsx"),
+        _REPO / "admin" / "spa" / "src" / "pages" / "RunsPage.jsx",
+    ],
+    "app_pkg": [
+        Path(__file__).resolve().parents[1] / "devcake",
+    ],
+    "images": [
+        Path("/srv/images-tree"),
+        Path("/srv/images"),
+        _REPO / "images",
+    ],
+}
+
+
+def _first_existing(key: str) -> Path:
+    for p in _CANDIDATES[key]:
+        if p.exists():
+            return p
+    return _CANDIDATES[key][-1]
+
+
+def _require(key: str) -> Path:
+    path = _first_existing(key)
+    assert path.exists(), (
+        f"missing {path} — bind the source into the pytest runner "
+        f"(see scripts/pytest_app.sh / ci.yml) for {key}"
+    )
+    return path
+
+
+def _attr_from_call_arg(node: ast.AST) -> set[str]:
+    """Resolve set_attribute's first arg to registry names (literals + tokens f-string)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        if node.value.startswith("devcake."):
+            return {node.value}
+        return set()
+    if isinstance(node, ast.JoinedStr) and node.values:
+        first = node.values[0]
+        if (isinstance(first, ast.Constant) and isinstance(first.value, str)
+                and first.value == "devcake.tokens."):
+            return set(TOKEN_ATTRS)
+    return set()
+
+
+def _collect_emitted(roots: list[Path]) -> set[str]:
+    found: set[str] = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            # Skip tests / __pycache__ if a tree is wide
+            if "/tests/" in path.as_posix() or path.name.startswith("test_"):
+                continue
+            try:
+                tree = ast.parse(path.read_text(), filename=str(path))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if not (isinstance(func, ast.Attribute) and func.attr == "set_attribute"):
+                    continue
+                if not node.args:
+                    continue
+                found |= _attr_from_call_arg(node.args[0])
+    return found
+
+
+def _docs12_section3_names(text: str) -> set[str]:
+    # Prose may sit between the heading and the fenced mirror of ATTRIBUTES.
+    m = re.search(
+        r"## 3\. Attribute registry.*?```\n(.*?)```",
+        text,
+        flags=re.DOTALL,
+    )
+    assert m, "docs/12 §3 code fence missing — registry must stay in a fenced block"
+    return set(re.findall(r"devcake\.[a-z0-9_.]+", m.group(1)))
+
+
+def test_oo_field_maps_dots_to_underscores():
+    assert oo_field("devcake.run.id") == "devcake_run_id"
+    assert oo_field("devcake.cost.usd") == "devcake_cost_usd"
+    assert oo_field("devcake.audit.action") == "devcake_audit_action"
+
+
+def test_registry_drops_never_emitted_and_keeps_queryable_core():
+    """Independent expected values: names that must / must not be in the set."""
+    assert "devcake.mission.id" not in ATTRIBUTES
+    assert "devcake.run.seq" not in ATTRIBUTES
+    for name in (
+        "devcake.run.id",
+        "devcake.outcome",
+        "devcake.cost.usd",
+        "devcake.cost.usd_estimated",
+        "devcake.instance",
+        "devcake.audit.action",
+        *TOKEN_ATTRS,
+    ):
+        assert name in ATTRIBUTES, name
+
+
+def test_emitters_only_stamp_registry_names():
+    app = _require("app_pkg")
+    images = _first_existing("images")
+    roots = [app]
+    if images.exists():
+        roots.append(images)
+    emitted = _collect_emitted(roots)
+    assert emitted, "AST scan found no set_attribute('devcake…') — path wrong?"
+    rogue = sorted(emitted - ATTRIBUTES)
+    assert not rogue, (
+        "emitters stamp names absent from telemetry.attributes.ATTRIBUTES: "
+        + ", ".join(rogue)
+    )
+
+
+def test_docs_12_section3_equals_registry():
+    text = _require("docs12").read_text()
+    fence = _docs12_section3_names(text)
+    assert fence == ATTRIBUTES, (
+        "docs/12 §3 drifted from ATTRIBUTES:\n"
+        f"  only_in_docs={sorted(fence - ATTRIBUTES)}\n"
+        f"  only_in_code={sorted(ATTRIBUTES - fence)}"
+    )
+
+
+def test_docs_12_tokens_and_cost_live_on_run_finalize_not_dev_run():
+    text = _require("docs12").read_text()
+    # §2 table row for dev.run must not claim tokens/cost (those ride run.finalize).
+    m = re.search(r"\|\s*`dev\.run`\s*\|([^|]+)\|([^|]+)\|([^|]+)\|", text)
+    assert m, "docs/12 §2 missing dev.run row"
+    content = m.group(3)
+    # Must not claim tokens/cost as carried attrs (negation prose is fine).
+    assert "`devcake.tokens" not in content, content
+    assert "`devcake.cost" not in content, content
+    assert COST_HOME_SPAN == "run.finalize"
+    assert "run.finalize" in text
+    # Outcome dashboard narrative / panel table must not pin outcome to dev.run.
+    panel = re.search(
+        r"\|\s*2\s*\|\s*\*\*Dev runs by outcome[^*]*\*\*\s*\|\s*([^|]+)\|",
+        text,
+    )
+    assert panel, "docs/12 §5 outcome panel row missing"
+    assert "run.finalize" in panel.group(1), panel.group(1)
+    assert "dev.run" not in panel.group(1), panel.group(1)
+
+
+def test_docs_12_pmo_transient_is_on_poll_instance():
+    text = _require("docs12").read_text()
+    cycle = re.search(r"\|\s*`poll\.cycle`\s*\|([^|]+)\|([^|]+)\|([^|]+)\|", text)
+    instance = re.search(
+        r"\|\s*`poll\.instance`\s*\|([^|]+)\|([^|]+)\|([^|]+)\|", text)
+    assert cycle and instance
+    assert "PMO_TRANSIENT" not in cycle.group(3), cycle.group(3)
+    assert "PMO_TRANSIENT" in instance.group(3), instance.group(3)
+    assert PMO_TRANSIENT_SPAN == "poll.instance"
+
+
+def test_pmo_transient_alert_queries_poll_instance():
+    provision = _require("provision").read_text()
+    docs15 = _require("docs15").read_text()
+    # Script alert arm
+    assert (
+        f"(operation_name = '{PMO_TRANSIENT_SPAN}' AND "
+        f"{oo_field('devcake.outcome')} = 'PMO_TRANSIENT')"
+    ) in provision, (
+        "provision_oo.py PMO_TRANSIENT arm must query poll.instance "
+        "(stamp lives on the per-instance child, not the cycle)"
+    )
+    assert "operation_name = 'poll.cycle' AND devcake_outcome = 'PMO_TRANSIENT'" not in provision
+    # docs/15 §6 table
+    row = re.search(
+        r"\|\s*`devcake-pmo-forge-transient`\s*\|\s*([^|]+)\|",
+        docs15,
+    )
+    assert row, "docs/15 §6 missing pmo-forge-transient row"
+    assert "poll.instance" in row.group(1), row.group(1)
+    assert "poll.cycle" not in row.group(1), row.group(1)
+
+
+def test_cost_and_outcome_sql_constrain_to_run_finalize():
+    provision = _require("provision").read_text()
+    cost_col = oo_field("devcake.cost.usd")
+    est_col = oo_field("devcake.cost.usd_estimated")
+    outcome_col = oo_field("devcake.outcome")
+
+    # Outcome panel — mission vocabulary lives on run.finalize, not dev.run
+    assert f"operation_name = '{COST_HOME_SPAN}'" in provision
+    assert "operation_name = 'dev.run'" not in provision
+
+    # Cost panels — string literals may split across lines; require both
+    # the home-span filter and the >0 guard next to each SUM.
+    assert (
+        f"WHERE operation_name = '{COST_HOME_SPAN}' AND {cost_col} > 0"
+        in provision
+    ), "billed cost panel must filter run.finalize + cost > 0"
+    assert re.search(
+        rf"SUM\({re.escape(est_col)}\).*?operation_name = '{COST_HOME_SPAN}'"
+        rf".*?{re.escape(est_col)} > 0",
+        provision,
+        flags=re.DOTALL,
+    ), "estimated cost panel must filter run.finalize"
+
+    # Daily cost alert — SQL is split across adjacent string literals
+    idx = provision.index('"devcake-daily-cost"')
+    alert_blob = provision[idx:idx + 280]
+    assert f"operation_name = '{COST_HOME_SPAN}'" in alert_blob, alert_blob
+    assert cost_col in alert_blob
+    # Outcome panel groups by outcome on finalize
+    assert outcome_col in provision
+
+
+def test_spa_trace_filter_uses_oo_field_for_run_id():
+    src = _require("runs_page").read_text()
+    expected = oo_field("devcake.run.id")
+    assert expected == "devcake_run_id"
+    # Concrete shape used by RunsPage.traceUrl (OO flattens dots → underscores)
+    assert f"{expected}='" in src, (
+        f"RunsPage.traceUrl must filter on {expected!r} "
+        f"(oo_field('devcake.run.id'))"
+    )

--- a/docs/12-observability.md
+++ b/docs/12-observability.md
@@ -27,8 +27,8 @@ observability gap.
 
 | Span | Parent | Emitted by | Content |
 |---|---|---|---|
-| `poll.cycle` | root | app | counts: missions seen/candidates/dispatched; `PMO_TRANSIENT`/`cycle_error` outcomes |
-| `poll.instance` | `poll.cycle` | app | one child per configured PMO instance (`devcake.instance`); a per-instance failure marks THIS span, not the cycle |
+| `poll.cycle` | root | app | counts: missions seen/candidates/dispatched; `cycle_error` outcome on the cycle itself |
+| `poll.instance` | `poll.cycle` | app | one child per configured PMO instance (`devcake.instance`); per-instance failures (`PMO_TRANSIENT` / `INSTANCE_ERROR`) mark THIS span, not the cycle |
 | `mission.dispatch` | `poll.cycle` (steward runs: `steward.periodic` / `steward.discovery`) | app | `devcake.mission.*`, `devcake.run.id`, `devcake.dev_type`; covers the ACL-user creation, run persist, and Dagu trigger |
 | `mission.give_up` | `poll.cycle` | app | ERROR status; covers the `DEVCAKE-FAILED` label write + feed post |
 | `sweep.merge` | `poll.cycle` | app | emitted only when the sweep acts (`merged`/`closed`); covers the PMO writes |
@@ -36,10 +36,10 @@ observability gap.
 | `sweep.tracking` | `poll.cycle` | app | emitted when a project auto-completes; covers the PMO writes |
 | `steward.periodic` | `poll.cycle` | app | how a DUE periodic steward run resolved: `dispatched` / `already_active` / `concurrency_deferred` / `degraded_skip` (ERROR). Emitted on outcome **transitions** (and every dispatch), not per tick — a steward stuck degraded for hours yields one span, not thousands |
 | `steward.discovery` | `poll.cycle` (or the harvest kick's task) | app | how a discovery-lane pass resolved: `dispatched` / `already_active` / `concurrency_deferred` / `degraded_skip` / `mirror_stale` / `secret_env_gate` / `dispatch_skipped` (ADR-0033). Same on-transition emission rule as `steward.periodic` |
-| `dev.run` | *linked to `mission.dispatch` via TRACEPARENT env* | Dev entrypoint | full registry incl. `devcake.tokens.*`, `devcake.cost.usd`, `devcake.outcome` |
-| `harness.exec` | `dev.run` | Dev entrypoint | `devcake.harness` |
+| `dev.run` | *linked to `mission.dispatch` via TRACEPARENT env* | Dev entrypoint | identity (`devcake.run.id`, `devcake.dev_type`, `devcake.harness`), `devcake.outcome` (harness-exit shaped), `devcake.continuations` — **not** tokens/cost |
+| `harness.exec` | `dev.run` | Dev entrypoint | `devcake.harness`; `devcake.continuation` per attempt |
 | `ingress.handle` | `dev.run` (via the run's traceparent) | app | one span per handled ingress message (`devcake.kind`: `run.started`, `runspec.get`, `activity.get`, `oauth.result`, `run.artifacts`, OAuth-shaped `run.log`, …). Deliberately span-free: `run.heartbeat` (2/min/run) and streamed `run.log {lines}` batches (one every few seconds while a harness talks) — pure liveness/output noise that would drown the trace |
-| `run.finalize` | `dev.run` (via the run's traceparent) | app | `devcake.run.id`, `devcake.outcome`, `devcake.tokens.*`, `devcake.cost.usd`, `devcake.verdict` (+ ERROR status on rejections) |
+| `run.finalize` | `dev.run` (via the run's traceparent) | app | `devcake.run.id`, `devcake.outcome` (mission vocabulary), `devcake.tokens.*`, `devcake.cost.usd` / `usd_estimated` / `rate_card`, `devcake.verdict`, `devcake.continuations` (+ ERROR status on rejections) |
 | `watchdog.kill` | `dev.run` (via the run's traceparent) | app | ERROR status, kill reason, resulting state |
 | `baker.dead` / `baker.alive` | root (poll.cycle sibling) | app | Transition only. The host baker heartbeats on `/data`; the **poll cycle** observes it (same chokepoint as `run_failures`). `baker.dead` is ERROR — restart with `./up.sh`. Quiet ticks are span-free. |
 | `baker.reconcile` | root | app (replay) | One claimed keep-set order. Children: `baker.compile`, `baker.probe.<row>` (`devcake.baker.cause` = aim/stub/dialect/auth), `baker.prune`. Host baker writes span records to the outbox; poll replays them. Quiet ticks emit nothing. |
@@ -61,22 +61,71 @@ Deliberately span-free besides heartbeats: the watchdog's quiet 10 s scan (its
 
 ## 3. Attribute registry (normative — spelled exactly)
 
+Authoritative source: `app/devcake/telemetry/attributes.py` (`ATTRIBUTES`).
+The fenced list below is a pinned mirror of that frozenset — every
+`set_attribute("devcake.…")` name that is queryable or cross-span must appear
+here; OpenObserve flattens dots to underscores (`devcake.run.id` →
+`devcake_run_id`). Dropped (never emitted): `devcake.mission.id`,
+`devcake.run.seq`.
+
 ```
-devcake.mission.id          devcake.mission.key        devcake.mission.type
-devcake.dev_type            devcake.harness
-devcake.run.id              devcake.run.seq            devcake.run.attempt
-devcake.tokens.input        devcake.tokens.output      devcake.tokens.total
-devcake.tokens.cache_read   devcake.tokens.cache_write devcake.tokens.reasoning
-devcake.cost.usd            devcake.cost.usd_estimated devcake.cost.rate_card
-devcake.outcome             (result.json outcome | error class)
-devcake.discoveries.harvested  (run.finalize; count only — discovery CONTENT
-                                never leaves the board, ADR-0033 D8)
-devcake.steward.duty           (mission.dispatch — "relations" | "discovery")
-devcake.steward.edges_created  devcake.steward.edges_rejected   (run.finalize,
-                                relations flavor)
-devcake.steward.routes_delivered  devcake.steward.routes_rejected
-                               (run.finalize, discovery flavor; counts only)
+devcake.audit.action
+devcake.audit.detail
+devcake.baker.cause
+devcake.baker.detail
+devcake.baker.state
+devcake.breaker
+devcake.cause
+devcake.children
+devcake.clear.dagu_deleted
+devcake.clear.ok
+devcake.clear.runs_deleted
+devcake.cli_version
+devcake.continuation
+devcake.continuations
+devcake.cost.rate_card
+devcake.cost.usd
+devcake.cost.usd_estimated
+devcake.dev_type
+devcake.discoveries.harvested
+devcake.harness
+devcake.instance
+devcake.kill.reason
+devcake.kind
+devcake.merge.verdict
+devcake.mission.key
+devcake.mission.type
+devcake.missions.candidates
+devcake.missions.dispatched
+devcake.missions.seen
+devcake.outcome
+devcake.pmo.id
+devcake.poison.entries
+devcake.poll.cycle
+devcake.reason
+devcake.repo
+devcake.run.attempt
+devcake.run.id
+devcake.steward.duty
+devcake.steward.edges_created
+devcake.steward.edges_rejected
+devcake.steward.routes_delivered
+devcake.steward.routes_rejected
+devcake.tokens.cache_read
+devcake.tokens.cache_write
+devcake.tokens.input
+devcake.tokens.output
+devcake.tokens.reasoning
+devcake.tokens.total
+devcake.verdict
 ```
+
+Notes (not attribute names): `devcake.outcome` carries result.json outcomes /
+error classes; `devcake.discoveries.harvested` is a count only (discovery
+CONTENT never leaves the board, ADR-0033 D8); steward edge/route attrs are
+counts on `run.finalize`; `devcake.steward.duty` is stamped on
+`mission.dispatch` (`relations` | `discovery`). Tokens and cost attrs home on
+`run.finalize` only.
 
 Every log line from app and Dev entrypoint carries `devcake.run.id` and `devcake.mission.key` for correlation.
 
@@ -138,7 +187,7 @@ default `default` — same multi-org footgun as fluent-bit, §1 / `13` §7):
 | # | Panel title | Primary signal |
 |---|---|---|
 | 1 | **Cost per hour (USD, by dev type)** | `devcake_cost_usd` (harness-reported) |
-| 2 | **Dev runs by outcome (daily)** | `dev.run` by `devcake_outcome` |
+| 2 | **Dev runs by outcome (daily)** | `run.finalize` by `devcake_outcome` |
 | 3 | **Failure signals (kills, give-ups)** | `watchdog.kill`, `mission.give_up` |
 | 4 | **Estimated cost per hour (USD, by dev type — rate card)** | `devcake_cost_usd_estimated` (ADR-0021) |
 

--- a/docs/15-errors-and-retries.md
+++ b/docs/15-errors-and-retries.md
@@ -47,7 +47,7 @@ prose.
 
 | Class | Retryable | Counts toward `max_attempts` | Who retries | User-visible surface |
 |---|---|---|---|---|
-| `PMO_TRANSIENT` | yes — **no in-adapter retry ladder.** Adapter raises `PMOTransient`; the poll cycle **skips that PMO instance's segment** and continues with the others; the next poll tick (`poll_interval_seconds`, default 30) re-attempts the sick instance | no | app (next poll tick) | `poll.cycle` outcome / logs; not latched into `poll_degraded` (that field is for permanent per-instance failures) |
+| `PMO_TRANSIENT` | yes — **no in-adapter retry ladder.** Adapter raises `PMOTransient`; the poll cycle **skips that PMO instance's segment** and continues with the others; the next poll tick (`poll_interval_seconds`, default 30) re-attempts the sick instance | no | app (next poll tick) | `poll.instance` outcome / logs; not latched into `poll_degraded` (that field is for permanent per-instance failures) |
 | `PMO_PERMANENT` | no | no | — | `poll_degraded` for that instance + SPA alert; other instances keep polling |
 | `PMO_GONE` | n/a — residual class only | no | — | *not implemented as a dedicated path* — do not expect a WARN+cancel special case |
 | `FORGE_TRANSIENT` | yes — **no exp-backoff matrix.** Poll re-probes forge health each cycle (latched breakers self-heal on a green probe; the re-probe sweep is bounded-parallel — `ForgeRuntime.refresh_all`, at most 8 in flight); finalization re-enters via ingress reclaim; adapters may short-sleep only where code has them (e.g. Gitea merge "try again later" 405 retries, GitHub 409 race retries — `06-forge-adapter.md` §5/§7a; the `.claims/` writer replays its checkout+commit+push cycle ONCE on a push race — ADR-0035). Dev clone/push is single-shot (exit 13 on failure) | no | app (poll / finalize resume) | health / breaker surfaces if a probe becomes definitive |
@@ -320,9 +320,9 @@ the script (period is minutes; threshold is the SQL result `>=` count):
 | `devcake-kills` | `operation_name = 'watchdog.kill'` | 10 | 1 |
 | `devcake-needs-human` | `audit.event` with `devcake_audit_action = 'devcake_needs_human'` (audit log is span-mirrored so this can fire) | 15 | 1 |
 | `devcake-dev-auth-breaker` | `operation_name = 'breaker.trip'` (DEV_AUTH or forge). Separately, `dev.backend_degraded` spans signal model-backend throttling (§4a) — **not** this alert | 15 | 1 |
-| `devcake-pmo-forge-transient` | `poll.cycle` with `devcake_outcome = 'PMO_TRANSIENT'` **or** `forge.probe_transient` | 15 | 3 |
+| `devcake-pmo-forge-transient` | `poll.instance` with `devcake_outcome = 'PMO_TRANSIENT'` **or** `forge.probe_transient` | 15 | 3 |
 | `devcake-poison` | `operation_name = 'ingress.poison'` | 10 | 1 |
-| `devcake-daily-cost` | `SUM(devcake_cost_usd)` where not null | 1440 (24 h) | `OO_DAILY_COST_ALERT_USD` (default **50**) |
+| `devcake-daily-cost` | `SUM(devcake_cost_usd)` on `run.finalize` where not null | 1440 (24 h) | `OO_DAILY_COST_ALERT_USD` (default **50**) |
 
 Without `OO_ALERT_WEBHOOK`, the script skips alerts (exit 0). Re-post is
 idempotent: an “already exists” body is success; other errors fail loud

--- a/scripts/ci_suite.sh
+++ b/scripts/ci_suite.sh
@@ -86,6 +86,7 @@ docker run --rm \
   -v "$(pwd)/images/Dockerfile:/srv/images.Dockerfile:ro" \
   -v "$(pwd)/docs:/srv/docs:ro" \
   -v "$(pwd)/admin/spa/src/lib/registry_fallback.json:/srv/admin-registry-fallback.json:ro" \
+  -v "$(pwd)/admin/spa/src/pages/RunsPage.jsx:/srv/admin-runs-page.jsx:ro" \
   -v "$(pwd)/scripts:/srv/repo-scripts:ro" \
   -v "$(pwd)/up.sh:/srv/up.sh:ro" \
   -w /srv \

--- a/scripts/provision_oo.py
+++ b/scripts/provision_oo.py
@@ -126,14 +126,17 @@ DASHBOARD = {
     "tabs": [{
         "tabId": "default", "name": "v0",
         "panels": [
+            # Cost / outcome panels constrain to run.finalize (docs/12 §3–§5;
+            # tokens/cost and mission outcomes live there — not on dev.run).
             panel(1, "Cost per hour (USD, by dev type)",
                   "SELECT histogram(_timestamp, '1 hour') AS ts, devcake_dev_type, "
                   "SUM(devcake_cost_usd) AS cost FROM default "
-                  "WHERE devcake_cost_usd > 0 GROUP BY ts, devcake_dev_type ORDER BY ts",
+                  "WHERE operation_name = 'run.finalize' AND devcake_cost_usd > 0 "
+                  "GROUP BY ts, devcake_dev_type ORDER BY ts",
                   "line", 0, 0, 24, 9),
             panel(2, "Dev runs by outcome (daily)",
                   "SELECT histogram(_timestamp, '1 day') AS ts, devcake_outcome, "
-                  "COUNT(*) AS runs FROM default WHERE operation_name = 'dev.run' "
+                  "COUNT(*) AS runs FROM default WHERE operation_name = 'run.finalize' "
                   "GROUP BY ts, devcake_outcome ORDER BY ts",
                   "bar", 0, 9, 12, 9),
             panel(3, "Failure signals (kills, give-ups)",
@@ -147,7 +150,8 @@ DASHBOARD = {
             panel(4, "Estimated cost per hour (USD, by dev type — rate card)",
                   "SELECT histogram(_timestamp, '1 hour') AS ts, devcake_dev_type, "
                   "SUM(devcake_cost_usd_estimated) AS cost_estimated FROM default "
-                  "WHERE devcake_cost_usd_estimated > 0 "
+                  "WHERE operation_name = 'run.finalize' AND "
+                  "devcake_cost_usd_estimated > 0 "
                   "GROUP BY ts, devcake_dev_type ORDER BY ts",
                   "line", 0, 18, 24, 9),
         ],
@@ -190,8 +194,9 @@ if _failed(dest):
 # Full documented alert set (docs/15 §6, ISSUES #23). Every query targets a
 # span the app actually emits (verified against the tracer inventory):
 # mission.give_up, watchdog.kill, audit.event (devcake_audit_action mirrors
-# the audit log), breaker.trip, poll.cycle outcome, forge.probe_transient,
-# ingress.poison, and the devcake_cost_usd attribute on run.finalize.
+# the audit log), breaker.trip, poll.instance PMO_TRANSIENT (per-instance
+# child — not poll.cycle), forge.probe_transient, ingress.poison, and
+# devcake_cost_usd on run.finalize only.
 DAILY_COST_USD = float(env("OO_DAILY_COST_ALERT_USD", "50"))
 for name, sql, period, threshold in [
     ("devcake-give-up", "SELECT COUNT(*) as cnt FROM \"default\" WHERE "
@@ -204,12 +209,13 @@ for name, sql, period, threshold in [
     ("devcake-dev-auth-breaker", "SELECT COUNT(*) as cnt FROM \"default\" WHERE "
      "operation_name = 'breaker.trip'", 15, 1),
     ("devcake-pmo-forge-transient", "SELECT COUNT(*) as cnt FROM \"default\" WHERE "
-     "(operation_name = 'poll.cycle' AND devcake_outcome = 'PMO_TRANSIENT') "
+     "(operation_name = 'poll.instance' AND devcake_outcome = 'PMO_TRANSIENT') "
      "OR operation_name = 'forge.probe_transient'", 15, 3),
     ("devcake-poison", "SELECT COUNT(*) as cnt FROM \"default\" WHERE "
      "operation_name = 'ingress.poison'", 10, 1),
     ("devcake-daily-cost", "SELECT SUM(CAST(devcake_cost_usd AS FLOAT)) as cnt "
-     "FROM \"default\" WHERE devcake_cost_usd IS NOT NULL", 60 * 24,
+     "FROM \"default\" WHERE operation_name = 'run.finalize' AND "
+     "devcake_cost_usd IS NOT NULL", 60 * 24,
      DAILY_COST_USD),
 ]:
     out = req("POST", "/default/alerts",

--- a/scripts/pytest_app.sh
+++ b/scripts/pytest_app.sh
@@ -76,6 +76,7 @@ docker run --rm \
   -v "$(pwd)/images/Dockerfile:/srv/images.Dockerfile:ro" \
   -v "$(pwd)/docs:/srv/docs:ro" \
   -v "$(pwd)/admin/spa/src/lib/registry_fallback.json:/srv/admin-registry-fallback.json:ro" \
+  -v "$(pwd)/admin/spa/src/pages/RunsPage.jsx:/srv/admin-runs-page.jsx:ro" \
   -v "$(pwd)/scripts:/srv/repo-scripts:ro" \
   -v "$(pwd)/up.sh:/srv/up.sh:ro" \
   -w /srv \


### PR DESCRIPTION
## Summary

Locks **one authoritative `devcake.*` OTel attribute vocabulary** across docs, emitters, OpenObserve SQL, alerts, and the SPA Runs trace link (CAKE-86).

- **Chokepoint:** `app/devcake/telemetry/attributes.py` (`ATTRIBUTES`, `oo_field`, home-span constants)
- **Pin test:** `app/tests/test_otel_attribute_vocabulary.py` — docs/12 §3 == registry; emitters ⊆ registry; `PMO_TRANSIENT` alert on `poll.instance`; cost/outcome SQL on `run.finalize`; SPA `devcake_run_id` == `oo_field("devcake.run.id")`
- **Docs:** `docs/12` §2/§3/§5 and `docs/15` §2/§6 aligned (drop never-emitted `mission.id` / `run.seq`; tokens/cost documented on `run.finalize`, not `dev.run`)
- **`scripts/provision_oo.py`:** transient alert + cost/outcome panels/alerts updated

**Operator note:** existing OpenObserve `DevCake` dashboard panels are **not** updated in place — delete the dashboard (or edit panels) and re-run `scripts/provision_oo.py` after merge.

Mission: https://linear.app/fidecastro/issue/CAKE-86/one-otel-attribute-vocabulary

## Test plan

- [x] Fresh `app-test` bake + `pytest tests/test_otel_attribute_vocabulary.py` (9 passed)
- [x] Related OO/structure tests (37 passed with pin suite)
- [ ] CI green on this PR
- [ ] Live OO alert firing not claimed (structural pin only)