### PR TITLE
[CAKE-92] App dead code and stale comments

### DIFF
--- a/app/devcake/adapters/claims_writer.py
+++ b/app/devcake/adapters/claims_writer.py
@@ -34,26 +34,6 @@ _GIT_IDENTITY = {
 }
 
 
-class NullClaims:
-    async def list_json_names(self, card):
-        return None
-
-    async def snapshot(self, card):
-        return None
-
-    async def list_claim_meta(self, card):
-        return None
-
-    async def has_readme(self, card):
-        return None
-
-    async def commit(self, card, *, creates, deletes, message):
-        raise RuntimeError("claims writer is not configured")
-
-    def can_write(self, card):
-        return False
-
-
 class ClaimsWriter:
     """One writer for every configured card that stores a write token."""
 
@@ -295,8 +275,7 @@ class ClaimsWriter:
             self._cleanup(dest)
 
 
-def make_claims_writer(config, internal_forge=None) -> ClaimsNotebooks:
-    """Always a real writer. `internal_forge` is accepted for call-site
-    compatibility and unused: operator notebooks already have a write
+def make_claims_writer(config) -> ClaimsNotebooks:
+    """Always a real writer. Operator notebooks already have a write
     token, same as external cards."""
     return ClaimsWriter(config)

--- a/app/devcake/adapters/github/adapter.py
+++ b/app/devcake/adapters/github/adapter.py
@@ -4,7 +4,6 @@ health probe. The GitLab twin is adapters/gitlab (docs/06 §7)."""
 
 import asyncio
 import logging
-import os
 from typing import Any, Optional
 
 import httpx

--- a/app/devcake/api/services.py
+++ b/app/devcake/api/services.py
@@ -241,7 +241,7 @@ def build_services() -> Services:
         repo_cache=repo_cache, internal_forge=internal_forge,
         skill_service=SkillService(internal_forge, repo_cache=repo_cache,
                                    config=config),
-        claims=make_claims_writer(config, internal_forge))
+        claims=make_claims_writer(config))
     s.cron = CronService(config, s.managers, claims=s.claims,
                          dev_types=s.dev_types, store=CronStore())
 

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -1,9 +1,7 @@
-"""Mission dispatch, attempt counting, credentials, activity payload (docs/04 §3.1)."""
+"""Mission dispatch, attempt counting, credentials (docs/04 §3.1)."""
 
 from __future__ import annotations
 
-import base64
-import json
 import logging
 import os
 from datetime import datetime
@@ -27,8 +25,7 @@ MEMORY_MOUNT_SENTENCE = (
     "contradict notes. Check both. Trust neither blindly."
 )
 from .. import failure_taxonomy
-from ..model import (Activity, LABEL_FAILED, Mission, MissionRef, MissionType,
-                     STAGE_LABELS, derive)
+from ..model import Activity, LABEL_FAILED, Mission, MissionType, derive
 from ..workspaces import WorkspaceUnavailable
 from . import markers
 from . import schedule

--- a/app/devcake/domain/orchestrator/family_graph.py
+++ b/app/devcake/domain/orchestrator/family_graph.py
@@ -33,12 +33,13 @@ class Family:
 
 
 def family_of(source: Mission, missions: list[Mission]) -> Family:
-    """BFS over the undirected union of blocked_by and decomposition-parent
-    edges, seeded at `source`. `missions` is one instance's snapshot;
-    matching is by pmo_id (the marker's parent= carries the parent's
-    pmo_id; key accepted as a defensive alias). Parent trust is
-    markers.decomposition_parent_ref (LABEL_CREATED gate — same chokepoint
-    as the family gate). blocked_by edges are PMO-native and trusted as-is."""
+    """DFS/stack walk over the undirected union of blocked_by and
+    decomposition-parent edges, seeded at `source`. `missions` is one
+    instance's snapshot; matching is by pmo_id (the marker's parent=
+    carries the parent's pmo_id; key accepted as a defensive alias).
+    Parent trust is markers.decomposition_parent_ref (LABEL_CREATED gate
+    — same chokepoint as the family gate). blocked_by edges are
+    PMO-native and trusted as-is."""
     pool = [m for m in missions if m.pmo_id]
     by_id = {m.pmo_id: m for m in pool}
     by_key = {m.key.upper(): m for m in pool if m.key}

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -28,19 +28,16 @@ from ...config import AppConfig, DevType
 from ...ports.pmo import PMOPort
 from ..blocker_locator import LEGACY_PMO_REFS
 from ..runs import RunManager
-from typing import TYPE_CHECKING as _TC
 
 from . import (activity_payload as activity_payload_mod, deliver, dispatch,
                feed, finalize, steward, review, schedule, sweeps)
-
-if _TC:
-    from ..forge_runtime import ForgeRuntime
 from .markers import LEGAL_OUTCOMES  # noqa: F401  — public re-export
 
 if TYPE_CHECKING:
     from datetime import datetime
 
     from ...ports.messaging import MessagingPort
+    from ..forge_runtime import ForgeRuntime
     from ..model import Activity, Mission, MissionType
     from ..run import Run
 

--- a/app/devcake/domain/orchestrator/schedule.py
+++ b/app/devcake/domain/orchestrator/schedule.py
@@ -7,7 +7,7 @@ import logging
 from ...config import assignment_for
 from .. import backend_health
 from ..model import (LABEL_FAILED, LABEL_SKIP, Mission,
-                     MissionType, PRIORITY_RANK, derive, find_cycles)
+                     PRIORITY_RANK, derive, find_cycles)
 from ..repo_sourcing import memory_mount_names
 from .markers import DISPATCHABLE_TYPES, decomposition_parent_ref
 

--- a/app/tests/test_claims_writer.py
+++ b/app/tests/test_claims_writer.py
@@ -59,7 +59,7 @@ def test_can_write_every_forge_when_the_card_has_a_write_token(tokens):
         RepoInstance(name="gt", forge="gitea",
                      url="https://git.example.com/acme/notes"),
     ]
-    w = make_claims_writer(_cfg(*cards), internal_forge=None)
+    w = make_claims_writer(_cfg(*cards))
     for c in cards:
         assert w.can_write(c.name) is True, c.forge
 
@@ -71,14 +71,14 @@ def test_can_write_false_for_reference_only_missing_and_empty(tokens):
                      url="https://github.com/acme/docs"),
         RepoInstance(name="bare", forge="github",
                      url="https://github.com/acme/bare"),
-    ), internal_forge=None)
+    ))
     assert w.can_write("ro") is False
     assert w.can_write("bare") is False
     assert w.can_write("nosuch") is False
 
 
 def test_make_claims_writer_does_not_need_bundled_gitea():
-    w = make_claims_writer(AppConfig(), internal_forge=None)
+    w = make_claims_writer(AppConfig())
     assert w.can_write("x") is False
     # not the Null that raises a "not configured" blanket
     with pytest.raises(Exception) as ei:
@@ -91,8 +91,7 @@ def test_commit_refuses_paths_outside_claims(tokens):
     tokens[("nb", "token")] = "tok"
     w = make_claims_writer(_cfg(
         RepoInstance(name="nb", forge="github",
-                     url="https://github.com/acme/nb")),
-        internal_forge=None)
+                     url="https://github.com/acme/nb")))
     with pytest.raises(ValueError, match=r"\.claims"):
         run_coro(w.commit("nb", creates={"notes/secret.md": "no"},
                           deletes=[], message="x"))
@@ -130,7 +129,7 @@ def test_round_trip_create_list_prune_on_local_origin(tmp_path, tokens):
     tokens[("nb", "token")] = "unused-for-local"
     card = RepoInstance(name="nb", forge="github", url=url,
                         default_branch="main")
-    w = make_claims_writer(_cfg(card), internal_forge=None)
+    w = make_claims_writer(_cfg(card))
     assert w.can_write("nb") is True
 
     rec = {"id": "abc123456789abcd", "source_instance": "eng",
@@ -265,7 +264,7 @@ def test_genuine_empty_remote_empty_inits_and_first_commit_works(
     tokens[("nb", "token")] = "unused-for-local"
     card = RepoInstance(name="nb", forge="github", url=url,
                         default_branch="main")
-    w = make_claims_writer(_cfg(card), internal_forge=None)
+    w = make_claims_writer(_cfg(card))
 
     assert run_coro(w.list_json_names("nb")) == []
     assert run_coro(w.has_readme("nb")) is False


### PR DESCRIPTION
## Intent
Mechanical app hygiene from REVIEW_LEDGER Phase-5 / CAKE-92: delete dead imports and symbols, correct misleading comments/docstrings. **No behavior change** beyond removing dead paths.

Mission: https://linear.app/fidecastro/issue/CAKE-92/app-dead-code-and-stale-comments

## Changes
- **Unused imports:** drop `base64`/`json`/`MissionRef`/`STAGE_LABELS` from `dispatch.py`, unused `MissionType` from `schedule.py`, unused `os` from `github/adapter.py`
- **NullClaims + `internal_forge`:** delete dead `NullClaims`; `make_claims_writer(config)` only; update `services.py` + `test_claims_writer.py` call sites
- **Docstrings:** dispatch module no longer claims activity-payload ownership; `family_of` labeled DFS/stack (was wrongly BFS)
- **`manager.py`:** single `TYPE_CHECKING` block (was duplicated via `_TC` alias)

## Already absent on tip (not in this PR)
- `CRON_MARKER_RE` already gone from `cron_service.py`
- `list_repos` already paginates via `paginate_rest` with no rewrite comment
- Steward phase-2 recipient-cap comment already corrected on tip

## Verify
Fresh `app-test` bake + full pytest: **2635 passed, 1 skipped**.

## Out of scope
Other REVIEW_LEDGER hygiene items; enabling deferred F401; behavior/API/docs beyond the comment fixes above.