### PR TITLE
[CAKE-91] SPA dead code removal

### DIFF
--- a/admin/spa/src/components/Alert.jsx
+++ b/admin/spa/src/components/Alert.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Info, TriangleAlert, OctagonAlert, ChevronRight, ExternalLink, X } from "lucide-react";
+import React from "react";
+import { Info, TriangleAlert, OctagonAlert, X } from "lucide-react";
 
 const STYLES = {
   info: {
@@ -20,27 +20,7 @@ const STYLES = {
   },
 };
 
-// items entries are "text — url"; render the trailing url as a link
-function Item({ entry }) {
-  const i = entry.lastIndexOf(" — ");
-  const [text, url] = i > -1 ? [entry.slice(0, i), entry.slice(i + 3)] : [entry, null];
-  return (
-    <li className="list-disc">
-      {text}
-      {url && (
-        <>
-          {" — "}
-          <a href={url} target="_blank" rel="noreferrer" className="underline underline-offset-2">
-            {url}
-          </a>
-        </>
-      )}
-    </li>
-  );
-}
-
-export default function Alert({ severity = "warning", title, body, items, collapsible, link, onDismiss }) {
-  const [open, setOpen] = useState(true);
+export default function Alert({ severity = "warning", title, body, onDismiss }) {
   const s = STYLES[severity] || STYLES.warning;
   const Icon = s.icon;
   return (
@@ -48,33 +28,11 @@ export default function Alert({ severity = "warning", title, body, items, collap
       <div className="flex items-start gap-2.5">
         <Icon size={17} strokeWidth={2} className={`mt-0.5 shrink-0 ${s.iconCls}`} aria-hidden />
         <div className="min-w-0 flex-1">
-          {collapsible ? (
-            <button className="flex w-full items-center gap-2 text-left font-medium"
-              onClick={() => setOpen(!open)}>
-              <span>{title}</span>
-              <ChevronRight size={13} className={`transition-transform ${open ? "rotate-90" : ""}`} aria-hidden />
-            </button>
-          ) : (
-            <p className="font-medium">{title}</p>
-          )}
+          <p className="font-medium">{title}</p>
           {body && (
             <p className="mt-0.5 opacity-90">
               {body}
-              {link && (
-                <>
-                  {" "}
-                  <a href={link.href} className="inline-flex items-center gap-0.5 font-medium underline underline-offset-2">
-                    {link.label}
-                    {link.href.startsWith("http") && <ExternalLink size={11} aria-hidden />}
-                  </a>
-                </>
-              )}
             </p>
-          )}
-          {items && open && (
-            <ul className="mt-1.5 space-y-0.5 pl-5">
-              {items.map((e) => <Item key={e} entry={e} />)}
-            </ul>
           )}
         </div>
         {onDismiss && (

--- a/admin/spa/src/components/DevTypeEditor.jsx
+++ b/admin/spa/src/components/DevTypeEditor.jsx
@@ -309,7 +309,7 @@ export default function DevTypeEditor({ name, draftDt, serverDt, harnesses, setF
             >
               <Textarea
                 rows={6}
-                value={d.dev_entrypoint ?? (d.mcp_setup_commands || []).join("\n")}
+                value={d.dev_entrypoint || ""}
                 onChange={(e) => set("dev_entrypoint", e.target.value)}
               />
             </Field>

--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -107,17 +107,6 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
       action: () => { setField(path, value); setConfirm(null); },
     });
 
-  const test = async (kind) => {
-    try {
-      const result = await send("POST", `/connections/${kind}/test`);
-      setTestResult((prev) => ({ ...prev, [kind]: result }));
-    } catch (e) {
-      setTestResult((prev) => ({
-        ...prev,
-        [kind]: { ok: false, error: String(e.message || e) },
-      }));
-    }
-  };
   // per-instance tests (schema v3 / M10): keyed pmo:{name} / forge:{name}
   const testPmo = async (name) => {
     const key = `pmo:${name}`;

--- a/admin/spa/src/lib/board.js
+++ b/admin/spa/src/lib/board.js
@@ -105,6 +105,6 @@ export function contextActions(row) {
     items.push({ id: "force_freshness", label: "Re-check freshness" });
   }
   if (set.has("DEVCAKE-SKIP"))         items.push({ id: "unpark", label: "Unpark" });
-  else                                  items.push({ id: "park",   label: "Park", danger: false });
+  else                                  items.push({ id: "park",   label: "Park" });
   return items;
 }

--- a/admin/spa/src/lib/configLabels.js
+++ b/admin/spa/src/lib/configLabels.js
@@ -141,7 +141,6 @@ const DEV_TYPE_FIELDS = {
   identifying_prompt: { label: "Identifying prompt", format: orEmpty, multiline: true },
   dev_entrypoint: { label: "Entrypoint script", format: orEmpty, multiline: true },
   override_harness_adapter: { label: "Override harness adapter", format: onOff },
-  mcp_setup_commands: { label: "Entrypoint script (legacy)", format: lines, multiline: true },
   skills: { label: "Skills (available)", format: lines, multiline: true },
   skills_required: { label: "Skills (required)", format: lines, multiline: true },
   secret_env: { label: "Secret env vars", format: lines, multiline: true },

--- a/admin/spa/src/pages/ReposPage.jsx
+++ b/admin/spa/src/pages/ReposPage.jsx
@@ -95,12 +95,9 @@ function RepoUsageChips({ name, cfg, devTypes, depth }) {
   const ref = (cfg.pmos || []).filter((p) => (p.reference_repos || []).includes(name)).length;
   const memB = (cfg.pmos || []).filter((p) => (p.memory_repos || []).includes(name)).length;
   const memD = Object.values(devTypes || {}).filter((d) => (d.memory_repos || []).includes(name)).length;
-  const skills = Object.values(devTypes || {}).some((d) =>
-    (d.skills || []).some((s) => s.startsWith(`${name}/`)));
   const chips = [];
   if (work) chips.push(`work ×${work}`);
   if (ref) chips.push(`reference ×${ref}`);
-  if (skills) chips.push("skills-source");
   if (memB) chips.push(`memory board-bound ×${memB}`);
   if (memD) chips.push(`memory domain-bound ×${memD}`);
   if (typeof depth === "number") chips.push(`queue ${depth}`);


### PR DESCRIPTION
## Intent
Delete dead Admin SPA code from the REVIEW_LEDGER SPA dead-code batch. No behavior inventing — unused props/helpers/branches only.

## Mission
https://linear.app/fidecastro/issue/CAKE-91/spa-dead-code-removal

## Changes (six deletions)
1. **`Alert.jsx`** — remove unused `items` / `collapsible` / `link` props and the `Item` helper (sole consumer spreads `deriveAlerts()` objects that never emit those fields).
2. **`DevTypeEditor.jsx`** — entrypoint textarea uses `d.dev_entrypoint || ""` only (drop unreachable `mcp_setup_commands` fallback).
3. **`configLabels.js`** — delete the dead `mcp_setup_commands` DEV_TYPE_FIELDS leaf.
4. **`PmoSection.jsx`** — delete unused `test(kind)` helper targeting nonexistent `POST /connections/{kind}/test`.
5. **`board.js`** — drop ignored `danger: false` on Park `contextActions` (consumers set `danger: it.id === "park"`).
6. **`ReposPage.jsx` `RepoUsageChips`** — remove leftover `skills-source` chip (impossible for a repo card after the skill_sources split).

## Already landed (not redone)
CAKE-89 (#262) already extracted `unusedRepos.js` without a skills branch and fixed unused-repos alert/dialog copy. This PR only clears the remaining chip residue plus the unused-prop/helper batch.

## Out of scope
- Live parallel `TERMINAL` / `TERMINAL_STATES` copies (both used)
- Other SPA medium findings (SecretField errors, enum pins, stage vocabulary, …)
- Docs/copy honesty beyond chip removal

## How to verify
- `npm run test:helpers --prefix admin/spa` (green locally)
- `docker build -f admin/Dockerfile -t localhost/devcake/admin:latest ./admin` (bake unavailable on agent host; Dockerfile fallback green; container `nginx-health` → `ok`)
- Optional UI smoke: Overview alerts still render; Repos chips show work/reference/memory only; Dev Type entrypoint edits `dev_entrypoint`; Missions Park still danger-styled in menus

## Risk
Deletion-only; no API or draft-semantics changes.