### PR TITLE
[CAKE-143] Teach CodeQL the redaction chokepoint (advanced setup + sanitizer model)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+# Advanced-setup CodeQL config for DevCake.
+# Wires the in-repo redact sanitizer model pack (scanner mirror of docs/14 §7).
+name: "DevCake CodeQL"
+
+packs:
+  python:
+    - ./.github/codeql/extensions/devcake-redact

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,10 @@
 # Advanced-setup CodeQL config for DevCake.
-# Wires the in-repo redact sanitizer model pack (scanner mirror of docs/14 §7).
+#
+# The local redact model pack lives at
+# `.github/codeql/extensions/devcake-redact/` (scanner mirror of docs/14 §7).
+# It is activated from `.github/workflows/codeql.yml` via
+# CODEQL_ACTION_EXTRA_OPTIONS (--additional-packs + --extension-packs).
+# The `packs:` key here only accepts registry specs (`scope/name`), not
+# filesystem paths — a path entry is ignored with
+# "Invalid CodeQL pack specification".
 name: "DevCake CodeQL"
-
-packs:
-  python:
-    - ./.github/codeql/extensions/devcake-redact

--- a/.github/codeql/extensions/devcake-redact/models/redact.yml
+++ b/.github/codeql/extensions/devcake-redact/models/redact.yml
@@ -1,0 +1,17 @@
+# Models-as-data barrier for the DevCake redaction chokepoint.
+#
+# Type uses a trailing "!" so CodeQL selects the module itself (not an
+# instance of the module). Without "!", Member[redact] never matches.
+# See github/codeql ApiGraphModelsSpecific.qll getExtraNodeFromType.
+#
+# Kind "cleartext-storage" is the forward-compatible name for
+# py/clear-text-storage-sensitive-data. Upstream CleartextStorageCustomizations
+# currently has no SanitizerFromModel hook that consumes barrierNode kinds
+# (unlike PathInjection / SqlInjection), so this pack alone cannot close
+# alert 1 until that hook exists or a false-positive packet dismisses it.
+extensions:
+  - addsTo:
+      pack: codeql/python-all
+      extensible: barrierModel
+    data:
+      - ["devcake.security!", "Member[redact].ReturnValue", "cleartext-storage"]

--- a/.github/codeql/extensions/devcake-redact/qlpack.yml
+++ b/.github/codeql/extensions/devcake-redact/qlpack.yml
@@ -1,0 +1,9 @@
+# Scanner-side mirror of app/devcake/security.py::redact (docs/14 §7).
+# When redact moves or gains siblings, update models/redact.yml in lockstep.
+name: flieber-inc/devcake-redact
+version: 0.0.1
+library: true
+extensionTargets:
+  codeql/python-all: "*"
+dataExtensions:
+  - models/*.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+# CodeQL advanced setup — replaces GitHub default setup for this repo.
+#
+# Coverage mirrors the previous default-setup languages (analyses on main):
+#   python, javascript-typescript, actions — on pull_request + push to main.
+# Query suite: default (same as former default-setup query_suite).
+#
+# Operator action at merge: disable CodeQL default setup in repo Settings →
+# Code security → CodeQL. Default setup and advanced setup cannot coexist;
+# leaving both on duplicates scans. Coordinate the flip when merging this PR.
+#
+# Action pins follow the same SHA-pin convention as ci.yml / docker-*.yml.
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly catch-up for newly published queries (default setup was weekly).
+    - cron: "17 5 * * 1"
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - javascript-typescript
+          - actions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,3 +57,12 @@ jobs:
         uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:${{ matrix.language }}"
+        env:
+          # Local model packs cannot be expressed via config `packs:` (that
+          # key only accepts registry scope/name). These CLI flags add the
+          # extensions search path and activate our pack by name — same
+          # pattern codeql-action uses for its own pr-diff-range pack.
+          CODEQL_ACTION_EXTRA_OPTIONS: >-
+            {"database":{"run-queries":[
+            "--additional-packs=${{ github.workspace }}/.github/codeql/extensions",
+            "--extension-packs=flieber-inc/devcake-redact"]}}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,10 +59,11 @@ jobs:
           category: "/language:${{ matrix.language }}"
         env:
           # Local model packs cannot be expressed via config `packs:` (that
-          # key only accepts registry scope/name). These CLI flags add the
-          # extensions search path and activate our pack by name — same
-          # pattern codeql-action uses for its own pr-diff-range pack.
+          # key only accepts registry scope/name). --additional-packs adds the
+          # extensions search path; --model-packs activates our pack by name
+          # without overriding codeql-action's own --extension-packs
+          # (pr-diff-range) flag on the same command line.
           CODEQL_ACTION_EXTRA_OPTIONS: >-
             {"database":{"run-queries":[
             "--additional-packs=${{ github.workspace }}/.github/codeql/extensions",
-            "--extension-packs=flieber-inc/devcake-redact"]}}
+            "--model-packs=flieber-inc/devcake-redact"]}}

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -391,6 +391,13 @@ values and token patterns with `«REDACTED»` (`app/devcake/security.py`):
 Redaction matters **because Devs hold secrets**. It is the last line of defense
 for **app-mediated** posts to PMO systems and forges, not a substitute for zone C.
 
+**Scanner models:** CodeQL advanced setup loads
+`.github/codeql/extensions/devcake-redact/` as a models-as-data pack that
+declares `security.redact` as a taint barrier (the scanner-side mirror of this
+chokepoint). When `redact()` moves, is renamed, or gains sibling scrubbers that
+must also stop taint, update that model file in the same change — the pack is a
+pinned mirror, not a second redaction implementation.
+
 ---
 
 ## 8. Warnings vs gates


### PR DESCRIPTION
## Intent

Convert CodeQL from GitHub **default setup** to **advanced setup** so we can load an in-repo models-as-data pack that declares `devcake.security.redact` as the scanner-side mirror of the redaction chokepoint (`docs/14` §7 / `app/devcake/security.py`). No app logic change — `feed._audit` already calls `redact(detail)` before the audit JSONL write.

Mission: [CAKE-143](https://linear.app/fidecastro/issue/CAKE-143/teach-codeql-the-redaction-chokepoint-advanced-setup-sanitizer-model)

## What landed

| Path | Role |
|---|---|
| `.github/workflows/codeql.yml` | Advanced setup: `python`, `javascript-typescript`, `actions` on PR + `main` (+ weekly). SHA-pinned like `ci.yml`. Local model pack via `CODEQL_ACTION_EXTRA_OPTIONS`: `--additional-packs=…/extensions` + `--model-packs=flieber-inc/devcake-redact`. |
| `.github/codeql/codeql-config.yml` | Named config; documents why `packs:` cannot hold a filesystem path. |
| `.github/codeql/extensions/devcake-redact/` | Model pack: `barrierModel` for `devcake.security!` / `Member[redact].ReturnValue` / kind `cleartext-storage`. |
| `docs/14-security.md` | Short §7 paragraph: scanner models move in lockstep with `redact()`. |

## Operator action required (blocks CodeQL check green)

**Default setup and advanced setup cannot coexist.** Observed on this PR:

```
##[error]Code Scanning could not process the submitted SARIF file:
CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled
```

Disable CodeQL default setup in **Settings → Code security → Code scanning / CodeQL**, then re-run the `CodeQL` workflow. The committed workflow is the new source of truth.

API disable attempt from the implementer token:

```
PATCH .../code-scanning/default-setup → 403
Resource not accessible by personal access token
```

## Fallback (alert 1)

Primary goal was closing alert **#1** (`py/clear-text-storage-sensitive-data` on `feed.py` `_audit`).

**Finding:** Upstream `CleartextStorageCustomizations.qll` has abstract `Sanitizer` but **no** `SanitizerFromModel` / `ModelOutput::barrierNode` (unlike PathInjection / SqlInjection / …). A `barrierModel` row is a silent no-op for this query. Kind used: forward-compatible `cleartext-storage`.

**Mission fallback:** do not contort `redact()`. Hand alert **#1** to the **false-positive packet** mission. This PR still lands CodeQL configuration in-repo.

## How clearance was verified

1. **`ci.yml`:** green on tip (`Bake (ci) + pytest + dispatch smoke`).
2. **Model pack wiring:** first tip used config `packs: ./path` → `Invalid CodeQL pack specification` (ignored). Fixed via `--additional-packs` / `--model-packs`. Re-run shows those flags on `database run-queries` and `Finished loading data extensions` with no invalid-pack warning.
3. **Alert #1:** still **open** (expected — missing upstream `SanitizerFromModel`). PR status check alone does not prove closure.
4. **Advanced-setup SARIF upload:** blocked until default setup is disabled (error quoted above).

## Proof (Always Works™)

- [x] Docs / config / workflow — YAML parse-checked; `docs/14` §7 re-read
- [x] `ci.yml` green on tip
- [ ] `CodeQL` upload green — **blocked on operator default-setup disable**

## Deviations

- Prior PLAN steps left no usable plan; EXECUTE followed the mission brief + DISCOVERY_1 + live library inspection.
- Three commits (land + two wiring fixes after first CodeQL runs); mission asked for one commit — force-push forbidden.
- Did not fork `CleartextStorage.ql` to add a local `SanitizerFromModel` bridge (fallback is the mission-approved path).