### PR TITLE
[CAKE-109] Roadmap header tells today’s truth

### DIFF
--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -20,18 +20,20 @@
 > **⏳ live-pending** = built, live end-to-end still owed ·
 > milestone `[x]` checkboxes mark exit criteria verified at that milestone's close.
 >
-> **Where we are (2026-08-04):** layers 1–2 closed through tag **v0.2**;
+> **Where we are (2026-08-19):** layers 1–2 closed through tag **v0.2**;
 > release tags through **v0.2.5 "Hummingbird"** on `main`. The product loop
-> (poll → dispatch → harness → finalize → forge/PMO) is operational with three
-> harness templates (`claude-code`, `grok-build`, `codex`, `pi`, `opencode`, `qwen-code`), multi-PMO /
-> multi-repo / internal Gitea, skills (ADR-0016), settings profiles/export
+> (poll → dispatch → harness → finalize → forge/PMO) is operational with six
+> harness templates (`claude-code`, `grok-build`, `codex`, `pi`, `opencode`,
+> `qwen-code`), multi-PMO / multi-repo / internal Gitea, skills (ADR-0016)
+> including dedicated skill sources (**built**), settings profiles/export
 > (ADR-0013), fault classification + backend brake (ADR-0018/0026), mandatory
 > source mirrors + provisioned workspaces (ADR-0024/0025), in-container
-> continuation (ADR-0022), and the 2026-08 evaluation fix campaign (spend
-> discipline, TOCTOU guards, composition-root tests, ops hardening — entries
-> below). Unit suite is on the order of **~1400+** tests (1421 counted
-> 2026-08-04; do not treat any single count as a permanent claim).
-> Ongoing append-only tracking: [Living log (after v0.2)](#living-log-after-v02).
+> continuation (ADR-0022), discovery routing (ADR-0033 — **graduated**
+> 2026-08-13), and the 2026-08 evaluation fix campaign (spend discipline,
+> TOCTOU guards, composition-root tests, ops hardening — entries below).
+> Unit suite is on the order of ~1400+ tests (do not treat any single count
+> as a permanent claim). Ongoing append-only tracking:
+> [Living log (after v0.2)](#living-log-after-v02).
 
 ## History — Layer 1: Milestone era (M0–M12)
 
@@ -543,7 +545,7 @@ until that run exists, field evidence below stays operator-self-reported.
   cache-export resilience fix (#113, `ignore-error=true` on `type=gha`
   cache-to across all three lanes); the live stack has **not** yet been
   redeployed onto them (R9 ritual + image rebake owed).
-- **Discovery routing: SHIPPED hermetically — graduation smoke owed.** Both
+- **Discovery routing: SHIPPED + GRADUATED (live smoke passed 2026-08-13).** Both
   ADR-0033 halves landed 2026-08-13. Harvest: the optional `discoveries`
   result key (ONBOARD/EXECUTE/REVIEW; PLAN relays via a marked PLAN.md
   section), `DISCOVERY_<seq>.md` always attached as the step's deliverable


### PR DESCRIPTION
## Summary

Docs-only curation of `docs/16-roadmap.md` so the living-log status header and one self-contradicting entry match today’s product truth. Root docs (`docs/00`–`15`, ADRs) untouched.

Closes REVIEW_LEDGER / ONBOARD findings for this mission:

1. **Where we are header** — dated forward to 2026-08-19; harness count fixed from internally inconsistent “three” + six names → **six** (matches `house_pins.LAUNCH_SUPPORTED`); notes dedicated skill sources as **built** and discovery routing as **graduated** 2026-08-13; drops the stale 1421 hard count (keeps order-of ~1400+ soft claim).
2. **Discovery-routing living-log heading** — was “graduation smoke owed” while the body already recorded **GRADUATED 2026-08-13**; heading now says shipped + graduated / live smoke passed.
3. **Dedicated skill sources** — confirmed already narrated as **built** / “Not residual (closed)”; no leftover unpaid **⏳** framing on that feature. Left Memory + Cron and other intentional residuals alone.

## Out of scope (explicit)

- Broader REVIEW_LEDGER docs drift outside `docs/16`
- Inventing a “docs/16 two-ledger doctrine” (that split is ADR-0033 Decision 8)
- Scrubbing / deleting open radar wait-gates titled `ISSUES #n` (left untouched)

## Proof (docs-only — no bake/pytest)

- `rg -n 'three harness|graduation smoke owed' docs/16-roadmap.md` → empty
- Skill-sources passages re-read: only **built** / closed inventory wording
- `house_pins.LAUNCH_SUPPORTED` = all six names claimed in the header

Mission: https://linear.app/fidecastro/issue/CAKE-109/roadmap-header-tells-todays-truth