### PR TITLE
[CAKE-135] Harden prompt-template DELETE against path traversal

### DIFF
--- a/app/devcake/api/devtypes_service.py
+++ b/app/devcake/api/devtypes_service.py
@@ -80,7 +80,9 @@ async def put_devtype_prompt(dev_type: str, name: str, body: dict, *,
     return {"dev_type": dev_type, "name": name, "saved": True}
 
 
-async def delete_devtype_prompt(dev_type: str, name: str, *, config):
+async def delete_devtype_prompt(dev_type: str, name: str, *, config, dev_types):
+    if dev_type not in dev_types:
+        raise HTTPException(404, f"no Dev Type named {dev_type!r}")
     active = config.active_devtype_prompts.get(dev_type, "Development")
     if active == name or (name == "Development" and active in ("Development",)):
         raise HTTPException(409, f"template {name!r} is ACTIVE for "
@@ -89,6 +91,8 @@ async def delete_devtype_prompt(dev_type: str, name: str, *, config):
         prompt_templates.delete_devtype_prompt(dev_type, name)
     except FileNotFoundError as e:
         raise HTTPException(404, str(e))
+    except ValueError as e:
+        raise HTTPException(422, str(e))
     return {"deleted": True}
 
 

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -603,8 +603,9 @@ async def put_devtype_prompt(dev_type: str, name: str, body: dict):
 
 @app.delete("/api/v1/devtype-prompts/{dev_type}/{name}")
 async def delete_devtype_prompt(dev_type: str, name: str):
-    return await devtypes_service.delete_devtype_prompt(dev_type, name,
-                                                        config=svc().config)
+    s = svc()
+    return await devtypes_service.delete_devtype_prompt(
+        dev_type, name, config=s.config, dev_types=s.dev_types)
 
 
 @app.get("/api/v1/harnesses")

--- a/app/devcake/prompts/templates.py
+++ b/app/devcake/prompts/templates.py
@@ -139,7 +139,17 @@ def delete_template(mission_type: str, name: str) -> None:
     _require_type(mission_type)
     if name in _builtins() or name == "default":
         raise ValueError(f"{name!r} is a built-in preset and cannot be deleted")
-    path = _dir(mission_type) / f"{name}.yaml"
+    if not _NAME_RE.fullmatch(name):
+        raise ValueError("template name must match "
+                         "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
+    root = _dir(mission_type).resolve()
+    path = root / f"{name}.yaml"
+    try:
+        path.resolve().relative_to(root)
+    except ValueError as e:
+        raise ValueError(
+            f"template path escapes {mission_type!r} template directory"
+        ) from e
     if not path.exists():
         raise FileNotFoundError(f"no template {mission_type}/{name}")
     path.unlink()
@@ -290,8 +300,23 @@ def save_devtype_prompt(dev_type: str, name: str, text: str) -> None:
                   "name": name, "template": text})
 
 
+_DEV_TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+
 def delete_devtype_prompt(dev_type: str, name: str) -> None:
-    path = _dev_dir(dev_type) / f"{name}.yaml"
+    if not _DEV_TYPE_NAME_RE.fullmatch(dev_type or ""):
+        raise ValueError("dev_type must match ^[A-Za-z0-9][A-Za-z0-9_-]*$")
+    if not _NAME_RE.fullmatch(name):
+        raise ValueError("template name must match "
+                         "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
+    root = _dev_dir(dev_type).resolve()
+    path = root / f"{name}.yaml"
+    try:
+        path.resolve().relative_to(root)
+    except ValueError as e:
+        raise ValueError(
+            f"template path escapes {dev_type!r} template directory"
+        ) from e
     if not path.exists():
         raise FileNotFoundError(f"no template {dev_type}/{name}")
     path.unlink()

--- a/app/tests/test_prompt_template_delete_traversal.py
+++ b/app/tests/test_prompt_template_delete_traversal.py
@@ -1,0 +1,127 @@
+"""Path-injection hardening on prompt-template DELETE (CAKE-135).
+
+Save paths already gate names with _NAME_RE; delete paths must refuse
+traversal names / invalid Dev Type names and must not unlink outside the
+intended template subdirectory.
+"""
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+
+def run_coro(c):
+    return asyncio.new_event_loop().run_until_complete(c)
+
+
+def _tpl(monkeypatch, tmp_path):
+    import devcake.config as config_mod
+    monkeypatch.setattr(config_mod, "CONFIG_PATH",
+                        tmp_path / "config" / "config.yaml")
+    from devcake.prompts import templates
+    return templates
+
+
+def test_delete_devtype_prompt_refuses_parent_dev_type_escape(monkeypatch, tmp_path):
+    """dev_type='..' must not resolve to /data/config/{name}.yaml and unlink.
+
+    The escape only resolves when the templates root exists (POSIX needs the
+    intermediate dir to walk `..`); create it so the pre-fix path would
+    reach the sentinel.
+    """
+    t = _tpl(monkeypatch, tmp_path)
+    config_dir = tmp_path / "config"
+    (config_dir / "devtype_prompt_templates").mkdir(parents=True)
+    sentinel = config_dir / "config.yaml"
+    sentinel.write_text("schema_version: 1\nkeep: me\n")
+
+    with pytest.raises(ValueError):
+        t.delete_devtype_prompt("..", "config")
+
+    assert sentinel.exists()
+    assert "keep: me" in sentinel.read_text()
+
+
+def test_delete_devtype_prompt_refuses_slash_and_dotdot_name(monkeypatch, tmp_path):
+    t = _tpl(monkeypatch, tmp_path)
+    root = tmp_path / "config" / "devtype_prompt_templates"
+    (root / "judgment").mkdir(parents=True)
+    sentinel = root / "evil.yaml"
+    sentinel.write_text("sentinel\n")
+    # name with slash / .. would escape the per-dev-type dir
+    for bad in ("../evil", "a/b"):
+        with pytest.raises(ValueError):
+            t.delete_devtype_prompt("judgment", bad)
+    assert sentinel.exists()
+
+
+def test_delete_template_refuses_slash_and_dotdot_name(monkeypatch, tmp_path):
+    t = _tpl(monkeypatch, tmp_path)
+    t.seed_default_templates()
+    base = tmp_path / "config" / "prompt_templates"
+    sentinel = base / "evil.yaml"
+    sentinel.write_text("sentinel\n")
+    for bad in ("../evil", "a/b"):
+        with pytest.raises(ValueError):
+            t.delete_template("EXECUTE", bad)
+    assert sentinel.exists()
+    # builtins under EXECUTE must still be present
+    assert (base / "EXECUTE" / "Development.yaml").exists()
+
+def test_delete_template_happy_path(monkeypatch, tmp_path):
+    t = _tpl(monkeypatch, tmp_path)
+    t.seed_default_templates()
+    t.save_template("EXECUTE", "terse", "just {key} on {branch}")
+    path = (tmp_path / "config" / "prompt_templates" / "EXECUTE" / "terse.yaml")
+    assert path.exists()
+    t.delete_template("EXECUTE", "terse")
+    assert not path.exists()
+
+
+def test_delete_devtype_prompt_happy_path(monkeypatch, tmp_path):
+    from devcake.config import DevType
+    t = _tpl(monkeypatch, tmp_path)
+    dts = {"judgment": DevType(name="judgment", harness_template="claude-code",
+                               identifying_prompt="You are judgment.")}
+    t.seed_devtype_prompts(dts)
+    t.save_devtype_prompt("judgment", "custom", "Custom identifying text.")
+    path = (tmp_path / "config" / "devtype_prompt_templates" / "judgment"
+            / "custom.yaml")
+    assert path.exists()
+    t.delete_devtype_prompt("judgment", "custom")
+    assert not path.exists()
+
+
+def test_api_delete_devtype_prompt_unknown_dev_type_404(monkeypatch, tmp_path):
+    """API DELETE must mirror PUT: unknown / traversal-shaped dev_type → 404."""
+    from devcake.api import devtypes_service
+    from devcake.config import AppConfig, DevType
+
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    dts = {"judgment": DevType(name="judgment", harness_template="claude-code")}
+    cfg = AppConfig()
+
+    with pytest.raises(HTTPException) as e:
+        run_coro(devtypes_service.delete_devtype_prompt(
+            "ghost-dev", "custom", config=cfg, dev_types=dts))
+    assert e.value.status_code == 404
+
+    with pytest.raises(HTTPException) as e:
+        run_coro(devtypes_service.delete_devtype_prompt(
+            "..", "config", config=cfg, dev_types=dts))
+    assert e.value.status_code == 404
+
+
+def test_api_delete_devtype_prompt_bad_name_422(monkeypatch, tmp_path):
+    from devcake.api import devtypes_service
+    from devcake.config import AppConfig, DevType
+
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    dts = {"judgment": DevType(name="judgment", harness_template="claude-code")}
+    cfg = AppConfig()
+
+    with pytest.raises(HTTPException) as e:
+        run_coro(devtypes_service.delete_devtype_prompt(
+            "judgment", "../evil", config=cfg, dev_types=dts))
+    assert e.value.status_code == 422


### PR DESCRIPTION
## Summary

Close path-injection on prompt-template **DELETE** paths (`delete_template` and `delete_devtype_prompt`). Save paths already validated names; delete did not. An authenticated admin DELETE must not unlink files outside the intended template subdirectory via `..` / slash segments.

Mission: https://linear.app/fidecastro/issue/CAKE-135/harden-prompt-template-delete-against-path-traversal

## Changes

- `delete_template`: `_NAME_RE` before join + `resolve().relative_to(intended_root)` confinement
- `delete_devtype_prompt`: DevType charset on `dev_type`, `_NAME_RE` on `name`, same confinement
- API `delete_devtype_prompt`: require `dev_type in dev_types` (404), map `ValueError` → 422; `main.py` forwards `dev_types=`

## CodeQL alerts closed

- https://github.com/flieber-inc/devcake/security/code-scanning/56
- https://github.com/flieber-inc/devcake/security/code-scanning/57
- https://github.com/flieber-inc/devcake/security/code-scanning/58
- https://github.com/flieber-inc/devcake/security/code-scanning/59

## Verification

```bash
./scripts/pytest_app.sh app/tests/test_prompt_template_delete_traversal.py app/tests/test_prompt_templates.py
# or: docker run … app-test pytest tests/test_prompt_template_delete_traversal.py tests/test_prompt_templates.py
```

Observed locally (rebaked `app-test`): **25 passed** (7 new traversal + existing prompt-template suite).

## Out of scope

- Shared `confined()` helper / secrets.py / RunStore / Dev Type `shutil` moves
- Unrelated CodeQL alerts