### PR TITLE
[CAKE-134] Ship baker launch-failure diagnostics to OpenObserve and the admin alert

### DIFF
--- a/admin/spa/src/lib/alerts.js
+++ b/admin/spa/src/lib/alerts.js
@@ -278,13 +278,18 @@ export default function deriveAlerts(health) {
   // honesty class as a tripped breaker: critical, not dismissable.
   const bake = health.bake_status || {};
   if (bake.baker_alive === false) {
+    const cause =
+      bake.state === "error" && bake.detail
+        ? ` ${String(bake.detail)}.`
+        : "";
     alerts.push({
       id: "baker-dead",
       severity: "critical",
       title: "Host baker is not running",
       body:
-        (bake.baker_detail ? `${bake.baker_detail}. ` : "") +
-        "Harness images will not compile. Restart with ./up.sh " +
+        (bake.baker_detail ? `${bake.baker_detail}.` : "") +
+        cause +
+        " Harness images will not compile. Restart with ./up.sh " +
         "(or ./up.sh --foreground-baker when the parent may reap detached " +
         "children). The baker is a host process started with the app, not a " +
         "container.",

--- a/admin/spa/tests/alerts.mjs
+++ b/admin/spa/tests/alerts.mjs
@@ -37,6 +37,42 @@ check("an alive baker does not warn", () => {
   assert.equal(alerts.some((a) => a.id === "baker-dead"), false);
 });
 
+// CAKE-134: launch-failure detail on /data must surface in the critical body.
+check("dead baker with error detail includes the launch-failure cause", () => {
+  const cause = "host baker died at launch: ModuleNotFoundError: No module named 'x'";
+  const alerts = deriveAlerts({
+    bake_status: {
+      baker_alive: false,
+      baker_detail: "host baker has not checked in",
+      state: "error",
+      detail: cause,
+    },
+  });
+  const hit = alerts.find((a) => a.id === "baker-dead");
+  assert.ok(hit, "baker-dead alert missing");
+  assert.equal(hit.severity, "critical");
+  assert.match(hit.body, /host baker has not checked in/);
+  assert.match(hit.body, /ModuleNotFoundError: No module named 'x'/);
+  assert.match(hit.body, /\.\/up\.sh/);
+  assert.match(hit.body, /\.\/up\.sh --foreground-baker/);
+  assert.equal(alerts.some((a) => a.id === "baker-error"), false);
+});
+
+check("dead baker without error detail stays generic", () => {
+  const alerts = deriveAlerts({
+    bake_status: {
+      baker_alive: false,
+      baker_detail: "host baker last checked in 41s ago",
+    },
+  });
+  const hit = alerts.find((a) => a.id === "baker-dead");
+  assert.ok(hit, "baker-dead alert missing");
+  assert.match(hit.body, /host baker last checked in 41s ago/);
+  assert.match(hit.body, /\.\/up\.sh/);
+  assert.doesNotMatch(hit.body, /host baker died at launch/);
+  assert.doesNotMatch(hit.body, /ModuleNotFoundError/);
+});
+
 check("circuit breaker stays critical red in the same list", () => {
   const alerts = deriveAlerts({
     bake_status: { baker_alive: false, baker_detail: "gone" },

--- a/app/tests/test_baker_spans.py
+++ b/app/tests/test_baker_spans.py
@@ -81,3 +81,18 @@ def test_replay_puts_claim_and_probe_on_the_same_trace(monkeypatch):
     probe = next(s for s in finished if s.name == "baker.probe.http_401")
     assert probe.attributes["devcake.baker.cause"] == "auth"
     assert probe.status.status_code.name == "ERROR"
+
+
+def test_replay_ignores_launch_failed_non_span_records(monkeypatch):
+    """CAKE-134: outbox launch_failed is OO-only; replay must not raise."""
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    from devcake.bake_status import replay_baker_spans
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    replay_baker_spans(
+        [{"event": "launch_failed", "detail": "host crash", "ts": "t"}],
+        provider.get_tracer("test"),
+    )
+    assert list(exporter.get_finished_spans()) == []

--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -961,6 +961,137 @@ main() {{
     assert "--foreground-baker" in result.stderr
 
 
+def _baker_host_docker_stub_body(data_root: Path, *, fail: bool = False) -> str:
+    """Shell body fragment: stub `docker compose exec -T app` into data_root."""
+    root = data_root.as_posix()
+    if fail:
+        return f"""
+docker() {{
+  echo "docker stub forced failure: $*" >&2
+  return 1
+}}
+"""
+    return f"""
+DATA_ROOT="{root}"
+docker() {{
+  if [[ "${{1:-}}" != "compose" || "${{2:-}}" != "exec" \\
+        || "${{3:-}}" != "-T" || "${{4:-}}" != "app" ]]; then
+    echo "unexpected docker $*" >&2
+    return 1
+  fi
+  shift 4
+  case "${{1:-}}" in
+    mkdir)
+      local path=""
+      for a in "$@"; do
+        if [[ "$a" == /data/* ]]; then path="$a"; fi
+      done
+      [[ -n "$path" ]] || return 1
+      mkdir -p "$DATA_ROOT/${{path#/data/}}"
+      return 0
+      ;;
+    tee)
+      local dest="${{2:-}}"
+      [[ "$dest" == /data/* ]] || return 1
+      local rel="${{dest#/data/}}"
+      mkdir -p "$(dirname "$DATA_ROOT/$rel")"
+      cat > "$DATA_ROOT/$rel"
+      return 0
+      ;;
+    *)
+      echo "unexpected docker compose exec app $*" >&2
+      return 1
+      ;;
+  esac
+}}
+"""
+
+
+def test_baker_host_liveness_failure_emits_outbox_and_error_status(tmp_path):
+    """CAKE-134: launch death ships outbox + honest error status (no heartbeat)."""
+    import json
+
+    logfile = tmp_path / "watch.log"
+    pidfile = tmp_path / "watch.pid"
+    data_root = tmp_path / "container_data"
+    data_root.mkdir()
+    launch = "nohup python3 -m dev_factory &"
+    logfile.write_text(
+        "Traceback (most recent call last):\n"
+        "  File \"<stdin>\", line 1, in <module>\n"
+        "ModuleNotFoundError: No module named 'missing_pkg'\n"
+    )
+    pidfile.write_text("8\n")
+    stub = _baker_host_docker_stub_body(data_root)
+    result = _run_baker_host_driver(tmp_path, f"""
+{stub}
+kill() {{
+  if [[ "${{1:-}}" == "-0" ]]; then return 1; fi
+  return 0
+}}
+sleep() {{ :; }}
+tail() {{ command tail "$@"; }}
+main() {{
+  set +e
+  devcake_baker_wait_liveness 8 "{logfile}" "{pidfile}" "{launch}" 4
+  echo "rc=$?"
+}}
+""")
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "rc=1" in result.stdout
+    assert f"launch: {launch}" in result.stderr
+    assert "--foreground-baker" in result.stderr
+
+    outbox = data_root / "harness_outbox"
+    assert outbox.is_dir(), result.stderr + result.stdout
+    failed = list(outbox.glob("*-launch_failed.jsonl"))
+    assert len(failed) == 1, failed
+    line = failed[0].read_text().strip()
+    assert "\n" not in line
+    rec = json.loads(line)
+    assert rec["event"] == "launch_failed"
+    assert isinstance(rec["ts"], str) and "T" in rec["ts"]
+    assert isinstance(rec["detail"], str)
+    assert launch in rec["detail"]
+    assert "ModuleNotFoundError: No module named 'missing_pkg'" in rec["detail"]
+    assert len(rec["detail"]) <= 2000
+
+    status_path = data_root / "harness_bake_status.json"
+    assert status_path.is_file(), result.stderr
+    status = json.loads(status_path.read_text())
+    assert status["state"] == "error"
+    assert "heartbeat_at" not in status
+    assert str(status["detail"]).startswith("host baker died at launch:")
+    assert "ModuleNotFoundError" in status["detail"] or "Traceback" in status["detail"]
+
+
+def test_baker_host_liveness_failure_emit_is_best_effort(tmp_path):
+    """Docker write failures must not mask diagnostics or change rc=1."""
+    logfile = tmp_path / "watch.log"
+    pidfile = tmp_path / "watch.pid"
+    logfile.write_text("boom\n")
+    pidfile.write_text("9\n")
+    stub = _baker_host_docker_stub_body(tmp_path / "unused", fail=True)
+    result = _run_baker_host_driver(tmp_path, f"""
+{stub}
+kill() {{
+  if [[ "${{1:-}}" == "-0" ]]; then return 1; fi
+  return 0
+}}
+sleep() {{ :; }}
+tail() {{ command tail "$@"; }}
+main() {{
+  set +e
+  devcake_baker_wait_liveness 9 "{logfile}" "{pidfile}" "nohup python3 -m dev_factory &" 4
+  echo "rc=$?"
+}}
+""")
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "rc=1" in result.stdout
+    assert "launch: nohup python3 -m dev_factory &" in result.stderr
+    assert "--foreground-baker" in result.stderr
+
+
 def test_up_sh_bake_invokes_hello_dispatch_smoke():
     """CAKE-130: --bake proves Dagu→Dev dispatch via ci_dispatch_hello.sh."""
     text = _up_sh_text()

--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -1020,6 +1020,7 @@ def test_baker_host_liveness_failure_emits_outbox_and_error_status(tmp_path):
         "Traceback (most recent call last):\n"
         "  File \"<stdin>\", line 1, in <module>\n"
         "ModuleNotFoundError: No module named 'missing_pkg'\n"
+        + "A" * 3000 + "\n"  # single oversized line — the 2000 cap must be total
     )
     pidfile.write_text("8\n")
     stub = _baker_host_docker_stub_body(data_root)
@@ -1054,7 +1055,7 @@ main() {{
     assert isinstance(rec["detail"], str)
     assert launch in rec["detail"]
     assert "ModuleNotFoundError: No module named 'missing_pkg'" in rec["detail"]
-    assert len(rec["detail"]) <= 2000
+    assert len(rec["detail"]) == 2000  # input exceeds the cap → exact truncation
 
     status_path = data_root / "harness_bake_status.json"
     assert status_path.is_file(), result.stderr

--- a/scripts/lib/baker_host.sh
+++ b/scripts/lib/baker_host.sh
@@ -48,7 +48,6 @@ devcake_baker_emit_launch_failure() {
     status_detail="host baker died at launch: ${first_line}"
     outbox_detail="$(printf 'launch: %s\n\n--- watch.log (last 15 lines) ---\n%s' \
       "$launch_cmd" "$excerpt")"
-    outbox_detail="$(printf '%s' "$outbox_detail" | cut -c1-2000)"
     ns="$(date +%s%N 2>/dev/null || date +%s)"
     outbox_json="$(DETAIL="$outbox_detail" python3 -c '
 import json, os
@@ -56,7 +55,8 @@ from datetime import datetime, timezone
 print(json.dumps({
     "ts": datetime.now(timezone.utc).isoformat(),
     "event": "launch_failed",
-    "detail": os.environ["DETAIL"],
+    # Total cap, character-safe (shell cut -c on multiline input caps per line)
+    "detail": os.environ["DETAIL"][:2000],
 }, separators=(",", ":")))
 ' 2>/dev/null)" || return 0
     status_json="$(DETAIL="$status_detail" python3 -c '

--- a/scripts/lib/baker_host.sh
+++ b/scripts/lib/baker_host.sh
@@ -29,6 +29,53 @@ devcake_baker_prepare_pidfile() {
   rm -f "$pidfile"
 }
 
+# Best-effort: push launch-failure evidence into the app /data mailbox so
+# OpenObserve (outbox drain) and the admin dead-baker alert (bake status)
+# see why the baker died. Never stamps heartbeat_at — liveness stays false.
+# Failures of docker/python here must not change the caller's exit path.
+#
+# Usage: devcake_baker_emit_launch_failure <logfile> <launch_cmd>
+devcake_baker_emit_launch_failure() {
+  local logfile="$1" launch_cmd="$2"
+  (
+    set +e
+    local excerpt first_line outbox_detail status_detail ns outbox_json status_json
+    excerpt="$(tail -n 15 "$logfile" 2>/dev/null || true)"
+    first_line="$(printf '%s\n' "$excerpt" | sed '/^[[:space:]]*$/d' | head -n 1)"
+    [[ -n "$first_line" ]] || first_line="(no log output)"
+    # Cap short status detail to one line / sane length.
+    first_line="$(printf '%s' "$first_line" | tr '\n' ' ' | cut -c1-200)"
+    status_detail="host baker died at launch: ${first_line}"
+    outbox_detail="$(printf 'launch: %s\n\n--- watch.log (last 15 lines) ---\n%s' \
+      "$launch_cmd" "$excerpt")"
+    outbox_detail="$(printf '%s' "$outbox_detail" | cut -c1-2000)"
+    ns="$(date +%s%N 2>/dev/null || date +%s)"
+    outbox_json="$(DETAIL="$outbox_detail" python3 -c '
+import json, os
+from datetime import datetime, timezone
+print(json.dumps({
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "event": "launch_failed",
+    "detail": os.environ["DETAIL"],
+}, separators=(",", ":")))
+' 2>/dev/null)" || return 0
+    status_json="$(DETAIL="$status_detail" python3 -c '
+import json, os
+print(json.dumps({
+    "state": "error",
+    "detail": os.environ["DETAIL"],
+}, separators=(",", ":")))
+' 2>/dev/null)" || return 0
+    [[ -n "$outbox_json" && -n "$status_json" ]] || return 0
+    docker compose exec -T app mkdir -p /data/harness_outbox >/dev/null 2>&1 || true
+    printf '%s\n' "$outbox_json" \
+      | docker compose exec -T app tee \
+          "/data/harness_outbox/${ns}-launch_failed.jsonl" >/dev/null 2>&1 || true
+    printf '%s\n' "$status_json" \
+      | docker compose exec -T app tee /data/harness_bake_status.json >/dev/null 2>&1 || true
+  ) || true
+}
+
 # Confirm a detached baker stays alive and its log progresses for ~seconds.
 # Requires PID alive AND logfile size growth past the pre-launch baseline
 # (stdout/stderr → watch.log). Pass baseline_bytes from BEFORE launch so the
@@ -56,6 +103,7 @@ devcake_baker_wait_liveness() {
       echo "   last log lines (${logfile}):" >&2
       tail -n 40 "$logfile" 2>/dev/null >&2 || true
       echo "   tip: retry with ./up.sh --foreground-baker when the parent reaps detached children" >&2
+      devcake_baker_emit_launch_failure "$logfile" "$launch_cmd"
       return 1
     fi
     size=$(wc -c <"$logfile" 2>/dev/null | tr -d ' ' || echo 0)
@@ -70,5 +118,6 @@ devcake_baker_wait_liveness() {
   echo "   last log lines (${logfile}):" >&2
   tail -n 40 "$logfile" 2>/dev/null >&2 || true
   echo "   tip: retry with ./up.sh --foreground-baker when the parent reaps detached children" >&2
+  devcake_baker_emit_launch_failure "$logfile" "$launch_cmd"
   return 1
 }


### PR DESCRIPTION
## Intent

When the host baker dies during `up.sh` post-launch liveness confirmation, push the same crash evidence the terminal already prints into the existing baker mailbox and bake-status file so OpenObserve and the admin critical alert show **why** it died.

Mission: https://linear.app/fidecastro/issue/CAKE-134/ship-baker-launch-failure-diagnostics-to-openobserve-and-the-admin

## What changed

- `scripts/lib/baker_host.sh`: on liveness failure, best-effort `devcake_baker_emit_launch_failure` writes:
  - one `/data/harness_outbox/<ns>-launch_failed.jsonl` record (`event: launch_failed`, launch cmd + last 15 log lines, detail capped at 2000 chars)
  - `/data/harness_bake_status.json` with `state: error`, one-line `detail`, **no** `heartbeat_at` (honest dead liveness)
- `admin/spa/src/lib/alerts.js`: dead-baker critical body appends `bake.detail` when `state === "error"`
- Tests: shell-stub emit shapes + best-effort docker failure; alerts.mjs with/without detail; replay ignores non-span `launch_failed`

## App / baker Python

No production app or baker Python changes (drain already ships all outbox dicts; `replay_baker_spans` already filters `event == "span"`).

## How to verify

```bash
node admin/spa/tests/alerts.mjs
./scripts/pytest_app.sh tests/test_dev_factory.py tests/test_baker_spans.py tests/test_bake_status.py
```

## Out of scope

Full `watch.log` upload; baker atexit/dying-words; launchd/systemd; changing `baker.dead` span attribute sourcing.