### PR TITLE
[CAKE-108] ADR ledger supersession notes

### DIFF
--- a/docs/adr/0007-mission-ordering-and-human-handoff.md
+++ b/docs/adr/0007-mission-ordering-and-human-handoff.md
@@ -1,6 +1,8 @@
 # ADR-0007 — Mission Ordering via Native PMO Relations + the Human Hand-off
 
-**Status:** accepted (post-v0 traffic-control increment). Confirmed with the founder 2026-07-12.
+**Status:** accepted (post-v0 traffic-control increment). Confirmed with the founder 2026-07-12. **Partially superseded** for the Relations Mapper identity (run kind / seed Dev Type / service module / staffing) by the MAPPER→STEWARD rename (PR #111) + ADR-0033 Decision 10 — banner below. The five coupled mechanisms and propose-only edge contract stand.
+
+> **Supersession note (runtime today — do not read Decision 5 / addendum #6 Mapper identifiers as current law):** the team-scoped vehicle is **STEWARD** / run kind `STEWARD` / `StewardService` (`domain/steward_service.py`) / route `run_steward` / finalize `finalize_steward`. Seed Dev Type is `steward` on `claude-code` with model **Claude Opus** (`claude-opus-5`) per **ADR-0033 Decision 10** (re-pin from `claude-haiku-4-5`). Config migration helper: `migrate_steward_names`. Historical "Mapper" / `MAPPER` / `mapper` / `MapperService` / `claude-haiku-4-5` prose below is provenance for the 2026-07-12 acceptance — leave it intact.
 
 ## Context
 
@@ -15,7 +17,7 @@ preserved — no persistent per-Mission lease and no local Mission authority):
 2. **Human hand-off = `DEVCAKE-NEEDS-HUMAN` (the tenth label) + the `human_needed` outcome.** A clean, deliberate hand-off: the run finishes, never counts toward `max_attempts`, the stage label stays, and an ONBOARD hand-off restores `backlog`. Removing the label resumes at the same step.
 3. **Intake pause (`intake_paused`).** One config bool gating only the dispatch step of the poll cycle; sweeps, finalization, and the watchdog keep running.
 4. **Comment provenance = the `` `devcake:v1` `` sentinel.** Every app-posted comment ends with the footer (single choke-point `_feed`); `ACTIVITY.md` classifies entries 🧑 HUMAN / 🤖 DevCake by content, never by author, and playbooks make human comments authoritative.
-5. **Relations Mapper.** A team-scoped `MAPPER` run kind (interval service + manual trigger, admin-configured Dev Type) that proposes missing edges across existing open Missions; the app validates (unknown/self/terminal/duplicate/cycle ⇒ dropped) and applies survivors as native relations with a signed notification comment.
+5. **Relations Mapper.** *(Runtime identity: STEWARD — see status banner.)* A team-scoped `MAPPER` run kind (interval service + manual trigger, admin-configured Dev Type) that proposes missing edges across existing open Missions; the app validates (unknown/self/terminal/duplicate/cycle ⇒ dropped) and applies survivors as native relations with a signed notification comment.
 
 ## Alternatives considered
 
@@ -42,7 +44,7 @@ Shipped as the immediate follow-up increment, after live verification (relation 
 3. **All Linear list reads paginate; `inverseRelations` reads 50 with a full-page WARNING** — silent truncation of the gate's inputs (or the mapper's validation graph) is never acceptable.
 4. **The gate is a poll artifact** (`gate_map`), computed even while paused, with **dependency-cycle detection** (`pmo.find_cycles`) naming unsatisfiable waits explicitly — an undetected routing deadlock is the one failure a traffic-routing product cannot afford.
 5. **Hand-off guardrail: evidence required, warnings only** — escalating "Hand-off #N" headers from the 2nd repeat; never auto-park (founder decision: the human always decides).
-6. **The Mapper runs on the seeded `mapper`** (claude-code, `claude-haiku-4-5`) by default, manual-only out of the box; `MapperService` serializes manual/periodic dispatch, advances its watermark only on success, and backs off after 3 consecutive dead runs (store-derived). The repo clone is kept (founder decision: preserves future code-aware ordering).
+6. **The Mapper runs on the seeded `mapper`** (claude-code, `claude-haiku-4-5`) by default, manual-only out of the box; `MapperService` serializes manual/periodic dispatch, advances its watermark only on success, and backs off after 3 consecutive dead runs (store-derived). *(Superseded identity/staffing: seed `steward` / `claude-opus-5`, `StewardService` — status banner / ADR-0033 D10.)* The repo clone is kept (founder decision: preserves future code-aware ordering).
 7. **Blocking stays pipeline-coarse** (founder decision): better bottlenecked than accumulating parallel garbage — routing quality is the product thesis (docs/04 §2).
 8. Provenance classification ignores `>`-quoted lines (a human quoting DevCake stays human); project-kind baton passes go out as project updates.
 

--- a/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
+++ b/docs/adr/0015-orchestrator-module-functions-and-api-composition.md
@@ -81,7 +81,9 @@ in `api/poll.py` as `PollRuntime`; health probes in `api/health.py`.
 The dominant private seams are legitimized, not relocated:
 `transitions.transition`, `sweeps.merge_sweep`/`tracking_sweep`,
 `dispatch.attempt_number`/`resolve_repo`, `review.finalize_review`,
-`decomposition.finalize_decomposition`, `mapper.apply_mapper_edges` become
+`decomposition.finalize_decomposition`, `mapper.apply_mapper_edges`
+*(historical name — live public seams are `steward.apply_steward_edges` /
+`finalize_steward` under `domain/orchestrator/steward.py`)* become
 their modules' public functions and the tests call them as such (AGENTS.md "no
 private tests / agree the seam first"). `_feed`/`_checkpoint` stay methods, so
 their test sites stand.

--- a/docs/adr/0016-skills-and-prompt-assembly.md
+++ b/docs/adr/0016-skills-and-prompt-assembly.md
@@ -3,7 +3,9 @@
 - **Status:** accepted (2026-07-20); **addendum 1** (2026-08-13, external skill
   repos over the ADR-0024 mirror); **addendum 2** (2026-08-14, dedicated
   `skill_sources` — supersedes addendum-1 decision 1 and makes the fail-closed
-  gate toggle-governed via `context_sourcing_strict`, shared with ADR-0035)
+  gate toggle-governed via `context_sourcing_strict`, shared with ADR-0035);
+  **MAPPER→STEWARD naming** in Decisions 1/2/5 (playbook / outcomes / seed row)
+  superseded by STEWARD / seed `steward` (ADR-0033 D10) — banner below
 - **Context:** DevCake composes every Dev run from identifying prompts, mission
   playbooks, and optional skill-store packages. Early product work shipped
   **illustrative vendored skills** (generic PM ceremony, interactive craft
@@ -15,6 +17,13 @@
   content rules so playbooks, Dev Types, and the skill store stay complementary
   rather than three competing instruction systems.
 
+> **Supersession note (runtime today — Relations Mapper naming):** the
+> Relations Mapper vehicle was renamed **STEWARD** (PR #111). Seed Dev Type
+> is `steward` (not `mapper`); playbook / run-kind identifiers are STEWARD /
+> `STEWARD` (not MAPPER). Staffing re-pin: **Claude Opus** (`claude-opus-5`)
+> per **ADR-0033 Decision 10**. Historical `mapper` / `MAPPER` spellings in
+> Decisions 1/2/5 and Rejected below are provenance — leave them intact.
+
 ## Decision 1 — three prompt layers, never collapsed
 
 Every mission (and mapper) run’s **composed prompt** is:
@@ -22,7 +31,7 @@ Every mission (and mapper) run’s **composed prompt** is:
 ```text
 spec_prompt =
     identifying prompt          # Dev Type vehicle × active workflow preset
-  + mission-type playbook       # (or MAPPER playbook)
+  + mission-type playbook       # (or MAPPER playbook)  # runtime: STEWARD playbook
   + [optional] required-skills soft-force block
 ```
 
@@ -56,13 +65,14 @@ A skill **must not**:
 
 - Encode Mission Type contracts (`ONBOARD` / `PLAN` / `EXECUTE` / `REVIEW` /
   `MAPPER` outcomes, stage labels, branch naming, “when you are in EXECUTE…”).
+  *(Runtime outcome vocabulary uses STEWARD / `stewarded`, not MAPPER — see status banner.)*
 - Invent or restate `LEGAL_OUTCOMES` / `result.json` legality.
 - Assume an interactive operator (“ask for sprint capacity”); Devs read the
   activity feed and repo under the playbook.
 
 Mission-step specialist skills (`onboard-mission`, `execute-mission`, …) are
 **rejected**. Cross-step utility is expected (e.g. company orientation on every
-vehicle; dependency reasoning on `judgment` **and** `mapper`).
+vehicle; dependency reasoning on `judgment` **and** `mapper` *(seed name now `steward`)*).
 
 Authoritative authoring contract for store content: `app/devcake/skills/README.md`.
 Domain model fields: `docs/02-domain-model.md` §6 (`skills`, `skills_required`).
@@ -114,7 +124,7 @@ skill chips), not junior/main/senior theater and not one-to-one skill packs:
 |---|---|
 | `judgment` | ONBOARD, PLAN, REVIEW |
 | `implementer` | EXECUTE |
-| `mapper` | Relations Mapper default |
+| `mapper` | Relations Mapper default *(runtime seed name: `steward` — status banner / ADR-0033 D10)* |
 
 Assignments (`AppConfig.assignments`; labeled **Mission Types** in the UI
 since the 2026-08-02 nav reorg — the config field stays `assignments`) remain

--- a/docs/adr/0021-app-side-estimated-cost-and-operator-rate-card.md
+++ b/docs/adr/0021-app-side-estimated-cost-and-operator-rate-card.md
@@ -1,6 +1,8 @@
 # ADR-0021 — App-side estimated cost and the operator rate card
 
-- **Status:** accepted (2026-08-02)
+- **Status:** accepted (2026-08-02); **partial identifier supersession** —
+  `finalize_mapper()` renamed to `finalize_steward` (MAPPER→STEWARD; same
+  costing stamp behavior) — note in Decision 2
 - **Context:** Grok runs extract full token splits but `cost_usd` is always
   null (grok-build 0.2.112 emits no cost field; `08-harness-templates.md`
   §5), so fleet spend was understated everywhere native cost is summed —
@@ -31,10 +33,11 @@ A pure module `domain/costing.py` prices an already-extracted token_report:
 
 `finalize()` and `finalize_mapper()` stamp `cost_usd_estimated` +
 `rate_card_id` into `run.token_report` (via `costing.stamp_estimate`)
-before OTel/feed/persist read the dict. `cost_usd` is never written by
-estimation, so every existing native-cost aggregation stays pure. The
-stamp lands even when native cost exists — the override display mode
-(§4) needs both numbers.
+before OTel/feed/persist read the dict. *(Runtime: the mapper finalize
+path is `finalize_steward` — MAPPER→STEWARD rename; costing stamp
+behavior unchanged.)* `cost_usd` is never written by estimation, so every
+existing native-cost aggregation stays pure. The stamp lands even when
+native cost exists — the override display mode (§4) needs both numbers.
 
 ### 3 — The rate card is operator config
 

--- a/docs/adr/0024-mandatory-repo-source-mirror.md
+++ b/docs/adr/0024-mandatory-repo-source-mirror.md
@@ -3,7 +3,8 @@
 - **Status:** accepted (2026-08-03); §5's "ambient mirror read" accepted risk
   SUPERSEDED by ADR-0025 — the mirrors are now mounted RO into the **provision**
   container only, never the agent's harness container, so the deployment-wide
-  ambient read surface named below no longer exists.
+  ambient read surface named below no longer exists. **MAPPER→STEWARD** path /
+  service rename (Decision 2 + Related) — banner below.
 - **Context:** A production stress test ran a multi-repo instance with 27
   GitLab repositories; every run re-cloned all of them (~300 MB) from the
   external forge — 25 mission steps ≈ 7.5 GB of redundant egress, plus
@@ -19,6 +20,13 @@
   earlier refuse-LFS position was retracted: dev images shipped no
   git-lfs, so pointers-without-content was already the status quo, and
   the toggle *upgrades* it); the escape hatch is `git revert`.
+
+> **Supersession note (MAPPER→STEWARD rename):** Decision 2's "MAPPER = its
+> one repo" and "the mapper's periodic path" refer to today's **STEWARD**
+> vehicle (run kind `STEWARD`, `StewardService`, seed `steward` / Opus per
+> ADR-0033 D10). Related still listed `domain/mapper_service.py` — live path
+> is `domain/steward_service.py`. Historical MAPPER spelling below is
+> provenance; grepping engineers should follow the STEWARD names.
 
 ## Decision
 
@@ -54,7 +62,7 @@ needed-set; the mirror contract itself is unchanged.
 
 `dispatch()` computes the run's mirror-eligible set (work repo + ONBOARD
 routing set + reference repos + configured blocker-work repos; MAPPER =
-its one repo; HELLO/OAUTH none) and awaits `ensure_fresh` BEFORE the
+its one repo *(runtime: STEWARD = its one repo)*; HELLO/OAUTH none) and awaits `ensure_fresh` BEFORE the
 activity-repo push (hoisted `resolve_blocker_work`; gating after the push
 would write one snapshot commit per gated cycle). Freshness:
 `repo_mirror.sync_max_age_seconds` (default 0 = sync before every
@@ -68,6 +76,7 @@ natural retry next poll. Auth-classed sync failures latch the EXISTING
 per-repo forge breaker (`mirror sync: …`); `repository not found` is
 deliberately NOT auth app-side (a 404 is a config problem; the breaker's
 "update the token" remediation would mislead). The mapper's periodic path
+*(runtime: steward periodic path)*
 skips with outcome `mirror_stale` (never raising into the poll segment);
 `Run now` returns the reason as a 422. Warm-up runs as a background task
 started by the poll loop — never awaited at boot (structure-guard
@@ -169,7 +178,7 @@ dags bind) fixed in compose via `DAGU_WIKI_DIR`.
 
 - Implement: `app/devcake/adapters/git.py`, `domain/repo_mirror.py`,
   `domain/orchestrator/dispatch.py` (gate, spec_env, extras),
-  `domain/mapper_service.py`, `api/{main,poll,health,config_service}.py`,
+  `domain/steward_service.py` *(was `mapper_service.py` — MAPPER→STEWARD)*, `api/{main,poll,health,config_service}.py`,
   `images/common/dev_entrypoint.py` + `devcake_dev/workspace/clone.py`,
   `docker-compose.yml`, `dagu/dags/dev-run.yaml`, `app/Dockerfile`,
   `images/Dockerfile` (git-lfs — ADR-0023 floor amendment).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,7 +14,7 @@
 | [0004](0004-label-namespace-and-versioning.md) | Label namespace and versioning | Accepted. **Amended:** eleven managed labels incl. `DEVCAKE-DISCOVERY` (`02` §5 / ADR-0033) |
 | [0005](0005-no-lock-atomicity-via-pmo-state.md) | No-lock atomicity via PMO state | Accepted. The single-process premise is now test-enforced (`test_repo_structural.py`) |
 | [0006](0006-projects-always-decompose.md) | Projects always decompose | Accepted |
-| [0007](0007-mission-ordering-and-human-handoff.md) | Mission ordering + human hand-off | Accepted |
+| [0007](0007-mission-ordering-and-human-handoff.md) | Mission ordering + human hand-off | Accepted; **MAPPER→STEWARD rename** (ADR-0033 D10 staffing) — banner in-body |
 | [0008](0008-pluggable-pmo-and-forge-adapters.md) | Pluggable PMO and forge adapters | **Partially superseded** — three decisions struck in-body (schema v4, ADR-0009, multi-PMO) |
 | [0009](0009-manager-per-pmo-instance.md) | One MissionManager per PMO instance | Accepted, **amended** (cross-instance blocker resolution) |
 | [0010](0010-internal-fallback-forge.md) | Internal fallback forge (bundled Gitea) | Accepted |
@@ -22,16 +22,16 @@
 | [0012](0012-decomposition-depth-and-edge-inheritance.md) | Decomposition depth + edge inheritance | Accepted |
 | [0013](0013-settings-bundle-profiles-and-export.md) | Settings bundle, profiles, export | Accepted |
 | [0014](0014-activity-feed-fidelity-and-activity-repos.md) | Activity feed fidelity + activity repos | Accepted |
-| [0015](0015-orchestrator-module-functions-and-api-composition.md) | Orchestrator module functions + composition root | Accepted, **amended by ADR-0028** (the composition root moved behind `build_services()`; the route-forward ratchet is unchanged). Close-out inventory drifted (the guard test allows seven residual forwards, the prose said nine — the ratchet is the truth) |
-| [0016](0016-skills-and-prompt-assembly.md) | Skills and prompt assembly | Accepted; **addendum 1** (2026-08-13) external skill repos over the ADR-0024 mirror; **addendum 2** (2026-08-14) dedicated `skill_sources` connections — supersedes addendum-1 decision 1 (repo-card sources; `skills_subdir` deleted) and makes the fail-closed gate toggle-governed (`context_sourcing_strict`, shared with ADR-0035 memory) |
+| [0015](0015-orchestrator-module-functions-and-api-composition.md) | Orchestrator module functions + composition root | Accepted, **amended by ADR-0028** (the composition root moved behind `build_services()`; the route-forward ratchet is unchanged). Live route allowlist is `{run_steward}` only; nesting-aware `_count_statements` is authority (earlier drafts claimed nine then seven residuals) |
+| [0016](0016-skills-and-prompt-assembly.md) | Skills and prompt assembly | Accepted; **addendum 1** (2026-08-13) external skill repos over the ADR-0024 mirror; **addendum 2** (2026-08-14) dedicated `skill_sources` connections — supersedes addendum-1 decision 1 (repo-card sources; `skills_subdir` deleted) and makes the fail-closed gate toggle-governed (`context_sourcing_strict`, shared with ADR-0035 memory); **MAPPER→STEWARD** seed/playbook naming (ADR-0033 D10) — banner in-body |
 | [0017](0017-blocker-work-ro-mounts-and-optional-pmo-zip.md) | Blocker work "RO mounts" + optional PMO zip | Accepted, **amended** (cross-instance). Read the body, not the title: the mechanism is an RO **token** + prompt contract in ordinary writable clone dirs — falling back to the write token when no `token_ro` is configured — not a filesystem mount |
 | [0018](0018-harness-fault-classification-and-backend-brake.md) | Harness fault classification + backend brake | Accepted. The exit-11 "known gap" is now an operator toggle (ADR-0026) |
 | [0019](0019-per-pmo-assignment-overrides.md) | Per-PMO assignment overrides | Accepted |
 | [0020](0020-per-repo-merge-doctrine.md) | Per-repository merge doctrine | Accepted, **amended by ADR-0035** (a memory-bound merge target additionally requires the global `memory_auto_merge`, default OFF — banner in-body) |
-| [0021](0021-app-side-estimated-cost-and-operator-rate-card.md) | App-side estimated cost + rate card | Accepted |
+| [0021](0021-app-side-estimated-cost-and-operator-rate-card.md) | App-side estimated cost + rate card | Accepted; mapper finalize identifier superseded (`finalize_steward`) — note in-body |
 | [0022](0022-in-container-run-continuation.md) | In-container run continuation | Accepted |
 | [0023](0023-dev-toolchain-floor.md) | Dev container toolchain floor | Accepted |
-| [0024](0024-mandatory-repo-source-mirror.md) | Mandatory repo source mirror | Accepted; **§5's ambient mirror-read superseded by ADR-0025** (banner in-body) |
+| [0024](0024-mandatory-repo-source-mirror.md) | Mandatory repo source mirror | Accepted; **§5's ambient mirror-read superseded by ADR-0025** (banner in-body); **MAPPER→STEWARD** path/service rename — banner in-body |
 | [0025](0025-provisioned-workspaces.md) | Provisioned workspaces | Accepted — supersedes ADR-0024 §5's risk posture |
 | [0026](0026-attempt-reset-policy-and-bad-output-brake.md) | Attempt-reset policy + opt-in bad-output brake | Accepted (2026-08-04) |
 | [0027](0027-failure-taxonomy-as-data.md) | Failure taxonomy as data | Accepted (2026-08-04) |


### PR DESCRIPTION
## Summary

Docs-only ADR ledger honesty for the **MAPPER→STEWARD** rename (PR #111 + ADR-0033 D10) and the ADR-0015 index residual-count drift (REVIEW_LEDGER ADRs finding + seven-vs-six).

- **0007 / 0016 / 0021 / 0024:** supersession banners + Status/header updates; historical Mapper-era prose left intact with footnotes at dead identifiers.
- **0015:** annotated historical `mapper.apply_mapper_edges` → live `steward.apply_steward_edges` / `finalize_steward`. **Did not** re-add ADR-0028 `build_services()` amendment (already present and correct). Index Status no longer claims seven residual forwards — live allowlist is `{run_steward}` only; nesting-aware count is authority.
- **Index (`docs/adr/README.md`):** Status cells for 0007/0015/0016/0021/0024 aligned with headers.

Mission: https://linear.app/fidecastro/issue/CAKE-108/adr-ledger-supersession-notes

## Test plan

- [x] Re-read touched ADR headers + banners + five index rows
- [x] Grep: no false “allows seven residual forwards” claim remains as current law
- [x] Mapper-era identifiers in 0007/0016/0021/0024 sit next to supersession notes
- Docs-only — no app/admin/image rebuild required