### PR TITLE
[CAKE-106] Error-taxonomy doc currency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Design and refactors must respect SOLID. Prefer **deep modules** (small interfac
 - Typing domain code against concrete `DaguExecutor` / `Messaging` / `RunStore` instead of ports
 - Duplicating the ACL → digest → save → start spine outside `RunBootstrap`
 - Giant untested functions in `orchestrator.py` without a public-seam test
-- `except Exception: pass` that swallows real failures without logging — lint-enforced: ruff `BLE001`; every blanket catch is narrowed or carries `# noqa: BLE001 — <justification>` naming its contract (docs/15 §7)
+- `except Exception: pass` that swallows real failures without logging — lint-enforced: ruff `BLE001`; every production blanket catch is narrowed, carries `# noqa: BLE001 — <justification>` naming its contract, or is a logged handler under a sanctioned docs/15 §7 contract (ruff accepts the logged arm without noqa; prefer an explicit noqa at long-lived seams)
 - Mutating production modules only “to make the test pass” by weakening invariants
 - New endpoint bodies in `api/main.py` or new attributes bound onto `MissionManager` after its class body — main.py is wiring + ≤4-statement route forwards (composition happens in `api/services.build_services()`, ADR-0028), orchestrator behavior lives in module functions taking `mgr` (ADR-0015; enforced by `tests/test_structure_guards.py`)
 - New checkpoint-step key literals — every `finalized_steps`/`_checkpoint` key registers in `domain/orchestrator/steps.py` (ADR-0034; the AST guard in `test_structure_guards` rejects bare literals). Same file forbids a domain module importing `adapters/*` outside the two allowlisted seams.

--- a/app/devcake/domain/orchestrator/completion.py
+++ b/app/devcake/domain/orchestrator/completion.py
@@ -181,6 +181,6 @@ async def route_conflict_to_execute(mgr, pmo_id: str, key: str, pr_url: str,
         mgr._audit(pmo_id, "conflict_resolve_dispatched",
                     f"attempt {n + 1} ({pr_url})")
         return True
-    except Exception:
+    except Exception:  # noqa: BLE001 — degrade with record: conflict routing failure is logged; caller keeps the mission parked for a human
         log.exception("conflict auto-resolve routing failed for %s", key)
         return False

--- a/app/devcake/domain/runs.py
+++ b/app/devcake/domain/runs.py
@@ -482,22 +482,22 @@ class RunManager:
         try:
             try:
                 await self.executor.stop(run.run_id)
-            except Exception:
+            except Exception:  # noqa: BLE001 — best-effort teardown: stop may raise on transport errors; ACL + terminal state must still run
                 log.exception("executor.stop failed for %s — continuing teardown",
                               run.run_id)
             try:
                 await self._ship_failure(run, new_state, reason)
-            except Exception:
+            except Exception:  # noqa: BLE001 — best-effort teardown: failure record may fail to ship; ACL + terminal state must still run
                 log.exception("ship_failure failed for %s — continuing teardown",
                               run.run_id)
         finally:
             try:
                 await self.messaging.delete_run_user(run.run_id)
-            except Exception:
+            except Exception:  # noqa: BLE001 — best-effort teardown: ACL delete is mandatory-attempt; continue past transport errors
                 log.exception("delete_run_user failed for %s", run.run_id)
             try:
                 await self.messaging.delete_reply_stream(run.run_id)
-            except Exception:
+            except Exception:  # noqa: BLE001 — best-effort teardown: reply-stream delete continues past transport errors
                 log.exception("delete_reply_stream failed for %s", run.run_id)
             # Two guards on one FRESH read, no await before save (atomic under
             # asyncio's cooperative scheduling):
@@ -551,7 +551,7 @@ class RunManager:
             # block is the fail-safe teardown, so belt-and-suspenders.
             try:
                 self.workspaces.cleanup(run.run_id)
-            except Exception:
+            except Exception:  # noqa: BLE001 — best-effort teardown: workspace cleanup is belt-and-suspenders; the sweep reclaims leftovers
                 log.exception("workspace cleanup failed for %s", run.run_id)
         # state_moved: the kill lost the race — the run's mover (finalize, or
         # another killer) now owns the mission transition, and restoring the
@@ -562,7 +562,7 @@ class RunManager:
         if self.finalizer and run.mission_pmo_id and not state_moved:
             try:
                 await self.finalizer.restore_after_failure(run)
-            except Exception:
+            except Exception:  # noqa: BLE001 — best-effort teardown: INV-3 restore must not undo a completed kill if PMO write fails
                 log.exception("restore_after_failure failed for %s", run.run_id)
         if self.oauth_mgr and run.run_id in self.oauth_mgr.sessions:
             self.oauth_mgr.sessions[run.run_id].update(

--- a/app/ruff.toml
+++ b/app/ruff.toml
@@ -7,8 +7,10 @@ line-length = 100
 [lint]
 # Narrow: syntax / undefined names only (caught the review.py merge_err capture),
 # plus BLE001 (blind except). Policy (docs/15 §7): every production
-# `except Exception` is narrowed or carries `# noqa: BLE001` with a one-line
-# justification. Silent swallows (bare pass/continue, no log) are never OK.
+# `except Exception` is (1) narrowed, (2) carries `# noqa: BLE001 — <reason>`,
+# or (3) a logged handler (`log.exception` / equivalent) under a sanctioned
+# contract — ruff accepts arm 3 without noqa; prefer an explicit noqa at
+# long-lived seams. Silent swallows (bare pass/continue, no log) are never OK.
 select = ["E9", "F63", "F7", "F82", "BLE001"]
 
 [lint.per-file-ignores]

--- a/docs/15-errors-and-retries.md
+++ b/docs/15-errors-and-retries.md
@@ -36,7 +36,7 @@ prose.
 | `DEV_FORGE` | exit 13 without the structured `DEV_FORGE_AUTH` class (transient forge/clone/push failure, or auth-ish wording without the structured class). Includes a **strict memory-notebook clone failure** in the provision step (ADR-0035: `context_sourcing_strict` on ⇒ the run must not start memoryless) | counted only after per-step excusals are spent (§4a) — **not** a latched breaker |
 | `DEV_FORGE_AUTH` | exit 13 carrying the Dev's **structured** `DEV_FORGE_AUTH` classification (auth wording in the detail alone is `DEV_FORGE`) | **per-repo** forge circuit breaker (`repo:{name}`); that repo's missions stop dispatching until the token can push. NOTE (ADR-0035): a strict memory mount's revoked credential classifies here too — a NOTEBOOK card's breaker then freezes dispatch for every mission that binds it, by design (fail closed beats silently memoryless). Distinct case: a memory/skill-source card that fails the MIRROR gate never reaches a container at all — it defers dispatch as an unschedulable gate reason (blocked-reasons row), no attempt, no class |
 | `DEV_HARNESS_FAULT` | exit 15: the harness reported a failure in-band, or produced no output at all, whatever its exit status (ADR-0018) | counted attempt — UNLESS correlated across ≥2 missions (§4a) |
-| `DEV_TURN_BUDGET` | exit 16: the harness stopped at its configured `--max-turns` cap — reachable for **`claude-code` and `grok-build`**, never for **codex** 0.147.0, which has no turn cap at all (`07-dev-runtime.md` §4, §2a below) | counted attempt; deterministic, so never correlated and never excused |
+| `DEV_TURN_BUDGET` | exit 16: the harness stopped at a configured run-budget cap — reachable for **`claude-code`** / **`grok-build`** (`--max-turns`) and **`qwen-code`** (`--max-session-turns` / `--max-wall-time` / `--max-tool-calls`, CLI exits 53/55); unreachable for **codex** 0.147.0, **pi**, and **opencode**, which have no turn/session cap that maps here (`07-dev-runtime.md` §4, §2a below) | counted attempt; deterministic, so never correlated and never excused |
 | `DEV_BAD_OUTPUT` | exit 11: `result.json` missing/invalid **after the in-container continuation budget is spent, when the loop is enabled** (ADR-0022; `07-dev-runtime.md` §5a); app-side: structurally invalid payload behind a legal outcome (empty decomposition, bad `blocked_by`) | counted attempt — when many Devs share one backend, exit 11 can still land fleet-wide (model invents tools as prose — `08` §8; grok silent non-progress halt — §2b); §4a's brake keys on exit 15 by default, with `brake_on_bad_output` (ADR-0026, default off) widening it to cover exactly this cascade |
 | `ILLEGAL_OUTCOME` | outcome not in `LEGAL_OUTCOMES` for the run type (`03` §6) — includes forged outcomes (e.g. EXECUTE claiming `reviewed`) | park with `DEVCAKE-SKIP` + comment; audit `illegal_outcome`; never acted on, never retried |
 | `LABEL_CONFLICT` | ≥2 stage labels (derivation row 6) | human-resolve |
@@ -60,7 +60,7 @@ prose.
 | `DEV_OPERATOR_STOP` | yes — the mission stays schedulable; stop the *mission*, not just the run, to prevent re-dispatch | **yes** | scheduler | Runs page names the operator stop |
 | `DEV_BAD_OUTPUT` | yes — same | **yes** | scheduler | same |
 | `DEV_HARNESS_FAULT` | yes — same | **yes**, unless correlated (§4a) | scheduler | `dev_backend_degraded` in `/health` + SPA warning while throttled |
-| `DEV_TURN_BUDGET` | yes — but retrying the same cap cannot help; raise `--max-turns` (claude-code and grok-build take it; **codex has none** — §2a) or assign a stronger Dev Type | **yes** | scheduler | `run.error` names the cap and where to change it |
+| `DEV_TURN_BUDGET` | yes — but retrying the same cap cannot help; raise the harness's budget flag (claude-code / grok-build: `--max-turns`; qwen-code: `--max-session-turns` / wall-time / tool-calls; **codex / pi / opencode have none** — §2a) or assign a stronger Dev Type | **yes** | scheduler | `run.error` names the cap and where to change it |
 | `DEV_FORGE` | yes — a forge outage should not burn missions | **no** while the step has excusals (§4a), **yes** once spent | scheduler | after the cap: `DEVCAKE-FAILED` |
 | `DEV_AUTH` | no — pointless until creds fixed | **no** | — | circuit breaker (§4) + SPA/health alert |
 | `DEV_FORGE_AUTH` | no — pointless until repository access is fixed | **no** | — | per-repo forge breaker + actionable connection-test error |
@@ -78,17 +78,22 @@ against each CLI (`adr/0018-harness-fault-classification-and-backend-brake.md`, 
 |---|---|---|
 | `claude-code` | `--max-turns <N>` | **yes** — on `terminal_reason:"max_turns"` / `subtype:"error_max_turns"` |
 | `grok-build` (0.2.112) | `--max-turns <N>` | **yes** — it emits a dedicated `{"type":"max_turns_reached"}` event **and** `end` `stopReason:"Cancelled"`, exits 1, and the predicate fires on that event type (`grok_turn_budget`). It landed on `DEV_CRASH` (exit 10) until the ADR-0018 fix round added the arm |
+| `qwen-code` | `--max-session-turns` / `--max-wall-time` / `--max-tool-calls` | **yes** — CLI exits 53/55 and budget subtypes map through `qwen_run_fault` → `FAULT_TURN_BUDGET` → exit 16 (`08-harness-templates.md` §1) |
 | `codex` (0.147.0) | **none** | **no** — no `--max-turns` equivalent and no config key for one, so the class is unreachable |
+| `pi` | **none** | **no** — no turn/session budget flag maps to `FAULT_TURN_BUDGET` |
+| `opencode` | **none** | **no** — no turn/session budget flag maps to `FAULT_TURN_BUDGET` |
 
 Consequences for the operator. On a **claude-code** or **grok-build** Dev, raising
 `--max-turns` in that Mission Type's extra CLI args (`11-admin-panel.md` §3) is
 the literal remedy the `run.error` names, and both report the stop as
-`DEV_TURN_BUDGET`. On a **codex** Dev there is nothing to raise: an unbounded run
-is stopped only by `dev_timeout_minutes` (`AppConfig.dev_timeout_minutes`, default 120 — a
+`DEV_TURN_BUDGET`. On a **qwen-code** Dev the levers are the three budget flags
+above (same class, different CLI surface). On a **codex**, **pi**, or **opencode**
+Dev there is nothing to raise: an unbounded run is stopped only by
+`dev_timeout_minutes` (`AppConfig.dev_timeout_minutes`, default 120 — a
 **global** setting, so lowering it to fence one Dev Type shortens every run) and
 it arrives as a signal kill reported `DEV_TIMEOUT`, never `DEV_TURN_BUDGET`. The
 levers there are a smaller task, a different Dev Type, or accepting the timeout as
-the bound. Do not go looking for a codex turn flag; at 0.147.0 there is not one.
+the bound. Do not go looking for a turn flag those three CLIs do not expose.
 
 **grok's cap has no default**, so nothing sits above the value you set: it stops
 exactly where it is told (`grok_loop_varying_cap20` at 20; `grok_turn_budget` at 2),
@@ -282,6 +287,9 @@ non-auth rejections — those words alone must **not** win over an in-band fault
    - `codex`: transport wording in error / `turn.failed` messages
      (`unexpected status NNN`, `last status: NNN`)
    - `grok-build`: `Unauthorized (NNN)` / `(status NNN` in error events
+   - `pi` / `opencode` / `qwen-code`: dialect `api_error_status` extractors
+     over error / terminal event text via `HARNESS_STATUS_PATTERNS` (plus
+     qwen's `api_error_status` / `[API Error: …]` bodies when present)
 2. **Or** stderr matches a **distinctive** marker (word-boundary): currently
    only the grok session phrases `not signed in` and `grok login`.
 
@@ -336,12 +344,17 @@ and teardown paths all deliberately outlive individual errors. The policy that
 keeps that deliberate without becoming sloppy:
 
 - **Lint-enforced** (`app/ruff.toml`, rule `BLE001`; runs in CI and
-  `scripts/ci_suite.sh`): every production `except Exception` is either
-  **narrowed** to the types the code can actually handle, or carries
-  `# noqa: BLE001 — <one-line justification>` naming the contract that makes a
-  blanket catch correct. The justification lives **inline at the site** — this
+  `scripts/ci_suite.sh`): every production `except Exception` satisfies one of
+  three arms — (1) **narrowed** to the types the code can actually handle, or
+  (2) carries `# noqa: BLE001 — <one-line justification>` naming the contract
+  that makes a blanket catch correct, or (3) is a handler that **logs**
+  (`log.exception` / equivalent) under a sanctioned contract below. Ruff's
+  BLE001 already accepts logged handlers without a noqa; the noqa form is
+  still preferred at long-lived seams (teardown, routing degrade) so the
+  contract is readable at the site. Justifications live **inline** — this
   section defines the vocabulary, never a site inventory (it would drift).
-- **Sanctioned contracts** (the justification should name one):
+- **Sanctioned contracts** (the justification — or the log line of arm 3 —
+  should name one):
   *loop guard* (a poll/sweep/consumer cycle must survive any single item's
   failure — the failure is logged and, where one exists, surfaced via
   `poll_degraded`/`blocked_reasons`/a breaker); *probe* (health and connection

--- a/scripts/export_receipts.py
+++ b/scripts/export_receipts.py
@@ -81,7 +81,7 @@ def sh(cmd):
     try:
         return subprocess.run(cmd, capture_output=True, text=True,
                               timeout=60).stdout.strip()
-    except Exception as e:                                    # noqa: BLE001
+    except Exception as e:  # noqa: BLE001 — best-effort probe: unavailable host detail must not abort the receipts pack
         return f"<unavailable: {e}>"
 
 


### PR DESCRIPTION
## Intent

Make `docs/15-errors-and-retries.md` (and the AGENTS / ruff mirrors of its §7 rule) state what the code and lint actually do, and close the REVIEW_LEDGER honesty gaps for harness enumerations, BLE001 policy vs enforcement, and the unjustified `noqa` in `scripts/export_receipts.py`.

Mission: https://linear.app/fidecastro/issue/CAKE-106/error-taxonomy-doc-currency

## What changed

- **Harness enums in docs/15:** `DEV_TURN_BUDGET` / §2a now include `qwen-code` (exits 53/55 → exit 16) and state honestly that `pi` / `opencode` have no turn-budget mapping; §4 distinctive-auth sources list `pi` / `opencode` / `qwen-code` `HARNESS_STATUS_PATTERNS` extractors.
- **BLE001 three-arm rule:** docs/15 §7, `AGENTS.md`, and `app/ruff.toml` now document the enforced rule — narrowed **or** `# noqa: BLE001 — <reason>` **or** a logged handler under a sanctioned §7 contract (ruff accepts the logged arm without noqa).
- **Seven ledger catches:** justified `# noqa: BLE001 — …` on `runs.py` `_kill_inner` (×6) and `completion.route_conflict_to_execute` (×1).
- **`scripts/export_receipts.py`:** added the required `— <reason>` tail on the existing noqa.

## Deviations from plan (tree already honest)

Re-verified and **left alone** (sibling missions already aligned code ↔ docs):

- `DEV_MCP_SETUP` 300s / `run_mcp_setup` (restored; docs claim holds)
- §3 give-up comment content (`_give_up_feed_body` already carries class + message + trace pointer)
- Notebook `DEV_FORGE_AUTH` breaker pairing (CAKE-60 latch + schedule passenger gate)
- `PMO_TRANSIENT` → `poll.instance` (docs/15 + `provision_oo.py` already aligned; no CAKE-86 SQL change)

## How to verify

```bash
docker buildx bake app-test   # or Dockerfile --target test fallback
docker run --rm -e RUFF_CACHE_DIR=/tmp/ruff-cache -w /srv \
  devcake/app-test:latest ruff check devcake tests
./scripts/pytest_app.sh app/tests/test_failure_taxonomy.py \
  app/tests/test_export_receipts.py app/tests/test_crash_recovery.py
```

Observed on this run: ruff clean on `devcake tests` + `export_receipts.py`; **59 passed** for the three test modules above (fresh `app-test` image).

## Out of scope

- `provision_oo.py` alert SQL (CAKE-86)
- Finalize latch behavior changes (already fixed elsewhere; not re-touched)
- MCP prelude / entrypoint behavior changes
- Tree-wide audit of every bare `except Exception` beyond the ledger’s named set