### PR TITLE
ci: cut the browser-suite step from ~8 minutes to ~2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,12 @@ jobs:
 
       # After hello + contracts: pmo_intake.mjs mutates live config (then
       # restores). Keep check:ui off the critical path of those batteries.
+      - name: Cache Playwright headless shell
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-shell-${{ runner.os }}-${{ hashFiles('admin/spa/package-lock.json') }}
+
       - name: Admin SPA browser UI suites (check:ui)
         run: |
           set -euo pipefail
@@ -181,10 +187,13 @@ jobs:
           # harness.mjs chromePath() looks under ~/.cache/ms-playwright for
           # chromium_headless_shell-*/chrome-linux/headless_shell. Unset any
           # PLAYWRIGHT_BROWSERS_PATH so install lands where the harness looks.
-          # --only-shell matches the harness (no full Chromium); --with-deps
-          # installs shared libs on ubuntu-latest runners.
+          # --only-shell matches the harness (no full Chromium). NO --with-deps:
+          # its apt pass cost ~7 min per run, and ubuntu-latest ships Chrome so
+          # every shared lib the headless shell needs is already present. If a
+          # runner image ever drops them, the launch fails loud in the first
+          # suite — reintroduce a minimal apt list then, not the blanket flag.
           unset PLAYWRIGHT_BROWSERS_PATH
-          npx --yes --prefix admin/spa playwright-core install --with-deps --only-shell chromium
+          npx --yes --prefix admin/spa playwright-core install --only-shell chromium
           # Resolve the executable explicitly: linux-x64 CFT layout is
           # chrome-headless-shell-linux64/chrome-headless-shell; linux-arm64
           # stays chrome-linux/headless_shell. UI_CHROME short-circuits


### PR DESCRIPTION
## Intent

The `check:ui` CI step added in #265 costs ~8 minutes per run, and the profile shows the suites themselves are innocent:

| Part | Time |
|---|---|
| `npm ci` | 5s |
| `playwright-core install --with-deps` apt pass | **~7 min** |
| headless-shell download | 4s |
| the 24 suites | ~90s |

`--with-deps` runs a full `apt-get update && install` of browser shared libraries on every run — but ubuntu-latest runners ship Chrome, so those libraries are already present.

## Changes

- Drop `--with-deps` from the playwright-core install; the step comment states the reintroduction rule (if a runner image ever drops the libs, the first suite fails loud — add a minimal apt list then, not the blanket flag).
- Cache `~/.cache/ms-playwright` keyed on `admin/spa/package-lock.json` (actions/cache SHA-pinned to v4.3.0 per the workflow's pin convention), so warm runs skip even the 4-second download.

## How to verify

This PR's own CI run: the check:ui step should complete in ~1.5–2 min with all 24 suites passing, and the whole job should return to ~4 min. A second run (or the post-merge main run) proves the cache hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)