### PR TITLE
[CAKE-138] Confine Dev Type rename/remove filesystem moves

### DIFF
--- a/app/devcake/api/devtypes_service.py
+++ b/app/devcake/api/devtypes_service.py
@@ -18,9 +18,14 @@ from ..config import (Assignment, DEFAULT_ASSIGNMENTS, DevType,
 from ..harness import HARNESSES, dev_type_status
 from ..house_pins import HOUSE_PINS, LAUNCH_SUPPORTED
 from ..keep_set import publish_keep_set
+from ..pathsafety import confined
 from ..prompts import templates as prompt_templates
 
 log = logging.getLogger("devcake")
+
+# Same charset as DevType.name — re-checked at rename/remove move sites even
+# when `name in dev_types` (defense in depth for shutil sinks / CodeQL).
+_DEV_TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 
 
 async def get_prompt_templates(*, config, dev_types):
@@ -153,7 +158,9 @@ async def rename_dev_type(name: str, body: dict, *, config, dev_types,
     new = str(body.get("new_name") or "")
     if name not in dev_types:
         raise HTTPException(404, f"no Dev Type named {name!r}")
-    if not re.fullmatch(r"^[A-Za-z0-9][A-Za-z0-9_-]*$", new) or ":" in new:
+    if not _DEV_TYPE_NAME_RE.fullmatch(name or ""):
+        raise HTTPException(422, "name must match ^[A-Za-z0-9][A-Za-z0-9_-]*$")
+    if not _DEV_TYPE_NAME_RE.fullmatch(new) or ":" in new:
         raise HTTPException(422, "new_name must match ^[A-Za-z0-9][A-Za-z0-9_-]*$")
     if new in dev_types:
         raise HTTPException(409, f"a Dev Type named {new!r} already exists")
@@ -162,10 +169,16 @@ async def rename_dev_type(name: str, body: dict, *, config, dev_types,
     save_dev_type(dt)
     delete_dev_type(name)
     data = _P(os.environ.get("DEVCAKE_DATA_DIR", "/data"))
-    for sub in ("secrets", "config/devtype_prompt_templates"):
-        src = data / sub / name
-        if src.is_dir():
-            shutil.move(str(src), str(data / sub / new))
+    secrets_root = data / "secrets"
+    templates_root = data / "config" / "devtype_prompt_templates"
+    try:
+        for root in (secrets_root, templates_root):
+            src = confined(root, name)
+            dst = confined(root, new)
+            if src.is_dir():
+                shutil.move(str(src), str(dst))
+    except ValueError as e:
+        raise HTTPException(422, str(e)) from e
     changed = False
     for mt, a in config.assignments.items():
         if a.dev_type == name:
@@ -200,6 +213,8 @@ async def remove_dev_type(name: str, *, config, dev_types):
 
     if name not in dev_types:
         raise HTTPException(404, f"no Dev Type named {name!r}")
+    if not _DEV_TYPE_NAME_RE.fullmatch(name or ""):
+        raise HTTPException(422, "name must match ^[A-Za-z0-9][A-Za-z0-9_-]*$")
     if any(a.dev_type == name for a in config.assignments.values()):
         raise HTTPException(409, f"{name} is assigned to a mission type")
     holders = sorted(p.name for p in config.pmos
@@ -215,10 +230,15 @@ async def remove_dev_type(name: str, *, config, dev_types):
     dev_types.pop(name, None)
     delete_dev_type(name)
     data = _P(os.environ.get("DEVCAKE_DATA_DIR", "/data"))
-    for sub in ("secrets", "config/devtype_prompt_templates"):
-        target = data / sub / name
-        if target.is_dir():
-            shutil.rmtree(target, ignore_errors=True)
+    secrets_root = data / "secrets"
+    templates_root = data / "config" / "devtype_prompt_templates"
+    try:
+        for root in (secrets_root, templates_root):
+            target = confined(root, name)
+            if target.is_dir():
+                shutil.rmtree(target, ignore_errors=True)
+    except ValueError as e:
+        raise HTTPException(422, str(e)) from e
     if name in config.active_devtype_prompts:
         config.active_devtype_prompts.pop(name, None)
         save_config(config)

--- a/app/devcake/config.py
+++ b/app/devcake/config.py
@@ -1483,7 +1483,18 @@ def save_dev_type(dt: DevType) -> None:
 
 
 def delete_dev_type(name: str) -> None:
-    (CONFIG_PATH.parent / "dev_types" / f"{name}.yaml").unlink(missing_ok=True)
+    """Unlink ``dev_types/{name}.yaml`` after charset + path confinement.
+
+    Callers normally pass Dev Type keys already validated at create time;
+    re-check here so unlink cannot leave ``CONFIG_PATH.parent / "dev_types"``.
+    """
+    from .pathsafety import confined
+    if not re.fullmatch(r"^[A-Za-z0-9][A-Za-z0-9_-]*$", name or ""):
+        raise ValueError(
+            "dev type name must match ^[A-Za-z0-9][A-Za-z0-9_-]*$"
+        )
+    path = confined(CONFIG_PATH.parent / "dev_types", f"{name}.yaml")
+    path.unlink(missing_ok=True)
 
 
 def load_dev_types() -> dict[str, DevType]:

--- a/app/tests/test_devtype_path_confinement.py
+++ b/app/tests/test_devtype_path_confinement.py
@@ -1,0 +1,188 @@
+"""Path confinement on Dev Type rename/remove/YAML-delete (CAKE-138).
+
+Charset re-check + pathsafety.confined before shutil.move / rmtree / unlink
+so forged names cannot leave /data/secrets, /data/config/devtype_prompt_templates,
+or CONFIG_PATH.parent / "dev_types".
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+
+def run_coro(c):
+    return asyncio.new_event_loop().run_until_complete(c)
+
+
+def _cfg_assignments(dev_type: str = "judgment"):
+    from devcake.config import AppConfig, Assignment
+    return AppConfig(assignments={
+        mt: Assignment(dev_type=dev_type)
+        for mt in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW")})
+
+
+# ── config.delete_dev_type ───────────────────────────────────────────────────
+
+@pytest.mark.parametrize("bad", ("..", "../x", "a/b", "../config"))
+def test_delete_dev_type_refuses_traversal_names(monkeypatch, tmp_path, bad):
+    """Bad names must raise ValueError and must not unlink a planted sibling."""
+    import devcake.config as config_mod
+
+    config_dir = tmp_path / "config"
+    dt_dir = config_dir / "dev_types"
+    dt_dir.mkdir(parents=True)
+    monkeypatch.setattr(config_mod, "CONFIG_PATH", config_dir / "config.yaml")
+
+    sentinel = config_dir / "config.yaml"
+    sentinel.write_text("schema_version: 1\nkeep: me\n")
+    # Intermediate jail root already exists (dt_dir) — CAKE-135: without it,
+    # unresolved `..` never reaches the sibling and the test is a false green.
+    with pytest.raises(ValueError):
+        config_mod.delete_dev_type(bad)
+
+    assert sentinel.exists()
+    assert "keep: me" in sentinel.read_text()
+
+
+def test_delete_dev_type_happy_path_unlinks_yaml(monkeypatch, tmp_path):
+    import devcake.config as config_mod
+
+    config_dir = tmp_path / "config"
+    dt_dir = config_dir / "dev_types"
+    dt_dir.mkdir(parents=True)
+    monkeypatch.setattr(config_mod, "CONFIG_PATH", config_dir / "config.yaml")
+    target = dt_dir / "junior-dev.yaml"
+    target.write_text("name: junior-dev\n")
+
+    config_mod.delete_dev_type("junior-dev")
+    assert not target.exists()
+
+
+# ── rename_dev_type / remove_dev_type refusal ────────────────────────────────
+
+def test_rename_dev_type_refuses_forged_traversal_name(monkeypatch, tmp_path):
+    """Inject a traversal-shaped key into dev_types (bypassing create-time
+    DevType.name validation). Rename must 422 and leave a sibling sentinel."""
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake.api import devtypes_service
+    from devcake.config import DevType
+
+    monkeypatch.setattr(devtypes_service, "save_config", lambda c: None)
+    monkeypatch.setattr(devtypes_service, "save_dev_type", lambda d: None)
+    monkeypatch.setattr(devtypes_service, "delete_dev_type", lambda n: None)
+    monkeypatch.setattr(devtypes_service, "publish_keep_set", lambda dts: None)
+
+    secrets_root = tmp_path / "secrets"
+    templates_root = tmp_path / "config" / "devtype_prompt_templates"
+    secrets_root.mkdir(parents=True)
+    templates_root.mkdir(parents=True)
+    sentinel = tmp_path / "outside-secret"
+    sentinel.mkdir()
+    (sentinel / "keep.txt").write_text("do-not-touch\n")
+
+    forged = "../outside-secret"
+    # Membership bypass: key is the path component rename uses.
+    dts = {forged: DevType(name="legit", harness_template="codex",
+                           identifying_prompt="x")}
+    cfg = _cfg_assignments("judgment")
+    # Point no assignment at the forged key so 409 cannot mask the charset check.
+    with pytest.raises(HTTPException) as e:
+        run_coro(devtypes_service.rename_dev_type(
+            forged, {"new_name": "safe-new"}, config=cfg, dev_types=dts,
+            shared_breakers={}))
+    assert e.value.status_code == 422
+    assert (sentinel / "keep.txt").read_text() == "do-not-touch\n"
+    assert forged in dts  # pop must not have happened
+
+
+def test_remove_dev_type_refuses_forged_traversal_name(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake.api import devtypes_service
+    from devcake.config import DevType
+
+    monkeypatch.setattr(devtypes_service, "delete_dev_type", lambda n: None)
+    monkeypatch.setattr(devtypes_service, "save_config", lambda c: None)
+    monkeypatch.setattr(devtypes_service, "publish_keep_set", lambda dts: None)
+
+    secrets_root = tmp_path / "secrets"
+    templates_root = tmp_path / "config" / "devtype_prompt_templates"
+    secrets_root.mkdir(parents=True)
+    templates_root.mkdir(parents=True)
+    sentinel = tmp_path / "outside-secret"
+    sentinel.mkdir()
+    (sentinel / "keep.txt").write_text("do-not-touch\n")
+
+    forged = "../outside-secret"
+    dts = {
+        forged: DevType(name="legit", harness_template="codex"),
+        "judgment": DevType(name="judgment", harness_template="claude-code"),
+    }
+    cfg = _cfg_assignments("judgment")
+
+    with pytest.raises(HTTPException) as e:
+        run_coro(devtypes_service.remove_dev_type(
+            forged, config=cfg, dev_types=dts))
+    assert e.value.status_code == 422
+    assert (sentinel / "keep.txt").read_text() == "do-not-touch\n"
+    assert forged in dts
+
+
+def test_rename_dev_type_refuses_bad_new_name_with_slash(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake.api import devtypes_service
+    from devcake.config import DevType
+
+    monkeypatch.setattr(devtypes_service, "save_dev_type", lambda d: None)
+    monkeypatch.setattr(devtypes_service, "delete_dev_type", lambda n: None)
+
+    dts = {"olddev": DevType(name="olddev", harness_template="codex")}
+    cfg = _cfg_assignments("olddev")
+
+    with pytest.raises(HTTPException) as e:
+        run_coro(devtypes_service.rename_dev_type(
+            "olddev", {"new_name": "a/b"}, config=cfg, dev_types=dts,
+            shared_breakers={}))
+    assert e.value.status_code == 422
+    assert "olddev" in dts
+
+
+# ── happy path: rename moves both sidecar dirs ───────────────────────────────
+
+def test_rename_dev_type_moves_secrets_and_templates(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEVCAKE_DATA_DIR", str(tmp_path))
+    from devcake.api import devtypes_service
+    from devcake.config import DevType
+
+    monkeypatch.setattr(devtypes_service, "save_config", lambda c: None)
+    monkeypatch.setattr(devtypes_service, "save_dev_type", lambda d: None)
+    monkeypatch.setattr(devtypes_service, "delete_dev_type", lambda n: None)
+    monkeypatch.setattr(devtypes_service, "publish_keep_set", lambda dts: None)
+
+    dt = DevType(name="olddev", harness_template="codex",
+                 identifying_prompt="I am old.")
+    dts = {"olddev": dt}
+    cfg = _cfg_assignments("olddev")
+    cfg.active_devtype_prompts = {"olddev": "Customer Success"}
+
+    templates = tmp_path / "config" / "devtype_prompt_templates" / "olddev"
+    templates.mkdir(parents=True)
+    (templates / "Development.yaml").write_text(
+        "name: Development\ntemplate: I am old.\n")
+    secrets = tmp_path / "secrets" / "olddev"
+    secrets.mkdir(parents=True)
+    (secrets / "creds.json").write_text("{}")
+
+    out = run_coro(devtypes_service.rename_dev_type(
+        "olddev", {"new_name": "newdev"}, config=cfg, dev_types=dts,
+        shared_breakers={}))
+    assert out["renamed"] and "newdev" in dts and "olddev" not in dts
+    assert cfg.assignments["EXECUTE"].dev_type == "newdev"
+    assert cfg.active_devtype_prompts == {"newdev": "Customer Success"}
+    assert (tmp_path / "config" / "devtype_prompt_templates" / "newdev"
+            / "Development.yaml").exists()
+    assert (tmp_path / "secrets" / "newdev" / "creds.json").exists()
+    assert not (tmp_path / "secrets" / "olddev").exists()
+    assert not (tmp_path / "config" / "devtype_prompt_templates" / "olddev").exists()


### PR DESCRIPTION
## Intent

Confine Dev Type **rename** / **remove** filesystem moves and `config.delete_dev_type` unlinks so `shutil.move` / `rmtree` / `unlink` cannot leave `/data/secrets`, `/data/config/devtype_prompt_templates`, or `dev_types/`. Addresses CodeQL `py/path-injection` alerts **13–18**.

Mission: https://linear.app/fidecastro/issue/CAKE-138/confine-dev-type-renameremove-filesystem-moves

## What changed

- `rename_dev_type` / `remove_dev_type`: re-validate `name` (and `new`) with `^[A-Za-z0-9][A-Za-z0-9_-]*$` even when `name in dev_types`; build src/dst/target via `pathsafety.confined` before move/rmtree; map `ValueError` → HTTP 422.
- `config.delete_dev_type`: same charset check + `confined` under `CONFIG_PATH.parent / "dev_types"` before unlink.
- Tests: refusal for forged traversal names (sentinel outside jail untouched) + happy-path rename that moves both secrets and prompt-template dirs.

## How to verify

```bash
./scripts/pytest_app.sh tests/test_devtype_path_confinement.py tests/test_prompt_templates.py
# or PYTHONPATH=app python3.12 -m pytest app/tests/test_devtype_path_confinement.py -q
```

## Out of scope

- Prompt-template DELETE (CAKE-135)
- Changing Dev Type naming rules
- `settings_bundle._prune_config_files` rmtree on known_devtype_dirs
- Dismissing CodeQL alerts in the GitHub UI without the code fix

## Note

Reuses CAKE-136 `app/devcake/pathsafety.py::confined` (already on main). CodeQL clearance for alerts 13–18 is confirmed by this PR's CodeQL check, not assumed from relative_to alone.