### PR TITLE
fix(baker): keep the host baker's import closure stdlib-only

### DIFF
--- a/app/devcake/versions.py
+++ b/app/devcake/versions.py
@@ -2,6 +2,11 @@
 
 Also owns the CLI-version semver shape (ADR-0034 / CAKE-87) — keep_set,
 config DevType.cli_version, and the host factory import this constant.
+
+Module scope must stay stdlib-only: the host baker (up.sh → bare
+`python3 -m dev_factory`, no venv) imports this module for the semver
+constant. The harness registry needs pydantic, which a host python
+does not have — resolve_latest imports it at call time (app-side only).
 """
 
 from __future__ import annotations
@@ -9,7 +14,6 @@ from __future__ import annotations
 import re
 
 from .house_pins import LAUNCH_SUPPORTED
-from .harness import HARNESSES
 
 # ONE CLI pin shape: major.minor.patch with optional pre-release suffix.
 CLI_VERSION_SEMVER = r"[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.]+)?"
@@ -18,6 +22,7 @@ CLI_VERSION_SEMVER_RE = re.compile(CLI_VERSION_SEMVER)
 
 def resolve_latest(template: str, *, source) -> str:
     """Look up the remote semver. Unknown ids refuse."""
+    from .harness import HARNESSES
     if template not in HARNESSES:
         raise ValueError(f"unknown harness {template!r}")
     if template not in LAUNCH_SUPPORTED:

--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -994,3 +996,45 @@ def test_append_baker_event_is_jsonl(tmp_path):
     assert json.loads(lines[0])["event"] == "tick"
     assert json.loads(lines[1])["event"] == "error"
     assert json.loads(lines[1])["detail"] == "nginx"
+
+
+# up.sh starts the baker with the host's bare `python3 -m dev_factory` — no
+# venv, no pip install. Everything it can import, at load or at runtime, must
+# be stdlib or first-party. This suite runs in the app image where pydantic
+# IS installed, so a plain import cannot catch a leak; the subprocess blocks
+# third-party imports to simulate a clean Mac/Debian host (the versions.py →
+# harness.py → pydantic edge shipped exactly this way).
+_HOST_GUARD = """
+import sys
+
+FIRST_PARTY = {"dev_factory", "devcake", "app_digest"}
+
+class BlockThirdParty:
+    def find_spec(self, name, path=None, target=None):
+        top = name.partition(".")[0]
+        if top in FIRST_PARTY or top in sys.stdlib_module_names:
+            return None
+        raise ImportError(f"third-party import on the baker's host path: {name}")
+
+sys.meta_path.insert(0, BlockThirdParty())
+
+import dev_factory            # package load: liveness + core + devcake.versions
+import dev_factory.watch      # the `python3 -m dev_factory` entrypoint
+import app_digest             # watch.py imports it at runtime
+import devcake.staffing       # core.py runtime import (receipt fail detail)
+import devcake.bake_status    # staffing's lazy liveness read
+print("HOST-CLOSURE-OK")
+"""
+
+
+def test_baker_host_import_closure_is_stdlib_only():
+    scripts_root = next((p for p in _FACTORY_CANDIDATES if p.is_dir()), None)
+    assert scripts_root is not None, "scripts/ missing — bind scripts → /srv/repo-scripts"
+    app_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ,
+           "PYTHONPATH": f"{scripts_root}{os.pathsep}{app_root}"}
+    proc = subprocess.run(
+        [sys.executable, "-c", _HOST_GUARD],
+        capture_output=True, text=True, env=env, timeout=60)
+    assert proc.returncode == 0, f"baker host closure broke:\n{proc.stderr}"
+    assert "HOST-CLOSURE-OK" in proc.stdout

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -671,6 +671,17 @@ until that run exists, field evidence below stays operator-self-reported.
   Still open (Memory + Cron pilot ship gate, fresh-`/data` drill, M9–M12
   demos, etc.) remain open as already listed.
 
+- **Baker host hotfix — stdlib-only import closure** (2026-08-20): the host
+  baker (`up.sh` → bare `python3 -m dev_factory`, no venv) imported pydantic
+  through `devcake.versions` → `devcake.harness`, so any host without
+  pydantic in system python (clean macOS, minimal Debian) crashed the baker
+  at start — dev machines with a global pydantic masked the hole, which is
+  why it surfaced only on fresh installs. `resolve_latest` now imports the
+  harness registry at call time (it is app-side only), and a regression
+  test imports the baker's full host closure — load-time and runtime
+  edges — inside a subprocess that blocks every third-party import, so the
+  app image's own installed deps can never mask a leak again. **built**.
+
 ### Field evidence (receipted)
 
 - **DevCake audits DevCake** (2026-08-17/18) — one board prompt became 54


### PR DESCRIPTION
## What broke

Starting the stack on a Mac (and on minimal Debian hosts) crashes the host baker at startup with `ModuleNotFoundError: No module named 'pydantic'`, so harness images never bake. `up.sh` runs the baker with the operator's bare system python — no venv, no pip install — and the baker's import of `devcake.versions` (for the CLI semver constant) pulled in `devcake.harness`, whose registry models are pydantic classes:

```
scripts/dev_factory/core.py → devcake.versions → devcake.harness → pydantic
```

Hosts that happen to have pydantic installed globally worked by accident, which is why this only surfaced on fresh installs. On newer Debian the failure is doubly painful because externally-managed python blocks a casual `pip install pydantic` — the right fix is for the baker not to need it at all, matching the factory's design (host verb, keep-set only, stdlib).

## The fix

- `devcake/versions.py` no longer imports the harness registry at module scope. `resolve_latest` — the only consumer, called exclusively app-side from `devtypes_service` where pydantic exists — imports it at call time. The module docstring now states the constraint: module scope must stay stdlib-only because the host baker imports it.
- New regression test (`test_baker_host_import_closure_is_stdlib_only`): imports the baker's full host closure — package load, the `python3 -m dev_factory` entrypoint, and every lazy runtime edge (`app_digest`, `devcake.staffing`, `devcake.bake_status`) — in a subprocess with an import hook that refuses any third-party package. The suite runs inside the app-test image where pydantic **is** installed, so a plain import can never catch this class of leak; the hook simulates the clean host. The test fails on `main` today and passes with this change.
- Roadmap living log entry (docs/16).

## Verification

- Simulated bare host (import hook active): baker import failed on `main` with the exact field traceback, passes after the fix.
- Full containerized suite via `scripts/pytest_app.sh`: **2698 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)