### PR TITLE
[CAKE-123] Resume relaunch degrades to fresh instead of crashing on a missing resume dialect

### DIFF
--- a/app/tests/test_dev_entrypoint.py
+++ b/app/tests/test_dev_entrypoint.py
@@ -163,6 +163,54 @@ def test_entrypoint_continuations_pass_empty_additive_script():
     assert "script=script," not in src
 
 
+# ── CAKE-123: missing resume dialect degrades to fresh (never crash) ─────────
+
+
+def test_composed_launch_raises_when_dialect_has_no_resume():
+    """Chokepoint stays fail-closed for direct callers (pi has no resume)."""
+    launch = _composed_launch()
+    with pytest.raises(ValueError, match="no resume dialect"):
+        launch(
+            "pi", "NUDGE", plan_mode=False, model="", extra=(),
+            script="", override=False, session_id="SID")
+
+
+def test_missing_resume_dialect_degrades_to_none():
+    """Resume arm helper: missing resume dialect → None (then fresh relaunch)."""
+    helper = _composed_launch_resume_or_none()
+    assert helper(
+        "pi", "NUDGE", plan_mode=False, model="", extra=(),
+        script="", override=False, session_id="SID") is None
+
+
+def test_resume_or_none_still_composes_supported_resume():
+    helper = _composed_launch_resume_or_none()
+    resume = _harness_resume_argv()
+    prompt = "NUDGE"
+    sid = "SID"
+    got = helper(
+        "grok-build", prompt, plan_mode=False, model="stub-model",
+        extra=(), script="", override=False, session_id=sid)
+    assert got == resume(
+        "grok-build", sid, prompt, model="stub-model")
+
+
+def test_resume_or_none_reraises_unrelated_valueerror():
+    helper = _composed_launch_resume_or_none()
+    with pytest.raises(ValueError, match="run_mcp_setup"):
+        helper(
+            "grok-build", "NUDGE", plan_mode=False, model="stub-model",
+            extra=(), script="false", override=False, session_id="SID")
+
+
+def test_entrypoint_resume_arm_wires_missing_dialect_to_fresh():
+    """Resume arm must use the degrade helper and still fall through to fresh."""
+    src = (_images_common_root() / "dev_entrypoint.py").read_text()
+    assert "composed_launch_resume_or_none" in src
+    assert 'mode = "fresh"' in src
+    assert "degrade to fresh, never crash" in src
+
+
 def _images_common_root() -> Path:
     roots = [
         Path(__file__).resolve().parents[2] / "images" / "common",
@@ -184,6 +232,17 @@ def _composed_launch():
     _images_common_root()
     from devcake_dev.harness.launch import composed_launch
     return composed_launch
+
+
+def _composed_launch_resume_or_none():
+    import os
+    os.environ.setdefault("DEVCAKE_RUN_ID", "T-LAUNCH")
+    os.environ.setdefault("REDIS_URL", "redis://127.0.0.1:6399/0")
+    os.environ.setdefault("REDIS_USER", "t")
+    os.environ.setdefault("REDIS_PASSWORD", "t")
+    _images_common_root()
+    from devcake_dev.harness.launch import composed_launch_resume_or_none
+    return composed_launch_resume_or_none
 
 
 def _harness_resume_argv():

--- a/images/common/dev_entrypoint.py
+++ b/images/common/dev_entrypoint.py
@@ -180,7 +180,10 @@ from devcake_dev.workspace.forensics import (  # noqa: E402
     workspace_forensics,
     _git_tracked,
 )
-from devcake_dev.harness.launch import composed_launch  # noqa: E402
+from devcake_dev.harness.launch import (  # noqa: E402
+    composed_launch,
+    composed_launch_resume_or_none,
+)
 from devcake_dev.workspace.setup import (  # noqa: E402
     MCP_SETUP_TIMEOUT_SECS,
     install_skills,
@@ -1014,15 +1017,17 @@ def harness_main() -> None:
                     budget=cont_cfg.max_continuations, stray_note=note)
                 os.environ["DEVCAKE_PROMPT"] = inv_prompt
                 # Additive setup already ran once (launch_script=""); resume
-                # argv via composed_launch(session_id=…) — same as
-                # harness_resume_argv when the body is empty (CAKE-62 + 63).
-                cmd = composed_launch(
+                # argv via composed_launch_resume_or_none(session_id=…) —
+                # same as harness_resume_argv when the body is empty
+                # (CAKE-62 + 63). Missing resume dialect → None so the
+                # fresh arm below runs (degrade to fresh, never crash).
+                cmd = composed_launch_resume_or_none(
                     harness, inv_prompt, plan_mode=False, model=model,
                     extra=extra, script=launch_script, override=False,
                     session_id=last_sid(chains))
             if relaunch == "fresh" or cmd is None:
-                # `cmd is None` is defensive only: a harness in RESUME_SPECS
-                # always has a builder arm — degrade to fresh, never crash
+                # `cmd is None` is defensive: missing resume dialect (or a
+                # future builder gap) must degrade to fresh, never crash.
                 mode = "fresh"
                 inv_prompt = fresh_nudge_prompt(
                     prompt, mission_type, legal, attempt=cont.used,

--- a/images/common/devcake_dev/harness/__init__.py
+++ b/images/common/devcake_dev/harness/__init__.py
@@ -5,7 +5,8 @@ Module map (entrypoint façade imports these; do not re-fork spines):
 * ``dialect`` / ``dialects`` — fail-closed ``HarnessDialect`` registry
   (docs/16 H1); unknown id raises, never Claude fall-through.
 * ``launch`` — ``composed_launch`` (dialect argv, or fail-closed override
-  script); additive setup is ``workspace.setup.run_mcp_setup``.
+  script) and ``composed_launch_resume_or_none`` (entrypoint resume degrade);
+  additive setup is ``workspace.setup.run_mcp_setup``.
 * ``aim`` — backend adaptor (docs/08 §8), not fault classification.
 * ``argv`` / ``render`` / ``tokens`` — CLI argv, live log lines, TokenReport v1.
 * ``continuation`` — ADR-0022 policy, nudges, session chains, token merge.

--- a/images/common/devcake_dev/harness/launch.py
+++ b/images/common/devcake_dev/harness/launch.py
@@ -59,3 +59,34 @@ def composed_launch(
     return dialect.argv(
         prompt, plan_mode=plan_mode, model=model,
         extra=list(extra), out_dir=out_dir)
+
+
+def composed_launch_resume_or_none(
+    template: str,
+    prompt: str,
+    *,
+    plan_mode: bool = False,
+    model: str = "",
+    extra: tuple[str, ...] | list[str] = (),
+    script: str = "",
+    override: bool = False,
+    out_dir=None,
+    session_id: str | None = None,
+) -> list[str] | None:
+    """Resume argv, or None when the dialect has no resume arm.
+
+    ``composed_launch`` stays fail-closed for direct callers. The Dev
+    entrypoint resume path uses this so a missing resume dialect degrades
+    to fresh (``cmd is None``) instead of burning the attempt on ValueError.
+    Other ValueErrors (unknown harness, additive refuse, empty override)
+    still propagate.
+    """
+    try:
+        return composed_launch(
+            template, prompt, plan_mode=plan_mode, model=model,
+            extra=extra, script=script, override=override, out_dir=out_dir,
+            session_id=session_id)
+    except ValueError as e:
+        if "no resume dialect" in str(e):
+            return None
+        raise


### PR DESCRIPTION
## Intent

Keep the Dev entrypoint resume arm’s never-crash promise: when `composed_launch(..., session_id=…)` would raise `ValueError` for a dialect with no resume argv, relaunch **fresh** (`mode == "fresh"`) instead of burning the attempt on a traceback.

## Context

- Mission: [CAKE-123](https://linear.app/fidecastro/issue/CAKE-123/resume-relaunch-degrades-to-fresh-instead-of-crashing-on-a-missing)
- CAKE-62/63 made `composed_launch` fail-closed on missing resume; the entrypoint still assumed `cmd is None → fresh`. This PR restores that degrade without weakening the chokepoint.

## Change

- Add `composed_launch_resume_or_none` in `images/common/devcake_dev/harness/launch.py`: maps `"no resume dialect"` → `None`; re-raises other `ValueError`s.
- Resume arm in `dev_entrypoint.py` calls that helper; existing `cmd is None` → `mode = "fresh"` path unchanged.
- `composed_launch` still raises for direct callers.

## How to verify

```bash
./scripts/pytest_app.sh tests/test_dev_entrypoint.py -q
# or focused:
# pytest … -k 'resume_or_none or missing_resume or composed_launch_raises_when or entrypoint_resume_arm'
```

Observed locally: red (ImportError / wiring assert) → green; `test_dev_entrypoint.py` + `test_entrypoint_continuation.py` = 55 passed; hermetic suite 2643 passed (1 redis-env fail unrelated: `test_clear_bodies` — scratch redis network unavailable on this host). Built `images/Dockerfile --target base` and smoked the helper inside `devcake/dev-base:latest`.

## Out of scope

`RESUME_SPECS` membership, continuation decision policy, token-merge semantics, crash-loud docs/07 alternative.

## Risk

Low — defensive path for a case policy normally avoids; resume-capable harnesses unchanged.