### PR TITLE
[CAKE-136] Add path confinement helper and apply it in secrets.py builders

### DIFF
--- a/app/devcake/pathsafety.py
+++ b/app/devcake/pathsafety.py
@@ -1,0 +1,26 @@
+"""Path-component hygiene + resolve confinement under a trusted base.
+
+Used by the secret-store builders (and reusable by later callers such as
+Dev Type move confinement) so untrusted path segments cannot escape a
+jail directory even when a higher-layer regex gate is skipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def confined(base: Path, *parts: str) -> Path:
+    """Join ``parts`` under ``base``; raise ``ValueError`` on unsafe segments
+    or any result that escapes ``base`` after resolve.
+
+    Each part must be a non-empty single path component (no ``/``, ``\\``,
+    NUL, ``.``, or ``..``). Whitespace inside a component is allowed —
+    profile names may contain spaces.
+    """
+    for p in parts:
+        if not p or p in (".", "..") or "/" in p or "\\" in p or "\x00" in p:
+            raise ValueError(f"unsafe path component {p!r}")
+    path = base.joinpath(*parts).resolve()
+    path.relative_to(base.resolve())  # raises ValueError on escape
+    return path

--- a/app/devcake/secrets.py
+++ b/app/devcake/secrets.py
@@ -25,6 +25,8 @@ import tempfile
 from pathlib import Path
 
 from . import security
+from .config import HARNESS_VAR_PATTERN, _INSTANCE_NAME_RE
+from .pathsafety import confined
 
 log = logging.getLogger("devcake.secrets")
 
@@ -40,6 +42,8 @@ CONNECTION_FIELDS: dict[str, set[str]] = {
     # skills source has no PR surface and is read-only by construction
     "skill": {"token", "token_ro"},
 }
+
+_HARNESS_VAR_RE = re.compile(f"^{HARNESS_VAR_PATTERN}$")
 
 
 def connection_instances(config) -> tuple[tuple[str, str], ...]:
@@ -81,11 +85,24 @@ def _root() -> Path:
 
 
 def _conn_path(scope: str, instance: str) -> Path:
-    return _root() / "connections" / f"{scope}-{instance}.json"
+    """Build connections/{scope}-{instance}.json under the secrets root.
+
+    Validates scope + instance *before* interpolating so a skipped caller
+    gate cannot turn ``instance`` into a path separator or ``..`` escape
+    (CAKE-136 / CodeQL py/path-injection).
+    """
+    if scope not in CONNECTION_FIELDS:
+        raise ValueError(f"unknown connection scope {scope!r}")
+    if not instance or re.fullmatch(_INSTANCE_NAME_RE, instance) is None:
+        raise ValueError(f"invalid connection instance {instance!r}")
+    return confined(_root() / "connections", f"{scope}-{instance}.json")
 
 
 def _harness_path(var: str) -> Path:
-    return _root() / "harness" / f"{var}.json"
+    """Build harness/{VAR}.json under the secrets root (store-level gate)."""
+    if not var or _HARNESS_VAR_RE.fullmatch(var) is None:
+        raise ValueError(f"invalid harness var {var!r}")
+    return confined(_root() / "harness", f"{var}.json")
 
 
 def _atomic_write_bytes(path: Path, data: bytes) -> None:
@@ -316,7 +333,7 @@ def write_credential_file(dev_type: str, filename: str, content: str) -> Path:
     if len(data) > MAX_CREDENTIAL_FILE_BYTES:
         raise ValueError(
             f"credential file too large ({len(data)} > {MAX_CREDENTIAL_FILE_BYTES})")
-    path = _root() / dev_type / filename
+    path = confined(_root(), dev_type, filename)
     _atomic_write_bytes(path, data)
     if len(raw) >= 8:
         security.register_runtime_secret(
@@ -327,7 +344,7 @@ def write_credential_file(dev_type: str, filename: str, content: str) -> Path:
 def delete_credential_file(dev_type: str, filename: str) -> None:
     """Unlink one OAuth/uploaded credential file. Missing = no-op."""
     require_credential_ref(dev_type, filename)
-    path = _root() / dev_type / filename
+    path = confined(_root(), dev_type, filename)
     path.unlink(missing_ok=True)
     # drop empty dir so inventory doesn't keep a ghost. suppress: a concurrent
     # OAuth write can race the empty check (TOCTOU) — unlink already succeeded.
@@ -507,7 +524,15 @@ def register_all() -> None:
 # bundle secrets section: {"connections": {...}, "harness": {...}}.
 
 def _profile_path(name: str) -> Path:
-    return _root() / "profiles" / f"{name}.json"
+    """Build profiles/{name}.json under the secrets root (store-level gate).
+
+    Charset matches ``profiles.PROFILE_NAME_RE`` (lazy import avoids the
+    profiles → secrets cycle). ``confined`` then closes traversal.
+    """
+    from .profiles import PROFILE_NAME_RE
+    if not PROFILE_NAME_RE.fullmatch(name or ""):
+        raise ValueError(f"invalid profile name {name!r}")
+    return confined(_root() / "profiles", f"{name}.json")
 
 
 def write_profile_secrets(name: str, data: dict) -> None:

--- a/app/tests/test_pathsafety.py
+++ b/app/tests/test_pathsafety.py
@@ -1,0 +1,84 @@
+"""Unit tests for ``devcake.pathsafety.confined`` — path-component hygiene
+plus resolve+relative_to confinement under a trusted base."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from devcake.pathsafety import confined
+
+
+def test_confined_rejects_dot_dot(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsafe path component"):
+        confined(tmp_path, "..")
+
+
+def test_confined_rejects_dot(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsafe path component"):
+        confined(tmp_path, ".")
+
+
+def test_confined_rejects_empty(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsafe path component"):
+        confined(tmp_path, "")
+
+
+def test_confined_rejects_slash_in_component(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsafe path component"):
+        confined(tmp_path, "a/b")
+
+
+def test_confined_rejects_backslash_in_component(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsafe path component"):
+        confined(tmp_path, "a\\b")
+
+
+def test_confined_rejects_null_byte(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsafe path component"):
+        confined(tmp_path, "a\x00b")
+
+
+def test_confined_accepts_normal_single_component(tmp_path: Path) -> None:
+    base = tmp_path / "secrets"
+    base.mkdir()
+    path = confined(base, "normal.json")
+    assert path == (base / "normal.json").resolve()
+    path.relative_to(base.resolve())  # does not raise
+
+
+def test_confined_multi_part_stays_under_base(tmp_path: Path) -> None:
+    base = tmp_path / "secrets"
+    base.mkdir()
+    path = confined(base, "connections", "repo-main.json")
+    assert path == (base / "connections" / "repo-main.json").resolve()
+    path.relative_to(base.resolve())
+
+
+def test_confined_allows_spaces_in_component(tmp_path: Path) -> None:
+    """Profile names may contain spaces; confined must not reject them."""
+    base = tmp_path / "profiles"
+    base.mkdir()
+    path = confined(base, "My Profile.json")
+    assert path.name == "My Profile.json"
+    path.relative_to(base.resolve())
+
+
+def test_confined_escape_cannot_leave_base(tmp_path: Path) -> None:
+    """Even a crafted multi-part join that would walk out must fail closed.
+
+    Component checks already reject ``..``; this asserts the resolve+
+    relative_to belt still holds the result under ``base``.
+    """
+    base = tmp_path / "jail"
+    base.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("nope")
+    # Direct ``..`` component is rejected before join.
+    with pytest.raises(ValueError):
+        confined(base, "..", "outside.txt")
+    assert not (base / "outside.txt").exists()
+    # Happy path stays inside.
+    inside = confined(base, "ok.txt")
+    assert str(inside).startswith(str(base.resolve()))

--- a/app/tests/test_secrets_store.py
+++ b/app/tests/test_secrets_store.py
@@ -67,6 +67,72 @@ def test_harness_delete_unlinks(monkeypatch, tmp_path):
     s.delete_harness_secret("NEVER_SET")                             # no-op
 
 
+# ── store-level path confinement (CAKE-136: defense-in-depth, not HTTP-only) ─
+
+def test_conn_path_rejects_traversal_directly(monkeypatch, tmp_path):
+    """Builders must refuse hostile instance/scope even when callers skip
+    the HTTP regex gates — CodeQL py/path-injection cluster on secrets.py."""
+    s = _store(monkeypatch, tmp_path)
+    conn_root = tmp_path / "secrets" / "connections"
+    conn_root.mkdir(parents=True)
+
+    for instance in ("../x", "a/b", "", ".", ".."):
+        with pytest.raises(ValueError):
+            s._conn_path("repo", instance)
+        with pytest.raises(ValueError):
+            s.write_connection_secret("repo", instance, "token", "v-1234")
+
+    with pytest.raises(ValueError):
+        s._conn_path("nope", "main")
+    with pytest.raises(ValueError):
+        s.write_connection_secret("nope", "main", "token", "v-1234")
+
+    # Nothing escaped the connections jail; no stray nested dirs from a/b.
+    assert list(conn_root.rglob("*")) == []
+    assert not (tmp_path / "secrets" / "x.json").exists()
+    assert not (tmp_path / "x.json").exists()
+
+
+def test_harness_path_rejects_traversal_directly(monkeypatch, tmp_path):
+    s = _store(monkeypatch, tmp_path)
+    harness_root = tmp_path / "secrets" / "harness"
+    harness_root.mkdir(parents=True)
+
+    for var in ("../evil", "bad/var", "lower_case", "1LEADING", ""):
+        with pytest.raises(ValueError):
+            s._harness_path(var)
+        with pytest.raises(ValueError):
+            s.write_harness_secret(var, "v-1234")
+
+    assert list(harness_root.rglob("*")) == []
+    assert not (tmp_path / "secrets" / "evil.json").exists()
+
+
+def test_profile_path_rejects_traversal_directly(monkeypatch, tmp_path):
+    s = _store(monkeypatch, tmp_path)
+    profiles_root = tmp_path / "secrets" / "profiles"
+    profiles_root.mkdir(parents=True)
+
+    for name in ("../evil", "a/b", "", ".hidden", "-leading-dash"):
+        with pytest.raises(ValueError):
+            s._profile_path(name)
+        with pytest.raises(ValueError):
+            s.write_profile_secrets(name, {"connections": {}})
+
+    assert list(profiles_root.rglob("*")) == []
+    assert not (tmp_path / "secrets" / "evil.json").exists()
+
+
+def test_store_builders_accept_well_formed_names(monkeypatch, tmp_path):
+    s = _store(monkeypatch, tmp_path)
+    s.write_connection_secret("repo", "main", "token", "tok-ok-1234")
+    assert (tmp_path / "secrets" / "connections" / "repo-main.json").is_file()
+    s.write_harness_secret("XAI_API_KEY", "xai-ok-1234")
+    assert (tmp_path / "secrets" / "harness" / "XAI_API_KEY.json").is_file()
+    s.write_profile_secrets("My Profile", {"harness": {}})
+    assert (tmp_path / "secrets" / "profiles" / "My Profile.json").is_file()
+
+
 # ── endpoint input validation (audit A5: the traversal oracle) ───────────────
 
 def _main(monkeypatch, tmp_path):

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -131,6 +131,7 @@ app/devcake/
   config.py        # single pydantic schema authority for config.yaml (root-level:
                    #   cross-cutting — consumed by domain, adapters, and api alike)
   security.py      # redaction choke point, fed token shapes by the registry (14)
+  pathsafety.py    # path-component hygiene + resolve confinement under a base
   harness.py       # harness registry: CLI/image/credential runtime adapters (08)
   secrets.py       # GUI-stored operator secrets under /data/secrets (ADR-0011)
   staffing.py      # staffability chokepoint vs ReceiptStore (dispatch/steward/OAuth)


### PR DESCRIPTION
## Intent

Add a shared `pathsafety.confined` helper and apply it inside `secrets.py` path builders (`_conn_path`, `_harness_path`, `_profile_path`) so connection, harness, and profile secret files cannot escape `/data/secrets/...` even when a caller skips HTTP/bundle regex gates.

This is defense-in-depth for the CodeQL **`py/path-injection`** alert cluster under `app/devcake/secrets.py` (roughly alerts 30–55 on the flieber-inc/devcake code-scanning view).

## Mission

https://linear.app/fidecastro/issue/CAKE-136/add-path-confinement-helper-and-apply-it-in-secretspy-builders

## What changed

- New `app/devcake/pathsafety.py` with `confined(base, *parts)` — rejects empty/`.`/`..`/`/`/`\`/NUL components, then `resolve` + `relative_to(base)`.
- `_conn_path` / `_harness_path` / `_profile_path` validate domain regexes (instance / harness var / `PROFILE_NAME_RE`) **then** join via `confined`.
- Credential write/delete also join via `confined` after `require_credential_ref` (allowlist semantics unchanged).
- Unit tests for `confined` + store-level direct-call traversal tests (bypass API).
- One-line `docs/01-architecture.md` package-root listing for `pathsafety.py`.

## How to verify

```bash
./scripts/pytest_app.sh app/tests/test_pathsafety.py app/tests/test_secrets_store.py app/tests/test_profiles.py
```

## Out of scope

- Prompt-template DELETE
- RunStore / Dev Type `shutil` move confinement (may reuse `confined` later)
- Changing on-disk layout or redaction globs
- Dismissing CodeQL alerts in the GitHub UI