### PR TITLE
[CAKE-110] Tutorials survive a literal reader

### DIFF
--- a/docs/tutorials/01-first-mission.md
+++ b/docs/tutorials/01-first-mission.md
@@ -19,9 +19,14 @@ Every step mirrors the project's integration-test shape.
   `contents` and `pull_requests` read/write. Prefer also a **read-only PAT** for
   non-EXECUTE stages. Enable **branch protection** on the default branch before
   production-ish use (`13` §8a).
-- **Model credentials** — subscriptions preferred:
-  - Claude Code: `claude setup-token` → paste in Config.
-  - Grok Build: OAuth via DevCake in step 3.
+- **Both default-staffing credentials** — default Mission Types send
+  ONBOARD / PLAN / REVIEW to Dev Type **`judgment`** (`claude-code`) and
+  EXECUTE to **`implementer`** (`grok-build`). A literal reader needs **both**
+  before creating the mission; missing Claude fails judgment stages, missing
+  Grok fails EXECUTE. Registry table: [`08-harness-templates.md`](../08-harness-templates.md) §4.
+  - Claude Code: `claude setup-token` → paste `CLAUDE_CODE_OAUTH_TOKEN` in
+    Configuration → Dev Types (or `ANTHROPIC_API_KEY`).
+  - Grok Build: device-code OAuth via DevCake in step 3 (or `XAI_API_KEY`).
 
 ## Step 1 — Bootstrap and start
 
@@ -55,12 +60,24 @@ Open **http://localhost:8080** (loopback; admin user/password from `.env`).
 ### Step 1b — Secrets and connections
 
 1. **PMO** (`#/pmo`, under Adapters) — Add PMO instance → team key → **Set** Linear API key → Test.
-2. **Repositories** (`#/repos`) — Add repository → URL → **Set** write token;
-   prefer **RO** for non-EXECUTE and a **reviewer** token (app-only, different
-   account) for formal forge approval → Test. Repositories and PMO both live
-   under the sidebar's **Adapters** group.
-3. **Configuration → Dev Types** — Assign harness secrets / OAuth.
-4. On **Repositories**, leave each card's **`auto_merge` OFF** for this tutorial.
+2. **Repositories** (`#/repos`) — Add repository → choose a short card **name**
+   (lowercase alnum, ≤12 chars — this is the `devcake-repo:<name>` marker) →
+   URL → **Set** write token; prefer **RO** for non-EXECUTE and a **reviewer**
+   token (app-only, different account) for formal forge approval → Test.
+   Repositories and PMO both live under the sidebar's **Adapters** group.
+3. **Bind that card on the PMO instance** — still on **PMO** (`#/pmo`), under
+   the instance's **Repositories** chips, select the sandbox card you just
+   added (first selected = default for unmarked tickets). **Save** the shared
+   draft. Without this bind, the instance's work-repo set stays empty and
+   missions take the **zero-repo** path: bundled internal Gitea with forced
+   auto-merge — not a GitHub PR ([operator-drill](operator-drill.md) §3;
+   ADR-0010 / `docs/06`).
+4. **Configuration → Dev Types** — set **both** harness credentials from
+   *What you need* (Claude for `judgment`, Grok OAuth or key for
+   `implementer`).
+5. On **Repositories**, leave the **external** card's **`auto_merge` OFF** for
+   this tutorial (after REVIEW approve you expect `DEVCAKE-MERGE` and merge
+   with `gh` yourself).
 
 Labels `DEVCAKE-*` appear on the team after a successful PMO connection.
 
@@ -79,7 +96,10 @@ Six top-level sidebar items (Adapters expands to two pages — seven surfaces to
 ## Step 3 — Log Grok in (one time)
 
 On Configuration → Dev Types, **implementer** → **Connect via OAuth…** — dialog shows URL + code.
-(Or `./scripts/grok_login.sh`.) Session is DevCake's own.
+(Or `./scripts/grok_login.sh`.) Session is DevCake's own. Device-code OAuth
+rides the operator's **xAI account billing / subscription quota** (same trust
+as pasting an `XAI_API_KEY`). Grok's feed cost is an **app-side rate-card
+estimate** (`08` §5 / ADR-0021) — the harness does not report billed USD.
 
 ## Step 3b — Supply-chain checklist (before you create the mission)
 
@@ -103,7 +123,11 @@ Full list: `14-security.md` §9.
 In your sandbox Linear team, create an issue:
 
 - **Title:** small and real — e.g. *"Add input validation to the parser, with tests"*.
-- **Description:** brief a competent contractor.
+- **Description:** brief a competent contractor, and include a backticked
+  work-repo marker matching the card name from step 1b, e.g.
+  `` `devcake-repo:sandbox` `` (lowercase alnum, ≤12). Resolution order is
+  marker → instance default (first chip) → zero-repo; this tutorial needs the
+  external card, so put the marker (or rely on the chip default from step 1b).
 - **Label:** **`DEVCAKE`** (opt-in adoption).
 - **Status:** Backlog. **Priority:** your call.
 

--- a/docs/tutorials/02-operating-devcake.md
+++ b/docs/tutorials/02-operating-devcake.md
@@ -99,10 +99,20 @@ Honesty rules worth knowing: profiles are snapshots, not live links — later
 edits never update a profile (the row shows "settings changed since" when
 you've drifted from the last-applied one); applying an old profile restores
 its **old** secret values, and the preview warns when a live secret is newer
-than the snapshot; run history, the skill store, internal repos (memory notebooks included), and `.env`
-are never touched by a profile — but note that skill-source and other
-connection secrets ARE in the snapshot (they restore with it). Profile snapshots live on `/data` and hold
-secret values — they are part of why backups are a password export.
+than the snapshot. Two different "skill" surfaces — do not conflate them:
+
+- **Skill-source connection secrets** (`skill-*` tokens for configured skill
+  source cards) **are** in the snapshot and **restore** with Apply (same
+  path as `pmo-*` / `repo-*`; ADR-0011 / `docs/11`).
+- The **skill store** (installed skill contents on disk), run history,
+  internal repos (memory notebooks included), and `.env` are **never**
+  touched by a profile.
+
+Save-time `snapshot_warnings` still name gaps only for PMO and repo cards —
+a skill source with a URL but no stored token may get no warning even though
+tokens that *are* stored do ride the snapshot. Profile snapshots live on
+`/data` and hold secret values — they are part of why backups are a password
+export.
 
 **Moving a setup to another install:** the same section's **Export…** writes
 one bundle file — configs stay readable YAML; secrets and `.env` setup

--- a/docs/tutorials/host-refresh.md
+++ b/docs/tutorials/host-refresh.md
@@ -47,7 +47,7 @@ live snapshots are crash-consistent only (`13` §8).
 |---|---|---|
 | `devcake_devcake_data` (`/data`) | **Wipe** | The only home of persisted app state — run store, config, `steward.yaml`, secrets. Wiping it is what makes the upgrade migration-free. |
 | `devcake_gitea_data` | **Keep** | Boards (Gitea Issues), internal repos, `activity-*` knowledge trail. No app state lives here; on a forge-issue host this volume *is* the board. |
-| OpenObserve volume | Optional | Exhaust, not knowledge (`docs/16` two-ledger doctrine). After Phase 0 it is fully disposable; keeping it costs only disk. |
+| OpenObserve volume | Optional | Exhaust, not knowledge ([ADR-0033](../adr/0033-discovery-routing-the-counterflow-lane.md) Decision 8: PMO = knowledge ledger, OpenObserve = operations exhaust; wiping OO must not change mission behavior). After Phase 0 it is fully disposable; keeping it costs only disk. |
 | `devcake_mirrors`, workspaces dir | Ignore | Disposable caches; the stack rebuilds them. |
 
 ```bash


### PR DESCRIPTION
## Intent

Make Tutorials 1–2 (and `host-refresh`) honest for a **literal** reader: every promised outcome is reachable by following the written steps. Docs-only; one PR.

Mission: https://linear.app/fidecastro/issue/CAKE-110/tutorials-survive-a-literal-reader

## What changed

1. **Tutorial 1 — work-repo bind (serious):** after adding the sandbox GitHub card, select it on the PMO instance **Repositories** chips and save; Step 4 requires a backticked `` `devcake-repo:<name>` `` marker. Explicit contrast: empty instance `repos` → zero-repo → internal Gitea auto-merge (not the promised GitHub PR).
2. **Tutorial 1 — credentials:** default staffing needs both Claude (`judgment`) and Grok (`implementer`); missing either fails the named stages. Points at `docs/08` §4.
3. **Tutorial 1 — Grok billing:** OAuth rides the operator's xAI account/quota; feed cost is rate-card estimate (ADR-0021), not billed USD.
4. **Tutorial 2 — skill-source honesty (post CAKE-65):** keep the restore promise for `skill-*` connection secrets; clarify skill **store** vs source tokens; note `snapshot_warnings` still omits skill cards.
5. **host-refresh:** replace dangling ``docs/16` two-ledger doctrine`` with ADR-0033 Decision 8 (keep real ``docs/16` versioning doctrine``).

## Drift vs mission description

Mission text still treated Tutorial 2 as a false promise. **CAKE-65 handoff wins:** skill-source secrets ride snapshots; residual is only save-time warnings omitting skill cards.

## How to verify

Docs-only Always Works™ (no bake/pytest):

- Re-read Tutorials 1–2 as a literal checklist (`#/pmo` RepoChips, `#/repos`, Dev Types OAuth).
- `rg 'two-ledger doctrine|docs/16\` two' docs/tutorials` → no hit; ADR-0033 present in `host-refresh.md`.
- Relative targets exist: `../08-harness-templates.md`, `../adr/0033-…`, `operator-drill.md`.
- No live stranger-mission run performed.

## Out of scope

- Re-implement skill-secret bundle code (CAKE-65).
- Fix `snapshot_warnings` omission (docs note only).
- SPA copy changes; Tutorial 3 / README expansion.