### PR TITLE
[CAKE-130] up.sh --bake: prove dispatch capability with a hello run before declaring success

### DIFF
--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -777,6 +777,41 @@ def test_up_sh_persists_devcake_tag_into_env():
         assert f"upsert_env_var {key}" in text
 
 
+def test_up_sh_bake_invokes_hello_dispatch_smoke():
+    """CAKE-130: --bake proves Dagu→Dev dispatch via ci_dispatch_hello.sh."""
+    text = _up_sh_text()
+    assert "ci_dispatch_hello.sh" in text
+    assert "--no-hello-smoke" in text
+    assert "NO_HELLO_SMOKE" in text
+
+
+def test_up_sh_hello_smoke_ordered_before_success_banner():
+    """Success banner must not print until the bake-path hello smoke finishes."""
+    text = _up_sh_text()
+    smoke_at = text.index("ci_dispatch_hello.sh")
+    success_at = text.index("stack starting")
+    assert smoke_at < success_at
+
+
+def test_up_sh_hello_smoke_reads_admin_without_sourcing_env():
+    """ADMIN_* for the smoke come from selective .env parse — never source .env."""
+    text = _up_sh_text()
+    assert "source .env" not in text
+    assert ". .env" not in text
+    assert "ADMIN_USER" in text
+    assert "ADMIN_PASSWORD" in text
+    # Same selective-key family as OO_INGEST_* (grep matching keys + export).
+    assert "ADMIN_USER=*" in text or "ADMIN_USER=" in text
+    assert "grep -E" in text
+
+
+def test_up_sh_hello_smoke_failure_points_at_dagu_and_socket():
+    """Failed hello gate names diagnostics operators need (dagu logs + sock)."""
+    text = _up_sh_text()
+    assert "docker compose logs" in text and "dagu" in text
+    assert "Docker-socket" in text or "docker socket" in text.lower() or "Docker Desktop" in text
+
+
 def test_tee_run_keeps_a_tail_and_writes_through():
     factory = _load_factory()
     from dev_factory.run import tee_run

--- a/up.sh
+++ b/up.sh
@@ -2,8 +2,9 @@
 # Bring up the DevCake stack with host-discovered DOCKER_GID.
 #
 #   ./up.sh                 # upsert GID/WS_HOST/TAG → compose up -d → baker
-#   ./up.sh --bake          # bake control plane + hello, then up + baker
+#   ./up.sh --bake          # bake control plane + hello, then up + baker + hello smoke
 #   ./up.sh --bake app admin
+#   ./up.sh --bake --no-hello-smoke   # bake/up without the dispatch proof
 #   ./up.sh -- dagu app     # pass service names to compose up
 #   ./up.sh --dry-run       # print discovered GID + planned actions
 #
@@ -11,17 +12,20 @@
 # requires it for Dagu's sock access; this script always re-discovers and
 # writes it (plus DEVCAKE_WS_HOST and DEVCAKE_TAG) into .env so plain
 # `docker compose up -d` works afterwards too.
+# On --bake, after the health gate, a hello dispatch smoke proves Dagu can
+# launch Dev containers (control-plane health ≠ dispatch health).
 set -euo pipefail
 cd "$(dirname "$0")"
 
 SOCK="${DOCKER_SOCK:-/var/run/docker.sock}"
 DRY_RUN=0
 DO_BAKE=0
+NO_HELLO_SMOKE=0
 BAKE_TARGETS=()
 COMPOSE_ARGS=()
 
 usage() {
-  sed -n '2,13p' "$0" | sed 's/^# \?//'
+  sed -n '2,16p' "$0" | sed 's/^# \?//'
   exit "${1:-0}"
 }
 
@@ -29,6 +33,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help) usage 0 ;;
     --dry-run) DRY_RUN=1; shift ;;
+    --no-hello-smoke) NO_HELLO_SMOKE=1; shift ;;
     --bake)
       DO_BAKE=1
       shift
@@ -155,6 +160,11 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
       echo "── would: DEVCAKE_TAG=${TAG} docker buildx bake app admin hello"
     else
       echo "── would: DEVCAKE_TAG=${TAG} docker buildx bake ${BAKE_TARGETS[*]}"
+    fi
+    if [[ "$NO_HELLO_SMOKE" -eq 1 ]]; then
+      echo "── would: skip hello dispatch smoke (--no-hello-smoke)"
+    else
+      echo "── would: hello dispatch smoke (scripts/ci_dispatch_hello.sh)"
     fi
   fi
   echo "── would: docker compose up -d ${COMPOSE_ARGS[*]:-}"
@@ -291,7 +301,7 @@ if [[ -f "$_FACTORY_DIR/watch.pid" ]]; then
 fi
 # Ingest creds so the baker can ship a dying word to OO if the app is
 # already gone (the app's push_oo_log chokepoint cannot run then).
-# Read only those keys — do not source the whole .env into this shell.
+# Read only those keys — do not shell-source the env file into this process.
 if [[ -f .env ]]; then
   while IFS= read -r line; do
     case "$line" in
@@ -308,6 +318,44 @@ nohup python3 -m dev_factory \
   >>"$_FACTORY_DIR/watch.log" 2>&1 &
 echo $! >"$_FACTORY_DIR/watch.pid"
 echo "── host baker watching keep-set (pid $! → .factory/watch.log)"
+
+# CAKE-130: --bake proves dispatch health (Dagu → Dev container → Redis →
+# finalize). Control-plane /health and image receipts do not catch a dagu that
+# cannot talk to the Docker socket (observed on Docker Desktop). Plain
+# ./up.sh (no --bake) skips this gate — day-to-day restarts stay fast.
+if [[ "$DO_BAKE" -eq 1 ]]; then
+  if [[ "$NO_HELLO_SMOKE" -eq 1 ]]; then
+    echo "── skipping hello dispatch smoke (--no-hello-smoke)"
+  else
+    # Selective ADMIN_* read — same family as OO_INGEST_* above; never
+    # shell-source the env file (Compose syntax ≠ shell; values may contain spaces).
+    _ADMIN_USER=""
+    _ADMIN_PASSWORD=""
+    if [[ -f .env ]]; then
+      while IFS= read -r line; do
+        case "$line" in
+          ADMIN_USER=*) _ADMIN_USER="${line#ADMIN_USER=}" ;;
+          ADMIN_PASSWORD=*) _ADMIN_PASSWORD="${line#ADMIN_PASSWORD=}" ;;
+        esac
+      done < <(grep -E '^(ADMIN_USER|ADMIN_PASSWORD)=' .env || true)
+    fi
+    if [[ -z "$_ADMIN_USER" || -z "$_ADMIN_PASSWORD" ]]; then
+      echo "── WARNING: skipping hello dispatch smoke — ADMIN_USER / ADMIN_PASSWORD missing from .env" >&2
+    else
+      export ADMIN_USER="$_ADMIN_USER"
+      export ADMIN_PASSWORD="$_ADMIN_PASSWORD"
+      echo "── hello dispatch smoke (scripts/ci_dispatch_hello.sh)…"
+      if ! ./scripts/ci_dispatch_hello.sh; then
+        echo "── ERROR: hello dispatch smoke failed — the stack is up but Dagu" >&2
+        echo "   cannot complete a Dev container run. Check:" >&2
+        echo "     docker compose logs --tail=50 dagu" >&2
+        echo "   Look for the preceding 'hello run_id=…' line for the run id." >&2
+        echo "   Known cause: Docker-socket permissions (Docker Desktop hosts especially)." >&2
+        exit 1
+      fi
+    fi
+  fi
+fi
 
 echo "── stack starting (admin: http://localhost:8080)"
 echo "   bootstrap passwords still come from .env; operator secrets via Config."


### PR DESCRIPTION
## Intent

On `./up.sh --bake`, after compose-up and the existing app health gate, prove the Dagu → Dev container → Redis → finalize path with one hello dispatch before printing the success banner. Plain `./up.sh` (no `--bake`) is unchanged.

## Why

Control-plane health and image/receipt health are not dispatch health. A 2026-08 Docker Desktop install reached healthy compose + ok harness receipts while dagu could not launch Dev containers (Docker socket permissions). That gap only surfaced on a later OAuth dispatch. Install-time proof closes it.

## What changed

- `up.sh`: `--no-hello-smoke` flag; bake-path gate invokes `scripts/ci_dispatch_hello.sh`; selective `ADMIN_USER` / `ADMIN_PASSWORD` read from `.env` (never shell-source the env file); fatal failure with `docker compose logs dagu` + Docker-socket / Desktop note; auto-skip with warning when `ADMIN_*` absent; dry-run prints a would-line.
- `app/tests/test_dev_factory.py`: new `test_up_sh_*` text assertions (invoke smoke, flag present, success ordered after smoke, no `source .env`, failure diagnostics).

## CI paths unaffected

`ci.yml` and `ci_suite.sh` are **not** changed. They already drive `scripts/ci_compose_for_dispatch.sh` + `scripts/ci_dispatch_hello.sh` directly (not via `up.sh`):

- `.github/workflows/ci.yml` ~L162: `./scripts/ci_dispatch_hello.sh`
- `scripts/ci_suite.sh` ~L115: `./scripts/ci_dispatch_hello.sh`

## How to verify

```bash
# Unit (rebakes app-test):
./scripts/pytest_app.sh app/tests/test_dev_factory.py -k 'test_up_sh' -v

# Or against a fresh app-test image with up.sh bind-mounted (as CI does).
```

Live `./up.sh --bake` hello run (~1 min) not exercised in this agent environment (no Docker socket path for `up.sh` GID discovery); unit text tests + script review are the proof for this change type.

## Out of scope

- `dispatch_backend` on `/api/v1/health` / admin three-way status split
- Changing the warn-only health gate to fatal
- Refactoring CI bring-up through `up.sh`

Mission: https://linear.app/fidecastro/issue/CAKE-130/upsh-bake-prove-dispatch-capability-with-a-hello-run-before-declaring