### PR TITLE
[CAKE-139] Verify and dismiss remaining CodeQL path-injection alerts

### DIFF
--- a/app/devcake/profiles.py
+++ b/app/devcake/profiles.py
@@ -31,6 +31,7 @@ import yaml
 
 from . import secrets as secrets_store
 from .config import AppConfig, DevType, _atomic_yaml
+from .pathsafety import confined
 from .settings_bundle import (BUNDLE_KIND, BUNDLE_SCHEMA_VERSION, BundleError,
                               _utcnow, serialize_current)
 
@@ -47,7 +48,7 @@ def _dir() -> Path:
 
 
 def _path(name: str) -> Path:
-    return _dir() / f"{name}.yaml"
+    return confined(_dir(), f"{name}.yaml")
 
 
 def _state_path() -> Path:

--- a/app/devcake/prompts/templates.py
+++ b/app/devcake/prompts/templates.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import yaml
 
+from ..pathsafety import confined
 from . import DEFAULT_PLAYBOOKS, PLAYBOOK_VARS, _VAR
 
 log = logging.getLogger("devcake.prompts")
@@ -130,7 +131,8 @@ def save_template(mission_type: str, name: str, text: str) -> None:
         raise ValueError("template name must match "
                          "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
     validate_template(mission_type, text)
-    _atomic_yaml(_dir(mission_type) / f"{name}.yaml",
+    path = confined(_dir(mission_type).resolve(), f"{name}.yaml")
+    _atomic_yaml(path,
                  {"schema_version": 1, "mission_type": mission_type,
                   "name": name, "template": text})
 
@@ -143,9 +145,8 @@ def delete_template(mission_type: str, name: str) -> None:
         raise ValueError("template name must match "
                          "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
     root = _dir(mission_type).resolve()
-    path = root / f"{name}.yaml"
     try:
-        path.resolve().relative_to(root)
+        path = confined(root, f"{name}.yaml")
     except ValueError as e:
         raise ValueError(
             f"template path escapes {mission_type!r} template directory"
@@ -295,7 +296,8 @@ def save_devtype_prompt(dev_type: str, name: str, text: str) -> None:
                          "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
     if len(text.encode()) > _MAX_TEMPLATE_BYTES:
         raise ValueError(f"template exceeds {_MAX_TEMPLATE_BYTES // 1024} KB")
-    _atomic_yaml(_dev_dir(dev_type) / f"{name}.yaml",
+    path = confined(_dev_dir(dev_type).resolve(), f"{name}.yaml")
+    _atomic_yaml(path,
                  {"schema_version": 1, "dev_type": dev_type,
                   "name": name, "template": text})
 
@@ -310,9 +312,8 @@ def delete_devtype_prompt(dev_type: str, name: str) -> None:
         raise ValueError("template name must match "
                          "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
     root = _dev_dir(dev_type).resolve()
-    path = root / f"{name}.yaml"
     try:
-        path.resolve().relative_to(root)
+        path = confined(root, f"{name}.yaml")
     except ValueError as e:
         raise ValueError(
             f"template path escapes {dev_type!r} template directory"

--- a/app/tests/test_profiles.py
+++ b/app/tests/test_profiles.py
@@ -110,6 +110,29 @@ def test_name_hygiene_rejects_traversal_shapes(monkeypatch, tmp_path, bad):
     assert e.value.status == 422
 
 
+@pytest.mark.parametrize("bad", ["../config", "a/b", ".."])
+def test_profile_path_confinement_refuses_escape_if_name_gate_bypassed(
+        monkeypatch, tmp_path, bad):
+    """Belt under require_name: hostile components must not leave profiles/.
+
+    Even if the PROFILE_NAME_RE gate is skipped, CRUD must refuse and must
+    not touch a sibling sentinel outside config/profiles/.
+    """
+    _, profiles, *_ = _env(monkeypatch, tmp_path)
+    profiles_dir = tmp_path / "config" / "profiles"
+    profiles_dir.mkdir(parents=True)
+    sentinel = tmp_path / "config" / "config.yaml"
+    sentinel.write_text("schema_version: 1\nkeep: me\n")
+    monkeypatch.setattr(profiles, "require_name", lambda n: None)
+
+    with pytest.raises(ValueError):
+        profiles.delete_profile(bad)
+
+    assert sentinel.exists()
+    assert "keep: me" in sentinel.read_text()
+    assert list(profiles_dir.glob("*")) == []
+
+
 def test_stale_profile_schema_refused(monkeypatch, tmp_path):
     sb, profiles, secrets, config_mod, _ = _env(monkeypatch, tmp_path)
     cfg, dts = _small_world(config_mod, secrets)

--- a/app/tests/test_prompt_template_delete_traversal.py
+++ b/app/tests/test_prompt_template_delete_traversal.py
@@ -1,11 +1,13 @@
-"""Path-injection hardening on prompt-template DELETE (CAKE-135).
+"""Path-injection hardening on prompt-template DELETE (CAKE-135 / CAKE-139).
 
 Save paths already gate names with _NAME_RE; delete paths must refuse
 traversal names / invalid Dev Type names and must not unlink outside the
-intended template subdirectory.
+intended template subdirectory. CAKE-139: filesystem sinks use
+pathsafety.confined so the unlink/exists value is the confined Path.
 """
 
 import asyncio
+import re
 
 import pytest
 from fastapi import HTTPException
@@ -77,6 +79,38 @@ def test_delete_template_happy_path(monkeypatch, tmp_path):
     assert path.exists()
     t.delete_template("EXECUTE", "terse")
     assert not path.exists()
+
+
+def test_delete_template_confined_belt_when_name_re_bypassed(monkeypatch, tmp_path):
+    """Even if _NAME_RE is skipped, delete must not unlink outside the type dir."""
+    t = _tpl(monkeypatch, tmp_path)
+    t.seed_default_templates()
+    base = tmp_path / "config" / "prompt_templates"
+    sentinel = base / "evil.yaml"
+    sentinel.write_text("sentinel\n")
+    monkeypatch.setattr(t, "_NAME_RE", re.compile(r".+"))
+
+    with pytest.raises(ValueError):
+        t.delete_template("EXECUTE", "../evil")
+
+    assert sentinel.exists()
+    assert (base / "EXECUTE" / "Development.yaml").exists()
+
+
+def test_delete_devtype_prompt_confined_belt_when_name_re_bypassed(
+        monkeypatch, tmp_path):
+    """Even if _NAME_RE is skipped, delete must not unlink outside the dev dir."""
+    t = _tpl(monkeypatch, tmp_path)
+    root = tmp_path / "config" / "devtype_prompt_templates"
+    (root / "judgment").mkdir(parents=True)
+    sentinel = root / "evil.yaml"
+    sentinel.write_text("sentinel\n")
+    monkeypatch.setattr(t, "_NAME_RE", re.compile(r".+"))
+
+    with pytest.raises(ValueError):
+        t.delete_devtype_prompt("judgment", "../evil")
+
+    assert sentinel.exists()
 
 
 def test_delete_devtype_prompt_happy_path(monkeypatch, tmp_path):


### PR DESCRIPTION
## Intent

Clear residual open `py/path-injection` alerts after CAKE-135–138 by wiring `pathsafety.confined` so filesystem sinks receive the confined `Path` (same pattern that cleared Dev Type move alerts on #323).

Mission: https://linear.app/fidecastro/issue/CAKE-139/verify-and-dismiss-remaining-codeql-path-injection-alerts

## Fixed vs dismissed

### Fixed (CodeQL Analyze on PR head `c0684c0` — open `py/path-injection` on branch ref = **0**)

| Site | Change | Alerts cleared |
|---|---|---|
| `profiles._path` | `confined(_dir(), f"{name}.yaml")` after existing `PROFILE_NAME_RE` | #19–27 |
| `prompts/templates.py` `delete_template` / `delete_devtype_prompt` | Replace check-then-unlink-unresolved with `confined` sink | #56–59, #62–65 |
| `save_template` / `save_devtype_prompt` | Pass confined path into `_atomic_yaml` | Cascade clears #8–12 |

Evidence: `Analyze (python)` SUCCESS on `c0684c0`; `gh api …/code-scanning/alerts?ref=refs/heads/devcake/DEVCAKEDEV-CAKE-139&state=open` → `[]` for `py/path-injection`. Alerts remain `open` on `main` until merge (auto-fix, same as #323).

### Dismissed

**None** — all 22 cleared by the confined wiring; no Security-tab dismissals required.

## How to verify

- CI on this PR: Bake + pytest + dispatch smoke, Analyze (python/js/actions), CodeQL — all **pass**
- Local: fresh `app-test` bake + pytest for changed modules (profiles / template delete / pathsafety)

## Out of scope

- Dependabot
- Other open CodeQL rules (clear-text logging/storage, incomplete-url-substring-sanitization, weak-sensitive-data-hashing)
- Re-hardening RunStore / secrets / Dev Type moves (already fixed on main)

## Risk

Admin-only path construction; no API contract change. `ValueError` from `confined` still maps to 422 on existing API paths.