### PR TITLE
[CAKE-90] Admin errors surface in the UI

### DIFF
--- a/admin/spa/src/components/Field.jsx
+++ b/admin/spa/src/components/Field.jsx
@@ -135,6 +135,7 @@ export function SecretField({ label, help, hint, refKey, checkKind = "conn",
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
   const [askRemove, setAskRemove] = useState(false);
+  const [err, setErr] = useState("");
   // `presence` (bulk-scale 2026-08-02): a page rendering MANY SecretFields
   // (350 repo cards × 3 tokens) supplies one batched /secrets-check result
   // instead of a per-field fetch storm. Optional — every other call site
@@ -162,6 +163,7 @@ export function SecretField({ label, help, hint, refKey, checkKind = "conn",
   const submit = async () => {
     if (!draft) return;
     setBusy(true);
+    setErr("");
     try {
       if (checkKind === "harness") {
         await send("PUT", `/harness-secrets/${encodeURIComponent(refKey)}`, { value: draft });
@@ -171,10 +173,13 @@ export function SecretField({ label, help, hint, refKey, checkKind = "conn",
       }
       setDraft("");
       refresh();
+    } catch (e) {
+      setErr(String(e.message || e));
     } finally { setBusy(false); }
   };
   const remove = async () => {
     setBusy(true);
+    setErr("");
     try {
       if (checkKind === "harness") {
         await send("DELETE", `/harness-secrets/${encodeURIComponent(refKey)}`);
@@ -182,8 +187,11 @@ export function SecretField({ label, help, hint, refKey, checkKind = "conn",
         const [scope, instance, field] = refKey.split(":");
         await send("DELETE", `/secrets/${scope}/${instance}/${field}`);
       }
+      setAskRemove(false);
       refresh();
-    } finally { setBusy(false); setAskRemove(false); }
+    } catch (e) {
+      setErr(String(e.message || e));
+    } finally { setBusy(false); }
   };
   const shapeWarn = paste && draft && !secretShapeRe().test(draft) && draft.length < 8
     ? "That does not look like a secret — double-check before saving."
@@ -205,17 +213,21 @@ export function SecretField({ label, help, hint, refKey, checkKind = "conn",
       <div className="flex gap-2">
         <Input type="password" value={draft} aria-label={label}
           placeholder={status?.present ? "•••••• (stored)" : "paste value"}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => { setDraft(e.target.value); if (err) setErr(""); }}
           onKeyDown={(e) => e.key === "Enter" && submit()} />
         <button type="button" disabled={!draft || busy}
           className="rounded bg-neutral-800 px-3 text-sm text-white disabled:opacity-40 dark:bg-neutral-200 dark:text-black"
           onClick={submit}>{status?.present ? "Replace" : "Set"}</button>
       </div>
       {shapeWarn && <span className="mt-1 block text-xs text-amber-600">⚠ {shapeWarn}</span>}
+      {err && !askRemove && (
+        <span className="mt-1 block text-xs text-red-600 dark:text-red-400">✗ {err}</span>
+      )}
       {status && status.present && (
         <span className="mt-1 flex items-center gap-2 text-xs">
           <span className="text-green-700 dark:text-green-400">✓ stored</span>
-          <button type="button" disabled={busy} onClick={() => setAskRemove(true)}
+          <button type="button" disabled={busy}
+            onClick={() => { setErr(""); setAskRemove(true); }}
             className="text-red-600 underline-offset-2 hover:underline disabled:opacity-40 dark:text-red-400">
             Remove
           </button>
@@ -224,8 +236,9 @@ export function SecretField({ label, help, hint, refKey, checkKind = "conn",
       <ConfirmDialog open={askRemove}
         title={`Remove the stored value for ${label}?`}
         body="Runs that need it will fail until a new one is set."
-        confirmLabel="Remove" busy={busy}
-        onConfirm={remove} onCancel={() => setAskRemove(false)} />
+        confirmLabel="Remove" busy={busy} error={err}
+        onConfirm={remove}
+        onCancel={() => { setAskRemove(false); setErr(""); }} />
       {status && !status.present && (
         optional
           ? <span className="mt-1 block text-xs text-neutral-500 dark:text-neutral-400">not set (optional)</span>

--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -99,12 +99,30 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
       action: () => { setField(path, value); setConfirm(null); },
     });
 
-  const test = async (kind) =>
-    setTestResult({ ...testResult, [kind]: await send("POST", `/connections/${kind}/test`) });
+  const test = async (kind) => {
+    try {
+      const result = await send("POST", `/connections/${kind}/test`);
+      setTestResult((prev) => ({ ...prev, [kind]: result }));
+    } catch (e) {
+      setTestResult((prev) => ({
+        ...prev,
+        [kind]: { ok: false, error: String(e.message || e) },
+      }));
+    }
+  };
   // per-instance tests (schema v3 / M10): keyed pmo:{name} / forge:{name}
-  const testPmo = async (name) =>
-    setTestResult({ ...testResult,
-                    [`pmo:${name}`]: await send("POST", `/connections/pmo/${name}/test`) });
+  const testPmo = async (name) => {
+    const key = `pmo:${name}`;
+    try {
+      const result = await send("POST", `/connections/pmo/${name}/test`);
+      setTestResult((prev) => ({ ...prev, [key]: result }));
+    } catch (e) {
+      setTestResult((prev) => ({
+        ...prev,
+        [key]: { ok: false, error: String(e.message || e) },
+      }));
+    }
+  };
 
   // Narrow endpoint — never rewrites the pmos list (lost-update / secret-delete race).
   // State comes from App /health; only saved instances can toggle live.

--- a/admin/spa/src/pages/ReposPage.jsx
+++ b/admin/spa/src/pages/ReposPage.jsx
@@ -345,9 +345,18 @@ export default function ReposPage({ onHealthChange }) {
     });
   };
 
-  const testForge = async (name) =>
-    setTestResult({ ...testResult,
-                    [`forge:${name}`]: await send("POST", `/connections/forge/${name}/test`) });
+  const testForge = async (name) => {
+    const key = `forge:${name}`;
+    try {
+      const result = await send("POST", `/connections/forge/${name}/test`);
+      setTestResult((prev) => ({ ...prev, [key]: result }));
+    } catch (e) {
+      setTestResult((prev) => ({
+        ...prev,
+        [key]: { ok: false, error: String(e.message || e) },
+      }));
+    }
+  };
 
   return (
     <div className="space-y-5">

--- a/admin/spa/src/pages/RunsPage.jsx
+++ b/admin/spa/src/pages/RunsPage.jsx
@@ -351,6 +351,7 @@ export default function RunsPage() {
   };
 
   const [stopErr, setStopErr] = useState("");
+  const [exportErr, setExportErr] = useState("");
   const doStopAll = async () => {
     setStopping(true);
     setStopErr("");
@@ -378,6 +379,11 @@ export default function RunsPage() {
       setStopping(false);
     }
   };
+  const doExportCsv = () => {
+    setExportErr("");
+    download(`/runs.csv?${filterQuery().slice(1)}`, null, "GET")
+      .catch((e) => setExportErr(String(e.message || e)));
+  };
 
   return (
     <div className="space-y-4">
@@ -391,13 +397,13 @@ export default function RunsPage() {
             <MoreMenu label="More run actions" items={[
               { label: "Export to CSV…",
                 desc: "Downloads the filtered set as a spreadsheet — every matching run, not just this page.",
-                onClick: () => { download(`/runs.csv?${filterQuery().slice(1)}`, null, "GET").catch((e) => setStopErr(String(e.message || e))); } },
+                onClick: doExportCsv },
               { label: "Cost inputs…",
                 desc: "Per-model rates behind estimated costs. Changes apply immediately.",
                 onClick: () => setCostOpen(true) },
               { label: "Stop all runs", danger: true,
                 desc: "Kills every in-flight Dev (each counts as a failed attempt). Finalizing runs complete on their own.",
-                onClick: () => { setStopConfirmOpen(true); setClearErr(""); } },
+                onClick: () => { setStopConfirmOpen(true); setClearErr(""); setExportErr(""); } },
               { label: "Clear run history", danger: true,
                 desc: "Wipes local records, Dagu history and OpenObserve data. Cannot be undone.",
                 onClick: () => { setConfirmOpen(true); setClearErr(""); } },
@@ -412,6 +418,11 @@ export default function RunsPage() {
       {clearErr && (
         <p className="rounded-card border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
           Partial clear: {clearErr}
+        </p>
+      )}
+      {exportErr && (
+        <p className="rounded-card border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+          Export failed: {exportErr}
         </p>
       )}
       {stopErr && (

--- a/admin/spa/tests/error_surface.mjs
+++ b/admin/spa/tests/error_surface.mjs
@@ -1,0 +1,264 @@
+// CAKE-90: three REVIEW_LEDGER failure paths must surface honest UI error
+// state instead of silent rejection or the wrong error channel.
+// Fully route-mocked — no live backend required.
+import { check, checked, gotoFresh, summary, withPage } from "./harness.mjs";
+
+const REPO = {
+  name: "demo",
+  forge: "github",
+  url: "https://github.com/acme/demo",
+  api_base: null,
+  default_branch: "main",
+  auto_merge: false,
+  auto_resolve_merge_conflicts: true,
+  merge_retry_window_minutes: 30,
+  merge_settle_minutes: 0,
+};
+
+const PMO = {
+  name: "linear1",
+  system: "linear",
+  team_key: "DEV",
+  api_base: null,
+  repos: ["demo"],
+  reference_repos: [],
+  memory_repos: [],
+  intake_paused: false,
+  discovery_routing: true,
+  assignments: {},
+  managed: false,
+};
+
+async function mockDraftApis(page, { configExtras = {} } = {}) {
+  const cfg = {
+    pmos: [PMO],
+    repos: [REPO],
+    dismissed_alerts: [],
+    ...configExtras,
+  };
+  await page.route(/\/api\/v1\/config$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify(cfg),
+    }));
+  await page.route(/\/api\/v1\/dev-types$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify([]),
+    }));
+  await page.route(/\/api\/v1\/assignments$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({}),
+    }));
+  await page.route(/\/api\/v1\/harnesses$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({}),
+    }));
+  await page.route(/\/api\/v1\/health$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        intake_paused: false,
+        pmo_instances: { linear1: { intake_paused: false } },
+        harness_pins: {},
+      }),
+    }));
+  await page.route(/\/api\/v1\/connections\/registry$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        pmo_systems: [{ id: "linear", display_name: "Linear", supports_priority: true }],
+        forges: [{ id: "github", display_name: "GitHub" }],
+        secret_shape_prefixes: ["ghp_"],
+        managed_labels_expected: 11,
+      }),
+    }));
+  await page.route(/\/api\/v1\/secrets-check/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        conn: {
+          "repo:demo:token": { present: true, updated_at: "2026-08-01T00:00:00Z" },
+          "repo:demo:token_ro": { present: false },
+          "repo:demo:reviewer_token": { present: false },
+          "pmo:linear1:api_key": { present: true, updated_at: "2026-08-01T00:00:00Z" },
+        },
+      }),
+    }));
+  await page.route(/\/api\/v1\/internal-repos$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({ repos: [], ui_url: null }),
+    }));
+}
+
+// ── 1. SecretField: PUT/DELETE rejection shows field / dialog error ─────────
+await withPage(async (page) => {
+  await mockDraftApis(page);
+  await page.route(/\/api\/v1\/secrets\/repo\/demo\/token(?:\?.*)?$/, async (route) => {
+    const method = route.request().method();
+    if (method === "PUT" || method === "DELETE") {
+      return route.fulfill({
+        status: 503, contentType: "application/json",
+        body: JSON.stringify({ detail: "secret store unavailable" }),
+      });
+    }
+    return route.fulfill({ status: 405, body: "method not allowed" });
+  });
+
+  await gotoFresh(page, "#/repos");
+  await page.waitForSelector('h1:has-text("Repositories")');
+  // draft names are empty on first paint, so cards often mount collapsed —
+  // expand before looking for secret controls (same pattern as repos.mjs)
+  if ((await page.locator('button[aria-label^="Collapse repository"]').count()) === 0) {
+    await page.locator('[data-testid="repo-summary-row"]').first().click();
+    await page.waitForTimeout(100);
+  }
+  await page.waitForSelector('input[aria-label="Access token"]', { timeout: 10000 });
+
+  // Prefer Remove path (stored secret) — ConfirmDialog must carry the error.
+  // Do NOT use bare button:has-text("Remove") — the repo card also has one.
+  const removeBtn = page.locator('span:has-text("✓ stored")')
+    .locator("xpath=..")
+    .locator('button:has-text("Remove")');
+  await checked("SecretField Remove control is present for a stored token",
+    async () => (await removeBtn.count()) >= 1);
+  if ((await removeBtn.count()) >= 1) {
+    await removeBtn.first().click();
+    await page.waitForSelector('[role="dialog"]:has-text("Remove the stored value")');
+    await page.locator('[role="dialog"] button:has-text("Remove")').click();
+    await checked("SecretField remove rejection surfaces in ConfirmDialog",
+      async () => {
+        // Dialog stays open with error= when catch is wired; silent finally
+        // closes it — either way, finish within 5s.
+        const deadline = Date.now() + 5000;
+        while (Date.now() < deadline) {
+          const dlg = page.locator('[role="dialog"]');
+          if ((await dlg.count()) === 0) return false;
+          const t = await dlg.innerText();
+          if (/secret store unavailable|503/.test(t)) return true;
+          await page.waitForTimeout(100);
+        }
+        return false;
+      });
+    if ((await page.locator('[role="dialog"]').count()) > 0) {
+      await page.click('[role="dialog"] button:has-text("Cancel")');
+      await page.waitForTimeout(100);
+    }
+  }
+
+  // Set/Replace path: type a value, force PUT failure, expect field-local error.
+  const tokenInput = page.locator('input[aria-label="Access token"]');
+  await tokenInput.fill("ghp_testtoken_notreal_xxxxxxxxxxxx");
+  await page.locator('button:has-text("Replace"), button:has-text("Set")').first().click();
+  await checked("SecretField submit rejection shows field-local error",
+    async () => {
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        const main = await page.innerText("main");
+        if (/secret store unavailable|503/.test(main)) return true;
+        await page.waitForTimeout(100);
+      }
+      return false;
+    });
+});
+
+// ── 2. Test connection: HTTP rejection writes testResult (✗ line) ───────────
+await withPage(async (page) => {
+  await mockDraftApis(page);
+  await page.route(/\/api\/v1\/connections\/forge\/demo\/test$/, (route) =>
+    route.fulfill({
+      status: 502, contentType: "application/json",
+      body: JSON.stringify({ detail: "forge unreachable" }),
+    }));
+  await page.route(/\/api\/v1\/connections\/pmo\/linear1\/test$/, (route) =>
+    route.fulfill({
+      status: 502, contentType: "application/json",
+      body: JSON.stringify({ detail: "pmo unreachable" }),
+    }));
+
+  await gotoFresh(page, "#/repos");
+  await page.waitForSelector('h1:has-text("Repositories")');
+  if ((await page.locator('button[aria-label^="Collapse repository"]').count()) === 0) {
+    await page.locator('[data-testid="repo-summary-row"]').first().click();
+    await page.waitForTimeout(100);
+  }
+  await page.waitForSelector('button:has-text("Test connection")');
+  await page.click('button:has-text("Test connection")');
+  await checked("Repos Test connection rejection shows ✗ message",
+    async () => {
+      await page.locator("text=/forge unreachable|502/").first()
+        .waitFor({ timeout: 5000 });
+      const t = await page.innerText("main");
+      return t.includes("✗") && /forge unreachable|502/.test(t);
+    });
+
+  await gotoFresh(page, "#/pmo");
+  await page.waitForSelector('h1:has-text("PMO"), h1:has-text("Adapters"), #pmo', {
+    timeout: 10000,
+  }).catch(() => {});
+  if ((await page.locator('button:has-text("Test connection")').count()) === 0) {
+    const summary = page.locator('[data-testid="pmo-summary-row"]').first();
+    if (await summary.count()) await summary.click();
+    await page.waitForTimeout(100);
+  }
+  await page.waitForSelector('button:has-text("Test connection")');
+  await page.click('button:has-text("Test connection")');
+  await checked("PMO Test connection rejection shows ✗ message",
+    async () => {
+      await page.locator("text=/pmo unreachable|502/").first()
+        .waitFor({ timeout: 5000 });
+      const t = await page.innerText("main");
+      return t.includes("✗") && /pmo unreachable|502/.test(t);
+    });
+});
+
+// ── 3. CSV export failure: dedicated channel, does not pollute Stop-all ─────
+await withPage(async (page) => {
+  await page.route(/\/api\/v1\/runs(?:\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        total: 0, total_runs: 0, runs: [], totals: null,
+        pmo_refs: [], rate_card: {},
+      }),
+    }));
+  await page.route(/\/api\/v1\/runs\.csv/, (route) =>
+    route.fulfill({
+      status: 500, contentType: "application/json",
+      body: JSON.stringify({ detail: "export boom" }),
+    }));
+  // draft APIs still fire from App chrome
+  await mockDraftApis(page);
+
+  await gotoFresh(page, "#/runs");
+  await page.waitForSelector('h1:has-text("Runs")');
+  await page.click('button[aria-label="More run actions"]');
+  await page.click('[role="menuitem"]:has-text("Export to CSV")');
+
+  await checked("CSV export failure banner names export (not Stop failed)",
+    async () => {
+      await page.locator("text=/export boom|Export failed|export failed/i").first()
+        .waitFor({ timeout: 5000 });
+      const main = await page.innerText("main");
+      const namesExport = /Export failed|export failed|CSV/i.test(main)
+        && /export boom|500/.test(main);
+      const mislabeled = /Stop failed \(nothing was deleted\):\s*(?:500 )?export boom/i
+        .test(main);
+      return namesExport && !mislabeled;
+    });
+
+  await page.click('button[aria-label="More run actions"]');
+  await page.click('[role="menuitem"]:has-text("Stop all runs")');
+  await page.waitForSelector('[role="dialog"]:has-text("Stop all in-flight runs")');
+  await checked("Stop-all ConfirmDialog does not carry the export error",
+    async () => {
+      const t = await page.locator('[role="dialog"]').innerText();
+      return !/export boom/i.test(t) && !/Export failed/i.test(t);
+    });
+  await page.click('[role="dialog"] button:has-text("Cancel")');
+});
+
+summary("error_surface");

--- a/admin/spa/tests/run.mjs
+++ b/admin/spa/tests/run.mjs
@@ -39,6 +39,7 @@ const SUITES = [
   "markdown.mjs",
   "repos.mjs",
   "costs.mjs",
+  "error_surface.mjs",
 ];
 
 // pick up admin credentials from the repo-root .env when not already set


### PR DESCRIPTION
## Intent

Surface three known admin-SPA failure paths in honest local error UI instead of swallowing rejections or reusing the Stop-all error channel.

Mission: https://linear.app/fidecastro/issue/CAKE-90/admin-errors-surface-in-the-ui

## Ledger items fixed

1. **SecretField** (`Field.jsx`) — `submit`/`remove` now `catch` and show `e.message` under the control / on the remove `ConfirmDialog` (`error` prop). Busy still clears in `finally`; remove dialog stays open on failure so the operator can retry or cancel.
2. **Test connection** (`ReposPage.jsx`, `PmoSection.jsx`) — HTTP/network rejection from `send()` writes `{ok:false, error}` into `testResult` (functional updater), so the existing ✗ render path lights up. Backend test endpoints unchanged.
3. **CSV export** (`RunsPage.jsx`) — dedicated `exportErr` + banner copy `Export failed: …`. `stopErr` / Stop-all `ConfirmDialog` are stop-only again.

## How to verify

```bash
npm --prefix admin/spa run build
# focused suite (boots vite; fully route-mocked — no live backend needed for this file):
node admin/spa/tests/error_surface.mjs   # with vite on :5199, or via npm run check:ui
docker build -f admin/Dockerfile -t devcake/admin:latest ./admin   # bake preferred when available
```

Browser evidence (playwright-core + Chromium headless shell): SecretField remove dialog shows `503 secret store unavailable`; Repos/PMO Test connection shows `✗ 502 …`; CSV failure banner says `Export failed:` (not `Stop failed`); Stop-all dialog after a failed export has no export error. Light + dark + 390px spot-checks taken for Test connection; regression mocks confirmed successful Test connection ✓ and successful CSV download still work.

## Deviations

Agent host has buildah/podman without `docker buildx bake` or compose plugin. Image proof used `docker build -f admin/Dockerfile` instead of bake; UI proof used vite + route-mocked playwright (DESIGN §8 suite pattern) rather than a live compose admin container.

## Out of scope

Other silent catches, registry FALLBACK drift, draft-save errors, shared toast infrastructure.