### PR TITLE
[CAKE-101] Repo-owned ignore coverage for local agent settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ dist/
 .vscode/
 .DS_Store
 
+# Claude Code local overrides (per-machine; never commit)
+.claude/settings.local.json
+
 # dagu-generated DAG scan index (rewritten on every boot)
 dagu/dags/.dag.index
 


### PR DESCRIPTION
## Intent

Add repository-owned `.gitignore` coverage for Claude Code’s machine-local settings file (`.claude/settings.local.json`) so every clone—not only machines with a personal global gitignore—cannot accidentally stage it.

## Context

- Mission: [CAKE-101](https://linear.app/fidecastro/issue/CAKE-101/repo-owned-ignore-coverage-for-local-agent-settings)
- Closes the REVIEW_LEDGER gap: ignore coverage previously depended on a personal global gitignore.
- Pattern is **local-only**; shared `.claude/settings.json` remains trackable if desired.

## How to verify

```bash
touch .claude/settings.local.json
git check-ignore -v .claude/settings.local.json
# expect: .gitignore:<line>:.claude/settings.local.json	.claude/settings.local.json

git check-ignore -v .claude/settings.json || true
# expect: no match (shared settings not ignored)
```

## Risk / rollout

None — config hygiene only; no runtime, bake, or product behavior change.

## Out of scope

- Ignoring all of `.claude/`
- Other agent dirs (`.cursor/`, `.codex/`, etc.)
- Docs / CONTRIBUTING updates