### PR TITLE
[CAKE-122] ci_suite PMO battery comment cites the pin, not a stale count

### DIFF
--- a/scripts/ci_suite.sh
+++ b/scripts/ci_suite.sh
@@ -106,7 +106,8 @@ echo "── forge contract battery (gitea lane — bundled instance, no externa
 docker compose exec -T app python - < scripts/contract_tests_forge.py
 
 echo "── PMO contract battery (gitea_issues auto-lane — bundled instance, no external tokens)"
-# Default path in contract_tests_pmo.py: GITEA_ADMIN_* → scratch board → 13 scenarios.
+# Default path in contract_tests_pmo.py: GITEA_ADMIN_* → scratch board;
+# row count pinned by EXPECTED_ROWS there — the battery self-fails if a check vanishes.
 # App container already has GITEA_ADMIN_USER/PASSWORD (compose). No Linear required.
 docker compose exec -T app python - < scripts/contract_tests_pmo.py
 


### PR DESCRIPTION
## Intent

Stop `scripts/ci_suite.sh` from hardcoding a PMO battery row count that already drifted (`13 scenarios` vs pinned `EXPECTED_ROWS = 14`). Point the comment at the pin in `scripts/contract_tests_pmo.py` instead.

## Mission

https://linear.app/fidecastro/issue/CAKE-122/ci-suite-pmo-battery-comment-cites-the-pin-not-a-stale-count

## Change

- `scripts/ci_suite.sh`: replace stale numeric comment with one that cites `EXPECTED_ROWS` and notes the battery self-fails if a check vanishes.

## How to verify

```bash
bash -n scripts/ci_suite.sh
# re-read lines ~108–111: no literal row/scenario count; EXPECTED_ROWS named
```

Comment-only; no pytest/bake required.

## Risk / rollout

None — comment-only, no runtime behavior change.

## Out of scope

- Do not retarget the comment to `14` (same drift class).
- Do not touch forge `EXPECTED_ROWS` or battery logic.