### PR TITLE
feat(probe): nested-engine rig receipts — replay the dev-run contract anywhere

### DIFF
--- a/app/tests/test_repo_structural.py
+++ b/app/tests/test_repo_structural.py
@@ -234,3 +234,25 @@ def test_dag_timeout_clears_max_legal_app_timeout():
         f"(dev_timeout_minutes.le={field_le_minutes} + 30) * 60 "
         f"= {min_belt} so the app watchdog owns the kill"
     )
+
+
+def test_nested_probe_extracts_the_exact_dag_seccomp_profile():
+    """scripts/harness_probe/nested_probe.sh replays the dev-run nested-engine
+    contract on new host types (the macOS Docker Desktop rig row the 2026-08-13
+    matrix never covered). Operator hosts have no PyYAML, so the probe lifts
+    the profile by regex (nested_seccomp.py); this pins that extraction to the
+    blob the DAG actually sends on BOTH steps — a YAML reshape that broke the
+    regex would otherwise surface only at probe time on someone's laptop."""
+    import importlib.util
+
+    src = Path("/srv/repo-scripts/harness_probe/nested_seccomp.py")
+    assert src.exists(), MOUNT_HINT.format(src="scripts → /srv/repo-scripts")
+    spec = importlib.util.spec_from_file_location("nested_seccomp", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    blob = mod.extract(DAG)
+
+    steps = _steps()
+    for sid in ("provision", "run_dev"):
+        assert steps[sid]["with"]["host"]["SecurityOpt"] == [f"seccomp={blob}"], \
+            f"{sid} SecurityOpt must equal the probe's extracted profile"

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -17,6 +17,22 @@ Dev containers): unprivileged user namespaces enabled on the host kernel
 recommended (native rootless overlay — older kernels fall back to
 fuse-overlayfs via the DAG's /dev/fuse device).
 
+**Nested-engine rig receipt** — the matrix behind those prerequisites was
+measured on one rig (WSL2 kernel 6.6, engine 29). On any other host type —
+macOS Docker Desktop (LinuxKit VM, VirtioFS binds), a new distro, a new
+engine major — run `scripts/harness_probe/nested_probe.sh` once after baking
+a harness image. It replays the dev-run DAG's exact runtime contract (the
+inline seccomp profile extracted from the DAG itself, /dev/fuse +
+/dev/net/tun, the image's dev user, the workspace bind, the reclaim chown)
+and writes a receipt under `.factory/nested_probe/`; a red run names the
+first failing step (uid_map → the file-caps newuidmap fix; graph → nested
+storage; nested run → seccomp/LSM/network). Known caveat to verify this way:
+hosts with AppArmor active (stock Ubuntu) are expected to need attention —
+the DAG overrides only seccomp, and the `docker-default` AppArmor profile
+denies mount regardless of seccomp. The inner test pull
+(`docker.io/library/alpine`, override via `NESTED_TEST_IMAGE`) needs egress
+from inside the Dev container.
+
 ## 1. Service names, volumes, network (normative — these are DNS names other docs reference)
 
 - Services: `app`, `dagu`, `redis`, `openobserve`, `admin`, `otel-collector`,

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -682,6 +682,23 @@ until that run exists, field evidence below stays operator-self-reported.
   edges — inside a subprocess that blocks every third-party import, so the
   app image's own installed deps can never mask a leak again. **built**.
 
+- **Nested-engine rig receipts** (2026-08-20): the rootless-podman matrix
+  behind ADR-0023 was measured on exactly one rig (WSL2 6.6, engine 29),
+  the file-caps newuidmap fix is explicitly "mechanism unexplained," and
+  nothing in-tree ever proved the runtime path on macOS Docker Desktop.
+  `scripts/harness_probe/nested_probe.sh` now replays the dev-run DAG's
+  exact runtime contract against a locally baked harness image — the inline
+  seccomp profile extracted from the DAG itself (structural-test-pinned,
+  never a copy), /dev/fuse + /dev/net/tun, the image's dev user, the
+  workspace bind, and the B1 reclaim chown — and writes a rig receipt
+  covering uid_map, graph driver, a real nested run, and the subuid
+  foreign-uid write → reclaim round-trip. First receipted row beyond the
+  original measurement: WSL2 6.6 **aarch64** engine 29.6.1 — graph=overlay,
+  subuid write landed 104320, reclaim returned 1000 (also the first arm64
+  receipt — the Apple Silicon arch). Owed: the macOS Docker Desktop row
+  (run the probe on a Mac per docs/13). **built** (probe live-run green on
+  one rig).
+
 ### Field evidence (receipted)
 
 - **DevCake audits DevCake** (2026-08-17/18) — one board prompt became 54

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -130,7 +130,10 @@ RUN npm install -g "playwright@${PLAYWRIGHT_VERSION}" \
 # uidmap (apt, below) supplies newuidmap/newgidmap — re-packaged Fedora-style
 # below: setuid bit STRIPPED, file caps applied (the measured fix).
 # Runtime needs the dev-run DAG's seccomp profile + /dev/fuse (kernels ≥5.13
-# use native rootless overlay and ignore fuse) — matrix measured 2026-08-13.
+# use native rootless overlay and ignore fuse) — matrix measured 2026-08-13
+# on ONE rig (WSL2 kernel 6.6, engine 29). Other rig types (macOS Docker
+# Desktop, distro hosts) earn their row via scripts/harness_probe/
+# nested_probe.sh — it replays the DAG's exact contract and writes a receipt.
 ARG PODMAN_STATIC_VERSION=v5.8.4
 # per-arch sha256 (the bake builds the HOST platform; both pinned)
 ARG PODMAN_STATIC_SHA256_AMD64=a58765fe8be6ab3fb79f892f1a027b4ce4a7e8eb589df1ef960c167cbde08d69

--- a/scripts/harness_probe/nested_probe.sh
+++ b/scripts/harness_probe/nested_probe.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Nested-engine rig receipt: replay the dev-run DAG's exact runtime contract
+# for rootless podman inside a Dev container — the inline seccomp profile
+# (extracted live from dagu/dags/dev-run.yaml, never a copy), /dev/fuse +
+# /dev/net/tun, the image's own dev user, the per-run /workspace bind, and
+# the B1 reclaim chown — against a locally baked harness image.
+#
+# One green run turns "matrix measured 2026-08-13, WSL2 kernel 6.6" (the one
+# rig in images/Dockerfile) into a receipt for THIS rig; a red run names the
+# first failing step instead of a shrug:
+#   uid_map red   → the file-caps newuidmap fix does not transfer here
+#   graph red     → storage driver setup (overlay-on-overlay / fuse fallback)
+#   nested red    → full path (seccomp, AppArmor on Ubuntu hosts, network)
+#   ws uids       → bind ownership semantics (VirtioFS on macOS) + reclaim
+#
+# Usage: nested_probe.sh [image]   (default devcake/dev-claude-code:$DEVCAKE_TAG)
+#   NESTED_TEST_IMAGE overrides the inner image (default docker.io/library/
+#   alpine — the nested pull needs egress from inside the Dev container).
+# Receipt: .factory/nested_probe/receipt-<utc>.json (log + sent profile beside it).
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+IMAGE="${1:-devcake/dev-claude-code:${DEVCAKE_TAG:-latest}}"
+NESTED_TEST_IMAGE="${NESTED_TEST_IMAGE:-docker.io/library/alpine}"
+
+# Same namespace fence as host_probe.sh — this replays the bake contract,
+# not arbitrary images.
+if [[ ! "$IMAGE" =~ ^devcake/dev-[a-z0-9-]+:[A-Za-z0-9._-]+$ ]]; then
+  echo "nested_probe: refusing image ${IMAGE@Q}" >&2
+  exit 2
+fi
+if [[ "$IMAGE" == devcake/dev-hello:* ]]; then
+  echo "nested_probe: hello does not carry the nested engine — pick a harness image" >&2
+  exit 2
+fi
+# Local bake only — never Hub (audit A7).
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "nested_probe: ${IMAGE} is not local — bake it first (devcake images are never pulled)" >&2
+  exit 2
+fi
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUTDIR=".factory/nested_probe"
+mkdir -p "$OUTDIR"
+# Repo-local scratch, not mktemp: the repo sits inside every Docker Desktop
+# file share, /var/folders may not.
+WS="$OUTDIR/ws-$STAMP"
+mkdir -p "$WS"
+chmod 777 "$WS"     # the image's uid-1000 dev user must write; reclaimed below
+WSABS="$(pwd)/$WS"
+LOG="$OUTDIR/container-$STAMP.log"
+RECEIPT="$OUTDIR/receipt-$STAMP.json"
+SECCOMP="$OUTDIR/seccomp-$STAMP.json"
+
+python3 scripts/harness_probe/nested_seccomp.py dagu/dags/dev-run.yaml > "$SECCOMP"
+SECCOMP_SHA="$(python3 -c 'import hashlib,sys
+print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$SECCOMP")"
+
+# Engine facts — on Docker Desktop these describe the LinuxKit VM, exactly
+# the half no in-tree matrix row has ever covered.
+ENGINE="$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo unknown)"
+KERNEL="$(docker info --format '{{.KernelVersion}}' 2>/dev/null || echo unknown)"
+HOST_OS="$(docker info --format '{{.OperatingSystem}}' 2>/dev/null || echo unknown)"
+ARCH="$(docker info --format '{{.Architecture}}' 2>/dev/null || echo unknown)"
+SECOPTS="$(docker info --format '{{join .SecurityOptions ","}}' 2>/dev/null || echo unknown)"
+
+# The inner probe rides the workspace bind — no argv quoting to go wrong,
+# and it exercises the same mount the real run uses. Never `set -e` inside:
+# a red step must still name itself and let the later steps report.
+cat > "$WS/np_inner.sh" <<'INNER'
+echo "NP_UID=$(id -u)"
+echo "NP_UNAME=$(uname -r)"
+out="$(podman unshare cat /proc/self/uid_map 2>&1)"; rc=$?
+echo "NP_UIDMAP_RC=$rc"
+# first actual map row (podman may prepend warnings, e.g. shared-mount)
+echo "NP_UIDMAP=$(printf '%s\n' "$out" \
+  | grep -E -m1 '^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+[0-9]+' \
+  | tr -s ' ')"
+[ "$rc" -eq 0 ] || printf '%s\n' "$out" | sed 's/^/NP_UIDMAP_ERR: /'
+out="$(podman info --format '{{.Store.GraphDriverName}}' 2>&1)"; rc=$?
+echo "NP_GRAPH_RC=$rc"
+echo "NP_GRAPH=$(printf '%s\n' "$out" | tail -1)"
+out="$(podman run --rm -v /workspace:/w "$NP_TEST_IMAGE" sh -c 'id -u > /w/np_write && echo nested-ok' 2>&1)"; rc=$?
+echo "NP_NESTED_RC=$rc"
+printf '%s\n' "$out" | sed 's/^/NP_NESTED_OUT: /'
+# Second write as a NON-root nested user: nested root maps back to the dev
+# uid (1000 outside), so only this write exercises the subuid range — the
+# foreign-uid files the B1 reclaim handler exists for, and the ownership
+# semantics VirtioFS binds must get right on macOS.
+out="$(podman run --rm --user 4321 -v /workspace:/w "$NP_TEST_IMAGE" sh -c 'echo x > /w/np_write_subuid' 2>&1)"; rc=$?
+echo "NP_SUBUID_RC=$rc"
+[ "$rc" -eq 0 ] || printf '%s\n' "$out" | sed 's/^/NP_SUBUID_ERR: /'
+exit 0
+INNER
+chmod 644 "$WS/np_inner.sh"
+
+# Mirror run_dev: image's own user + entrypoint overridden only so the full
+# harness bootstrap (redis, runspec) is not required for an engine probe.
+echo "── nested_probe: $IMAGE on ${HOST_OS} kernel ${KERNEL} (engine ${ENGINE}, ${ARCH})"
+set +e
+docker run --rm \
+  --security-opt seccomp="$(pwd)/$SECCOMP" \
+  --device /dev/fuse --device /dev/net/tun \
+  -e NP_TEST_IMAGE="$NESTED_TEST_IMAGE" \
+  -v "$WSABS:/workspace" \
+  --entrypoint /bin/sh \
+  "$IMAGE" /workspace/np_inner.sh > "$LOG" 2>&1
+DOCKER_RC=$?
+set -e
+sed 's/^/   /' "$LOG"
+
+np_uid() {
+  python3 -c 'import os, sys; print(os.stat(sys.argv[1]).st_uid)' "$1" 2>/dev/null \
+    || echo absent
+}
+WRITE_UID="$(np_uid "$WS/np_write")"
+SUBUID_WRITE_UID="$(np_uid "$WS/np_write_subuid")"
+
+# Mirror the DAG's exit handler verbatim: root, no network, -h chown.
+set +e
+docker run --rm --user 0 --network none \
+  -v "$WSABS:/workspace" \
+  --entrypoint /bin/sh \
+  "$IMAGE" -c 'chown -R -h 1000:1000 /workspace || true' >> "$LOG" 2>&1
+RECLAIM_RC=$?
+set -e
+RECLAIM_UID="$(np_uid "$WS/np_write")"
+RECLAIM_SUBUID_UID="$(np_uid "$WS/np_write_subuid")"
+
+val() { { grep -m1 "^$1=" "$LOG" || true; } | cut -d= -f2-; }
+UIDMAP_RC="$(val NP_UIDMAP_RC)"
+UIDMAP="$(val NP_UIDMAP)"
+GRAPH_RC="$(val NP_GRAPH_RC)"
+GRAPH="$(val NP_GRAPH)"
+NESTED_RC="$(val NP_NESTED_RC)"
+SUBUID_RC="$(val NP_SUBUID_RC)"
+INNER_KERNEL="$(val NP_UNAME)"
+INNER_UID="$(val NP_UID)"
+
+NESTED_OK=false
+if [[ "$DOCKER_RC" -eq 0 && "${NESTED_RC:-1}" = "0" ]] \
+   && grep -q "^NP_NESTED_OUT: nested-ok$" "$LOG"; then
+  NESTED_OK=true
+fi
+# The rig verdict also demands the B1 story: a non-root nested user could
+# write the workspace, and the reclaim brought that file back to uid 1000 —
+# anything else means WorkspaceStore leaks trees on this rig.
+RIG_OK=false
+if [[ "$NESTED_OK" = true && "${SUBUID_RC:-1}" = "0" \
+      && "$RECLAIM_SUBUID_UID" = "1000" ]]; then
+  RIG_OK=true
+fi
+
+NP_RECEIPT="$RECEIPT" NP_IMAGE="$IMAGE" NP_TEST_IMG="$NESTED_TEST_IMAGE" \
+NP_STAMP="$STAMP" NP_ENGINE="$ENGINE" NP_KERNEL="$KERNEL" NP_HOST_OS="$HOST_OS" \
+NP_ARCH="$ARCH" NP_SECOPTS="$SECOPTS" NP_SECCOMP_SHA="$SECCOMP_SHA" \
+NP_DOCKER_RC="$DOCKER_RC" NP_INNER_UID="${INNER_UID:-}" \
+NP_INNER_KERNEL="${INNER_KERNEL:-}" NP_UIDMAP_RC="${UIDMAP_RC:-}" \
+NP_UIDMAP="${UIDMAP:-}" NP_GRAPH_RC="${GRAPH_RC:-}" NP_GRAPH="${GRAPH:-}" \
+NP_NESTED_RC="${NESTED_RC:-}" NP_NESTED_OK="$NESTED_OK" \
+NP_SUBUID_RC="${SUBUID_RC:-}" NP_SUBUID_WRITE_UID="$SUBUID_WRITE_UID" \
+NP_RECLAIM_SUBUID_UID="$RECLAIM_SUBUID_UID" NP_RIG_OK="$RIG_OK" \
+NP_WRITE_UID="$WRITE_UID" NP_RECLAIM_UID="$RECLAIM_UID" \
+NP_RECLAIM_RC="$RECLAIM_RC" \
+python3 - <<'PY'
+import json
+import os
+
+e = os.environ
+receipt = {
+    "measured_at": e["NP_STAMP"],
+    "image": e["NP_IMAGE"],
+    "nested_test_image": e["NP_TEST_IMG"],
+    "host": {"engine": e["NP_ENGINE"], "kernel": e["NP_KERNEL"],
+             "os": e["NP_HOST_OS"], "arch": e["NP_ARCH"],
+             "security_options": e["NP_SECOPTS"]},
+    "seccomp_sha256": e["NP_SECCOMP_SHA"],
+    "container": {"uid": e["NP_INNER_UID"], "kernel": e["NP_INNER_KERNEL"]},
+    "docker_run_rc": int(e["NP_DOCKER_RC"]),
+    "uid_map": {"rc": e["NP_UIDMAP_RC"], "first_row": e["NP_UIDMAP"]},
+    "graph_driver": {"rc": e["NP_GRAPH_RC"], "name": e["NP_GRAPH"]},
+    "nested_run": {"rc": e["NP_NESTED_RC"], "ok": e["NP_NESTED_OK"] == "true"},
+    "workspace_bind": {
+        # nested ROOT maps back to the dev uid; the subuid row is the
+        # foreign-uid case the B1 reclaim handler exists for
+        "uid_after_nested_root_write": e["NP_WRITE_UID"],
+        "subuid_write_rc": e["NP_SUBUID_RC"],
+        "uid_after_nested_subuid_write": e["NP_SUBUID_WRITE_UID"],
+        "uid_after_reclaim_root_file": e["NP_RECLAIM_UID"],
+        "uid_after_reclaim_subuid_file": e["NP_RECLAIM_SUBUID_UID"],
+        "reclaim_rc": int(e["NP_RECLAIM_RC"]),
+    },
+    "rig_ok": e["NP_RIG_OK"] == "true",
+}
+with open(e["NP_RECEIPT"], "w", encoding="utf-8") as f:
+    json.dump(receipt, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+
+echo
+if [[ "$RIG_OK" = true ]]; then
+  echo "── nested_probe: PASS — receipt: $RECEIPT"
+else
+  echo "── nested_probe: FAIL — first red NP_ step above; log: $LOG" >&2
+fi
+echo "matrix row: $STAMP | ${HOST_OS} kernel=${KERNEL} engine=${ENGINE} ${ARCH} | graph=${GRAPH:-?} | uid_map_rc=${UIDMAP_RC:-?} nested_ok=${NESTED_OK} | ws uid root ${WRITE_UID}→${RECLAIM_UID} subuid ${SUBUID_WRITE_UID}→${RECLAIM_SUBUID_UID}"
+rm -rf "$WS" 2>/dev/null \
+  || echo "nested_probe: scratch left behind (foreign uids — reclaim red?): $WS" >&2
+[[ "$RIG_OK" = true ]]

--- a/scripts/harness_probe/nested_seccomp.py
+++ b/scripts/harness_probe/nested_seccomp.py
@@ -1,0 +1,31 @@
+"""Extract the dev-run DAG's inline nested-engine seccomp profile.
+
+Stdlib-only — this runs on operator hosts (nested_probe.sh), which have no
+PyYAML and no venv, so the profile is lifted by regex from the one-line
+anchor in dev-run.yaml. The structural test asserts this extraction equals
+the profile the DAG actually sends on both steps, so a YAML reshape breaks
+CI instead of failing at probe time on some operator's laptop.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+DAG = Path(__file__).resolve().parents[2] / "dagu" / "dags" / "dev-run.yaml"
+
+
+def extract(path: Path = DAG) -> str:
+    """The seccomp JSON blob exactly as the DAG ships it (no seccomp= prefix)."""
+    m = re.search(r"'seccomp=(\{.*\})'", path.read_text())
+    if not m:
+        raise SystemExit(f"nested_seccomp: no inline seccomp profile in {path}")
+    blob = m.group(1)
+    json.loads(blob)  # refuse to emit something a container runtime would reject
+    return blob
+
+
+if __name__ == "__main__":
+    print(extract(Path(sys.argv[1]) if len(sys.argv) > 1 else DAG))


### PR DESCRIPTION
## Why

The rootless-podman-in-Dev-containers floor (ADR-0023 addendum) rests on measurements from exactly one rig — WSL2 kernel 6.6, engine 29 — and the load-bearing newuidmap file-caps fix is marked "mechanism unexplained" in the Dockerfile itself. Nothing in-tree has ever proven the runtime path on macOS Docker Desktop (LinuxKit VM, VirtioFS binds), and with Mac and Debian installs now in play, "worked on the dev rig" is not a portability claim. This PR turns that one-rig matrix comment into a tool any rig can run for a receipt.

## What

**`scripts/harness_probe/nested_probe.sh`** — operator-run, one command after baking a harness image. It replays the dev-run DAG's exact runtime contract, not an approximation of it:

- the inline seccomp profile is extracted live from `dagu/dags/dev-run.yaml` (never a copy that could drift),
- `/dev/fuse` + `/dev/net/tun` devices, the image's own dev user, the per-run `/workspace` bind,
- the B1 reclaim mirrored verbatim (root container, `--network none`, `chown -R -h 1000:1000`).

Inside the container it measures four things, each with its own verdict so a red rig names its first failing step: the uid_map write (the unexplained newuidmap fix), the storage graph driver (overlay-on-overlay vs fuse fallback), a real nested `podman run`, and — the case the reclaim handler exists for — a write by a **non-root** nested user, which lands in the subuid range (foreign uid on the host bind) and must come back to uid 1000 after reclaim. Nested-root writes map back to the dev uid, so without that second write the reclaim test would prove nothing. The receipt (JSON under `.factory/nested_probe/`, gitignored) records engine, kernel, arch, security options, seccomp sha256, and all step verdicts, plus a paste-ready matrix row.

Guards match `host_probe.sh`: `devcake/dev-*` namespace only, local images only (never pulled — audit A7), hello refused (no nested engine aboard).

**`scripts/harness_probe/nested_seccomp.py`** — stdlib-only extraction (operator hosts have no PyYAML; same host rule as the baker). A new structural test pins its regex extraction to the exact `SecurityOpt` blob both DAG steps send, so a YAML reshape breaks CI rather than failing at probe time on someone's laptop.

**Docs**: the Dockerfile matrix comment now names the probe as the way new rigs earn a row; docs/13 gains a "nested-engine rig receipt" section, including the honest caveat that AppArmor hosts (stock Ubuntu) are expected to need attention — the DAG overrides only seccomp, and `docker-default` denies mount regardless.

## Measured

Live on this rig (which turns out to also be the first **arm64** receipt — the Apple Silicon architecture):

```
matrix row: 20260820T192237Z | Ubuntu 24.04.4 LTS kernel=6.6.87.2-microsoft-standard-WSL2
  engine=29.6.1 aarch64 | graph=overlay | uid_map_rc=0 nested_ok=true
  | ws uid root 1000→1000 subuid 104320→1000
```

Refusal paths exercised (hello / non-devcake image / non-local image → exit 2 with guidance). Full containerized suite: **2699 passed, 1 skipped**.

## Owed after merge

The macOS Docker Desktop row: bake a harness image on the Mac, run `scripts/harness_probe/nested_probe.sh`, and the receipt settles the three open questions (newuidmap fix transfer, overlay-on-overlay, VirtioFS bind ownership + reclaim) in one shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)