### PR TITLE
[CAKE-140] Close the remaining path-injection alerts: pass tainted components as confined PARTS, never as the base

### DIFF
--- a/app/devcake/api/devtypes_service.py
+++ b/app/devcake/api/devtypes_service.py
@@ -8,12 +8,11 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 
 from fastapi import HTTPException
 
-from ..config import (Assignment, DEFAULT_ASSIGNMENTS, DevType,
-                      delete_dev_type, save_config, save_dev_type,
+from ..config import (Assignment, DEFAULT_ASSIGNMENTS, DEV_TYPE_NAME_RE,
+                      DevType, delete_dev_type, save_config, save_dev_type,
                       validate_assignment_map, validate_memory_bindings)
 from ..harness import HARNESSES, dev_type_status
 from ..house_pins import HOUSE_PINS, LAUNCH_SUPPORTED
@@ -22,10 +21,6 @@ from ..pathsafety import confined
 from ..prompts import templates as prompt_templates
 
 log = logging.getLogger("devcake")
-
-# Same charset as DevType.name — re-checked at rename/remove move sites even
-# when `name in dev_types` (defense in depth for shutil sinks / CodeQL).
-_DEV_TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 
 
 async def get_prompt_templates(*, config, dev_types):
@@ -158,9 +153,9 @@ async def rename_dev_type(name: str, body: dict, *, config, dev_types,
     new = str(body.get("new_name") or "")
     if name not in dev_types:
         raise HTTPException(404, f"no Dev Type named {name!r}")
-    if not _DEV_TYPE_NAME_RE.fullmatch(name or ""):
+    if not DEV_TYPE_NAME_RE.fullmatch(name or ""):
         raise HTTPException(422, "name must match ^[A-Za-z0-9][A-Za-z0-9_-]*$")
-    if not _DEV_TYPE_NAME_RE.fullmatch(new) or ":" in new:
+    if not DEV_TYPE_NAME_RE.fullmatch(new) or ":" in new:
         raise HTTPException(422, "new_name must match ^[A-Za-z0-9][A-Za-z0-9_-]*$")
     if new in dev_types:
         raise HTTPException(409, f"a Dev Type named {new!r} already exists")
@@ -213,7 +208,7 @@ async def remove_dev_type(name: str, *, config, dev_types):
 
     if name not in dev_types:
         raise HTTPException(404, f"no Dev Type named {name!r}")
-    if not _DEV_TYPE_NAME_RE.fullmatch(name or ""):
+    if not DEV_TYPE_NAME_RE.fullmatch(name or ""):
         raise HTTPException(422, "name must match ^[A-Za-z0-9][A-Za-z0-9_-]*$")
     if any(a.dev_type == name for a in config.assignments.values()):
         raise HTTPException(409, f"{name} is assigned to a mission type")

--- a/app/devcake/config.py
+++ b/app/devcake/config.py
@@ -609,6 +609,13 @@ class CostInputs(BaseModel):
         return "operator:" + hashlib.sha256(canon.encode()).hexdigest()[:8]
 
 
+# Single charset authority for Dev Type names (beside DevType). Call sites
+# that re-check before path sinks / shutil must import these — do not
+# re-spell the character class inline (CAKE-140).
+DEV_TYPE_NAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_-]*$"
+DEV_TYPE_NAME_RE = re.compile(DEV_TYPE_NAME_PATTERN)
+
+
 class DevType(BaseModel):
     """docs/02 §6 — one YAML per Dev Type under /data/config/dev_types/.
 
@@ -620,7 +627,7 @@ class DevType(BaseModel):
     # no ":" — dev-type breakers share /health's circuit_breakers map with
     # per-repo `repo:<name>` entries (M10); a colon would let a dev type
     # collide with (and mask) a repo breaker
-    name: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+    name: str = Field(pattern=DEV_TYPE_NAME_PATTERN)
     harness_template: str
     identifying_prompt: str = ""
     # Operator shell. Additive after aiming unless override_harness_adapter.
@@ -1351,7 +1358,9 @@ def reconcile_managed_pmos(current: list[dict], incoming: list[dict], *,
 
 def _atomic_yaml(path: Path, data: dict) -> None:
     """tmp + fsync + replace; unlink temp on any failure after mkstemp
-    (same atomic-write cleanup contract as secrets._atomic_write_bytes)."""
+    (same atomic-write cleanup contract as secrets._atomic_write_bytes).
+
+    Unconfined sink — callers must pass an already-confined or otherwise trusted path."""
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
     try:
@@ -1479,7 +1488,14 @@ def save_config(cfg: AppConfig) -> None:
 
 
 def save_dev_type(dt: DevType) -> None:
-    _atomic_yaml(CONFIG_PATH.parent / "dev_types" / f"{dt.name}.yaml", dt.model_dump())
+    """Write ``dev_types/{name}.yaml`` after charset + path confinement."""
+    from .pathsafety import confined
+    if not DEV_TYPE_NAME_RE.fullmatch(dt.name or ""):
+        raise ValueError(
+            "dev type name must match ^[A-Za-z0-9][A-Za-z0-9_-]*$"
+        )
+    path = confined(CONFIG_PATH.parent / "dev_types", f"{dt.name}.yaml")
+    _atomic_yaml(path, dt.model_dump())
 
 
 def delete_dev_type(name: str) -> None:
@@ -1489,7 +1505,7 @@ def delete_dev_type(name: str) -> None:
     re-check here so unlink cannot leave ``CONFIG_PATH.parent / "dev_types"``.
     """
     from .pathsafety import confined
-    if not re.fullmatch(r"^[A-Za-z0-9][A-Za-z0-9_-]*$", name or ""):
+    if not DEV_TYPE_NAME_RE.fullmatch(name or ""):
         raise ValueError(
             "dev type name must match ^[A-Za-z0-9][A-Za-z0-9_-]*$"
         )

--- a/app/devcake/pathsafety.py
+++ b/app/devcake/pathsafety.py
@@ -1,26 +1,40 @@
 """Path-component hygiene + resolve confinement under a trusted base.
 
-Used by the secret-store builders (and reusable by later callers such as
-Dev Type move confinement) so untrusted path segments cannot escape a
-jail directory even when a higher-layer regex gate is skipped.
+**Parts-not-base rule:** tainted values ride as ``*parts``; ``base`` must be
+a constant (trusted root). Never build ``base`` from user input — that is
+what left template save/delete open to CodeQL ``py/path-injection`` after
+profiles/secrets cleared (CAKE-140).
+
+Used by the secret-store builders, profiles, prompt templates, and Dev Type
+path sinks so untrusted path segments cannot escape a jail directory even
+when a higher-layer regex gate is skipped.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 
 def confined(base: Path, *parts: str) -> Path:
     """Join ``parts`` under ``base``; raise ``ValueError`` on unsafe segments
-    or any result that escapes ``base`` after resolve.
+    or any result that escapes ``base`` after normalize / resolve.
 
-    Each part must be a non-empty single path component (no ``/``, ``\\``,
-    NUL, ``.``, or ``..``). Whitespace inside a component is allowed —
-    profile names may contain spaces.
+    **Parts-not-base:** tainted values ride as ``*parts``; ``base`` must be a
+    constant (trusted root). Each part must be a non-empty single path
+    component (no ``/``, ``\\``, NUL, ``.``, or ``..``). A normalize-then-
+    prefix check then ``resolve()`` + ``relative_to`` hold the result under
+    ``base`` (the resolve belt follows symlinks). Whitespace inside a
+    component is allowed — profile names may contain spaces.
     """
     for p in parts:
         if not p or p in (".", "..") or "/" in p or "\\" in p or "\x00" in p:
             raise ValueError(f"unsafe path component {p!r}")
+    # CodeQL-recognized barrier (normalize-then-prefix) before resolve sink.
+    norm = os.path.normpath(str(base.joinpath(*parts)))
+    base_norm = os.path.normpath(str(base))
+    if not norm.startswith(base_norm + os.sep):
+        raise ValueError(f"path {norm!r} escapes base {base_norm!r}")
     path = base.joinpath(*parts).resolve()
     path.relative_to(base.resolve())  # raises ValueError on escape
     return path

--- a/app/devcake/prompts/templates.py
+++ b/app/devcake/prompts/templates.py
@@ -45,9 +45,19 @@ def _canon(name: str | None) -> str:
 _MAX_TEMPLATE_BYTES = 64 * 1024   # the prompt rides a Redis runspec reply
 
 
-def _dir(mission_type: str) -> Path:
+def _prompt_templates_root() -> Path:
+    """Constant trusted root for mission-type prompt templates (CAKE-140).
+
+    Tainted ``mission_type`` values must ride as ``confined`` parts under this
+    root — never be joined into the base before confinement.
+    """
     from ..config import CONFIG_PATH
-    return CONFIG_PATH.parent / "prompt_templates" / mission_type
+    return CONFIG_PATH.parent / "prompt_templates"
+
+
+def _dir(mission_type: str) -> Path:
+    """Per-type subdirectory for read/list/seed (type from PLAYBOOK_VARS or disk)."""
+    return _prompt_templates_root() / mission_type
 
 
 def _require_type(mission_type: str) -> None:
@@ -131,7 +141,7 @@ def save_template(mission_type: str, name: str, text: str) -> None:
         raise ValueError("template name must match "
                          "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
     validate_template(mission_type, text)
-    path = confined(_dir(mission_type).resolve(), f"{name}.yaml")
+    path = confined(_prompt_templates_root(), mission_type, f"{name}.yaml")
     _atomic_yaml(path,
                  {"schema_version": 1, "mission_type": mission_type,
                   "name": name, "template": text})
@@ -144,9 +154,8 @@ def delete_template(mission_type: str, name: str) -> None:
     if not _NAME_RE.fullmatch(name):
         raise ValueError("template name must match "
                          "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
-    root = _dir(mission_type).resolve()
     try:
-        path = confined(root, f"{name}.yaml")
+        path = confined(_prompt_templates_root(), mission_type, f"{name}.yaml")
     except ValueError as e:
         raise ValueError(
             f"template path escapes {mission_type!r} template directory"
@@ -238,16 +247,25 @@ def template_warnings(config) -> list[str]:
 # seeded trio also gets the "Customer Success" preset. Identifying prompts
 # are plain prefix text: no {var} rendering, no placeholder validation.
 
-def _dev_dir(dev_type: str) -> Path:
+def _devtype_prompt_templates_root() -> Path:
+    """Constant trusted root for Dev-Type identifying-prompt templates (CAKE-140).
+
+    Tainted ``dev_type`` values must ride as ``confined`` parts under this
+    root — never be joined into the base before confinement.
+    """
     from ..config import CONFIG_PATH
-    return CONFIG_PATH.parent / "devtype_prompt_templates" / dev_type
+    return CONFIG_PATH.parent / "devtype_prompt_templates"
+
+
+def _dev_dir(dev_type: str) -> Path:
+    """Per-dev-type subdirectory for read/list/seed (type from dev_types keys or disk)."""
+    return _devtype_prompt_templates_root() / dev_type
 
 
 def known_devtype_dirs() -> list[Path]:
     """Every dev type that has a prompt-template dir on disk — the settings-
     bundle apply prunes dirs of dev types the bundle removed (ADR-0013)."""
-    from ..config import CONFIG_PATH
-    root = CONFIG_PATH.parent / "devtype_prompt_templates"
+    root = _devtype_prompt_templates_root()
     return sorted(p for p in root.iterdir() if p.is_dir()) if root.is_dir() else []
 
 
@@ -296,24 +314,21 @@ def save_devtype_prompt(dev_type: str, name: str, text: str) -> None:
                          "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
     if len(text.encode()) > _MAX_TEMPLATE_BYTES:
         raise ValueError(f"template exceeds {_MAX_TEMPLATE_BYTES // 1024} KB")
-    path = confined(_dev_dir(dev_type).resolve(), f"{name}.yaml")
+    path = confined(_devtype_prompt_templates_root(), dev_type, f"{name}.yaml")
     _atomic_yaml(path,
                  {"schema_version": 1, "dev_type": dev_type,
                   "name": name, "template": text})
 
 
-_DEV_TYPE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
-
-
 def delete_devtype_prompt(dev_type: str, name: str) -> None:
-    if not _DEV_TYPE_NAME_RE.fullmatch(dev_type or ""):
+    from ..config import DEV_TYPE_NAME_RE
+    if not DEV_TYPE_NAME_RE.fullmatch(dev_type or ""):
         raise ValueError("dev_type must match ^[A-Za-z0-9][A-Za-z0-9_-]*$")
     if not _NAME_RE.fullmatch(name):
         raise ValueError("template name must match "
                          "^[A-Za-z0-9][A-Za-z0-9 _-]{0,63}$")
-    root = _dev_dir(dev_type).resolve()
     try:
-        path = confined(root, f"{name}.yaml")
+        path = confined(_devtype_prompt_templates_root(), dev_type, f"{name}.yaml")
     except ValueError as e:
         raise ValueError(
             f"template path escapes {dev_type!r} template directory"

--- a/app/devcake/secrets.py
+++ b/app/devcake/secrets.py
@@ -25,7 +25,7 @@ import tempfile
 from pathlib import Path
 
 from . import security
-from .config import HARNESS_VAR_PATTERN, _INSTANCE_NAME_RE
+from .config import DEV_TYPE_NAME_RE, HARNESS_VAR_PATTERN, _INSTANCE_NAME_RE
 from .pathsafety import confined
 
 log = logging.getLogger("devcake.secrets")
@@ -312,7 +312,7 @@ def require_credential_ref(dev_type: str, filename: str) -> None:
     """Path components only — refuse reserved dirs and traversal."""
     if (not dev_type or dev_type in _RESERVED_SECRET_DIRS
             or "/" in dev_type or "\\" in dev_type or ".." in dev_type
-            or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", dev_type)):
+            or not DEV_TYPE_NAME_RE.fullmatch(dev_type)):
         raise ValueError(f"invalid credential dev_type {dev_type!r}")
     base = os.path.basename(filename or "")
     if (not base or base != filename or base in (".", "..")
@@ -464,7 +464,7 @@ def inventory() -> dict[str, list[dict]]:
         for d in sorted(root.iterdir()):
             if not d.is_dir() or d.name in _RESERVED_SECRET_DIRS:
                 continue
-            if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", d.name):
+            if not DEV_TYPE_NAME_RE.fullmatch(d.name):
                 continue
             for p in sorted(d.iterdir()):
                 if p.is_file():

--- a/app/tests/test_pathsafety.py
+++ b/app/tests/test_pathsafety.py
@@ -82,3 +82,41 @@ def test_confined_escape_cannot_leave_base(tmp_path: Path) -> None:
     # Happy path stays inside.
     inside = confined(base, "ok.txt")
     assert str(inside).startswith(str(base.resolve()))
+
+
+def test_confined_multi_part_normpath_belt_under_constant_base(
+        tmp_path: Path) -> None:
+    """Multi-part join under a constant base stays inside after the
+    normalize-then-prefix belt (CAKE-140) and resolve."""
+    import os
+
+    base = tmp_path / "prompt_templates"
+    base.mkdir()
+    path = confined(base, "EXECUTE", "terse.yaml")
+    base_norm = os.path.normpath(str(base))
+    assert os.path.normpath(str(path)).startswith(base_norm + os.sep)
+    assert path == (base / "EXECUTE" / "terse.yaml").resolve()
+
+
+def test_confined_refuses_symlink_escape_after_normpath_belt(
+        tmp_path: Path) -> None:
+    """A symlink inside the jail that points outside must still raise;
+    the outside sentinel must remain untouched (CAKE-140).
+
+    The normalize-then-prefix check is lexical (does not follow links);
+    resolve()+relative_to remains the symlink belt.
+    """
+    jail = tmp_path / "jail"
+    jail.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    sentinel = outside_dir / "secret.txt"
+    sentinel.write_text("keep-me\n")
+    link = jail / "escape"
+    link.symlink_to(outside_dir)
+
+    with pytest.raises(ValueError):
+        confined(jail, "escape", "secret.txt")
+
+    assert sentinel.exists()
+    assert sentinel.read_text() == "keep-me\n"

--- a/app/tests/test_prompt_template_type_as_part_traversal.py
+++ b/app/tests/test_prompt_template_type_as_part_traversal.py
@@ -1,0 +1,132 @@
+"""Store-level traversal refusal when mission_type / dev_type ride as
+confined PARTS under constant roots (CAKE-140).
+
+After #324, save/delete already called confined, but built the base from
+user-supplied type via _dir/_dev_dir. Hostile types must be refused at the
+store layer; a sentinel outside the template tree must stay untouched.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+def _tpl(monkeypatch, tmp_path):
+    import devcake.config as config_mod
+    monkeypatch.setattr(config_mod, "CONFIG_PATH",
+                        tmp_path / "config" / "config.yaml")
+    from devcake.prompts import templates
+    return templates
+
+
+_HOSTILE_TYPES = ("..", "foo/bar", "../x", "a\\b")
+
+
+@pytest.mark.parametrize("bad", _HOSTILE_TYPES)
+def test_save_template_refuses_hostile_mission_type(
+        monkeypatch, tmp_path, bad):
+    t = _tpl(monkeypatch, tmp_path)
+    (tmp_path / "config" / "prompt_templates").mkdir(parents=True)
+    sentinel = tmp_path / "config" / "outside.yaml"
+    sentinel.write_text("keep: me\n")
+
+    with pytest.raises(ValueError):
+        t.save_template(bad, "terse", "just {key} on {branch}")
+
+    assert sentinel.exists()
+    assert "keep: me" in sentinel.read_text()
+
+
+@pytest.mark.parametrize("bad", _HOSTILE_TYPES)
+def test_delete_template_refuses_hostile_mission_type(
+        monkeypatch, tmp_path, bad):
+    t = _tpl(monkeypatch, tmp_path)
+    (tmp_path / "config" / "prompt_templates").mkdir(parents=True)
+    sentinel = tmp_path / "config" / "outside.yaml"
+    sentinel.write_text("keep: me\n")
+
+    with pytest.raises(ValueError):
+        t.delete_template(bad, "terse")
+
+    assert sentinel.exists()
+    assert "keep: me" in sentinel.read_text()
+
+
+@pytest.mark.parametrize("bad", _HOSTILE_TYPES)
+def test_save_devtype_prompt_refuses_hostile_dev_type(
+        monkeypatch, tmp_path, bad):
+    t = _tpl(monkeypatch, tmp_path)
+    (tmp_path / "config" / "devtype_prompt_templates").mkdir(parents=True)
+    sentinel = tmp_path / "config" / "outside.yaml"
+    sentinel.write_text("keep: me\n")
+
+    with pytest.raises(ValueError):
+        t.save_devtype_prompt(bad, "custom", "Custom identifying text.")
+
+    assert sentinel.exists()
+    assert "keep: me" in sentinel.read_text()
+
+
+@pytest.mark.parametrize("bad", _HOSTILE_TYPES)
+def test_delete_devtype_prompt_refuses_hostile_dev_type(
+        monkeypatch, tmp_path, bad):
+    t = _tpl(monkeypatch, tmp_path)
+    (tmp_path / "config" / "devtype_prompt_templates").mkdir(parents=True)
+    sentinel = tmp_path / "config" / "outside.yaml"
+    sentinel.write_text("keep: me\n")
+
+    with pytest.raises(ValueError):
+        t.delete_devtype_prompt(bad, "custom")
+
+    assert sentinel.exists()
+    assert "keep: me" in sentinel.read_text()
+
+
+def test_save_devtype_prompt_confined_alone_when_gates_bypassed(
+        monkeypatch, tmp_path):
+    """With regex / membership gates monkeypatched away, confined alone
+    must refuse a hostile dev_type and leave the outside sentinel alone."""
+    t = _tpl(monkeypatch, tmp_path)
+    root = tmp_path / "config" / "devtype_prompt_templates"
+    root.mkdir(parents=True)
+    sentinel = tmp_path / "config" / "outside.yaml"
+    sentinel.write_text("keep: me\n")
+
+    monkeypatch.setattr(t, "_NAME_RE", re.compile(r".+"))
+    # delete_devtype_prompt's charset gate — save has none today; patch the
+    # shared authority too so a future gate cannot mask the confined belt.
+    if hasattr(t, "_DEV_TYPE_NAME_RE"):
+        monkeypatch.setattr(t, "_DEV_TYPE_NAME_RE", re.compile(r".+"))
+    import devcake.config as config_mod
+    if hasattr(config_mod, "DEV_TYPE_NAME_RE"):
+        monkeypatch.setattr(config_mod, "DEV_TYPE_NAME_RE", re.compile(r".+"))
+
+    with pytest.raises(ValueError):
+        t.save_devtype_prompt("..", "custom", "Custom identifying text.")
+
+    assert sentinel.exists()
+    assert "keep: me" in sentinel.read_text()
+    # Nothing written under the templates root from the hostile type.
+    assert list(root.iterdir()) == []
+
+
+def test_save_template_confined_alone_when_type_gate_bypassed(
+        monkeypatch, tmp_path):
+    """With _require_type / validate_template bypassed, confined refuses
+    a hostile mission_type under the constant root."""
+    t = _tpl(monkeypatch, tmp_path)
+    (tmp_path / "config" / "prompt_templates").mkdir(parents=True)
+    sentinel = tmp_path / "config" / "outside.yaml"
+    sentinel.write_text("keep: me\n")
+
+    monkeypatch.setattr(t, "_require_type", lambda *_a, **_k: None)
+    monkeypatch.setattr(t, "validate_template", lambda *_a, **_k: None)
+    monkeypatch.setattr(t, "_NAME_RE", re.compile(r".+"))
+
+    with pytest.raises(ValueError):
+        t.save_template("..", "terse", "anything")
+
+    assert sentinel.exists()
+    assert "keep: me" in sentinel.read_text()


### PR DESCRIPTION
## Intent

Close residual `py/path-injection` alerts left after #324 by making tainted `mission_type` / `dev_type` values ride as `confined` **parts** under **constant** template roots, adding a CodeQL-recognized normalize-then-prefix belt inside `pathsafety.confined` before `resolve()`, and landing the carried-over Dev Type charset authority + `confined` on `config.save_dev_type`.

Mission: https://linear.app/fidecastro/issue/CAKE-140/close-the-remaining-path-injection-alerts-pass-tainted-components-as

## Why templates stayed open after #324

`confined(base, *parts)` trusts `base` and only barrier-checks `*parts`. Secrets/profiles already pass a constant base → CodeQL cleared. Template save/delete still did `confined(_dir|_dev_dir(user_type).resolve(), name.yaml)`, so the user-supplied type became the trusted base and taint still reached `resolve` / `relative_to` / `exists` / `unlink` / `_atomic_yaml`.

**Parts-not-base rule** (now in `confined`'s docstring): tainted values ride as `*parts`; `base` must be a constant.

## Changes

1. **`prompts/templates.py`** — constant roots `_prompt_templates_root()` / `_devtype_prompt_templates_root()`; save/delete use `confined(root, type, f"{name}.yaml")`.
2. **`pathsafety.confined`** — after component checks: `os.path.normpath` + `startswith(base_norm + os.sep)`, then existing `resolve()` + `relative_to`.
3. **Charset + `save_dev_type`** — `DEV_TYPE_NAME_PATTERN` / `DEV_TYPE_NAME_RE` beside `DevType`; callers in templates, `devtypes_service`, `secrets`, `delete_dev_type` / `save_dev_type` share it. `save_dev_type` now confines before `_atomic_yaml`.

### `_dir` / `_dev_dir` choice

**Kept** for read/list/seed paths whose type comes from `PLAYBOOK_VARS` / `dev_types` keys or the filesystem. They now compose from the same constant-root helpers. Only the four save/delete sinks build paths via `confined(root, type, name)`.

### `_atomic_yaml` callers (dumb-sink invariant)

One-line comment on `_atomic_yaml`: unconfined sink — callers must pass an already-confined or otherwise trusted path.

| Caller | Path provenance |
|---|---|
| `config.save_config` / first-boot `load_config` | `CONFIG_PATH` (constant) |
| `config.save_dev_type` | **this PR:** `confined(CONFIG_PATH.parent / "dev_types", …)` |
| `config.load_dev_types` migrate/seed | under `dev_types/` from trusted default / migrated names |
| `profiles.py` save/rename | already via confined profile paths (post-#324) |
| `templates` save | **this PR:** confined from constant roots |
| `templates` seed | `_dir`/`_dev_dir` from trusted dict keys (`PLAYBOOK_VARS` / `dev_types`) |

## Tests

- Extended `test_pathsafety.py` (multi-part normpath belt + symlink escape).
- New `test_prompt_template_type_as_part_traversal.py` — hostile `mission_type`/`dev_type` refused at store for all four save/delete; gates-bypassed cases prove `confined` alone.
- Existing suites kept green: delete traversal, profiles, Dev Type path confinement.

**Evidence (this run):**
- Fresh `devcake/app-test` image via Dockerfile `--target test` (bake unavailable on this host's buildah shim).
- `docker run … pytest` on pathsafety + type-as-part + delete-traversal + devtype-path + profiles → **70 passed**.
- Broader `-k 'pathsafe or prompt_template or profiles or devtype_path or secrets'` → **145 passed**.
- `ruff check` on touched files → clean.

## CodeQL verification method (honest)

**Do not** treat the PR status check or a branch-ref alert listing as clearance (measured false-green on #324 — branch ref showed zero while main later showed 15).

**Verification method:** code-scanning board on `refs/heads/main` after the post-merge analysis.

**Expected result:** alerts 56–59, 66–71, and 8–12 closed; board → ~7 remaining, all non-`path-injection` heuristics.

Until that main-board scan completes, unit green ≠ CodeQL closed.

## Out of scope

- Changing CodeQL config / claiming board clearance from this PR check.
- Hardening the ~7 residual non-path-injection heuristics.