### PR TITLE
[CAKE-142] Dispatch reads credential files through the secrets store port

### DIFF
--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 from datetime import datetime
-from pathlib import Path
 
 from opentelemetry import trace
 from opentelemetry.propagate import inject
@@ -1011,33 +1010,39 @@ def _credential_spec(mgr, dev_type: DevType) -> tuple[dict[str, str], list[dict]
             log.warning("secret env %s for dev type %s not stored — add it "
                         "on the admin Config page", var, dev_type.name)
     files = []
-    secrets_dir = (Path(os.environ.get("DEVCAKE_DATA_DIR", "/data"))
-                   / "secrets" / dev_type.name)
     for cf in harness.credential_files:
-        p = secrets_dir / cf.secret_file
-        if not p.exists():
-            log.warning("credential file %s missing for %s — connect via OAuth "
-                        "or upload it on the admin Config page", p, dev_type.name)
+        content = _secrets.read_credential_file(dev_type.name, cf.secret_file)
+        if content is None:
+            log.warning(
+                "credential file %s missing for %s — connect via OAuth "
+                "or upload it on the admin Config page",
+                cf.secret_file, dev_type.name,
+            )
             continue
-        content = p.read_text()
         # Host-side Grok OAuth refresh at the inject chokepoint (no Dev
         # write-back). Fail closed → CredentialRefreshError → runspec.error.
         if (cf.secret_file == "grok-auth.json"
                 and getattr(mgr, "oidc_tokens", None) is not None):
             from ..grok_oauth import (CredentialRefreshError,
                                       ensure_fresh_for_inject)
-            from ... import secrets as _sec
 
             def _write(text: str, _dt=dev_type.name, _fn=cf.secret_file) -> None:
-                _sec.write_credential_file(_dt, _fn, text)
+                _secrets.write_credential_file(_dt, _fn, text)
+
+            _dt, _fn = dev_type.name, cf.secret_file
+            _snapshot = content
+
+            def _reread(_dt=_dt, _fn=_fn, _snapshot=_snapshot) -> str:
+                return _secrets.read_credential_file(_dt, _fn) or _snapshot
 
             try:
                 content = ensure_fresh_for_inject(
                     content,
                     token_port=mgr.oidc_tokens,
                     write_full=_write,
-                    lock_path=secrets_dir / ".grok-auth.lock",
-                    reread=p.read_text,
+                    lock_path=_secrets.credential_path(
+                        dev_type.name, ".grok-auth.lock"),
+                    reread=_reread,
                 )
             except CredentialRefreshError:
                 raise

--- a/app/devcake/secrets.py
+++ b/app/devcake/secrets.py
@@ -320,6 +320,18 @@ def require_credential_ref(dev_type: str, filename: str) -> None:
         raise ValueError(f"invalid credential filename {filename!r}")
 
 
+def credential_path(dev_type: str, filename: str) -> Path:
+    """Confined path under /data/secrets/{dev_type}/{filename}.
+
+    Allowlist via ``require_credential_ref`` then ``confined`` — the single
+    builder for credential write / read / delete and the grok-auth lock
+    sidecar. Callers that only need bytes should prefer
+    ``read_credential_file`` / ``write_credential_file``.
+    """
+    require_credential_ref(dev_type, filename)
+    return confined(_root(), dev_type, filename)
+
+
 # Operator-uploaded / OAuth credential files (raw text, not JSON dicts).
 MAX_CREDENTIAL_FILE_BYTES = 1 * 1024 * 1024
 
@@ -327,13 +339,12 @@ MAX_CREDENTIAL_FILE_BYTES = 1 * 1024 * 1024
 def write_credential_file(dev_type: str, filename: str, content: str) -> Path:
     """Atomically write a raw credential file under /data/secrets/{dev_type}/.
     0600; registers content for redaction when long enough (≥8)."""
-    require_credential_ref(dev_type, filename)
     raw = content if isinstance(content, str) else str(content or "")
     data = raw.encode()
     if len(data) > MAX_CREDENTIAL_FILE_BYTES:
         raise ValueError(
             f"credential file too large ({len(data)} > {MAX_CREDENTIAL_FILE_BYTES})")
-    path = confined(_root(), dev_type, filename)
+    path = credential_path(dev_type, filename)
     _atomic_write_bytes(path, data)
     if len(raw) >= 8:
         security.register_runtime_secret(
@@ -341,10 +352,17 @@ def write_credential_file(dev_type: str, filename: str, content: str) -> Path:
     return path
 
 
+def read_credential_file(dev_type: str, filename: str) -> str | None:
+    """Read a raw credential file. ``None`` when absent (caller logs)."""
+    path = credential_path(dev_type, filename)
+    if not path.exists():
+        return None
+    return path.read_text()
+
+
 def delete_credential_file(dev_type: str, filename: str) -> None:
     """Unlink one OAuth/uploaded credential file. Missing = no-op."""
-    require_credential_ref(dev_type, filename)
-    path = confined(_root(), dev_type, filename)
+    path = credential_path(dev_type, filename)
     path.unlink(missing_ok=True)
     # drop empty dir so inventory doesn't keep a ghost. suppress: a concurrent
     # OAuth write can race the empty check (TOCTOU) — unlink already succeeded.
@@ -352,7 +370,6 @@ def delete_credential_file(dev_type: str, filename: str) -> None:
     if parent.is_dir() and not any(parent.iterdir()):
         with contextlib.suppress(OSError):
             parent.rmdir()
-
 
 # ── status (never echoes values) ────────────────────────────────────────────
 

--- a/app/tests/test_secrets_store.py
+++ b/app/tests/test_secrets_store.py
@@ -288,6 +288,53 @@ def test_delete_credential_file_unlinks(monkeypatch, tmp_path):
         s.delete_credential_file("judgment", "../harness/X.json")
 
 
+def test_read_credential_file_allowlist_refusal(monkeypatch, tmp_path):
+    """Reserved dirs and invalid dev_type names refuse before any read."""
+    s = _store(monkeypatch, tmp_path)
+    with pytest.raises(ValueError):
+        s.read_credential_file("harness", "x.json")
+    with pytest.raises(ValueError):
+        s.read_credential_file("connections", "x.json")
+    with pytest.raises(ValueError):
+        s.read_credential_file("../etc", "passwd")
+    with pytest.raises(ValueError):
+        s.read_credential_file("bad.name", "auth.json")
+
+
+def test_read_credential_file_traversal_refusal(monkeypatch, tmp_path):
+    """Hostile filenames must not escape the Dev-Type credential dir."""
+    s = _store(monkeypatch, tmp_path)
+    with pytest.raises(ValueError):
+        s.read_credential_file("judgment", "../harness/X.json")
+    with pytest.raises(ValueError):
+        s.read_credential_file("judgment", "../etc/passwd")
+    with pytest.raises(ValueError):
+        s.read_credential_file("judgment", "a/b.json")
+
+
+def test_read_credential_file_absent_returns_none(monkeypatch, tmp_path):
+    s = _store(monkeypatch, tmp_path)
+    assert s.read_credential_file("judgment", "grok-auth.json") is None
+
+
+def test_read_credential_file_present_returns_content(monkeypatch, tmp_path):
+    s = _store(monkeypatch, tmp_path)
+    expected = '{"token":"oauth-read-sentinel-abcdef"}'
+    s.write_credential_file("judgment", "grok-auth.json", expected)
+    assert s.read_credential_file("judgment", "grok-auth.json") == expected
+
+
+def test_credential_path_confined_lock_sidecar(monkeypatch, tmp_path):
+    """Lock sidecar path for grok refresh — same allowlist + confined builder."""
+    s = _store(monkeypatch, tmp_path)
+    path = s.credential_path("main-dev", ".grok-auth.lock")
+    assert path == (tmp_path / "secrets" / "main-dev" / ".grok-auth.lock").resolve()
+    with pytest.raises(ValueError):
+        s.credential_path("harness", ".grok-auth.lock")
+    with pytest.raises(ValueError):
+        s.credential_path("main-dev", "../etc/passwd")
+
+
 def test_inventory_presence_only_never_values(monkeypatch, tmp_path):
     s = _store(monkeypatch, tmp_path)
     s.write_connection_secret("pmo", "linear", "api_key", "pmo-sentinel-secret-xyz")


### PR DESCRIPTION
## Intent

Move Dev-Type credential **reads** behind `secrets.py` (ADR-0011 owner of `/data/secrets`) so `dispatch._credential_spec` no longer hand-builds secret paths. Reword the two missing-file warnings to interpolate `cf.secret_file` / `dev_type.name` only (names, not a joined path) so CodeQL `py/clear-text-logging` alerts 2–3 lose the secret-typed path expression.

Mission: https://linear.app/fidecastro/issue/CAKE-142/dispatch-reads-credential-files-through-the-secrets-store-port

## Changes

- **`secrets.credential_path`** — shared confined builder (`require_credential_ref` + `confined`); used by write / read / delete.
- **`secrets.read_credential_file`** — returns content or `None` when absent (no logging; dispatch owns operator context).
- **`dispatch._credential_spec`** — uses the accessor; grok-auth refresh uses `credential_path(..., ".grok-auth.lock")` for the lock sidecar and `read_credential_file` for reread. **Write-back path untouched:** `write_full` still calls `write_credential_file`.
- Warnings interpolate filename + Dev Type name only.

## Other `/data/secrets` hand-builds (listed, not migrated)

1. `settings_bundle._read_credential_files` — directory walk for bundle export (needs inventory/list accessor).
2. `adapters/gitea/provision._secrets_dir` — reserved `internal_forge/` system secrets.
3. `harness.dev_type_status` — `Path(DEVCAKE_DATA_DIR)/"secrets"/dt.name` glob for admin `secrets_present` (directory listing, not a single-file read).

## How to verify

```bash
./scripts/pytest_app.sh   # or focused:
# tests/test_secrets_store.py (new accessor cases)
# tests/test_harness.py::test_credential_spec_*
```

Observed locally (fresh `devcake/app-test` bake): **2753 passed**, 2 skipped (live Redis messaging ignored; one Redis-dependent clear test deselected — host cannot create throwaway docker networks). Focused accessor + credential_spec suite: **53 passed**.

## CodeQL

Do **not** claim alerts 2–3 closed until main’s next Analyze scan. Reworded warnings either clear on scan or feed the false-positive packet mission with this PR as evidence.

## Out of scope

- Migrating settings_bundle / gitea / harness status path builders
- Changing `ensure_fresh_for_inject` algorithm or fail-closed refresh policy