### PR TITLE
[CAKE-104] Core docs match the code

### DIFF
--- a/app/devcake/ports/pmo.py
+++ b/app/devcake/ports/pmo.py
@@ -30,9 +30,9 @@ class PMOHealth(BaseModel):
 
 
 class PMOCapabilities(BaseModel):
-    """Adapter self-description. No v0 reader — the single Linear adapter's
-    quirks are handled where they occur — but future multi-PMO scheduling and
-    the admin UI select behavior on these flags (kept by founder decision)."""
+    """Adapter self-description consumed by the feed chokepoint, blocker
+    locator, health probe, and admin mission-action paths (attachments,
+    comment caps, global_ids, relations)."""
     projects_supported: bool
     project_labels_supported: bool
     attachment_max_bytes: int

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -14,9 +14,11 @@ ticket resolutions — designed for a
 **single operator on a dedicated host**. It runs automated coding agents
 ("**Devs**") inside Docker containers that systematically resolve work items
 ("**Missions**") pulled from a project-management system ("**PMO System**"). Devs are scheduled through [Dagu](https://docs.dagu.sh), talk back to the main app through Redis Streams and a Gitea internal server, and telemetry lands in OpenObserve.
-The CLI coding agents it runs (Claude Code, Grok Build, Codex) are the
-**harnesses**; DevCake is the envelope that staffs, sequences, isolates, and
-accounts for their sessions — it is not itself a CLI coding agent.
+The CLI coding agents it runs are the **harnesses** — six launch-supported
+templates (`claude-code`, `grok-build`, `codex`, `pi`, `opencode`,
+`qwen-code`; glossary / `08-harness-templates.md`); DevCake is the envelope
+that staffs, sequences, isolates, and accounts for their sessions — it is
+not itself a CLI coding agent.
 
 **Deployment premise:** one machine you control; host `docker.sock` on Dagu;
 admin + secrets ≅ host trust. Not multi-tenant SaaS. Ticket writers and repo

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -82,9 +82,8 @@ class PMOPort(Protocol):
     # ── meta ──
     async def health_probe(self, team_ref: str) -> PMOHealth: ...
     def capabilities(self) -> PMOCapabilities: ...
-        # adapter self-description. No v0 reader — kept on the contract for
-        # future multi-PMO scheduling / admin-UI behavior selection
-        # (founder decision, v0 crystallization)
+        # adapter self-description consumed by feed, blocker locator, health,
+        # and admin mission-action paths (attachments, caps, global_ids, …)
 ```
 
 ```python

--- a/docs/10-persistence.md
+++ b/docs/10-persistence.md
@@ -43,8 +43,8 @@ Run records are accessed through **`StatePort`** (`ports/state.py`); the product
     runlogs/{run_id}.log        # condensed Dev stdout (run.log relay; SSE for admin terminal)
     events.jsonl                # append-only audit log: every PMO write + settings changes (profile ops, exports)
     mission_owner.json          # multi-PMO claim map (which instance owns which pmo_id)
-    profiles.json               # last-applied-profile breadcrumb (advisory; survives clear-runs —
-                                #   clear_local_state wipes runs/runlogs/events.jsonl only)
+    profiles.json               # last-applied-profile breadcrumb (advisory; cleared by clear-runs —
+                                #   clear_local_state also wipes runs/runlogs/events.jsonl; ADR-0013)
     baker_log.offset            # byte cursor for draining leftover harness_baker.jsonl (12 §1)
   # Host baker / pin factory (top-level on this volume — not under config/ or state/;
   # never part of a settings bundle — settings_bundle.py). Normative ops: 13 §6.

--- a/docs/adr/0004-label-namespace-and-versioning.md
+++ b/docs/adr/0004-label-namespace-and-versioning.md
@@ -1,6 +1,8 @@
 # ADR-0004 — Label Namespace and Versioning
 
-**Status:** accepted (v0).
+**Status:** accepted (v0). **Amended:** managed set is the eleven names in
+`02-domain-model.md` §5 / `ALL_LABELS`, including `DEVCAKE-DISCOVERY`
+(ADR-0033).
 
 ## Context
 
@@ -8,7 +10,17 @@ The mission state machine is driven by labels living in the PMO System, visible 
 
 ## Decision
 
-A flat uppercase namespace with exactly ten managed labels, defined once in `02-domain-model.md` §5 and mirrored in a single code constants module: `DEVCAKE` (opt-in adoption signal), three stage labels (`-PLAN`, `-EXECUTE`, `-REVIEW`), plus `-MERGE` (awaiting merge), `-CREATED` (provenance), `-FAILED` (attention), `-SKIP` (opt-out), `-TRACKING` (decomposed projects), and `-NEEDS-HUMAN` (deliberate hand-off — added post-v0 with `adr/0007`; the set was nine through v0). No version suffixes in names. The app ensures all ten exist in the configured team at startup. Renaming is a documented migration: create new → copy on touched missions → retire old.
+A flat uppercase namespace whose managed set is defined once in
+`02-domain-model.md` §5 and mirrored in `ALL_LABELS`: `DEVCAKE` (opt-in
+adoption signal), three stage labels (`-PLAN`, `-EXECUTE`, `-REVIEW`), plus
+`-MERGE` (awaiting merge), `-CREATED` (provenance), `-FAILED` (attention),
+`-SKIP` (opt-out), `-TRACKING` (decomposed projects), `-NEEDS-HUMAN`
+(deliberate hand-off — added post-v0 with `adr/0007`; the set was nine
+through v0 and ten after NEEDS-HUMAN), and `-DISCOVERY` (sweep-gate for
+harvested discoveries — ADR-0033; not a `derive()` / schedule row). No
+version suffixes in names. The app ensures every `ALL_LABELS` member exists
+in the configured team at startup. Renaming is a documented migration:
+create new → copy on touched missions → retire old.
 
 ## Alternatives considered
 

--- a/docs/adr/0023-dev-toolchain-floor.md
+++ b/docs/adr/0023-dev-toolchain-floor.md
@@ -180,7 +180,7 @@ Measured recipe (feasibility matrix + live probes, 2026-08-13):
 
 ## Related
 
-- Implement: `images/Dockerfile` (base + all three harness stages).
+- Implement: `images/Dockerfile` (base + every harness stage in the `images` bake group).
 - Evidence: the base-stage smoke RUN; CI "Bake Dev harnesses"; the
   nested-matrix probes (addendum above); `test_repo_structural.py`
   nested-engine pins.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,7 +11,7 @@
 | [0001](0001-redis-streams-for-dev-callback.md) | Redis Streams for the Dev → App channel | Accepted. Notes its own vaporware honestly (`devcake-relay` never shipped). ACL durability added 2026-08 (docs/09 §1a) |
 | [0002](0002-file-based-persistence.md) | File-based local persistence | Accepted. **Amended 2026-08-04**: the backup sentence is superseded by docs/13 §8 (mirrors + workspaces exist now) |
 | [0003](0003-pmo-as-single-source-of-truth.md) | PMO as single source of truth | Accepted — INV-1's home |
-| [0004](0004-label-namespace-and-versioning.md) | Label namespace and versioning | Accepted |
+| [0004](0004-label-namespace-and-versioning.md) | Label namespace and versioning | Accepted. **Amended:** eleven managed labels incl. `DEVCAKE-DISCOVERY` (`02` §5 / ADR-0033) |
 | [0005](0005-no-lock-atomicity-via-pmo-state.md) | No-lock atomicity via PMO state | Accepted. The single-process premise is now test-enforced (`test_repo_structural.py`) |
 | [0006](0006-projects-always-decompose.md) | Projects always decompose | Accepted |
 | [0007](0007-mission-ordering-and-human-handoff.md) | Mission ordering + human hand-off | Accepted |


### PR DESCRIPTION
## Intent

Docs-only alignment: consume REVIEW_LEDGER / mission-brief drift where the live tree is already the authority. No product behavior change (one docstring on `PMOCapabilities` corrected to match existing readers).

Mission: https://linear.app/fidecastro/issue/CAKE-104/core-docs-match-the-code

## What changed

| Area | Fix |
|---|---|
| `docs/10-persistence.md` | `profiles.json` is **cleared by clear-runs** (matches `clear.py`, ADR-0013, docs/11) |
| `docs/05` + `ports/pmo.py` | Drop stale “No v0 reader”; capabilities are consumed by feed / blocker locator / health / admin paths |
| ADR-0004 + `adr/README.md` | Managed set is the **eleven** names in `02` §5 / `ALL_LABELS`, incl. `DEVCAKE-DISCOVERY` |
| `docs/00-overview.md` | Opening names all six launch-supported harness templates |
| ADR-0023 | Related implement line → every harness stage in the `images` bake group |

## Already aligned (no churn)

Freshness default 5; `docs/04` orchestrator inventory; `docs/01` ports; capabilities field sample; no `09-dev-protocol` refs; six-harness deploy tables; OO four panels; CI-with-Gitea wording. Left ADR-0022 Phase-0 “all three” as dated history.

## How to verify

```bash
rg -n 'survives clear-runs|No v0 reader|exactly ten managed|09-dev-protocol|all three harness stages' docs app/devcake/ports
# expect: empty (or only intentional historical hits)
```

Spot-check: `clear.py` unlink ↔ docs/10 ↔ ADR-0013 ↔ docs/11; ADR-0004 ↔ docs/02 §5 (eleven incl. DISCOVERY).

## Out of scope

- No app/orchestrator/SPA behavior changes.
- SPA FALLBACK `managed_labels_expected` already **11** on this tip (plan residual closed).
- Cron `maybe_fire` fence / memory-wiki clear-runs note — not product docs.

## Risk

Docs + docstring only. Hierarchy preserved (`02` / `08` remain inventory chokepoints; ADRs amended, not forked).