### PR TITLE
[CAKE-99] grok_login and ci_suite work beyond one machine layout

### DIFF
--- a/docs/18-operator-contract.md
+++ b/docs/18-operator-contract.md
@@ -52,7 +52,9 @@ Rotation is four different motions depending on the secret:
    **Skill sources** card (Configuration → Skills). The write path
    hot-reloads adapters ([`11`](11-admin-panel.md)).
 2. **Model / harness credentials** — upload via the Dev Type card under
-   Configuration (OAuth wizard, credential upload, or `scripts/grok_login.sh`).
+   Configuration (OAuth wizard, credential upload, or `scripts/grok_login.sh`
+   — defaults to seeded `implementer`; override with `DEVCAKE_DEV_TYPE` or a
+   positional name; app container via `DEVCAKE_APP_CONTAINER` / compose `ps`).
    The write clears any `DEV_AUTH` breaker for Dev Types using that credential
    ([`15`](15-errors-and-retries.md) §4).
 3. **Stack bootstrap passwords** (`ADMIN_*`, `REDIS_*`, `DAGU_*`, `OO_*`,

--- a/docs/tutorials/01-first-mission.md
+++ b/docs/tutorials/01-first-mission.md
@@ -96,7 +96,8 @@ Six top-level sidebar items (Adapters expands to two pages — seven surfaces to
 ## Step 3 — Log Grok in (one time)
 
 On Configuration → Dev Types, **implementer** → **Connect via OAuth…** — dialog shows URL + code.
-(Or `./scripts/grok_login.sh`.) Session is DevCake's own. Device-code OAuth
+(Or `./scripts/grok_login.sh` — defaults to the seeded `implementer`; override with
+`DEVCAKE_DEV_TYPE` or a positional Dev Type name.) Session is DevCake's own. Device-code OAuth
 rides the operator's **xAI account billing / subscription quota** (same trust
 as pasting an `XAI_API_KEY`). Grok's feed cost is an **app-side rate-card
 estimate** (`08` §5 / ADR-0021) — the harness does not report billed USD.

--- a/scripts/ci_suite.sh
+++ b/scripts/ci_suite.sh
@@ -42,9 +42,18 @@ fi
 # and every docker run below (tag lockstep, like up.sh); and when the live
 # app container is not running the freshly-baked image, the run is loudly
 # labeled so a mixed-version green can never read as tree evidence.
+# shellcheck disable=SC1091
+source scripts/lib/app_container.sh
+
 mixed_version_banner() {
-  local live_id local_id
-  live_id="$(docker inspect -f '{{.Image}}' devcake-app-1 2>/dev/null || true)"
+  local live_id local_id app
+  # Project name ≠ checkout dirname — do not hardcode `devcake-app-1`.
+  # Empty app → leave live_id empty (warn-not-fail); rest of suite uses compose exec.
+  app="$(devcake_app_container)"
+  live_id=""
+  if [[ -n "$app" ]]; then
+    live_id="$(docker inspect -f '{{.Image}}' "$app" 2>/dev/null || true)"
+  fi
   local_id="$(docker image inspect -f '{{.Id}}' "devcake/app:${DEVCAKE_TAG:-latest}" 2>/dev/null || true)"
   if [[ -n "$live_id" && -n "$local_id" && "$live_id" != "$local_id" ]]; then
     echo "⚠️  MIXED-VERSION RUN: the live app container is NOT running the"

--- a/scripts/grok_login.sh
+++ b/scripts/grok_login.sh
@@ -1,17 +1,42 @@
 #!/usr/bin/env bash
-# One-time (or re-run on expiry) Grok Build OAuth login for DevCake's main-dev.
+# One-time (or re-run on expiry) Grok Build OAuth login for a DevCake Dev Type.
+#
+# Usage: ./scripts/grok_login.sh [dev-type]
+#   Positional wins over DEVCAKE_DEV_TYPE; default is the seeded grok-build
+#   Dev Type `implementer`.
+# Env:
+#   DEVCAKE_DEV_TYPE       — Dev Type name (default: implementer)
+#   DEVCAKE_APP_CONTAINER  — app container id/name (default: docker compose ps -q app)
 #
 # Runs `grok login --device-auth` INSIDE the dev-grok-build image so the session
 # is created in the exact runtime that will use it, then stores the resulting
-# auth.json in the devcake_data volume at /data/secrets/main-dev/grok-auth.json
+# auth.json in the data volume at /data/secrets/<dev-type>/grok-auth.json
 # (0600). Dev containers receive it per-run over the runspec channel and install
 # it at ~/.grok/auth.json (docs/08 §4, docs/09 §3). Your local ~/.grok is never
-# touched. Re-run this script whenever main-dev trips the DEV_AUTH breaker.
+# touched. Re-run this script whenever that Dev Type trips the DEV_AUTH breaker.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# shellcheck disable=SC1091
+source scripts/lib/app_container.sh
+
+DEV_TYPE="${1:-${DEVCAKE_DEV_TYPE:-implementer}}"
+# Align with DevType.name in app/devcake/config.py (path-safe token).
+if [[ ! "$DEV_TYPE" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]]; then
+  echo "grok_login: refusing Dev Type name ${DEV_TYPE@Q}" >&2
+  exit 2
+fi
+
+APP="$(devcake_app_container)"
+if [[ -z "$APP" ]]; then
+  echo "grok_login: no app container — start the stack (docker compose up -d app) or set DEVCAKE_APP_CONTAINER" >&2
+  exit 1
+fi
+
 OUT=$(mktemp -d)
 trap 'rm -rf "$OUT"' EXIT
+# Image user is uid 1000; mktemp is 0700 owned by the host operator.
+chmod a+rwx "$OUT" 2>/dev/null || true
 
 echo "── A URL and a code will appear below: open the URL, enter the code, approve."
 docker run -it --rm -v "$OUT:/out" --entrypoint sh devcake/dev-grok-build:latest \
@@ -19,8 +44,8 @@ docker run -it --rm -v "$OUT:/out" --entrypoint sh devcake/dev-grok-build:latest
 
 [ -f "$OUT/grok-auth.json" ] || { echo "login did not produce auth.json"; exit 1; }
 
-docker exec devcake-app-1 mkdir -p /data/secrets/main-dev
-docker cp "$OUT/grok-auth.json" devcake-app-1:/data/secrets/main-dev/grok-auth.json
-docker exec devcake-app-1 sh -c \
-  'chmod 600 /data/secrets/main-dev/grok-auth.json && ls -l /data/secrets/main-dev/'
-echo "── stored. main-dev is ready; the DEV_AUTH breaker (if tripped) clears on next dispatch."
+docker exec "$APP" mkdir -p "/data/secrets/${DEV_TYPE}"
+docker cp "$OUT/grok-auth.json" "${APP}:/data/secrets/${DEV_TYPE}/grok-auth.json"
+docker exec "$APP" sh -c \
+  "chmod 600 /data/secrets/${DEV_TYPE}/grok-auth.json && ls -l /data/secrets/${DEV_TYPE}/"
+echo "── stored. ${DEV_TYPE} is ready; the DEV_AUTH breaker (if tripped) clears on next dispatch."

--- a/scripts/lib/app_container.sh
+++ b/scripts/lib/app_container.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Shared resolve for the compose `app` container (ADR-0034: one path).
+# Compose names the container from the project name ({project}-app-1 /
+# {project}_app_1); hardcoding `devcake-app-1` only works when the checkout
+# directory is literally `devcake`. Override: DEVCAKE_APP_CONTAINER=<id|name>.
+# Prints the id/name on stdout; empty when unset and no running `app` service.
+# Callers decide whether empty is fatal (grok_login) or warn-only (ci_suite banner).
+
+devcake_app_container() {
+  if [[ -n "${DEVCAKE_APP_CONTAINER:-}" ]]; then
+    printf '%s\n' "$DEVCAKE_APP_CONTAINER"
+    return 0
+  fi
+  docker compose ps -q app 2>/dev/null | head -1
+}


### PR DESCRIPTION
## Intent

Make operator scripts work when the compose project name is not `devcake` and when the Grok-credentialed Dev Type is not named `main-dev`. Also fix the host-uid trap that breaks `grok_login` for non-1000 operators.

Mission: https://linear.app/fidecastro/issue/CAKE-99/grok-login-and-ci-suite-work-beyond-one-machine-layout

## Context (REVIEW_LEDGER)

- `scripts/grok_login.sh` hardcoded container `devcake-app-1` and Dev Type `main-dev`
- `scripts/ci_suite.sh` `mixed_version_banner` hardcoded the same container name
- `mktemp -d` → mode `0700` broke `cp … /out/` when host uid ≠ 1000 (image user)

**Correctness fix:** default Dev Type is now `implementer` (seeded grok-build in `DEFAULT_DEV_TYPES`), not the stale `main-dev` literal that matched no seed.

## Changes

- New chokepoint `scripts/lib/app_container.sh` — `DEVCAKE_APP_CONTAINER` or `docker compose ps -q app`
- `grok_login.sh` — env/positional Dev Type; validate name shape; uid `chmod a+rwx` on OUT
- `ci_suite.sh` — same resolve in banner only (empty → warn-not-fail)
- Tutorial + operator-contract one-liners for the knobs

## How to verify

```bash
bash -n scripts/grok_login.sh scripts/ci_suite.sh scripts/lib/app_container.sh
# zero code literals:
grep -nE 'main-dev|devcake-app-1' scripts/grok_login.sh scripts/ci_suite.sh | grep -v '^[^:]*:[0-9]*:[[:space:]]*#'
# with stack up:
docker compose ps -q app   # non-empty
# banner must not error on non-devcake project names
```

## Risk / rollout

Scripts-only; no bake/runtime Python. Default `implementer` changes where credentials land vs the old (broken) `main-dev` path — correct for seeded configs.

## Out of scope

Other REVIEW_LEDGER script findings; SPA OAuth wizard; compose service renames.