### PR TITLE
[CAKE-84] Backup and restore keep their promises

### DIFF
--- a/app/tests/test_backup_cli.py
+++ b/app/tests/test_backup_cli.py
@@ -242,6 +242,25 @@ def test_backup_czf_failure_does_not_clobber_an_existing_archive(tmp_path):
     )
 
 
+def _fake_tar_fail_dir_extract(fake_bin: Path) -> None:
+    """Fail only `tar … -C …` (volume extract). Must NOT fail `tar xzf -O`
+    (kind-marker read) or `tar tzf` — those run before move-aside, so a
+    blanket xzf failure never reaches restore_aside (false green).
+
+    Use `command -p tar` without `exec`: under dash, `exec command` looks for
+    an external binary named command and exits 127 before any extract runs.
+    """
+    wrapper = fake_bin / "tar"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        'case " $* " in\n'
+        '  *" -C "*) echo "xzf boom" >&2; exit 1 ;;\n'
+        "esac\n"
+        'command -p tar "$@"\n'
+    )
+    wrapper.chmod(0o700)
+
+
 def test_restore_extract_failure_puts_original_tree_back(tmp_path):
     """tzf can succeed and xzf still fail. The aside must come back to
     the original paths — a follow-up compose up must not boot a partial."""
@@ -252,13 +271,7 @@ def test_restore_extract_failure_puts_original_tree_back(tmp_path):
     assert _run_backup_payload(src, out, "data").returncode == 0
     fake_bin = tmp_path / "tarbin"
     fake_bin.mkdir()
-    wrapper = fake_bin / "tar"
-    wrapper.write_text(
-        "#!/bin/sh\n"
-        'if [ "$1" = xzf ]; then echo "xzf boom" >&2; exit 1; fi\n'
-        'exec command -p tar "$@"\n'
-    )
-    wrapper.chmod(0o700)
+    _fake_tar_fail_dir_extract(fake_bin)
     r = _run_restore_payload(
         dst, out, "data",
         extra_env={"PATH": f"{fake_bin}:{os.environ['PATH']}"})
@@ -266,6 +279,30 @@ def test_restore_extract_failure_puts_original_tree_back(tmp_path):
     assert _tree(dst) == {"precious.txt": "only copy"}, (
         "extract failure must restore the previous tree to its original paths"
     )
+
+
+def test_restore_extract_failure_keeps_older_pre_restore_leftovers(tmp_path):
+    """A second failed restore must not wipe prior .pre-restore-* leftovers
+    the move-aside step (and its comment) deliberately leave in place."""
+    src, out, dst = tmp_path / "src", tmp_path / "out", tmp_path / "dst"
+    src.mkdir(), out.mkdir(), dst.mkdir()
+    (src / "new.txt").write_text("incoming")
+    (dst / "precious.txt").write_text("only copy")
+    old = dst / ".pre-restore-OLD"
+    (old / "nested").mkdir(parents=True)
+    (old / "nested" / "kept.txt").write_text("from an earlier failed attempt")
+    assert _run_backup_payload(src, out, "data").returncode == 0
+    fake_bin = tmp_path / "tarbin"
+    fake_bin.mkdir()
+    _fake_tar_fail_dir_extract(fake_bin)
+    r = _run_restore_payload(
+        dst, out, "data",
+        extra_env={"PATH": f"{fake_bin}:{os.environ['PATH']}"})
+    assert r.returncode != 0
+    assert (dst / "precious.txt").read_text() == "only copy"
+    assert (old / "nested" / "kept.txt").read_text() == (
+        "from an earlier failed attempt"
+    ), "older .pre-restore-* leftovers must survive extract-failure put-back"
 
 
 # --- host-side contract: the scripts drive docker with the pinned image ---

--- a/app/tests/test_export_receipts.py
+++ b/app/tests/test_export_receipts.py
@@ -1,0 +1,62 @@
+"""Structural verify + path-print contract for scripts/export_receipts.py.
+
+The OO export path needs a live OpenObserve; these drills hit only the
+post-write tar verify seam (mirrors backup_payload.sh's tzf walk) without
+spinning OO or docker.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path("/srv/repo-scripts/export_receipts.py")
+
+
+def _load():
+    assert SCRIPT.exists(), (
+        "mount missing — the pytest runner must bind scripts → /srv/repo-scripts"
+    )
+    spec = importlib.util.spec_from_file_location("export_receipts", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _good_tar(path: Path) -> None:
+    with tarfile.open(path, "w:gz") as tf:
+        info = tarfile.TarInfo(name="runs/example.json")
+        data = b'{"ok": true}\n'
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+
+
+def test_verify_written_tar_rejects_truncated_archive(tmp_path):
+    mod = _load()
+    archive = tmp_path / "data-sans-secrets.tar.gz"
+    _good_tar(archive)
+    archive.write_bytes(archive.read_bytes()[:40])
+
+    with pytest.raises(SystemExit) as ei:
+        mod.verify_written_tar(archive)
+    assert ei.value.code != 0
+    assert "verify" in str(ei.value).lower() or "data tar" in str(ei.value).lower()
+
+
+def test_verify_written_tar_returns_absolute_path_on_success(tmp_path, capsys):
+    mod = _load()
+    archive = tmp_path / "data-sans-secrets.tar.gz"
+    _good_tar(archive)
+
+    verified = mod.verify_written_tar(archive)
+    assert verified == archive.resolve()
+    assert verified.is_absolute()
+    # Listing must succeed independently of the helper's return value.
+    assert subprocess.run(
+        ["tar", "tzf", str(archive)], capture_output=True
+    ).returncode == 0

--- a/scripts/export_receipts.py
+++ b/scripts/export_receipts.py
@@ -85,6 +85,20 @@ def sh(cmd):
         return f"<unavailable: {e}>"
 
 
+def verify_written_tar(archive: pathlib.Path) -> pathlib.Path:
+    """Full tzf walk of a just-written archive (same contract as backup_payload).
+
+    Returns the absolute path on success. Exits non-zero if the archive cannot
+    be listed — a pack that cannot be listed today must fail today.
+    """
+    r = subprocess.run(
+        ["tar", "tzf", str(archive)], capture_output=True, text=True)
+    if r.returncode != 0:
+        detail = (r.stderr or r.stdout or f"rc {r.returncode}").strip()
+        sys.exit(f"data tar verify failed: {archive} — {detail}")
+    return archive.resolve()
+
+
 def export_stream(name, stream_type, start_us, end_us, out_path):
     """Page SELECT * into JSONL. Returns row count; loud on the page cap."""
     rows = 0
@@ -165,8 +179,11 @@ def main():
     if rc != 0:
         sys.exit(f"/data export failed (volume {volume}) — rc {rc}")
 
+    verified = verify_written_tar(out / tar_base)
+
     (out / "MANIFEST.json").write_text(json.dumps(manifest, indent=2))
     print(f"\nreceipts pack: {out}")
+    print(f"  verified data tar: {verified}")
     if manifest["skipped_log_streams"]:
         print(f"  log streams NOT exported (named in MANIFEST): "
               f"{len(manifest['skipped_log_streams'])} — use --include-logs")

--- a/scripts/lib/restore_payload.sh
+++ b/scripts/lib/restore_payload.sh
@@ -43,8 +43,10 @@ fi
 ASIDE="$DST/.pre-restore-$(date -u +%Y%m%d-%H%M%S)-$$"
 mkdir "$ASIDE"
 restore_aside() {
-  # best-effort: put the previous tree back on its original paths
-  find "$DST" -mindepth 1 -maxdepth 1 ! -name "$(basename "$ASIDE")" -exec rm -rf {} +
+  # best-effort: put the previous tree back on its original paths; keep
+  # older .pre-restore-* leftovers (same exclusion as the move-aside step)
+  find "$DST" -mindepth 1 -maxdepth 1 \
+    ! -name "$(basename "$ASIDE")" ! -name '.pre-restore-*' -exec rm -rf {} +
   find "$ASIDE" -mindepth 1 -maxdepth 1 -exec mv {} "$DST/" \;
   rmdir "$ASIDE" 2>/dev/null || true
 }

--- a/scripts/restore_data.sh
+++ b/scripts/restore_data.sh
@@ -4,7 +4,9 @@
 # but never destructively: the payload validates the whole archive and its
 # kind marker first, moves the current contents aside, and deletes the aside
 # only after a clean extract (2026-08-12 audit OPS-H1; on failure the
-# previous contents survive at the printed .pre-restore-* path).
+# previous tree is put back on its original paths under the volume root —
+# prior .pre-restore-* leftovers are kept, not nested or wiped).
+
 #
 # After restore: run files reflect the backup's moment — the app's boot
 # reconciliation (docs/04 §6) orphans anything whose container no longer

--- a/scripts/restore_gitea.sh
+++ b/scripts/restore_gitea.sh
@@ -4,8 +4,9 @@
 # REPLACES the volume's current contents — but never destructively: the
 # payload validates the whole archive and its kind marker first, moves the
 # current contents aside, and deletes the aside only after a clean extract
-# (2026-08-12 audit OPS-H1; on failure the previous contents survive at the
-# printed .pre-restore-* path).
+# (2026-08-12 audit OPS-H1; on failure the previous tree is put back on its
+# original paths under the volume root — prior .pre-restore-* leftovers are
+# kept, not nested or wiped).
 #
 # Usage: docker compose stop gitea && scripts/restore_gitea.sh <backup.tar.gz>
 set -euo pipefail


### PR DESCRIPTION
## Intent

Make restore failure handling, receipts export, and operator-facing path messages match what the code and comments already claim (CAKE-84).

## Changes

1. **`restore_aside` keeps older leftovers** — on extract failure, exclude `.pre-restore-*` from the wipe (same glob as move-aside), put the current aside back on original paths.
2. **`export_receipts` verifies the data tar** — after docker `tar czf`, run a full `tar tzf` walk via `verify_written_tar`; fail loud; print `verified data tar: <abs path>`.
3. **Path-print honesty** — `restore_data.sh` / `restore_gitea.sh` headers now match docs/13 put-back semantics (no claim of a printed `.pre-restore-*` path).

## Deviation from plan

The plan’s “same fake-`tar` xzf pattern” never reached `restore_aside`: blanket `xzf` failure dies on the kind-marker `tar xzf -O` read, and `exec command -p tar` under dash exits 127 before mutation. Extract-failure drills now fail only on `tar … -C …` and call `command -p tar` without `exec`.

## How to verify

- `./scripts/pytest_app.sh` (or rebake `app-test` + pytest) — includes `test_backup_cli.py` leftover drill + `test_export_receipts.py`
- `shellcheck scripts/lib/restore_payload.sh scripts/lib/backup_payload.sh scripts/backup_data.sh scripts/backup_gitea.sh scripts/restore_data.sh scripts/restore_gitea.sh`
- Observed locally: pytest **2546 passed**, 1 skipped; shellcheck exit **0**; Alpine failure-path keeps `.pre-restore-OLD` and puts `precious.txt` back

## Out of scope

Redesigning restore to leave the current aside in place; backup_payload / refuse-while-running gates; live compose-volume drills; Admin SPA.

Mission: https://linear.app/fidecastro/issue/CAKE-84/backup-and-restore-keep-their-promises