### PR TITLE
[CAKE-144] False-positive audit and dismissal packet for the remaining heuristic alerts

### DIFF
--- a/app/devcake/adapters/gitea/provision.py
+++ b/app/devcake/adapters/gitea/provision.py
@@ -695,6 +695,7 @@ class GiteaProvisioner:
         try:
             return json.loads(path.read_text())
         except Exception:  # noqa: BLE001 — unreadable secret reads as absent (logged); provisioning re-mints from absence
+            # Logs the secret file path only — content never reaches this call.
             log.error("unreadable internal-forge secret %s", path)
             return None
 

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -1007,6 +1007,7 @@ def _credential_spec(mgr, dev_type: DevType) -> tuple[dict[str, str], list[dict]
         if (v := _secrets.read_harness_secret(var)):
             env[var] = v
         else:
+            # Logs the env var NAME only — values never reach this call.
             log.warning("secret env %s for dev type %s not stored — add it "
                         "on the admin Config page", var, dev_type.name)
     files = []

--- a/app/devcake/domain/orchestrator/feed.py
+++ b/app/devcake/domain/orchestrator/feed.py
@@ -244,6 +244,7 @@ def _audit(mgr, pmo_id: str, action: str, detail: str = "") -> None:
     # match settings_bundle.audit_event so on-disk JSONL is scrubbed too.
     detail = redact(detail)
     markers.AUDIT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    # redact(detail) already scrubbed; JSONL write is post-barrier (scanner cannot see MaD yet).
     with open(markers.AUDIT_PATH, "a") as f:
         f.write(json.dumps({"ts": datetime.now(timezone.utc).isoformat(),
                             "instance": getattr(mgr, "instance_name", ""),

--- a/app/devcake/domain/run.py
+++ b/app/devcake/domain/run.py
@@ -45,6 +45,8 @@ def aware(ts: datetime) -> datetime:
 
 
 def auth_digest(value: str) -> str:
+    # Fingerprints a high-entropy machine-minted ACL secret (token_urlsafe);
+    # not a human-password KDF use.
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 

--- a/app/devcake/domain/steward_service.py
+++ b/app/devcake/domain/steward_service.py
@@ -114,6 +114,7 @@ class StewardService:
             outcome = "secret_env_gate"
             error = (f"secret env {', '.join(missing)} referenced by "
                      "mcp_setup_commands but not stored")
+            # Logs missing env var NAMEs only — values never reach this call.
             log.warning("steward periodic run skipped — %s", error)
         else:
             async with self._lock:

--- a/app/tests/test_giveup_and_tripwire_loud.py
+++ b/app/tests/test_giveup_and_tripwire_loud.py
@@ -195,6 +195,7 @@ def test_give_up_feed_includes_trace_id_when_oo_ui_configured(
     assert "missing result.json" in body
     assert "T-1-1-EXECUTE-CCCCCC" in body
     assert trace_id in body
+    # Test assertion on comment-body text — not URL sanitization.
     assert "https://oo.example" in body
 
 

--- a/docs/14-security.md
+++ b/docs/14-security.md
@@ -541,3 +541,40 @@ contract:
 **Not backlog (explicit non-goals):** multi-tenant SaaS hardening; treating
 prompt injection as a ship-blocking defect; hard-gating dispatch on every
 advisory warning by default; promising sandboxed multi-customer isolation.
+
+---
+
+## 12. CodeQL heuristic false-positive packet
+
+After confinement and chokepoint work (credential reads through the secrets
+port; redaction models-as-data pack), remaining open CodeQL alerts on tip are
+**heuristic false positives**, not code defects. This section is the operator
+evidence packet: each row proves what actually flows into the flagged sink so
+a human can dismiss honestly in GitHub Security → Code scanning.
+
+**This document does not dismiss alerts.** Dismissal is an operator security
+decision in the GitHub UI. Branch protection (making the CodeQL check required)
+is also a repo setting, not code.
+
+### Operator handoff
+
+1. For each open alert in the table below: GitHub Security → Code scanning →
+   dismiss as **False positive**, comment citing `docs/14-security.md` §12 and
+   the alert number.
+2. After the board is zero: make the CodeQL check a **required** status check
+   in branch protection so new regressions cannot merge silently.
+
+### Open-alert proofs
+
+Inventory re-verified open on `main` @ `9139bca` via
+`gh api …/code-scanning/alerts?state=open`. Alert numbers are GitHub’s
+stable IDs for this repository.
+
+| Alert | Rule | Site | Proof | Disposition |
+|---|---|---|---|---|
+| **#1** | `py/clear-text-storage-sensitive-data` | `app/devcake/domain/orchestrator/feed.py` `_audit` (~L248) | `detail = redact(detail)` runs before the JSONL append. Only the scrubbed string is written to `markers.AUDIT_PATH`. The models-as-data pack (§7 Scanner models; `.github/codeql/extensions/devcake-redact/`) declares `redact` as a `cleartext-storage` barrier, but upstream Python CleartextStorage has no `SanitizerFromModel` wiring — the pack is a silent no-op for this query until upstream adds the hook. Runtime posture is post-barrier. | False positive — operator dismiss citing this row (or wait for upstream CodeQL). Do **not** add a second scrubber. |
+| **#4** | `py/clear-text-logging-sensitive-data` | `app/devcake/adapters/gitea/provision.py` `_load` (~L698) | On unreadable JSON under `internal_forge/`, `log.error` interpolates only the filesystem **path** (`path`). `path.read_text()` / parsed token fields never reach the log call; the handler returns `None` so provisioning treats the secret as absent. | False positive — operator dismiss citing this row. |
+| **#6** | `py/clear-text-logging-sensitive-data` | `app/devcake/domain/steward_service.py` periodic gate (~L117) | `missing_referenced_secret_env(dt)` returns env **var names** that are referenced but have no stored value (`harness.py`). The warning string joins those names; secret **values** are absent by construction and never enter the log. | False positive — operator dismiss citing this row. |
+| **#7** | `py/incomplete-url-substring-sanitization` | `app/tests/test_giveup_and_tripwire_loud.py` (~L198) | Pytest assertion `assert "https://oo.example" in body` checks that a fixture OpenObserve URL substring appears in a PMO comment body. This is test expectation text, not application URL sanitization. | False positive — operator dismiss citing this row. |
+| **#60** | `py/weak-sensitive-data-hashing` | `app/devcake/domain/run.py` `auth_digest` (~L48) | SHA-256 fingerprints the per-run Redis ACL password so a Dev reply can be verified without retaining plaintext. The mint is `secrets.token_urlsafe(24)` in `adapters/redis/messaging.py` `create_run_user` — high-entropy machine generation, not a human password. A fingerprint of that secret does not need a password KDF; the alert’s “password” label is naming, not substance. Verified still `token_urlsafe(24)` at packet time. | False positive — operator dismiss citing this row. (If the mint ever regresses to low entropy, upgrade the mint and keep sha256.) |
+| **#72** | `py/clear-text-logging-sensitive-data` | `app/devcake/domain/orchestrator/dispatch.py` `_credential_spec` (~L1011) | When a Dev-Type `secret_env` name has no stored value, `log.warning` records the env var **name** and the Dev Type **name** only. `read_harness_secret(var)` returned falsy, so no secret value is interpolated. (Prior Path-logging credential-file sink is gone after the secrets-port read migration; this tip alert is the name-only residual.) | False positive — operator dismiss citing this row. |


### PR DESCRIPTION
## Intent

Operator-ready evidence packet for every **open** CodeQL alert on tip so a human can dismiss each one honestly. This PR **does not** dismiss alerts and **does not** change branch protection.

Mission: https://linear.app/fidecastro/issue/CAKE-144/false-positive-audit-and-dismissal-packet-for-the-remaining-heuristic

## What changed

1. **`docs/14-security.md` §12** — proof table (alert → rule → site → proof → disposition) for the six open alerts, plus operator handoff (dismiss in GitHub citing §12; then make CodeQL a required status).
2. **One-line invariant comments** at each flagged sink so the next reader need not know scanner history.

## Open alerts covered (re-verified `@9139bca`, still open at push)

| Alert | Rule | Disposition |
|---|---|---|
| **#1** | `py/clear-text-storage-sensitive-data` (`feed._audit`) | FP — `redact(detail)` before JSONL write; MaD pack is silent no-op for CleartextStorage until upstream wires `SanitizerFromModel` (CAKE-143 / §7) |
| **#4** | `py/clear-text-logging-sensitive-data` (`provision._load`) | FP — logs filesystem **path** only |
| **#6** | `py/clear-text-logging-sensitive-data` (`steward_service`) | FP — logs missing env **var names** only |
| **#7** | `py/incomplete-url-substring-sanitization` (test) | FP — pytest assertion, not sanitization |
| **#60** | `py/weak-sensitive-data-hashing` (`auth_digest`) | FP — SHA-256 of `secrets.token_urlsafe(24)` mint in `create_run_user`; **mint verified high-entropy — no upgrade** |
| **#72** | `py/clear-text-logging-sensitive-data` (`dispatch._credential_spec`) | FP — name-only secret-env warning residual after CAKE-142 removed Path sink (#3) |

## Blockers

- **CAKE-142** (#326) — credential reads via secrets port; Path-logging #3 fixed; #72 is tip name-only residual.
- **CAKE-143** (#327) — MaD pack for `redact`; does not close #1 until upstream CleartextStorage consumes barriers.

## Deviations

None on substance. Inventory follows tip (`#1` + `#72` beyond the brief’s `81d7a8f` candidate list) per ONBOARD plan.

## How to verify

- Re-read `docs/14-security.md` §12 against live `gh api …/code-scanning/alerts?state=open`.
- Confirm comments sit immediately above each sink; no behavior change.
- CI on this PR (docs + comments only — no bake/runtime change expected).

## Out of scope

- Dismissing alerts or setting branch protection (operator handoff in §12).
- Migrating CAKE-142 residuals (`settings_bundle._read_credential_files`, `provision._secrets_dir`, `harness.dev_type_status` glob).
- Changing CodeQL workflow / MaD pack.

## Operator next steps (after merge)

1. Dismiss each alert as **False positive**, citing `docs/14-security.md` §12.
2. When the board is zero, make the CodeQL check **required** in branch protection.