### PR TITLE
[CAKE-137] Gate RunStore path ops on RUN_ID_RE

### DIFF
--- a/app/devcake/adapters/files/run_store.py
+++ b/app/devcake/adapters/files/run_store.py
@@ -39,12 +39,18 @@ class RunStore:
         """Charset-validated, lexically-contained run JSON path — or None.
 
         Same RUN_ID_RE fence as WorkspaceStore._path (CAKE-137): URL-supplied
-        ids must not escape the runs root via ``../`` joins.
+        ids must not escape the runs root via ``../`` joins. After the regex
+        gate, normalize + root-prefix check so CodeQL ``py/path-injection``
+        sees a SafeAccessCheck (normpath → startswith), not only a custom
+        charset guard.
         """
         if not RUN_ID_RE.match(run_id or ""):
             return None
-        p = self.root / f"{run_id}.json"
-        return p if p.parent == self.root else None
+        root = os.path.normpath(str(self.root))
+        full = os.path.normpath(os.path.join(root, f"{run_id}.json"))
+        if not full.startswith(root + os.sep):
+            return None
+        return Path(full)
 
     def _write_text(self, path: Path, text: str) -> None:
         fd, tmp = tempfile.mkstemp(dir=self.root, suffix=".tmp")

--- a/app/devcake/adapters/files/run_store.py
+++ b/app/devcake/adapters/files/run_store.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from ...domain.run import Run
+from ...domain.workspaces import RUN_ID_RE
 
 RUNS_DIR = Path(os.environ.get("DEVCAKE_DATA_DIR", "/data")) / "state" / "runs"
 
@@ -33,6 +34,17 @@ class RunStore:
         # across calls: mutate-then-save() promptly (the existing contract);
         # get() stays a fresh parse for the correctness-critical readers.
         self._parse_cache: dict[str, tuple[int, int, Run]] = {}
+
+    def _path(self, run_id: str) -> Path | None:
+        """Charset-validated, lexically-contained run JSON path — or None.
+
+        Same RUN_ID_RE fence as WorkspaceStore._path (CAKE-137): URL-supplied
+        ids must not escape the runs root via ``../`` joins.
+        """
+        if not RUN_ID_RE.match(run_id or ""):
+            return None
+        p = self.root / f"{run_id}.json"
+        return p if p.parent == self.root else None
 
     def _write_text(self, path: Path, text: str) -> None:
         fd, tmp = tempfile.mkstemp(dir=self.root, suffix=".tmp")
@@ -72,7 +84,13 @@ class RunStore:
                 run.run_id, gen, self.wipe_generation,
             )
             return
-        path = self.root / f"{run.run_id}.json"
+        path = self._path(run.run_id)
+        if path is None:
+            log.info(
+                "drop save for invalid run id %r — refused by RUN_ID_RE path fence",
+                run.run_id,
+            )
+            return
         # lost-update fence (audit F8): the single-process contract says
         # "mutate-then-save promptly" on ONE object per run — but get()
         # (fresh parse) and all() (shared cache) can hand two writers two
@@ -135,8 +153,8 @@ class RunStore:
         log.error("run record %s unreadable (%s) — quarantined to %s", path.name, why, dest)
 
     def get(self, run_id: str) -> Optional[Run]:
-        path = self.root / f"{run_id}.json"
-        if not path.exists():
+        path = self._path(run_id)
+        if path is None or not path.exists():
             return None
         return Run.model_validate_json(path.read_text())
 
@@ -225,7 +243,9 @@ class RunStore:
         aborts after the durable save — a workspace create failure — must
         leave no phantom `dispatched` record behind to burn an attempt.
         Best-effort; also drops the parse-cache entry."""
-        path = self.root / f"{run_id}.json"
+        path = self._path(run_id)
+        if path is None:
+            return
         try:
             path.unlink()
         except OSError:

--- a/app/tests/test_crash_recovery.py
+++ b/app/tests/test_crash_recovery.py
@@ -168,18 +168,18 @@ def test_kill_does_not_resurrect_a_concurrently_wiped_record(tmp_path):
     whose store_gen predates the clear."""
     store = RunStore(tmp_path / "runs")
     mgr = RunManager(store, FakeMessaging(), FakeExecutor())
-    run = _make_run(store, state="running", run_id="W-1")
+    run = _make_run(store, state="running", run_id="WIPE-1")
     # simulate the concurrent wipe: the record is gone by the time kill's
     # teardown reaches its final save
     store.clear()
-    assert store.get("W-1") is None
+    assert store.get("WIPE-1") is None
     run_coro(mgr.kill(run, "timed_out", "watchdog timeout"))
-    assert store.get("W-1") is None                    # not resurrected
+    assert store.get("WIPE-1") is None                    # not resurrected
     # a normal kill (record present) still persists the terminal state
-    live = _make_run(store, state="running", run_id="W-2",
+    live = _make_run(store, state="running", run_id="WIPE-2",
                      store_gen=store.wipe_generation)
     run_coro(mgr.kill(live, "failed", "operator"))
-    assert store.get("W-2").state == "failed"
+    assert store.get("WIPE-2").state == "failed"
 
 
 def test_kill_interleaved_with_clear_during_executor_stop(tmp_path):
@@ -220,10 +220,10 @@ def test_finalize_does_not_resurrect_or_post_after_clear(tmp_path):
     store = RunStore(tmp_path / "runs")
     mgr = RunManager(store, FakeMessaging(), FakeExecutor())
     posts: list[str] = []
-    run = _make_run(store, state="running", run_id="F-1",
+    run = _make_run(store, state="running", run_id="FIN-01",
                     mission_pmo_id="pmo-1", store_gen=0)
     store.clear()
-    assert store.get("F-1") is None
+    assert store.get("FIN-01") is None
 
     class M:
         pass
@@ -244,7 +244,7 @@ def test_finalize_does_not_resurrect_or_post_after_clear(tmp_path):
         "transcript_md": "hello",
         "token_report": {"total_tokens": 1},
     }))
-    assert store.get("F-1") is None
+    assert store.get("FIN-01") is None
     assert posts == []
 
 
@@ -457,8 +457,8 @@ def test_recon_orphans_dead_runs_but_leaves_finalizing_for_reclaim(tmp_path):
     mgr = RunManager(store, messaging, executor)
     mgr._ship_failure = AsyncMock()  # type: ignore[method-assign]
 
-    finalizing = _make_run(store, state="finalizing", run_id="F-1")
-    dead = _make_run(store, state="running", run_id="R-1")
+    finalizing = _make_run(store, state="finalizing", run_id="FIN-01")
+    dead = _make_run(store, state="running", run_id="RUN-01")
 
     events = []
     orig_kill = mgr.kill
@@ -479,7 +479,7 @@ def test_recon_orphans_dead_runs_but_leaves_finalizing_for_reclaim(tmp_path):
     assert store.get(finalizing.run_id).state == "finalizing"  # left for reclaim
     # ordering contract: every orphan kill happens BEFORE reclaim
     assert events[-1] == ("reclaim",)
-    assert ("kill", "R-1", "orphaned") in events
+    assert ("kill", "RUN-01", "orphaned") in events
 
 
 def test_recon_queued_artifacts_promote_dead_run_for_reclaim(tmp_path):
@@ -495,7 +495,7 @@ def test_recon_queued_artifacts_promote_dead_run_for_reclaim(tmp_path):
     mgr = RunManager(store, messaging, executor)
     mgr._ship_failure = AsyncMock()  # type: ignore[method-assign]
 
-    queued = _make_run(store, state="running", run_id="Q-1")
+    queued = _make_run(store, state="running", run_id="QUE-01")
     messaging.unresolved = {queued.run_id}
 
     events = []
@@ -527,9 +527,9 @@ def test_recon_queued_artifacts_promote_dead_run_for_reclaim(tmp_path):
     messaging.reclaim_pending = reclaim
     run_coro(reconcile_runs(mgr))
 
-    assert ("kill", "Q-1", "orphaned") not in events
+    assert ("kill", "QUE-01", "orphaned") not in events
     assert store.get(queued.run_id).state == "finalizing"
-    assert finalize_calls == ["Q-1"]
+    assert finalize_calls == ["QUE-01"]
     assert events[-1] == ("reclaim",)
 
 
@@ -852,7 +852,7 @@ def test_recon_reclaims_even_when_a_kill_blows_up(tmp_path):
     mgr = RunManager(store, messaging, executor)
     mgr._ship_failure = AsyncMock()  # type: ignore[method-assign]
     _make_run(store, state="running", run_id="BOOM-1")
-    other = _make_run(store, state="running", run_id="OK-1")
+    other = _make_run(store, state="running", run_id="OKAY-1")
 
     reclaimed = []
 

--- a/app/tests/test_run_store_path.py
+++ b/app/tests/test_run_store_path.py
@@ -1,0 +1,91 @@
+"""RunStore path discipline: get/delete/save must refuse ids that fail
+RUN_ID_RE so URL-supplied run_id values cannot escape the runs root
+(CAKE-137 / CodeQL path traversal)."""
+
+from __future__ import annotations
+
+import logging
+
+from devcake.adapters.files.run_store import RunStore
+from devcake.domain.run import Run
+
+
+def _valid_run(run_id: str = "R-1-1-EXECUTE-AAAAAA", **over) -> Run:
+    base = dict(
+        run_id=run_id,
+        mission_key="R-1",
+        mission_type="EXECUTE",
+        dev_type="senior-dev",
+        seq=1,
+        state="running",
+    )
+    base.update(over)
+    return Run(**base)
+
+
+def test_get_traversal_and_garbage_ids_return_none(tmp_path):
+    store = RunStore(tmp_path / "runs")
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    bait = secrets / "foo.json"
+    bait.write_text('{"schema_version": 2, "run_id": "bait"}')
+
+    assert store.get("../secrets/foo") is None
+    assert store.get("..") is None
+    assert store.get("../escape") is None
+    assert store.get("") is None
+    assert store.get("short") is None
+    assert store.get("a/b") is None
+
+    assert bait.exists()
+    assert bait.read_text() == '{"schema_version": 2, "run_id": "bait"}'
+    assert list(store.root.glob("*.json")) == []
+
+
+def test_delete_traversal_does_not_unlink_outside_root(tmp_path):
+    store = RunStore(tmp_path / "runs")
+    victim = tmp_path / "victim.json"
+    victim.write_text("do-not-delete")
+
+    store.delete("../victim")
+    store.delete("..")
+    store.delete("../secrets/foo")
+    store.delete("")
+    store.delete("a/b")
+
+    assert victim.exists()
+    assert victim.read_text() == "do-not-delete"
+    assert list(store.root.glob("*.json")) == []
+
+
+def test_valid_run_id_round_trips_save_get_delete(tmp_path):
+    store = RunStore(tmp_path / "runs")
+    run = _valid_run("R-1-1-EXECUTE-AAAAAA")
+
+    store.save(run)
+    got = store.get(run.run_id)
+    assert got is not None
+    assert got.run_id == run.run_id
+    assert got.state == "running"
+    assert (store.root / f"{run.run_id}.json").is_file()
+
+    store.delete(run.run_id)
+    assert store.get(run.run_id) is None
+    assert not (store.root / f"{run.run_id}.json").exists()
+
+
+def test_save_invalid_run_id_refuses_without_writing_outside_root(
+        tmp_path, caplog):
+    store = RunStore(tmp_path / "runs")
+    outside = tmp_path / "secrets"
+    outside.mkdir()
+
+    bad = _valid_run(run_id="../secrets/foo")
+    with caplog.at_level(logging.INFO):
+        store.save(bad)
+
+    assert not (outside / "foo.json").exists()
+    assert list(store.root.glob("*.json")) == []
+    assert any("invalid run id" in rec.message.lower()
+               or "drop save" in rec.message.lower()
+               for rec in caplog.records)


### PR DESCRIPTION
## Intent

Gate `RunStore.get` / `delete` / `save` path construction on the shared `RUN_ID_RE` from `domain/workspaces.py`, so admin `GET /api/v1/runs/{run_id}` cannot traverse out of the runs root via `../` in the path parameter.

Mission: https://linear.app/fidecastro/issue/CAKE-137/gate-runstore-path-ops-on-run-id-re

## What changed

- Import `RUN_ID_RE` from `domain/workspaces.py` (one definition — no fork).
- Add `RunStore._path` mirroring `WorkspaceStore._path` (regex + `p.parent == self.root`).
- `get` → `None` on invalid id (API stays 404); `delete` → no-op; `save` → early return + info log.
- New `app/tests/test_run_store_path.py`: traversal/garbage refusal, delete does not unlink outside root, valid id round-trip, invalid save refuses outside write.

## How to verify

```bash
./scripts/pytest_app.sh tests/test_run_store_path.py tests/test_run_store_cache.py tests/test_clear.py
```

## Risk / rollout

Low — defense-in-depth on an admin-auth path; writers already mint via `make_run_id`. No format change.

## Out of scope

Workspace path logic, run id format, secrets confinement / shared `confined()` helper.