### PR TITLE
feat(spa): accent palette anchored on the brand mark's frosting violet

### DIFF
--- a/admin/spa/DESIGN.md
+++ b/admin/spa/DESIGN.md
@@ -16,7 +16,7 @@ sections, SettingRow, MoreMenu, InstantZone), `src/pages/OverviewPage.jsx`
 ## 1. Identity — "bakery-warm, terminal-precise"
 
 The product is an oven that bakes software missions. The UI is warm (stone
-surfaces, espresso ink, crust-orange accent) but operates with terminal
+surfaces, espresso ink, frosting-violet accent) but operates with terminal
 precision (mono ids, tabular numerals, dense honest tables).
 
 ### Color — tokens only, never raw hex in components
@@ -27,10 +27,10 @@ color family in a component.**
 
 | Register | Classes | Meaning |
 |---|---|---|
-| **Accent** | `accent-*` (brand `#b4550a` at 600) | The ONLY brand accent. Primary buttons, active nav, links, the current StageGlyph layer, InstantZone tint. Don't dilute it with a second accent color. |
+| **Accent** | `accent-*` (brand `#6042cc` at 600; 400/500/600 are the brand mark's frosting-gradient stops) | The ONLY brand accent. Primary buttons, active nav, links, the current StageGlyph layer, InstantZone tint. Don't dilute it with a second accent color. |
 | **Neutrals** | `neutral-*` (warm, stone-tinted; 900 = espresso `#2a2018`) | All text/borders/surfaces. The warmth is token-side — keep using `neutral-*` classes. |
 | **Surfaces** | `bg-surface` / `bg-surface-raised` (+ `-dark`) | Page ground / cards. Cards via the `Card` component, not hand-rolled divs. |
-| **Warning** | `amber-*` (retuned yellower, 600 = `#a1720d`) | Warnings/partial states. Deliberately pushed away from the brand orange — never use `accent-*` for a warning or `amber-*` as decoration. |
+| **Warning** | `amber-*` (true amber, 600 = `#a1720d`) | Warnings/partial states — a register of its own: never use `accent-*` for a warning or `amber-*` as decoration. |
 | **Danger** | `red-*` (stock) | Destructive actions and errors only. |
 | **Success** | `green-*` (stock) | Confirmations only. |
 
@@ -41,8 +41,9 @@ color family in a component.**
   (The wordmark is no longer set in type: the brand mark and wordmark are SVG
   artwork — canonical files in `docs/img/brand/`, bundled copies in
   `src/assets/` — rendered per theme: black-violet on light, cream-violet on
-  dark. The artwork's own palette is the one sanctioned exception to the
-  single-accent rule; UI accents stay `accent-*`.)
+  dark. The UI's `accent-*` ramp is anchored on the artwork's violet gradient;
+  the artwork's cream cake layers remain artwork-only — don't promote them
+  into UI classes. UI accents stay `accent-*`.)
 - Mono (`font-mono`) for machine identifiers: run ids, mission keys, env var
   names, InstantZone eyebrow labels.
 - Numerals that line up in columns get `tabular-nums`.
@@ -237,7 +238,7 @@ semantically distinct:
   config fields must join this flow and get labels in `configLabels.js`.
   **Never change draft semantics** — no per-section save buttons, no autosave.
 - **Instant**: anything that hits the server the moment it's used gets wrapped
-  in `InstantZone` (crust-tinted region with the ⚡ "applies immediately"
+  in `InstantZone` (accent-tinted region with the ⚡ "applies immediately"
   eyebrow) or carries `ImmediateBadge`. No third regime.
 
 ---

--- a/admin/spa/src/components/InstantZone.jsx
+++ b/admin/spa/src/components/InstantZone.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Zap } from "lucide-react";
 
 // Spatial convention for the two persistence regimes: anything inside a
-// crust-tinted zone hits the server the moment it's used — plain zones ride
+// accent-tinted zone hits the server the moment it's used — plain zones ride
 // the unified draft and wait for the page-level Save.
 export default function InstantZone({ children, note = "applies immediately — does not wait for Save", className = "" }) {
   return (

--- a/admin/spa/src/index.css
+++ b/admin/spa/src/index.css
@@ -4,19 +4,20 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  /* bakery orange, anchored on the brand #b4550a at 600 */
-  --color-accent-50: #fdf6ef;
-  --color-accent-100: #f9e8d8;
-  --color-accent-200: #f2cdab;
-  --color-accent-300: #e9ab74;
-  --color-accent-400: #df833f;
-  --color-accent-500: #cf661c;
-  --color-accent-600: #b4550a;
-  --color-accent-700: #954409;
-  --color-accent-800: #7a380e;
-  --color-accent-900: #652f0f;
-  --color-accent-950: #3a1805;
-  --color-accent: #b4550a;
+  /* frosting violet — 400/500/600 are the brand mark's own gradient stops
+     (#a28ef1 / #7b61dc / #6042cc); the rest of the ramp interpolates them */
+  --color-accent-50: #f7f5fe;
+  --color-accent-100: #efeafd;
+  --color-accent-200: #ded4fa;
+  --color-accent-300: #c5b3f6;
+  --color-accent-400: #a28ef1;
+  --color-accent-500: #7b61dc;
+  --color-accent-600: #6042cc;
+  --color-accent-700: #4f35ab;
+  --color-accent-800: #422d8a;
+  --color-accent-900: #38276f;
+  --color-accent-950: #211744;
+  --color-accent: #6042cc;
 
   /* warm surfaces: stone-tinted light, warm near-black dark */
   --color-surface: #faf9f7;
@@ -38,8 +39,8 @@
   --color-neutral-900: #2a2018;
   --color-neutral-950: #1c1610;
 
-  /* warnings pushed toward true amber so they stop reading as the brand
-     orange (accent) — alarms get their own register */
+  /* warnings: true amber, a register of its own — never the accent, and the
+     accent is never a warning */
   --color-amber-50: #fcf9ec;
   --color-amber-100: #f8f0d3;
   --color-amber-200: #efdfa4;

--- a/admin/spa/src/pages/OverviewPage.jsx
+++ b/admin/spa/src/pages/OverviewPage.jsx
@@ -552,18 +552,8 @@ export default function OverviewPage({
               icon={GitMerge} title="Gitea (internal forge)"
               desc="The bundled forge — internal repos, PRs and history" />
           )}
-          <Card className="flex items-start gap-3 p-4">
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent-50 text-accent-700 dark:bg-accent-950/70 dark:text-accent-300">
-              <BookOpen size={16} aria-hidden />
-            </span>
-            <span className="min-w-0">
-              <span className="text-sm font-semibold">Spec &amp; source</span>
-              <span className="mt-0.5 block text-xs text-neutral-500 dark:text-neutral-400">
-                Design docs live in the repository under <code className="text-[11px]">docs/</code>
-                {" "}(no fixed public product URL published yet)
-              </span>
-            </span>
-          </Card>
+          <QuickLink href="https://github.com/flieber-inc/devcake" icon={BookOpen}
+            title="Spec &amp; source" desc="The public repository — design docs under docs/, ADRs, releases" />
         </div>
       </div>
 


### PR DESCRIPTION
The admin's `accent-*` ramp moves from bakery orange to the violet of the brand mark's frosting gradient: `accent-400/500/600` are the artwork's own gradient stops (`#a28ef1` / `#7b61dc` / `#6042cc`); the rest of the ramp interpolates them. Warm neutrals, surfaces, and the amber warning register keep their values — only the amber comment changes, since its rationale referenced an orange accent that no longer exists.

DESIGN.md moves with it: the identity line ("frosting-violet accent"), the accent and amber table rows, the artwork-palette note (the UI accent is now drawn from the mark's violet; the cream cake layers stay artwork-only), and two leftover "crust-tinted" metaphors (doc + InstantZone comment).

Also: the Overview **Spec & source** card becomes a QuickLink to the public repository — its "no fixed public product URL published yet" copy was stale.

## Evidence
- `npm run build` green.
- Full `npm run check:ui` green — 387 checks across 25 suites against the live backend, including the design-tokens guard (no off-palette classes; components were already tokens-only, so this is a token-file-only palette change).
- Light + dark screenshots of Overview, Missions, Runs, Configuration reviewed.
- Contrast: `accent-600` `#6042cc` on white ≈ 6.7:1 (old orange ≈ 4.9:1); `accent-400` on the dark surface stays well above AA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)