### PR TITLE
[CAKE-107] Security doc factual currency (no posture change)

### DIFF
--- a/app/tests/test_forge.py
+++ b/app/tests/test_forge.py
@@ -644,7 +644,7 @@ def test_descriptor_complete_and_renderable(cls):
         assert getattr(d, field), f"{cls.__name__}.descriptor.{field} empty"
     # token_patterns/secret_shape_prefixes MAY be deliberately empty (Gitea:
     # 40-hex tokens collide with git SHAs — value registration is the
-    # redaction line, docs/14 §5); when present they must compile/behave
+    # redaction line, docs/14 §7); when present they must compile/behave
     # templates must render without KeyError against the documented placeholders
     d.pr_instructions.format(key="DEV-1", title="t", default="main",
                              branch="devcake/DEV-1")

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -186,7 +186,7 @@ Empty or `change-me*` bootstrap passwords refuse app boot unless
   `{"params": "{\"RUN_ID\": \"LINEAR-ENG-142-3-EXECUTE-9GX2TQ\", \"IMAGE\": \"devcake/dev-claude-code:latest\", \"TRACEPARENT\": \"<w3c>\", …}", "dagRunId": "LINEAR-ENG-142-3-EXECUTE-9GX2TQ"}` —
   `params` is a JSON-**encoded string** of named params; the client-chosen `dagRunId` (`^[-a-zA-Z0-9_]+$`, ≤ 64 chars — our human-readable run id fits) makes duplicate triggers return **HTTP 409** `already_exists` (`04-orchestrator.md` §6.3). Auth: **HTTP Basic** with `DAGU_USER` / `DAGU_PASSWORD` (same as `DAGU_AUTH_MODE=basic` above) — not a Bearer API key.
 - **Stop (watchdog kill, verified):** `POST /api/v1/dag-runs/dev-run/{dagRunId}/stop`, empty body, returns 200 immediately (async).
-- **Params are visible unmasked in the Dagu UI and run API** (verified) — therefore params carry only non-secret values (`RUN_ID`, `IMAGE`, `TRACEPARENT`) **plus one deliberate exception**: the per-run scoped Redis ACL credential (`REDIS_USER`/`REDIS_PASSWORD`), acceptable because the Dagu UI/API is itself authenticated and the credential is revoked at finalization (`09-messaging.md` §1a). All real secrets reach the Dev via the Redis `runspec.get` channel (`14-security.md` §4). Keep params small (they travel as one CLI arg; practical ceiling ~128 KiB).
+- **Params are visible unmasked in the Dagu UI and run API** (verified) — therefore params carry only non-secret values (`RUN_ID`, `IMAGE`, `TRACEPARENT`, plus `MEMORY_BYTES` / `NANO_CPUS` / `PIDS` container limits since 2026-08-13) **plus one deliberate exception**: the per-run scoped Redis ACL credential (`REDIS_USER`/`REDIS_PASSWORD`), acceptable because the Dagu UI/API is itself authenticated and the credential is revoked at finalization (`09-messaging.md` §1a). All real secrets reach the Dev via the Redis `runspec.get` channel (`14-security.md` §4). Keep params small (they travel as one CLI arg; practical ceiling ~128 KiB).
 - **The single `dev-run` DAG** (`dagu/dags/dev-run.yaml`) — all business logic stays in the app; the DAG is a dumb container launcher. Since 2026-08-13 both steps use the **docker-executor form** (`action: docker.run` — image/container_name/pull/auto_remove/volumes under `with:`, env as SDK `container.Env`, network + cgroup limits under `host:`), live-verified end-to-end on 2.13.0 (hello battery, mounts re-measured, limits on `docker inspect`). The excerpt below is the OLD `container:`-shorthand shape kept for history — the committed dev-run.yaml is the truth:
 
 ```yaml
@@ -200,9 +200,10 @@ preconditions:                  # fence manual runs: default/empty RUN_ID must n
   - condition: "${params.RUN_ID}"
     expected: "re:^[A-Za-z0-9_-]{6,64}$"
 
-params:                         # RUN_ID, IMAGE, TRACEPARENT, REDIS_USER, REDIS_PASSWORD
-  - {name: RUN_ID, default: ""}     #   (per-run ACL user dev-{run_id}, 09 §1a — the one
-  # …                               #    param-borne secret; revoked at finalization)
+params:                         # RUN_ID, IMAGE, TRACEPARENT, MEMORY_BYTES, NANO_CPUS, PIDS,
+  - {name: RUN_ID, default: ""}     #   REDIS_USER, REDIS_PASSWORD (per-run ACL user
+  # …                               #   dev-{run_id}, 09 §1a — the one param-borne secret;
+                                    #   revoked at finalization)
 
 steps:
   - id: provision                    # ADR-0025 step 1: trusted code, no agent

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -86,7 +86,7 @@ Compromise of Dagu auth, the admin password, or the host is total for that machi
 
 | Surface | Stance |
 |---|---|
-| Mission text + repo content in prompts | **Trusted by design** (adult-operator / OpenClaw-class). Prompt injection is not a product defect (§3). |
+| Mission text + repo content in prompts | **Trusted by design** (adult-operator: mission and repo text are accepted as written). Prompt injection is not a product defect (§3). |
 | Forge + model credentials in the Dev | Required for clone/push and harnesses. Open **egress** by design (forge, package registries, model APIs). |
 | Operator “latest CLI” / “check for a newer version” | **Asked egress** to npm (`registry.npmjs.org`) and x.ai (`/cli/stable`). Not polled; not on editor open. The app never talks to Docker. |
 | MCP setup commands / `extra_cli_args` | **Admin-equivalent code execution** inside the disposable container (`11-admin-panel.md`). |
@@ -235,7 +235,8 @@ branch protection is weak or absent**, or exfiltrating tokens.
    DAG params or YAML** — trigger params are rendered unmasked in the Dagu UI
    (verified on v2.10.5; re-verified at the pinned 2.13.0, 2026-08-13 — the
    dag-run API the UI renders returns `params` in clear, the scoped Redis
-   credential included). Dagu receives `RUN_ID`, `IMAGE`, `TRACEPARENT`, plus
+   credential included). Dagu receives `RUN_ID`, `IMAGE`, `TRACEPARENT`,
+   `MEMORY_BYTES`, `NANO_CPUS`, `PIDS` (container limits, 2026-08-13), plus
    one deliberate exception: the per-run scoped Redis ACL credential, revoked at
    finalization. Secret material is rebuilt on authenticated `runspec.get`
    (`09-messaging.md` §§3, 5).
@@ -431,8 +432,9 @@ dismiss.
    (app-only, different account) for formal PR/MR approval under branch
    protection. REVIEW is always a pipeline stage; staffing which Dev Type runs
    it is not a security control.
-7. Strong bootstrap passwords in `.env` (empty/`change-me*` refuse boot unless
-   `DEVCAKE_ALLOW_INSECURE=1` — local sandbox only).
+7. Strong bootstrap passwords in `.env`: empty/`change-me*` refuse boot, and
+   `ADMIN_PASSWORD` must be ≥ 12 characters. `DEVCAKE_ALLOW_INSECURE=1` waives
+   both checks (local sandbox only).
 8. Read `/health`: **`security_warnings`**, **`forge_protection`**,
    **`circuit_breakers`**, and (ops, not credentials) **`dev_backend_degraded`**
    if present — do not dismiss warnings unread (`15` §4 / §4a for breaker vs
@@ -518,8 +520,8 @@ contract:
   `api_base` origin, path pin `/attachments/`, netloc pin, body size cap;
   no off-allowlist redirects with auth headers). Operator use of the Gitea UI
   / direct git (migrate, clone, push) remains out of band and unrestricted by
-  this app-side policy. Stronger bootstrap password policy than a short
-  deny-list remains open.
+  this app-side policy. Bootstrap password floor shipped: empty/`change-me*`
+  deny-list plus `ADMIN_PASSWORD` ≥ 12 (`DEVCAKE_ALLOW_INSECURE=1` waives both).
 - Optional: gVisor/Kata for Devs; egress allowlists / credential-injection
   proxy (e.g. [iron-proxy](https://github.com/ironsh/iron-proxy) class —
   deferred radar in `16-roadmap.md`; note the ADR-0023 baked browser widens

--- a/docs/tutorials/01-first-mission.md
+++ b/docs/tutorials/01-first-mission.md
@@ -39,8 +39,9 @@ cp .env.example .env
 Fill in **bootstrap only** (schema v4 — see `.env.example`):
 
 - Strong passwords: `ADMIN_*`, `REDIS_PASSWORD`, `DAGU_PASSWORD`, `OO_*`,
-  `GITEA_ADMIN_PASSWORD` (empty/`change-me*` refuse boot unless
-  `DEVCAKE_ALLOW_INSECURE=1`).
+  `GITEA_ADMIN_PASSWORD` (empty/`change-me*` refuse boot; `ADMIN_PASSWORD`
+  must be ≥ 12 characters; `DEVCAKE_ALLOW_INSECURE=1` waives both — local
+  sandbox only).
 - Leave `DOCKER_GID` blank — `./up.sh` discovers it from
   `/var/run/docker.sock` (or set manually with `stat -c %g /var/run/docker.sock`).
 

--- a/up.sh
+++ b/up.sh
@@ -166,7 +166,7 @@ upsert_env_var DOCKER_GID "$GID" .env
 upsert_env_var DEVCAKE_WS_HOST "$WS_HOST" .env
 upsert_env_var DEVCAKE_TAG "$TAG" .env
 # 2026-08 evaluation: .env holds every bootstrap password (and the admin
-# password is host-root-equivalent via settings export — docs/14 §3), yet a
+# password is host-root-equivalent via settings export — docs/14 §0 / §4), yet a
 # file created before up.sh existed kept whatever mode it was born with —
 # 0644 observed in the wild. Upserts above preserve-by-reference, so enforce
 # the floor every run, not only at creation.


### PR DESCRIPTION
## Intent

Factual currency only for the product security contract (`docs/14-security.md`) and lockstep cites — no posture change.

Mission: https://linear.app/fidecastro/issue/CAKE-107/security-doc-factual-currency-no-posture-change

## What changed

1. **ADMIN_PASSWORD 12-char boot floor** — docs/14 §9.7 + §11 and tutorial 01 now match `_refuse_insecure_passwords` (deny-list **and** length ≥ 12; `DEVCAKE_ALLOW_INSECURE=1` waives both).
2. **DAG param inventory** — docs/14 §4 and docs/13 §4 include `MEMORY_BYTES` / `NANO_CPUS` / `PIDS` already in `dagu/dags/dev-run.yaml` (secrets still must not ride params except Redis ACL).
3. **Undefined “OpenClaw-class”** — replaced with self-contained adult-operator wording aligned with §3.
4. **Stale section cites** — `test_forge.py` redaction comment §5→§7; `up.sh` ADMIN host-root cite §3→§0/§4. (Other plan loci were already correct on `main`.)

## Explicit non-goals

- **INV-4 Hard / residual / `pmo-forge-mono-repo` warning** — left byte-unchanged; CAKE-55 / PR #240 founder track.
- No new security controls, health warnings, or boot-check behavior.

## How to verify

Docs-only (no bake/runtime):

```bash
rg -n 'OpenClaw|remains open|params carry only|Dagu receives' docs/14-security.md docs/13-deployment.md docs/tutorials/01-first-mission.md
# expect: no OpenClaw / no "remains open"; DAG lists include MEMORY_BYTES/NANO_CPUS/PIDS
git diff origin/main -- docs/14-security.md | rg 'INV-4|pmo-forge-mono' || echo 'INV-4 untouched'
```

## Risk

Comment/doc text only. No runtime path change.