### PR TITLE
[CAKE-113] Implement INV-4 mono-repo security ruling

### DIFF
--- a/app/devcake/adapters/registry.py
+++ b/app/devcake/adapters/registry.py
@@ -42,6 +42,16 @@ class PMOSystemInfo(BaseModel):
     # this; it is NOT a second code path — adapters still implement full
     # PMOPort.
     experimental: bool = False
+    # Forge-issues family (board is owner/repo on a forge). Drives INV-4
+    # mono-repo overlap detection in security.security_warnings (CAKE-113)
+    # without putting forge-host literals outside adapters/ (F1).
+    forge_issue: bool = False
+    # Hostnames that count as the same forge face when comparing a PMO
+    # api_base to a RepoInstance.url (e.g. API host vs clone host).
+    host_aliases: list[list[str]] = []
+    # When api_base is empty, use this host for overlap comparison (public
+    # default). Empty = path-only match when api_base is unset.
+    default_host: str = ""
 
 
 PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
@@ -74,6 +84,7 @@ PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
             "http://gitea:3000 (browser UI is http://localhost:3300). "
             "External: https://gitea.example.com"),
         supports_priority=False,   # forge-issue: priority always medium (§9.2)
+        forge_issue=True,
     ),
     "github_issues": PMOSystemInfo(
         id="github_issues",
@@ -96,6 +107,10 @@ PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
         attachments_supported=False,
         relations_supported=True,
         experimental=True,
+        forge_issue=True,
+        # API origin vs clone URL (CAKE-113 mono-repo host match).
+        host_aliases=[["api.github.com", "github.com"]],
+        default_host="github.com",
         operator_note=(
             "Experimental (not launch-supported). GitHub's public API cannot "
             "attach files to issues. Transcripts, plans, and other "
@@ -124,6 +139,7 @@ PMO_SYSTEMS: dict[str, PMOSystemInfo] = {
         attachments_supported=True,
         relations_supported=False,
         experimental=True,
+        forge_issue=True,
         operator_note=(
             "Experimental (not launch-supported). Blocked-by issue links "
             "need GitLab Premium (or self-hosted EE). DevCake probes the "

--- a/app/devcake/security.py
+++ b/app/devcake/security.py
@@ -307,9 +307,10 @@ def security_warnings(config) -> list[dict]:
     # forge-issues board lives in the same repository a Dev holds a forge
     # token for, the Dev can reach Issues via the forge API even though the
     # app remains the sole PMO client. Warning only — not a save/dispatch gate.
+    # Host/alias knowledge lives on PMO_SYSTEMS (adapters/) so this module
+    # stays free of forge-host literals (F1 / test_agnosticism).
     from urllib.parse import urlsplit
-    _FORGE_ISSUE_SYSTEMS = frozenset(
-        {"gitea_issues", "github_issues", "gitlab_issues"})
+    from .adapters.registry import PMO_SYSTEMS
 
     def _repo_path(url: str) -> str:
         parts = urlsplit(url if "://" in url else f"https://{url}")
@@ -320,14 +321,22 @@ def security_warnings(config) -> list[dict]:
             return ""
         parts = urlsplit(
             url_or_base if "://" in url_or_base else f"https://{url_or_base}")
-        host = (parts.hostname or "").lower()
-        # GitHub Issues api_base is api.github.com; clone URLs use github.com.
-        if host == "api.github.com":
-            return "github.com"
-        return host
+        return (parts.hostname or "").lower()
+
+    def _hosts_equivalent(a: str, b: str, aliases: list[list[str]]) -> bool:
+        if not a or not b:
+            return False
+        if a == b:
+            return True
+        for group in aliases:
+            members = {h.lower() for h in group}
+            if a in members and b in members:
+                return True
+        return False
 
     for pmo in config.pmos:
-        if not pmo.configured or pmo.system not in _FORGE_ISSUE_SYSTEMS:
+        info = PMO_SYSTEMS.get(pmo.system)
+        if not pmo.configured or info is None or not info.forge_issue:
             continue
         board_path = pmo.team_key.strip().strip("/").lower()
         if not board_path:
@@ -335,8 +344,8 @@ def security_warnings(config) -> list[dict]:
         api_base = (pmo.api_base or "").strip()
         if api_base:
             pmo_host = _host(api_base)
-        elif pmo.system == "github_issues":
-            pmo_host = "github.com"
+        elif info.default_host:
+            pmo_host = info.default_host.lower()
         else:
             # No api_base to compare — treat host check as satisfied only when
             # a repo path matches (operator gave no host to disambiguate).
@@ -348,7 +357,8 @@ def security_warnings(config) -> list[dict]:
             if _repo_path(repo.url) != board_path:
                 continue
             repo_host = _host(repo.url)
-            if pmo_host is None or pmo_host == repo_host:
+            if pmo_host is None or _hosts_equivalent(
+                    pmo_host, repo_host, info.host_aliases):
                 overlap_path = board_path
                 break
         if overlap_path:

--- a/app/devcake/security.py
+++ b/app/devcake/security.py
@@ -303,4 +303,70 @@ def security_warnings(config) -> list[dict]:
                          f"REFERENCE material: move it to the instance's "
                          f"Reference repos, or add a write token."),
             })
+    # INV-4 mono-repo residual (CAKE-55 decision 2 / CAKE-113): when a
+    # forge-issues board lives in the same repository a Dev holds a forge
+    # token for, the Dev can reach Issues via the forge API even though the
+    # app remains the sole PMO client. Warning only — not a save/dispatch gate.
+    from urllib.parse import urlsplit
+    _FORGE_ISSUE_SYSTEMS = frozenset(
+        {"gitea_issues", "github_issues", "gitlab_issues"})
+
+    def _repo_path(url: str) -> str:
+        parts = urlsplit(url if "://" in url else f"https://{url}")
+        return (parts.path or "").strip("/").removesuffix(".git").lower()
+
+    def _host(url_or_base: str) -> str:
+        if not (url_or_base or "").strip():
+            return ""
+        parts = urlsplit(
+            url_or_base if "://" in url_or_base else f"https://{url_or_base}")
+        host = (parts.hostname or "").lower()
+        # GitHub Issues api_base is api.github.com; clone URLs use github.com.
+        if host == "api.github.com":
+            return "github.com"
+        return host
+
+    for pmo in config.pmos:
+        if not pmo.configured or pmo.system not in _FORGE_ISSUE_SYSTEMS:
+            continue
+        board_path = pmo.team_key.strip().strip("/").lower()
+        if not board_path:
+            continue
+        api_base = (pmo.api_base or "").strip()
+        if api_base:
+            pmo_host = _host(api_base)
+        elif pmo.system == "github_issues":
+            pmo_host = "github.com"
+        else:
+            # No api_base to compare — treat host check as satisfied only when
+            # a repo path matches (operator gave no host to disambiguate).
+            pmo_host = None
+        overlap_path = None
+        for repo in config.repos:
+            if not repo.configured:
+                continue
+            if _repo_path(repo.url) != board_path:
+                continue
+            repo_host = _host(repo.url)
+            if pmo_host is None or pmo_host == repo_host:
+                overlap_path = board_path
+                break
+        if overlap_path:
+            warns.append({
+                "id": f"pmo-forge-mono-repo:{pmo.name}",
+                "severity": "warning",
+                "title": (f"PMO '{pmo.name}' Issues board overlaps a "
+                          f"work-repo forge token"),
+                "body": (
+                    f"Forge-issues PMO '{pmo.name}' watches '{overlap_path}', "
+                    f"which is also a configured repository Devs receive a "
+                    f"forge token for. The app remains the sole PMO client "
+                    f"(INV-4), but a Dev forge token can still reach that "
+                    f"Issues board over the forge API — a residual, not a "
+                    f"hard product gate (docs/14 §8). Prefer a dedicated "
+                    f"Issues repo (e.g. owner/missions) or a Linear PMO so "
+                    f"board credentials stay disjoint from work-repo forge "
+                    f"tokens."
+                ),
+            })
     return warns

--- a/app/tests/test_security.py
+++ b/app/tests/test_security.py
@@ -501,6 +501,29 @@ def test_security_warnings_mono_repo_different_hosts_no_warning(
     assert "pmo-forge-mono-repo:missions" not in ids
 
 
+def test_security_warnings_mono_repo_github_api_host_alias(
+        tmp_path, monkeypatch):
+    """Registry host_aliases: API origin matches clone host for overlap."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import security
+    from devcake.config import AppConfig, PMOInstance, RepoInstance
+    cfg = AppConfig(
+        repos=[RepoInstance(
+            name="code",
+            forge="github",
+            url="https://github.com/acme/missions.git",
+        )],
+        pmos=[PMOInstance(
+            name="ghiss",
+            system="github_issues",
+            team_key="acme/missions",
+            api_base="https://api.github.com",
+        )],
+    )
+    ids = {w["id"] for w in security.security_warnings(cfg)}
+    assert "pmo-forge-mono-repo:ghiss" in ids
+
+
 def test_profile_secret_snapshots_are_covered_by_the_redaction_glob(tmp_path, monkeypatch):
     """ADR-0013 glob tripwire: /data/secrets/profiles/{name}.json sits at
     scan level two, so a DORMANT profile's values must mask with ZERO

--- a/app/tests/test_security.py
+++ b/app/tests/test_security.py
@@ -376,6 +376,131 @@ def test_security_warnings_bodies_match_product_contract(tmp_path, monkeypatch):
     assert "merge" in wbody.lower()
 
 
+# ── INV-4 mono-repo forge-issues residual (CAKE-113 / CAKE-55 decision 2) ──
+
+
+def test_security_warnings_mono_repo_overlap_fires(tmp_path, monkeypatch):
+    """Forge-issues board path == a configured repo URL → warn (not gate)."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import security
+    from devcake.config import AppConfig, PMOInstance, RepoInstance
+    cfg = AppConfig(
+        repos=[RepoInstance(
+            name="missions",
+            forge="gitea",
+            url="https://git.example/acme/missions.git",
+        )],
+        pmos=[PMOInstance(
+            name="missions",
+            system="gitea_issues",
+            team_key="acme/missions",
+            api_base="https://git.example",
+        )],
+    )
+    ids = {w["id"] for w in security.security_warnings(cfg)}
+    assert "pmo-forge-mono-repo:missions" in ids
+
+
+def test_security_warnings_mono_repo_silent_when_disjoint(tmp_path, monkeypatch):
+    """Dedicated Issues board path ≠ work repo → no mono-repo warning."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import security
+    from devcake.config import AppConfig, PMOInstance, RepoInstance
+    cfg = AppConfig(
+        repos=[RepoInstance(
+            name="code",
+            forge="gitea",
+            url="https://git.example/acme/code",
+        )],
+        pmos=[PMOInstance(
+            name="missions",
+            system="gitea_issues",
+            team_key="acme/missions",
+            api_base="https://git.example",
+        )],
+    )
+    ids = {w["id"] for w in security.security_warnings(cfg)}
+    assert "pmo-forge-mono-repo:missions" not in ids
+
+
+def test_security_warnings_mono_repo_silent_for_linear(tmp_path, monkeypatch):
+    """Linear PMO is not a forge-issues board — never emit mono-repo warning."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import security
+    from devcake.config import AppConfig, PMOInstance, RepoInstance
+    cfg = AppConfig(
+        repos=[RepoInstance(
+            name="code",
+            url="https://github.com/acme/missions",
+        )],
+        pmos=[PMOInstance(
+            name="lin",
+            system="linear",
+            team_key="ACME",
+        )],
+    )
+    ids = {w["id"] for w in security.security_warnings(cfg)}
+    assert not any(i.startswith("pmo-forge-mono-repo:") for i in ids)
+
+
+def test_security_warnings_mono_repo_body_honest(tmp_path, monkeypatch):
+    """Warning copy names the residual and recommends Issues repo or Linear."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import security
+    from devcake.config import AppConfig, PMOInstance, RepoInstance
+    cfg = AppConfig(
+        repos=[RepoInstance(
+            name="missions",
+            forge="gitea",
+            url="https://git.example/acme/missions.git",
+        )],
+        pmos=[PMOInstance(
+            name="missions",
+            system="gitea_issues",
+            team_key="acme/missions",
+            api_base="https://git.example",
+        )],
+    )
+    by_id = {w["id"]: w for w in security.security_warnings(cfg)}
+    warn = by_id["pmo-forge-mono-repo:missions"]
+    assert warn["severity"] == "warning"
+    body = warn["body"]
+    body_l = body.lower()
+    # Residual: Dev forge token can reach the Issues board
+    assert "forge" in body_l and ("issues" in body_l or "board" in body_l)
+    assert "token" in body_l
+    # Recommendation: separate Issues repo OR Linear PMO
+    assert "linear" in body_l
+    assert "separate" in body_l or "dedicated" in body_l
+    # Must not claim INV-4 remains unconditionally Hard / fully enforced here
+    assert "fully enforced" not in body_l
+    assert "unconditionally" not in body_l
+    assert "hard gate" not in body_l
+
+
+def test_security_warnings_mono_repo_different_hosts_no_warning(
+        tmp_path, monkeypatch):
+    """Same path on different hosts is not mono-repo overlap."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake import security
+    from devcake.config import AppConfig, PMOInstance, RepoInstance
+    cfg = AppConfig(
+        repos=[RepoInstance(
+            name="code",
+            forge="gitea",
+            url="https://other.example/acme/missions.git",
+        )],
+        pmos=[PMOInstance(
+            name="missions",
+            system="gitea_issues",
+            team_key="acme/missions",
+            api_base="https://git.example",
+        )],
+    )
+    ids = {w["id"] for w in security.security_warnings(cfg)}
+    assert "pmo-forge-mono-repo:missions" not in ids
+
+
 def test_profile_secret_snapshots_are_covered_by_the_redaction_glob(tmp_path, monkeypatch):
     """ADR-0013 glob tripwire: /data/secrets/profiles/{name}.json sits at
     scan level two, so a DORMANT profile's values must mask with ZERO

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -262,7 +262,7 @@ First **forge-issue** PMO: issue trackers that are not Linear-style product PMOs
 | `team_key` | Exactly `owner/repo` of a **dedicated issues board** (e.g. `devcake-pmo/missions`). Not a per-mission internal-forge work repo. |
 | `api_key` | PAT with issue (and label) write on that repo. GUI-stored; **empty `token_patterns`** (40-hex tokens collide with git SHAs — value registration only, same posture as the Gitea forge). |
 
-Internal vs external is **only** `api_base` + token + board path — one system, not two registry entries. Credential separation is mandatory: PMO PAT ≠ forge write tokens ≠ `GITEA_ADMIN_*`.
+Internal vs external is **only** `api_base` + token + board path — one system, not two registry entries. Credential separation is mandatory: PMO PAT ≠ forge write tokens ≠ `GITEA_ADMIN_*`. When `team_key` overlaps a configured work-repo URL, `/health` surfaces dismissable `pmo-forge-mono-repo:*` (`14` §8) — warning only, not a save/dispatch gate.
 
 ### 9.2 Normalization (forge-issue profile)
 

--- a/docs/11-admin-panel.md
+++ b/docs/11-admin-panel.md
@@ -101,7 +101,7 @@ All writes go through the app (single validation point, `10-persistence.md` §4)
 | `dependency_cycles` | detected blocked-by loops (each names the mission keys in the loop) |
 | `blocked_reasons` | pmo_id → why the scheduler is currently holding a mission back (advisory mirror of the last gate map) |
 | `steward_degraded` | `null`, or the error string when the last 3 steward runs all died (periodic service backs off; Run now still works). Surfaced on the **Scheduled Tasks** Relations Steward panel, **not** as an Overview SPA alert |
-| `security_warnings` | dismissable credential-posture list from `security.security_warnings` (`14` §8) — e.g. `gui-secrets-basic-auth`, `forge-write-token:{repo}`, `repo-read-only:{repo}` |
+| `security_warnings` | dismissable credential-posture list from `security.security_warnings` (`14` §8) — e.g. `gui-secrets-basic-auth`, `forge-write-token:{repo}`, `repo-read-only:{repo}`, `pmo-forge-mono-repo:{pmo}` |
 | `prompt_template_warnings` | active templates that no longer resolve (fallback-to-default in effect) |
 
 ## 2. Overview page

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -111,7 +111,7 @@ LLM, and not by pretending tickets are sterile.
 | Per-repo `auto_merge` off (**app** does not merge that repo) | **Operator** (default off per card) | Confirm dialog when enabling; **not** a Dev capability fence — see below |
 | Read-only forge PAT for non-EXECUTE stages | **Operator** (recommended) | Dismissable `forge-write-token` warning if missing |
 | Reviewer token (app-only; different account from write) | **Operator** (recommended for protected-branch formal approval) | Used by the app after REVIEW approve — never injected into a Dev; **no** dismissable health warning if missing (unlike RO) |
-| LEGAL_OUTCOMES + INV-4 (Dev never writes PMO; forged outcomes cannot approve own work via app deputy path) | **Product (hard)** | Enforced |
+| LEGAL_OUTCOMES + INV-4 (Dev never writes PMO via the app deputy path; forged outcomes cannot approve own work) | **Product (hard)** | Enforced for app-mediated PMO writes and outcome application; **residual** when a forge-issues board is the same repo a Dev holds a forge token for — dismissable `pmo-forge-mono-repo:*` warning (§8), not a dispatch gate |
 
 #### Per-repo `auto_merge` gates the app, not the Dev (normative)
 
@@ -210,7 +210,9 @@ agent work out.” Users are adults; the job of the docs and product is to
 ### What the app actually enforces (not “the model behaved”)
 
 - Single-team scoping — nothing outside the configured team key is polled.
-- Devs never call the PMO (INV-4); app finalization is the only PMO writer.
+- Devs never call the PMO as a client (INV-4); app finalization is the only
+  PMO writer. A forge-issues board that shares a work-repo forge token is a
+  warned residual (`pmo-forge-mono-repo:*`), not a second PMO client.
 - **`LEGAL_OUTCOMES`** (`03-mission-lifecycle.md` §6): e.g. EXECUTE claiming
   `reviewed` is refused; parked with `DEVCAKE-SKIP`, never acted on — so an
   agent cannot make the app merge by forging outcomes.
@@ -396,13 +398,16 @@ for **app-mediated** posts to PMO systems and forges, not a substitute for zone 
 |---|---|---|
 | `forge-write-token:{repo}` | **Warning** in `security_warnings` (dismissable) | No RO PAT — all stages get write token for that repo |
 | `repo-read-only:{repo}` | **Warning** in `security_warnings` (dismissable) | Repo is in a PMO work set but stores only a RO token (no write) — EXECUTE will fail at push; move it to reference repos or add a write token |
+| `pmo-forge-mono-repo:{pmo}` | **Warning** in `security_warnings` (dismissable) | Forge-issues `team_key` normalizes to the same repository path (and host) as a configured work-repo URL — Dev forge token can reach that Issues board; prefer a dedicated Issues repo or Linear PMO |
 | `gui-secrets-basic-auth` | **Info** in `security_warnings` | Reminder of control-plane posture |
 | Unprotected default branch | **Advisory** via `/health` `forge_protection` (SPA alert) — **not** in the `security_warnings` list | Operator must fix forge-side |
 | `secret_env` value missing **and** referenced by an mcp_setup_command | **Gate** (dispatch refused) | `blocked_reasons`/health names the var; self-heals the poll cycle after the value is pasted. Declared-but-unreferenced = warning only (log + ✗ on the Config card) |
 | `auto_merge` enable | Confirm dialog | Operator accepts **app**-driven merge after REVIEW (not a Dev sandbox) |
 | `LEGAL_OUTCOMES` violations | **Hard** | Illegal outcomes not applied |
 | Out-of-pipeline merge | **Hard detection** | Comment + audit + health — does not prevent the merge |
-| INV-4 (Dev → PMO) | **Hard** | Architecture |
+| INV-4 (Dev → PMO) | **Hard** (app-mediated path) | Devs still have no PMO client and no PMO credential injected — the app is the sole PMO writer. **Residual** when a forge-issues board is the same repository a Dev holds a forge token for: forge-API reachability to that board is warned via `pmo-forge-mono-repo:*`, not refused at config save or dispatch |
+
+Prefer a **dedicated Issues repo** (or the provisioned `devcake-pmo/missions` board) **or** a **Linear** PMO so board credentials stay disjoint from work-repo forge tokens.
 
 Dismissing a warning is an **explicit acceptance** of that residual risk. Prefer
 keeping a mental (or health) inventory of active posture issues even after UI


### PR DESCRIPTION
## Intent

Implement CAKE-55 founder decision 2 (INV-4 mono-repo forge-issues): soften/clarify INV-4 **Hard** in `docs/14-security.md` for the mono-repo residual, recommend a dedicated Issues repo or Linear PMO, and emit a dismissable `/health` `security_warnings` entry when a forge-issues board overlaps a configured work-repo URL. **No hard gate** on config save or dispatch.

Mission: https://linear.app/fidecastro/issue/CAKE-113/implement-inv-4-mono-repo-security-ruling

## What changed

- `security.security_warnings(config)` — new `pmo-forge-mono-repo:{pmo}` warning when a configured forge-issues PMO (`forge_issue` on `PMOSystemInfo`) has a `team_key` that normalizes to the same repository path **and** host as a configured `RepoInstance.url`.
- `PMOSystemInfo` — `forge_issue`, `host_aliases`, `default_host` so host equivalence (API vs clone) lives in the adapter registry (F1-clean).
- `docs/14-security.md` — Zone C + §8 honesty: INV-4 remains Hard for the app-mediated PMO path; mono-repo forge-token reachability is a warned residual; recommendation sentence added.
- Light cross-links in `docs/05-pmo-adapter.md` and `docs/11-admin-panel.md`.
- TDD tests in `app/tests/test_security.py` (overlap / disjoint / Linear / body honesty / different hosts / GitHub API-host alias).

## Deviations from plan

1. **No hard gate** — follows founder Action (warning only); mission brief’s “and/or gate” is superseded by CAKE-55.
2. **GitHub API vs clone host** — equivalence (`api.github.com` ↔ `github.com`) and empty-`api_base` default host live on `PMOSystemInfo` in the registry, not as literals in `security.py` (required by `test_no_forge_host_literals_outside_adapters`).

## How to verify

```bash
./scripts/pytest_app.sh tests/test_security.py -k mono_repo
# plus the F1 tripwire:
python -m pytest tests/test_agnosticism.py::test_no_forge_host_literals_outside_adapters -q
```

## Out of scope

- Hard gate on save/dispatch
- INV-5 / feed-policy changes (other CAKE-55 item)
- Secret-value equality checks between PMO and forge tokens
- `dispatch.py` injection changes

## Risk

Docs + dismissable health warning only; no runtime refusal path.