### PR TITLE
[CAKE-131] Validate OpenObserve's password policy in up.sh and document it in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@
 # ── OpenObserve ──────────────────────────────────────────────────────────────
 OO_ROOT_EMAIL=admin@example.com
 # REQUIRED: set a strong password (not change-me). Used by provisioner + admin.
+# OpenObserve v0.91.5 policy: 8-128 chars; at least one lowercase, one
+# uppercase, one digit, and one special (non-alphanumeric) character.
+# All-hex strings are rejected. Empty still refused at app boot.
 OO_ROOT_PASSWORD=
 # REQUIRED (M8): OO service account the stack authenticates with
 # (otel-collector, fluentbit, app log-push). Boot refuses empty email or
@@ -23,6 +26,9 @@ OO_ROOT_PASSWORD=
 # from OO_INGEST_*. Optional dashboard/alerts only:
 #   python3 scripts/provision_oo.py
 # Dev containers hold NO OO credentials — they export via the otel-collector.
+# OpenObserve v0.91.5 policy: 8-128 chars; at least one lowercase, one
+# uppercase, one digit, and one special (non-alphanumeric) character.
+# All-hex strings are rejected. Empty still refused at app boot.
 OO_INGEST_EMAIL=
 OO_INGEST_PASSWORD=
 # OO_ALERT_WEBHOOK=           # optional; provisions the alert set (docs/15 §6)

--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -777,6 +777,41 @@ def test_up_sh_persists_devcake_tag_into_env():
         assert f"upsert_env_var {key}" in text
 
 
+def test_up_sh_validates_oo_passwords_before_bake_and_compose():
+    """CAKE-131: OO policy gate must fail before any bake/compose action."""
+    text = _up_sh_text()
+    assert "require_oo_password OO_ROOT_PASSWORD" in text
+    assert "require_oo_password OO_INGEST_PASSWORD" in text
+    assert "oo_password.sh" in text
+    # Match real action lines (leading indent), not earlier comments that
+    # mention the same verbs.
+    lines = text.splitlines()
+    gate_line = next(
+        i for i, line in enumerate(lines)
+        if "require_oo_password OO_ROOT_PASSWORD" in line
+    )
+    bake = next(
+        i for i, line in enumerate(lines)
+        if line.lstrip().startswith("docker buildx bake")
+    )
+    compose = next(
+        i for i, line in enumerate(lines)
+        if line.lstrip().startswith("docker compose up -d")
+    )
+    assert gate_line < bake
+    assert gate_line < compose
+
+
+def test_up_sh_health_gate_hints_openobserve_logs():
+    """Weak OO root password crash-loops OO; the app health gate must name it."""
+    text = _up_sh_text()
+    # Locate the ~60s live-timeout warning branch (not the redis/dagu probe).
+    idx = text.index("app did not report live within")
+    branch = text[idx : idx + 400]
+    assert "docker compose logs" in branch and "app" in branch
+    assert "docker compose logs openobserve" in branch
+
+
 def test_tee_run_keeps_a_tail_and_writes_through():
     factory = _load_factory()
     from dev_factory.run import tee_run

--- a/app/tests/test_oo_password_policy.py
+++ b/app/tests/test_oo_password_policy.py
@@ -1,0 +1,78 @@
+"""OpenObserve password-policy gate used by up.sh (CAKE-131).
+
+Public seam: scripts/lib/oo_password.sh — `require_oo_password VAR value`
+mirrors OpenObserve v0.91.5 src/config/src/utils/password.rs.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _lib() -> Path:
+    candidates = [
+        Path(__file__).resolve().parents[2] / "scripts" / "lib" / "oo_password.sh",
+        Path("/srv/repo-scripts/lib/oo_password.sh"),
+    ]
+    path = next((p for p in candidates if p.is_file()), None)
+    assert path is not None, (
+        "oo_password.sh missing — bind scripts → /srv/repo-scripts"
+    )
+    return path
+
+
+def _require(var: str, value: str) -> subprocess.CompletedProcess[str]:
+    # Invoke bash directly: source the lib, call the public seam.
+    script = (
+        f'source "{_lib()}" && '
+        f'require_oo_password {var} {value!r}; echo rc=$?'
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+_RULE_SNIPPET = (
+    "must be 8-128 characters and contain at least one lowercase letter, "
+    "one uppercase letter, one digit, and one special character"
+)
+
+
+def test_require_oo_password_rejects_all_hex():
+    """Long hex looks strong but fails OO's class requirements."""
+    got = _require("OO_ROOT_PASSWORD", "deadbeefcafebabe0123456789abcdef")
+    # Function returns 1; bash -c continues to echo rc= unless set -e.
+    assert "rc=1" in got.stdout
+    err = got.stderr
+    assert "OO_ROOT_PASSWORD" in err
+    assert "OpenObserve v0.91.5" in err
+    assert _RULE_SNIPPET in err
+
+
+def test_require_oo_password_rejects_too_short():
+    """All classes present but under MIN_PASSWORD_LEN=8."""
+    got = _require("OO_INGEST_PASSWORD", "Ab1!")
+    assert "rc=1" in got.stdout
+    assert "OO_INGEST_PASSWORD" in got.stderr
+    assert _RULE_SNIPPET in got.stderr
+
+
+def test_require_oo_password_accepts_minimum_compliant():
+    got = _require("OO_ROOT_PASSWORD", "Abcdef1!")
+    assert "rc=0" in got.stdout
+    assert got.stderr == ""
+
+
+def test_require_oo_password_accepts_ci_shaped():
+    got = _require("OO_INGEST_PASSWORD", "Ci-oo-root-Pass1!")
+    assert "rc=0" in got.stdout
+    assert got.stderr == ""
+
+
+def test_require_oo_password_skips_empty():
+    """Empty stays with app-boot _refuse_insecure_passwords — not this gate."""
+    got = _require("OO_ROOT_PASSWORD", "")
+    assert "rc=0" in got.stdout
+    assert got.stderr == ""

--- a/scripts/lib/oo_password.sh
+++ b/scripts/lib/oo_password.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# OpenObserve bootstrap password composition check (CAKE-131).
+#
+# Lockstep with docker-compose.yml openobserve pin v0.91.5
+# (src/config/src/utils/password.rs). Update this rule when bumping the image.
+#
+# Sourced, not executed. Empty values are skipped — app boot still refuses
+# empties via _refuse_insecure_passwords; this gate is composition-only.
+
+# Return 0 iff password meets OO v0.91.5 strength (non-empty assumed).
+oo_password_ok() {
+  local pw="$1"
+  local len=${#pw}
+  if (( len < 8 || len > 128 )); then
+    return 1
+  fi
+  # ASCII class checks — mirrors is_ascii_lowercase/uppercase/digit.
+  [[ "$pw" =~ [a-z] ]] || return 1
+  [[ "$pw" =~ [A-Z] ]] || return 1
+  [[ "$pw" =~ [0-9] ]] || return 1
+  # Anything not an ASCII letter/digit counts as special (symbols + non-ASCII).
+  [[ "$pw" =~ [^a-zA-Z0-9] ]] || return 1
+  return 0
+}
+
+# require_oo_password <VAR_NAME> <value>
+# Empty → 0 (defer to app boot). Non-empty violation → stderr + return 1.
+require_oo_password() {
+  local var="$1"
+  local value="${2-}"
+  if [[ -z "$value" ]]; then
+    return 0
+  fi
+  if oo_password_ok "$value"; then
+    return 0
+  fi
+  echo "error: ${var} does not meet OpenObserve v0.91.5 password policy: must be 8-128 characters and contain at least one lowercase letter, one uppercase letter, one digit, and one special character" >&2
+  return 1
+}

--- a/up.sh
+++ b/up.sh
@@ -148,7 +148,7 @@ fi
 
 # OpenObserve bootstrap passwords: fail before any bake/compose when a
 # non-empty value cannot satisfy the pinned OO image. Selective parse only —
-# never source .env. Empty values skip (app boot still refuses them).
+# do not shell-source the env file. Empty values skip (app boot still refuses them).
 # Lockstep with docker-compose.yml openobserve pin v0.91.5
 # (src/config/src/utils/password.rs). Update this rule when bumping the image.
 if [[ -f .env ]]; then

--- a/up.sh
+++ b/up.sh
@@ -58,6 +58,8 @@ done
 # ONE derivation, shared with the CI bring-up (ADR-0034; policy stays here)
 # shellcheck source=scripts/lib/stack_env.sh
 source "$(dirname "$0")/scripts/lib/stack_env.sh"
+# shellcheck source=scripts/lib/oo_password.sh
+source "$(dirname "$0")/scripts/lib/oo_password.sh"
 
 discover_docker_gid() {
   local gid=""
@@ -142,6 +144,24 @@ if [[ ! -f .env ]]; then
     echo "error: no .env and no .env.example — create .env with bootstrap passwords first" >&2
     exit 1
   fi
+fi
+
+# OpenObserve bootstrap passwords: fail before any bake/compose when a
+# non-empty value cannot satisfy the pinned OO image. Selective parse only —
+# never source .env. Empty values skip (app boot still refuses them).
+# Lockstep with docker-compose.yml openobserve pin v0.91.5
+# (src/config/src/utils/password.rs). Update this rule when bumping the image.
+if [[ -f .env ]]; then
+  _oo_root=""
+  _oo_ingest=""
+  while IFS= read -r line; do
+    case "$line" in
+      OO_ROOT_PASSWORD=*) _oo_root="${line#OO_ROOT_PASSWORD=}" ;;
+      OO_INGEST_PASSWORD=*) _oo_ingest="${line#OO_INGEST_PASSWORD=}" ;;
+    esac
+  done < <(grep -E '^(OO_ROOT_PASSWORD|OO_INGEST_PASSWORD)=' .env || true)
+  require_oo_password OO_ROOT_PASSWORD "$_oo_root" || exit 1
+  require_oo_password OO_INGEST_PASSWORD "$_oo_ingest" || exit 1
 fi
 
 if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -274,6 +294,7 @@ if [[ "$_ok" -eq 1 ]]; then
 else
   echo "── WARNING: app did not report live within ~60s. The stack is up," >&2
   echo "   but the app may be wedged — check: docker compose logs --tail=50 app" >&2
+  echo "   (OpenObserve crash-loop on a weak root password? also: docker compose logs openobserve)" >&2
 fi
 
 # Host baker: same machine and socket as today's bake — not a compose


### PR DESCRIPTION
## Intent

Fail `./up.sh` immediately when `OO_ROOT_PASSWORD` or `OO_INGEST_PASSWORD` cannot satisfy the password policy of the pinned OpenObserve image, and document that rule next to both vars in `.env.example`. Also hint `docker compose logs openobserve` when the app health gate times out (the historical symptom of an OO crash-loop on a weak root password).

Mission: https://linear.app/fidecastro/issue/CAKE-131/validate-openobserves-password-policy-in-upsh-and-document-it-in

## OpenObserve policy (source citation)

Pinned image: `public.ecr.aws/zinclabs/openobserve:v0.91.5` (`docker-compose.yml`).

Exact rule (tag `v0.91.5`):

> Password must be **8–128** characters and contain at least one **lowercase** letter, one **uppercase** letter, one **digit**, and one **special** character.

Sources:

- Policy module: https://github.com/openobserve/openobserve/blob/v0.91.5/src/config/src/utils/password.rs (`MIN_PASSWORD_LEN=8`, `MAX_PASSWORD_LEN=128`, `PASSWORD_POLICY_HINT`; special = any non-ASCII-letter/digit)
- Root-user enforcement at first boot: https://github.com/openobserve/openobserve/blob/v0.91.5/src/job/mod.rs — panics `ZO_ROOT_USER_PASSWORD is too weak: …` (crash-loop cause)

Empty values are **not** newly required by `up.sh`; composition validation skips empties and defers to app-boot `_refuse_insecure_passwords`. This gate is composition-only for non-empty OO passwords.

## Changes

- `scripts/lib/oo_password.sh` — `oo_password_ok` / `require_oo_password` (lockstep comment names `v0.91.5`)
- `up.sh` — selective `.env` parse (never shell-sources the env file) of the two OO passwords **before** bake/compose; health-gate timeout hint adds openobserve logs
- `.env.example` — composition rule comments next to `OO_ROOT_PASSWORD` and `OO_INGEST_PASSWORD`
- Tests: bash unit cases via pytest (`test_oo_password_policy.py`) + `test_up_sh_*` text asserts

## Review follow-up

Reworded the OO selective-parse comment so the contiguous substring `source .env` never appears in `up.sh` (matches CAKE-130's ban in `test_up_sh_hello_smoke_reads_admin_without_sourcing_env`; wording is now `do not shell-source the env file`).

## How to verify

```bash
# Unit + text asserts (rebakes app-test)
./scripts/pytest_app.sh \
  app/tests/test_oo_password_policy.py \
  app/tests/test_dev_factory.py::test_up_sh_validates_oo_passwords_before_bake_and_compose \
  app/tests/test_dev_factory.py::test_up_sh_health_gate_hints_openobserve_logs

# Manual reject path (all-hex fails in <1s naming the var + rule)
# Set OO_ROOT_PASSWORD=deadbeefcafebabe0123456789abcdef in .env, then:
./up.sh --dry-run
```

## Risk / rollout

- Existing compliant installs unchanged.
- Operators with all-hex / class-incomplete OO passwords will now fail at `./up.sh` instead of OO crash-looping behind a ~60s app health timeout.

## Out of scope

- App-boot `_refuse_insecure_passwords` deny-list / ADMIN length floor
- Bumping the OpenObserve image
- Validating non-OO bootstrap passwords against OO's rule