### PR TITLE
[CAKE-120] registry version probe tolerates an empty release feed

### DIFF
--- a/app/devcake/adapters/registry_versions.py
+++ b/app/devcake/adapters/registry_versions.py
@@ -19,10 +19,10 @@ TIMEOUT_SECS = 8.0
 class RegistryVersionSource:
     def latest(self, template: str) -> str:
         if template == "grok-build":
-            return _http_text(GROK_STABLE).splitlines()[0].strip()
+            return _stable_feed_version(_http_text(GROK_STABLE))
         pkg = PACKAGE_IDS.get(template)
         if pkg == "x.ai/cli":
-            return _http_text(GROK_STABLE).splitlines()[0].strip()
+            return _stable_feed_version(_http_text(GROK_STABLE))
         if not pkg:
             raise ValueError(f"no remote latest source for {template}")
         body = json.loads(_http_text(f"https://registry.npmjs.org/{pkg}/latest"))
@@ -30,6 +30,14 @@ class RegistryVersionSource:
         if not ver:
             raise ValueError(f"npm returned no version for {pkg}")
         return ver
+
+
+def _stable_feed_version(body: str) -> str:
+    lines = body.splitlines()
+    ver = lines[0].strip() if lines else ""
+    if not ver:
+        raise ValueError(f"empty release feed from {GROK_STABLE}")
+    return ver
 
 
 def _http_text(url: str) -> str:

--- a/app/tests/test_registry_versions.py
+++ b/app/tests/test_registry_versions.py
@@ -1,0 +1,28 @@
+"""RegistryVersionSource — empty/whitespace stable feed stays in ValueError."""
+
+from __future__ import annotations
+
+import pytest
+
+from devcake.adapters.registry_versions import GROK_STABLE, RegistryVersionSource
+
+
+def test_empty_stable_feed_raises_value_error(monkeypatch):
+    monkeypatch.setattr(
+        "devcake.adapters.registry_versions._http_text",
+        lambda url: "",
+    )
+    with pytest.raises(ValueError, match="empty") as excinfo:
+        RegistryVersionSource().latest("grok-build")
+    assert GROK_STABLE in str(excinfo.value)
+    assert not isinstance(excinfo.value, IndexError)
+
+
+def test_whitespace_only_stable_feed_raises_value_error(monkeypatch):
+    monkeypatch.setattr(
+        "devcake.adapters.registry_versions._http_text",
+        lambda url: "   \n\n",
+    )
+    with pytest.raises(ValueError, match="empty") as excinfo:
+        RegistryVersionSource().latest("grok-build")
+    assert GROK_STABLE in str(excinfo.value)


### PR DESCRIPTION
## Intent
`RegistryVersionSource.latest` now raises `ValueError` (naming `https://x.ai/cli/stable` and that the body was empty) when the grok stable feed returns an empty or whitespace-only 200 body, instead of leaking `IndexError`.

## Mission
https://linear.app/fidecastro/issue/CAKE-120/registry-version-probe-tolerates-an-empty-release-feed

## Change
- Shared `_stable_feed_version` chokepoint for both `grok-build` and `x.ai/cli` parse sites in `app/devcake/adapters/registry_versions.py`
- New `app/tests/test_registry_versions.py` covering empty and whitespace-only bodies

## How to verify
```bash
./scripts/pytest_app.sh app/tests/test_registry_versions.py
# or (freshly baked image)
docker run --rm -e OTEL_SDK_DISABLED=true localhost/devcake/app-test:latest python -m pytest tests/test_registry_versions.py -q
```

## Out of scope
Retry policy, caching, version-comparison logic in `versions.resolve_latest`.