### PR TITLE
[CAKE-121] Credential hints only on definitive probe failures

### DIFF
--- a/app/devcake/adapters/gitea/adapter.py
+++ b/app/devcake/adapters/gitea/adapter.py
@@ -131,11 +131,13 @@ class GiteaForge:
             definitive = e.status in (401, 403, 404)
             if e.status is None:
                 detail = "repository access failed (network)"
-            else:
+            elif definitive:
                 detail = (
                     f"repository access failed (HTTP {e.status}); the "
                     f"token needs write:repository scope and repo access"
                 )
+            else:
+                detail = f"repository access failed (HTTP {e.status})"
             return ForgeHealth(
                 ok=False, repository=repository, transient=not definitive,
                 detail=detail)

--- a/app/devcake/adapters/github/adapter.py
+++ b/app/devcake/adapters/github/adapter.py
@@ -90,10 +90,12 @@ class GitHubForge:
                 e.status == 403 and "rate limit" in str(e).lower())
             if e.status is None:
                 detail = "repository access failed (network)"
-            else:
+            elif definitive:
                 hint = ("; for a fine-grained PAT, select this repository and grant "
                         "Contents and Pull requests read/write")
                 detail = f"repository access failed (HTTP {e.status}){hint}"
+            else:
+                detail = f"repository access failed (HTTP {e.status})"
             return ForgeHealth(ok=False, repository=repository, transient=not definitive,
                                detail=detail)
         can_push = bool((repo.get("permissions") or {}).get("push"))

--- a/app/devcake/adapters/gitlab/adapter.py
+++ b/app/devcake/adapters/gitlab/adapter.py
@@ -100,11 +100,13 @@ class GitLabForge:
                 e.status == 403 and "rate limit" in str(e).lower())
             if e.status is None:
                 detail = "repository access failed (network)"
-            else:
+            elif definitive:
                 detail = (
                     f"repository access failed (HTTP {e.status}); grant api and "
                     "write_repository scopes"
                 )
+            else:
+                detail = f"repository access failed (HTTP {e.status})"
             return ForgeHealth(
                 ok=False, repository=self.project, transient=not definitive,
                 detail=detail,

--- a/app/tests/test_forge.py
+++ b/app/tests/test_forge.py
@@ -588,6 +588,35 @@ def test_health_probe_distinguishes_transient_from_credential_failure():
     assert ok.ok and not ok.transient
 
 
+@pytest.mark.parametrize("forge_factory,status,text,hint,expect_hint", [
+    # Transient integer statuses: plain HTTP detail, no credential lecture.
+    (gh, 500, "err", "fine-grained PAT", False),
+    (gl, 500, "err", "write_repository", False),
+    (gt, 500, "err", "write:repository", False),
+    (gh, 403, "API rate limit exceeded for install", "fine-grained PAT", False),
+    (gl, 403, "API rate limit exceeded", "write_repository", False),
+    # Definitive credential/permission failures: hint remains.
+    (gh, 403, "Resource not accessible", "fine-grained PAT", True),
+    (gh, 404, "Not Found", "fine-grained PAT", True),
+    (gl, 403, "forbidden", "write_repository", True),
+    (gl, 404, "Not Found", "write_repository", True),
+    (gt, 403, "forbidden", "write:repository", True),
+    (gt, 404, "Not Found", "write:repository", True),
+])
+def test_health_probe_credential_hint_only_on_definitive(
+        forge_factory, status, text, hint, expect_hint):
+    """Credential/scope lecture is appended only when the probe is definitive
+    (CAKE-121). Transient 5xx / rate-limit 403 keep the plain HTTP copy."""
+    h = _probe_error(forge_factory(), status, text)
+    assert h.detail.startswith(f"repository access failed (HTTP {status})")
+    assert h.transient is (not expect_hint)
+    if expect_hint:
+        assert hint in h.detail
+    else:
+        assert hint not in h.detail
+        assert h.detail == f"repository access failed (HTTP {status})"
+
+
 def test_api_base_defaults_and_overrides():
     assert gh().api == "https://api.github.com"
     assert GitHubForge("https://github.com/o/r", "t",


### PR DESCRIPTION
## Summary

Forge `health_probe` detail strings now append the credential/scope lecture **only** when the existing `definitive` predicate is true.

- **Before:** every integer HTTP status got the PAT/scope reconfigure hint (so a transient 500 or GitHub/GitLab rate-limit 403 told operators to fix a token that was fine).
- **After:** transient int statuses keep plain `repository access failed (HTTP nnn)`; definitive 401/403/404 (non–rate-limit) keep the vendor hint unchanged.
- Applies to GitHub, GitLab, and Gitea adapters — keyed off the already-computed `definitive` boolean (no second status list).

Mission: https://linear.app/fidecastro/issue/CAKE-121/credential-hints-only-on-definitive-probe-failures

## Test plan

- [x] Red→green: `test_health_probe_credential_hint_only_on_definitive` (500 / rate-limit 403 → no hint + transient; plain 403/404 → hint + definitive) for all three adapters
- [x] Related suite green: `tests/test_forge.py`, `tests/test_forge_error_contract.py`, `tests/test_connection_test.py` (92 passed after rebake)