### PR TITLE
[CAKE-128] up.sh: derive DOCKER_GID from the in-container socket view, not the host path

### DIFF
--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -782,6 +782,10 @@ def test_up_sh_prefers_incontainer_docker_gid_and_gates_socket():
 
     Text contract only — live Desktop acceptance is a residual on Linux agents.
     Exact operator strings are the public seam operators and dry-run share.
+
+    The writability gate must exec as the post-entrypoint credentials (uid 1000
+    / gid $DOCKER_GID). The pinned dagu image has empty Config.User, so bare
+    ``compose exec`` is root and false-greens a wrong DOCKER_GID.
     """
     text = _up_sh_text()
     assert "devcake_docker_gid_incontainer" in text
@@ -790,7 +794,8 @@ def test_up_sh_prefers_incontainer_docker_gid_and_gates_socket():
     assert "in-container probe failed" in text
     assert "docs/14-security.md" in text
     assert "root-group" in text
-    assert "docker compose exec -T dagu" in text
+    # Gate identity must match the running daemon (not root).
+    assert 'docker compose exec -T --user "1000:${GID}" dagu' in text
     assert "test -w /var/run/docker.sock" in text
     assert "docker-compose.override.yml" in text
     assert 'DOCKER_GID: "0"' in text

--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -777,6 +777,25 @@ def test_up_sh_persists_devcake_tag_into_env():
         assert f"upsert_env_var {key}" in text
 
 
+def test_up_sh_prefers_incontainer_docker_gid_and_gates_socket():
+    """CAKE-128: host-stat alone is wrong on Docker Desktop; probe + gate.
+
+    Text contract only — live Desktop acceptance is a residual on Linux agents.
+    Exact operator strings are the public seam operators and dry-run share.
+    """
+    text = _up_sh_text()
+    assert "devcake_docker_gid_incontainer" in text
+    assert "in-container view" in text
+    assert "host path says" in text
+    assert "in-container probe failed" in text
+    assert "docs/14-security.md" in text
+    assert "root-group" in text
+    assert "docker compose exec -T dagu" in text
+    assert "test -w /var/run/docker.sock" in text
+    assert "docker-compose.override.yml" in text
+    assert 'DOCKER_GID: "0"' in text
+
+
 def test_tee_run_keeps_a_tail_and_writes_through():
     factory = _load_factory()
     from dev_factory.run import tee_run

--- a/app/tests/test_stack_env_docker_gid.py
+++ b/app/tests/test_stack_env_docker_gid.py
@@ -138,3 +138,100 @@ def test_host_docker_gid_returns_numeric_gid_for_statable_path(tmp_path: Path):
     )
     assert got.returncode == 0, got.stderr
     assert got.stdout.strip() == expected
+
+
+def _compose_yml() -> Path | None:
+    for p in (
+        Path(__file__).resolve().parents[2] / "docker-compose.yml",
+        Path("/srv/docker-compose.yml"),
+    ):
+        if p.is_file():
+            return p
+    return None
+
+
+def _dagu_image_pin() -> str | None:
+    """Digest-pinned dagu image from compose — no second pin in the suite."""
+    import re
+
+    compose = _compose_yml()
+    if compose is None:
+        return None
+    m = re.search(
+        r"image:\s*(ghcr\.io/dagucloud/dagu:[^\s@]+@sha256:[0-9a-f]{64})",
+        compose.read_text(),
+    )
+    return m.group(1) if m else None
+
+
+def test_dagu_socket_writability_polarity_matches_entrypoint_creds():
+    """Wrong DOCKER_GID class must fail ``test -w``; matching gid must pass.
+
+    Mirrors the REVIEW reject evidence on the pinned dagu image: root (bare
+    compose exec) false-greens a root-owned 0660 socket; ``--user 1000:1``
+    fails; ``--user 1000:0`` passes. Creates the stand-in as root inside the
+    container, then re-runs with docker ``--user`` — the same identity switch
+    ``up.sh`` uses for the post-start gate. Skips when docker/image unavailable.
+    """
+    import pytest
+
+    image = _dagu_image_pin()
+    if image is None:
+        pytest.skip("docker-compose.yml / dagu pin not mounted")
+
+    try:
+        inspect = subprocess.run(
+            ["docker", "image", "inspect", image],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except FileNotFoundError:
+        pytest.skip("docker CLI not on PATH (hermetic app-test)")
+
+    if inspect.returncode != 0:
+        pull = subprocess.run(
+            ["docker", "pull", image],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if pull.returncode != 0:
+            pytest.skip(
+                f"dagu image unavailable for polarity probe: {pull.stderr[-200:]}"
+            )
+
+    # Seed a root-owned 0660 file into a tiny volume the follow-up runs share.
+    # Mount must stay writable: ``test -w`` fails on :ro binds even for root.
+    vol = "devcake-cake128-sock-polarity"
+    subprocess.run(["docker", "volume", "rm", "-f", vol], capture_output=True)
+    seed = subprocess.run(
+        [
+            "docker", "run", "--rm", "-v", f"{vol}:/sock",
+            "--entrypoint", "sh", image, "-c",
+            "install -m 0660 /dev/null /sock/fake.sock && "
+            "stat -c '%u:%g %a' /sock/fake.sock",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if seed.returncode != 0:
+        pytest.skip(f"could not seed fake socket: {seed.stderr[-200:]}")
+    assert "0:0 660" in seed.stdout.replace("\n", " ")
+
+    def _test_w(user: str | None) -> int:
+        cmd = ["docker", "run", "--rm", "-v", f"{vol}:/sock", "--entrypoint", "sh"]
+        if user is not None:
+            cmd.extend(["--user", user])
+        cmd.extend([image, "-c", "test -w /sock/fake.sock"])
+        return subprocess.run(
+            cmd, capture_output=True, text=True, timeout=120,
+        ).returncode
+
+    try:
+        assert _test_w(None) == 0, "root (bare exec) false-greens root-owned 0660"
+        assert _test_w("1000:1") != 0, "uid 1000 gid 1 must not write root:root 0660"
+        assert _test_w("1000:0") == 0, "uid 1000 gid 0 must write root:root 0660"
+    finally:
+        subprocess.run(["docker", "volume", "rm", "-f", vol], capture_output=True)

--- a/app/tests/test_stack_env_docker_gid.py
+++ b/app/tests/test_stack_env_docker_gid.py
@@ -1,0 +1,140 @@
+"""CAKE-128: stack_env.sh DOCKER_GID helpers (host + in-container).
+
+Public seams: ``devcake_docker_gid`` and ``devcake_docker_gid_incontainer``.
+Policy (fail-hard vs permissive) stays with callers — these tests only cover
+derivation contracts. Stub ``docker`` on PATH; do not hit a real daemon.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+# Local checkout: …/devcake/scripts/lib; app-test: /srv/repo-scripts/lib.
+_STACK_ENV_CANDIDATES = (
+    Path(__file__).resolve().parents[2] / "scripts" / "lib" / "stack_env.sh",
+    Path("/srv/repo-scripts/lib/stack_env.sh"),
+)
+
+
+def _stack_env() -> Path:
+    path = next((p for p in _STACK_ENV_CANDIDATES if p.is_file()), None)
+    assert path is not None, (
+        "scripts/lib/stack_env.sh missing — bind scripts → /srv/repo-scripts"
+    )
+    return path
+
+
+def _run_helper(
+    tmp_path: Path,
+    *,
+    fn: str,
+    sock: Path,
+    docker_script: str | None,
+) -> subprocess.CompletedProcess[str]:
+    """Source stack_env.sh and invoke ``fn`` with a stubbed ``docker`` on PATH."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    if docker_script is not None:
+        docker = bin_dir / "docker"
+        docker.write_text(docker_script)
+        docker.chmod(docker.stat().st_mode | stat.S_IXUSR)
+    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+    # Isolate from a real docker earlier on PATH when we intentionally omit the stub.
+    if docker_script is None:
+        # Empty bin_dir first on PATH; no docker executable → command not found.
+        pass
+    script = f"""
+set -euo pipefail
+source {_stack_env().as_posix()!r}
+{fn} {sock.as_posix()!r}
+"""
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_incontainer_probe_success_returns_container_view_gid(tmp_path: Path):
+    sock = tmp_path / "docker.sock"
+    sock.write_text("")  # existence only; bind path is passed through to stub
+    # Stub records argv and prints the in-container gid the mission requires.
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    log = tmp_path / "docker-argv.log"
+    docker = stub / "docker"
+    docker.write_text(
+        f"""#!/bin/sh
+printf '%s\\n' "$*" >> {log.as_posix()!r}
+# Only the probe's `docker run` path must succeed with a gid.
+case " $* " in
+  *" run "*) echo 0; exit 0 ;;
+esac
+echo "unexpected docker invocation: $*" >&2
+exit 99
+"""
+    )
+    docker.chmod(docker.stat().st_mode | stat.S_IXUSR)
+
+    env = {**os.environ, "PATH": f"{stub}{os.pathsep}{os.environ.get('PATH', '')}"}
+    script = f"""
+set -euo pipefail
+source {_stack_env().as_posix()!r}
+devcake_docker_gid_incontainer {sock.as_posix()!r}
+"""
+    got = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, env=env,
+    )
+    assert got.returncode == 0, got.stderr
+    assert got.stdout.strip() == "0"
+    argv = log.read_text()
+    assert f"-v {sock}:/var/run/docker.sock:ro" in argv or (
+        f"-v{sock}:/var/run/docker.sock:ro" in argv
+    )
+    assert "stat -c %g /var/run/docker.sock" in argv or (
+        "stat" in argv and "%g" in argv and "/var/run/docker.sock" in argv
+    )
+
+
+def test_incontainer_probe_failure_returns_rc1_and_empty_stdout(tmp_path: Path):
+    sock = tmp_path / "docker.sock"
+    sock.write_text("")
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    docker = stub / "docker"
+    docker.write_text("#!/bin/sh\nexit 1\n")
+    docker.chmod(docker.stat().st_mode | stat.S_IXUSR)
+
+    env = {**os.environ, "PATH": f"{stub}{os.pathsep}{os.environ.get('PATH', '')}"}
+    script = f"""
+set +e
+source {_stack_env().as_posix()!r}
+out="$(devcake_docker_gid_incontainer {sock.as_posix()!r})"
+rc=$?
+printf 'RC=%s\\n' "$rc"
+printf 'OUT=%s\\n' "$out"
+"""
+    got = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, env=env,
+    )
+    assert got.returncode == 0, got.stderr  # wrapper itself succeeds
+    assert "RC=1" in got.stdout
+    assert "OUT=\n" in got.stdout or got.stdout.rstrip().endswith("OUT=")
+
+
+def test_host_docker_gid_returns_numeric_gid_for_statable_path(tmp_path: Path):
+    sock = tmp_path / "fake.sock"
+    sock.write_text("")
+    expected = subprocess.run(
+        ["stat", "-c", "%g", str(sock)], capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert expected.isdigit()
+
+    got = _run_helper(
+        tmp_path, fn="devcake_docker_gid", sock=sock, docker_script=None,
+    )
+    assert got.returncode == 0, got.stderr
+    assert got.stdout.strip() == expected

--- a/scripts/lib/stack_env.sh
+++ b/scripts/lib/stack_env.sh
@@ -22,6 +22,38 @@ devcake_docker_gid() {
   printf '%s\n' "$gid"
 }
 
+# gid of the docker socket as a Linux container sees the bind-mounted path
+# (CAKE-128). Host-side stat is wrong on Docker Desktop (symlink / VM
+# remapping). Probe with the same bind the stack will use; image pin is
+# grepped from docker-compose.yml so there is no second digest to drift.
+# Same contract as devcake_docker_gid: numeric stdout, rc 1 on any failure.
+devcake_docker_gid_incontainer() {
+  local sock="${1:-/var/run/docker.sock}" compose="" image="" gid="" root=""
+  [[ -e "$sock" ]] || return 1
+  # scripts/lib → repo root (host) or /srv (pytest: scripts → /srv/repo-scripts,
+  # compose bind → /srv/docker-compose.yml).
+  root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  for compose in "${root}/docker-compose.yml" "./docker-compose.yml" \
+                 "/srv/docker-compose.yml"; do
+    [[ -f "$compose" ]] && break
+    compose=""
+  done
+  [[ -n "$compose" ]] || return 1
+  # Extract the digest-pinned redis:7-alpine@sha256:… token already in compose.
+  image="$(
+    grep -E 'image:[[:space:]]*redis:7-alpine@sha256:[0-9a-f]{64}' "$compose" \
+      | head -1 \
+      | sed -E 's/.*image:[[:space:]]*(redis:7-alpine@sha256:[0-9a-f]{64}).*/\1/'
+  )"
+  [[ "$image" =~ ^redis:7-alpine@sha256:[0-9a-f]{64}$ ]] || return 1
+  gid="$(
+    docker run --rm -v "${sock}:/var/run/docker.sock:ro" "$image" \
+      stat -c %g /var/run/docker.sock 2>/dev/null
+  )" || return 1
+  [[ "$gid" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$gid"
+}
+
 # DEVCAKE_WS_HOST resolution order (ADR-0025: bind sources resolve on the
 # daemon host, so the value must be host-absolute): existing .env value wins
 # (operator relocation), else <repo>/workspaces. Prints the value; the

--- a/up.sh
+++ b/up.sh
@@ -303,10 +303,16 @@ fi
 # Fatal post-start gate (CAKE-128): dagu HTTP health can be green while the
 # process still cannot open docker.sock (wrong DOCKER_GID). Bounded retry so
 # we measure writability, not a startup race. dry-run never reaches here.
+#
+# MUST exec as uid 1000 / gid $DOCKER_GID — the credentials the stock
+# entrypoint drops to via sudo. The pinned dagu image has empty Config.User,
+# so bare `compose exec` is root and `test -w` on a root-owned 0660 socket
+# always succeeds (false green for the Desktop wrong-gid failure class).
 echo "── verifying dagu can write the Docker socket…"
 _sock_ok=0
 for _ in $(seq 1 15); do
-  if docker compose exec -T dagu sh -c 'test -w /var/run/docker.sock' \
+  if docker compose exec -T --user "1000:${GID}" dagu \
+      sh -c 'test -w /var/run/docker.sock' \
       >/dev/null 2>&1; then
     _sock_ok=1
     break

--- a/up.sh
+++ b/up.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bring up the DevCake stack with host-discovered DOCKER_GID.
+# Bring up the DevCake stack with discovered DOCKER_GID.
 #
 #   ./up.sh                 # upsert GID/WS_HOST/TAG → compose up -d → baker
 #   ./up.sh --bake          # bake control plane + hello, then up + baker
@@ -7,10 +7,12 @@
 #   ./up.sh -- dagu app     # pass service names to compose up
 #   ./up.sh --dry-run       # print discovered GID + planned actions
 #
-# DOCKER_GID is host-specific (the group of /var/run/docker.sock). Compose
-# requires it for Dagu's sock access; this script always re-discovers and
-# writes it (plus DEVCAKE_WS_HOST and DEVCAKE_TAG) into .env so plain
-# `docker compose up -d` works afterwards too.
+# DOCKER_GID is the group of /var/run/docker.sock as a Linux container sees
+# it (CAKE-128). Host-path stat alone is wrong on Docker Desktop (symlink /
+# VM remapping). Prefer the in-container probe; fall back to host-stat when
+# the probe fails. Compose requires the gid for Dagu's sock access; this
+# script always re-discovers and writes it (plus DEVCAKE_WS_HOST and
+# DEVCAKE_TAG) into .env so plain `docker compose up -d` works afterwards too.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -60,12 +62,34 @@ done
 source "$(dirname "$0")/scripts/lib/stack_env.sh"
 
 discover_docker_gid() {
-  local gid=""
-  if ! gid="$(devcake_docker_gid "$SOCK")"; then
+  # Prefer in-container view (CAKE-128); fall back to host-stat. Prints the
+  # operator resolution line to stdout *after* returning the gid via a
+  # nameref would fight command-substitution — so this sets the global GID
+  # and prints the ── line itself. Caller must not re-echo.
+  local host_gid="" in_gid=""
+  if ! host_gid="$(devcake_docker_gid "$SOCK")"; then
     echo "error: cannot derive DOCKER_GID from $SOCK — is the Docker daemon running?" >&2
     exit 1
   fi
-  printf '%s\n' "$gid"
+  if in_gid="$(devcake_docker_gid_incontainer "$SOCK")"; then
+    GID="$in_gid"
+    if [[ "$in_gid" != "$host_gid" ]]; then
+      echo "── DOCKER_GID=${GID}  (in-container view; host path says ${host_gid})"
+    else
+      echo "── DOCKER_GID=${GID}  (from ${SOCK})"
+    fi
+  else
+    GID="$host_gid"
+    echo "── DOCKER_GID=${GID}  (from ${SOCK}; in-container probe failed — using host-stat)"
+  fi
+  if [[ "$GID" == "0" ]]; then
+    cat >&2 <<'EOF'
+── WARNING: DOCKER_GID=0 grants the dagu service root-group access to the
+   Docker socket (root-equivalent control of the engine host — see
+   docs/14-security.md). Any docker.sock grant is already root-equivalent;
+   this is not a new privilege class. Continuing non-interactively.
+EOF
+  fi
 }
 
 upsert_env_var() {
@@ -104,8 +128,8 @@ upsert_env_var() {
   mv "$tmp" "$file"
 }
 
-GID="$(discover_docker_gid)"
-echo "── DOCKER_GID=${GID}  (from ${SOCK})"
+GID=""
+discover_docker_gid
 
 # ADR-0025: per-run workspace base. HOST-ABSOLUTE on purpose — dev-run.yaml
 # bind sources resolve on the daemon host. Existing .env value wins (operator
@@ -275,6 +299,39 @@ else
   echo "── WARNING: app did not report live within ~60s. The stack is up," >&2
   echo "   but the app may be wedged — check: docker compose logs --tail=50 app" >&2
 fi
+
+# Fatal post-start gate (CAKE-128): dagu HTTP health can be green while the
+# process still cannot open docker.sock (wrong DOCKER_GID). Bounded retry so
+# we measure writability, not a startup race. dry-run never reaches here.
+echo "── verifying dagu can write the Docker socket…"
+_sock_ok=0
+for _ in $(seq 1 15); do
+  if docker compose exec -T dagu sh -c 'test -w /var/run/docker.sock' \
+      >/dev/null 2>&1; then
+    _sock_ok=1
+    break
+  fi
+  sleep 2
+done
+if [[ "$_sock_ok" -ne 1 ]]; then
+  _obs_gid="$(
+    docker compose exec -T dagu sh -c 'stat -c %g /var/run/docker.sock' \
+      2>/dev/null || echo unknown
+  )"
+  cat >&2 <<EOF
+error: dagu cannot write /var/run/docker.sock (resolved DOCKER_GID=${GID}; socket gid inside the container=${_obs_gid}).
+Fix: set the gid the container actually sees, e.g. in docker-compose.override.yml:
+
+services:
+  dagu:
+    environment:
+      DOCKER_GID: "0"
+
+Then re-run ./up.sh (or export DOCKER_GID and recreate dagu).
+EOF
+  exit 1
+fi
+echo "── dagu docker.sock writable ✓"
 
 # Host baker: same machine and socket as today's bake — not a compose
 # service, not a new socket-holder. It reads the app-published keep-set


### PR DESCRIPTION
## Intent

Stop deriving `DOCKER_GID` solely from the host `stat` of `/var/run/docker.sock`. On Docker Desktop (macOS), that host view (often gid 1 via a symlink) does not match the gid presented inside Linux containers (gid 0), so dagu cannot open the socket despite healthy compose services.

## Mission

https://linear.app/fidecastro/issue/CAKE-128/upsh-derive-docker-gid-from-the-in-container-socket-view-not-the-host

## Changes

- Add `devcake_docker_gid_incontainer()` in `scripts/lib/stack_env.sh`: `docker run` + bind-mount probe; image pin grepped at runtime from compose’s digest-pinned `redis:7-alpine@sha256:…` (no second pin). Same contract as host helper (numeric stdout / rc 1); callers own policy (ADR-0034).
- `up.sh` prefers the in-container gid; prints mismatch / explicit fallback / gid-0 warning (non-interactive); `--dry-run` shares the same resolution.
- Fatal post-`compose up` gate runs as **`--user "1000:${GID}"`** (stock entrypoint credentials). Bare `compose exec` is root on the pinned dagu image (empty `Config.User`) and false-greens a wrong `DOCKER_GID` — REVIEW reject fix.
- CI `ci_compose_for_dispatch.sh` policy unchanged (`|| echo 0`).

## Deviation from plan

Plan/mission text said `docker compose exec -T dagu …` “(exec runs as the container's configured uid/gid)”. That parenthetical is false for this image; the gate uses `--user "1000:${GID}"` so it measures the daemon’s socket access, not root’s.

## How to verify

```bash
./scripts/pytest_app.sh \
  app/tests/test_stack_env_docker_gid.py \
  app/tests/test_dev_factory.py::test_up_sh_prefers_incontainer_docker_gid_and_gates_socket
```

Polarity (host with docker + pinned dagu image): root/`1000:0` can `test -w` a root-owned 0660 stand-in; `1000:1` cannot.

On Docker Desktop: `./up.sh --bake` should resolve `DOCKER_GID=0` with the mismatch + warning lines and pass the writability gate (no override file).

## Residual

Docker Desktop macOS live acceptance could not be proven on this Linux/Podman agent host (no `/var/run/docker.sock`). Hermetic stub + `up.sh` text contracts are green; host polarity probe for the gate identity passed.

## Out of scope

- Dagu-API engine ping
- Admin UI health / first-run dispatch surfaces