### PR TITLE
[CAKE-145] Repo list can't reach all repos — add pagination

### DIFF
--- a/admin/spa/package.json
+++ b/admin/spa/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "check:ui": "node tests/run.mjs",
-    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs && node tests/config_draft.mjs && node tests/contracts.mjs && node tests/req_seq.mjs && node tests/mission_identity.mjs && node tests/alerts.mjs && node tests/design_tokens.mjs && node tests/unused_repos.mjs && node tests/fleet_expand.mjs && node tests/services_helpers.mjs && node tests/memory_notebook.mjs && node tests/banner_copy.mjs"
+    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs && node tests/config_draft.mjs && node tests/contracts.mjs && node tests/req_seq.mjs && node tests/mission_identity.mjs && node tests/alerts.mjs && node tests/design_tokens.mjs && node tests/unused_repos.mjs && node tests/fleet_expand.mjs && node tests/services_helpers.mjs && node tests/memory_notebook.mjs && node tests/banner_copy.mjs && node tests/list_window_helpers.mjs"
   },
   "dependencies": {
     "@fontsource-variable/bricolage-grotesque": "^5.2.10",

--- a/admin/spa/src/lib/listWindow.js
+++ b/admin/spa/src/lib/listWindow.js
@@ -1,0 +1,32 @@
+// Client-side filtered list window — page a name list without a silent
+// hard cap (CAKE-145). Callers reset pageIndex to 0 when the query changes;
+// this util still clamps a stale high pageIndex to the last page.
+
+/**
+ * @param {string[]} names ordered names
+ * @param {string} query case-insensitive substring; empty → all names
+ * @param {number} pageSize
+ * @param {number} pageIndex 0-based
+ * @returns {{ matched: string[], pageNames: string[], pageIndex: number, pageCount: number, totalMatched: number }}
+ */
+export function listWindow(names, query, pageSize, pageIndex) {
+  const q = (query || "").trim().toLowerCase();
+  const matched = q
+    ? names.filter((n) => n.toLowerCase().includes(q))
+    : names.slice();
+  const totalMatched = matched.length;
+  const pageCount = totalMatched === 0 ? 0 : Math.ceil(totalMatched / pageSize);
+  let page = Number(pageIndex) || 0;
+  if (pageCount === 0) page = 0;
+  else if (page < 0) page = 0;
+  else if (page >= pageCount) page = pageCount - 1;
+  const start = page * pageSize;
+  const pageNames = matched.slice(start, start + pageSize);
+  return { matched, pageNames, pageIndex: page, pageCount, totalMatched };
+}
+
+/** 0-based page that holds absolute list index `i` at the given pageSize. */
+export function pageForIndex(i, pageSize) {
+  if (pageSize <= 0) return 0;
+  return Math.floor(Math.max(0, i) / pageSize);
+}

--- a/admin/spa/src/pages/ReposPage.jsx
+++ b/admin/spa/src/pages/ReposPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Trash2 } from "lucide-react";
 import { get, send } from "../api.js";
 import PageHeader from "../components/PageHeader.jsx";
 import AdapterTabs from "../components/AdapterTabs.jsx";
@@ -21,6 +21,7 @@ import { unusedRepoNames } from "../lib/unusedRepos.js";
 import { isMemoryNotebookCard } from "../lib/memoryNotebook.js";
 import { fleetSeedIndexes } from "../lib/fleetExpand.js";
 import { CONNECTION_FIELDS, connRef } from "../lib/connectionFields.js";
+import { listWindow, pageForIndex } from "../lib/listWindow.js";
 
 // Repositories page (v0.1.1 B4, founder request): the repository cards +
 // merge policy lifted out of Configuration, plus the internal-forge
@@ -223,32 +224,29 @@ export default function ReposPage({ onHealthChange }) {
   const newNames = useNewNames(dr.server?.cfg.repos, dr.draft?.cfg.repos,
                                repoNewNamesState);
   // bulk-scale (2026-08-02): 350 cards × (3 SecretField self-fetches + a
-  // RoOnlyNote fetch) was ~1,400 requests per page load. The page renders at
-  // most CARD_CAP filtered cards, and ONE chunked batch covers their three
-  // token fields; SecretFields receive it via the `presence` prop and skip
-  // their self-fetch. The filter is debounced so typing doesn't refetch per
+  // RoOnlyNote fetch) was ~1,400 requests per page load. The page renders one
+  // PAGE_SIZE window of filtered cards (CAKE-145 pagination — not a silent
+  // hard cap), and ONE chunked batch covers their three token fields;
+  // SecretFields receive it via the `presence` prop and skip their
+  // self-fetch. The filter is debounced so typing doesn't refetch per
   // keystroke.
-  const CARD_CAP = 30;
+  const PAGE_SIZE = 30;
   const [filter, setFilter] = useState("");
   const [query, setQuery] = useState("");
+  const [page, setPage] = useState(0);
   useEffect(() => {
     const t = setTimeout(() => setQuery(filter), 300);
     return () => clearTimeout(t);
   }, [filter]);
   const [presence, setPresence] = useState({});   // "repo:name:field" → {present}
   const draftRepoNames = (dr.draft?.cfg.repos || []).map((r) => r.name);
-  // filter + cap engage only past CARD_CAP — small fleets keep every card,
-  // and a leftover filter can never hide cards while its input is hidden.
-  // 2026-08 reviewer round: the input now appears past 5 repos (it used to
-  // wait for the 30-card cap); the hard render cap stays at CARD_CAP.
+  // Filter input appears past 5 repos (2026-08 reviewer round); a leftover
+  // filter can never hide cards while its input is hidden. Pagination
+  // pages the filtered match set at PAGE_SIZE so every repo stays reachable.
   const filterActive = draftRepoNames.length > 5;
-  const fq = filterActive ? query.trim().toLowerCase() : "";
-  const matchedNames = filterActive
-    ? draftRepoNames.filter((n) => !fq || n.toLowerCase().includes(fq))
-    : draftRepoNames;
-  const visibleNames = draftRepoNames.length > CARD_CAP
-    ? matchedNames.slice(0, CARD_CAP)
-    : matchedNames;
+  const fq = filterActive ? query : "";
+  const win = listWindow(draftRepoNames, fq, PAGE_SIZE, page);
+  const visibleNames = win.pageNames;
   const visibleKey = visibleNames.join(",");
 
   // 2026-08 reviewer round: collapsed summary rows — one ~350px card per
@@ -295,8 +293,6 @@ export default function ReposPage({ onHealthChange }) {
   const cfg = dr.draft.cfg;
   const setField = dr.setField;
   const visibleSet = new Set(visibleNames);
-  const shownRepos = cfg.repos.filter((r) => visibleSet.has(r.name));
-  const hiddenCount = cfg.repos.length - shownRepos.length;
   // stored tokens key on the repo name — locked once saved. A card counts as
   // saved only when the server holds its name AND it isn't the card that was
   // (re)added this session, so a new card can never be born frozen. When a
@@ -376,26 +372,50 @@ export default function ReposPage({ onHealthChange }) {
               onClick: () => setClearSecrets(true) },
           ]} />
         }>
-        {filterActive && (
+        {(filterActive || win.pageCount > 1) && (
           <div className="flex flex-wrap items-center gap-3">
-            <span className="relative w-64 shrink-0">
-              <Input className="pr-7" value={filter}
-                placeholder={`Filter ${cfg.repos.length} repositories…`}
-                aria-label="Filter repositories by name"
-                onChange={(e) => setFilter(e.target.value)} />
-              {filter && (
-                <button type="button" aria-label="Clear repository filter"
-                  onClick={() => setFilter("")}
-                  className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-0.5 text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-100">
-                  ✕
-                </button>
-              )}
-            </span>
-            {hiddenCount > 0 && (
-              <span className="text-xs text-neutral-500 dark:text-neutral-400">
-                Showing {shownRepos.length} of {cfg.repos.length} — refine the filter
+            {filterActive && (
+              <span className="relative w-64 shrink-0">
+                <Input className="pr-7" value={filter}
+                  placeholder={`Filter ${cfg.repos.length} repositories…`}
+                  aria-label="Filter repositories by name"
+                  onChange={(e) => { setFilter(e.target.value); setPage(0); }} />
+                {filter && (
+                  <button type="button" aria-label="Clear repository filter"
+                    onClick={() => { setFilter(""); setPage(0); }}
+                    className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-0.5 text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-100">
+                    ✕
+                  </button>
+                )}
               </span>
             )}
+            {win.pageCount > 1 ? (
+              <span className="ml-auto flex shrink-0 items-center gap-3">
+                <Button kind="ghost" size="sm" icon={ChevronLeft}
+                  disabled={win.pageIndex === 0}
+                  aria-label="Previous repository page"
+                  onClick={() => setPage(win.pageIndex - 1)}>Prev</Button>
+                <span className="whitespace-nowrap text-xs tabular-nums text-neutral-500 dark:text-neutral-400">
+                  {win.totalMatched === 0
+                    ? "0"
+                    : `${win.pageIndex * PAGE_SIZE + 1}–${win.pageIndex * PAGE_SIZE + win.pageNames.length}`}
+                  {" of "}{win.totalMatched}
+                  {fq.trim() && win.totalMatched < cfg.repos.length
+                    ? ` matching (${cfg.repos.length} total)`
+                    : ""}
+                </span>
+                <Button kind="ghost" size="sm"
+                  disabled={win.pageIndex + 1 >= win.pageCount}
+                  aria-label="Next repository page"
+                  onClick={() => setPage(win.pageIndex + 1)}>
+                  Next <ChevronRight size={13} aria-hidden />
+                </Button>
+              </span>
+            ) : filterActive && fq.trim() && win.totalMatched < cfg.repos.length ? (
+              <span className="text-xs text-neutral-500 dark:text-neutral-400">
+                {win.totalMatched} matching ({cfg.repos.length} total)
+              </span>
+            ) : null}
           </div>
         )}
         {cfg.repos.map((repo, idx) => {
@@ -627,8 +647,14 @@ export default function ReposPage({ onHealthChange }) {
         })}
         <Button kind="ghost" onClick={() => {
           const name = nextFreeName("repo", cfg.repos, dr.server.cfg.repos);
+          const newIdx = cfg.repos.length;
           newNames.track(name);
-          setExpandedRepos((prev) => new Set(prev).add(cfg.repos.length));
+          // Clear any active filter and jump to the page that holds the new
+          // card so Add never parks a card past a silent window (CAKE-145).
+          setFilter("");
+          setQuery("");
+          setPage(pageForIndex(newIdx, PAGE_SIZE));
+          setExpandedRepos((prev) => new Set(prev).add(newIdx));
           setField("cfg.repos", [...cfg.repos, newRepoCard(name)]);
         }}>
           + Add repository

--- a/admin/spa/tests/list_window_helpers.mjs
+++ b/admin/spa/tests/list_window_helpers.mjs
@@ -1,0 +1,92 @@
+// Hermetic checks for filtered list pagination (CAKE-145) —
+// literal page windows over synthetic names; never re-derive the util's math.
+import assert from "node:assert/strict";
+import { listWindow, pageForIndex } from "../src/lib/listWindow.js";
+
+let failed = 0;
+const check = (name, fn) => {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.log(`  ✗ ${name}: ${e.message}`);
+  }
+};
+
+const names160 = Array.from({ length: 160 }, (_, i) => `repo${String(i).padStart(3, "0")}`);
+
+check("160 names, empty query, pageSize 30: page 0 is first 30", () => {
+  const w = listWindow(names160, "", 30, 0);
+  assert.equal(w.totalMatched, 160);
+  assert.equal(w.pageCount, 6);
+  assert.equal(w.pageIndex, 0);
+  assert.deepEqual(w.pageNames, names160.slice(0, 30));
+  assert.equal(w.matched.length, 160);
+});
+
+check("160 names: page 5 holds the last 10; every name on exactly one page", () => {
+  const seen = new Set();
+  for (let p = 0; p < 6; p++) {
+    const w = listWindow(names160, "", 30, p);
+    assert.equal(w.pageCount, 6);
+    assert.equal(w.pageIndex, p);
+    for (const n of w.pageNames) {
+      assert.equal(seen.has(n), false, `duplicate ${n}`);
+      seen.add(n);
+    }
+  }
+  assert.equal(seen.size, 160);
+  const last = listWindow(names160, "", 30, 5);
+  assert.deepEqual(last.pageNames, names160.slice(150, 160));
+});
+
+check("filter matching 45 names yields two pages with no silent drop", () => {
+  const matched = Array.from({ length: 45 }, (_, i) => `alpha${String(i).padStart(2, "0")}`);
+  const fillers = Array.from({ length: 20 }, (_, i) => `other${i}`);
+  const names = [...matched, ...fillers];
+  const w0 = listWindow(names, "alpha", 30, 0);
+  assert.equal(w0.totalMatched, 45);
+  assert.equal(w0.pageCount, 2);
+  assert.deepEqual(w0.pageNames, matched.slice(0, 30));
+  const w1 = listWindow(names, "alpha", 30, 1);
+  assert.deepEqual(w1.pageNames, matched.slice(30, 45));
+  assert.equal(w0.pageNames.length + w1.pageNames.length, 45);
+});
+
+check("empty query returns all names; case-insensitive substring filter", () => {
+  const names = ["Alpha", "beta", "GAMMA"];
+  assert.deepEqual(listWindow(names, "", 10, 0).pageNames, names);
+  assert.deepEqual(listWindow(names, "LP", 10, 0).pageNames, ["Alpha"]);
+  assert.deepEqual(listWindow(names, "BETA", 10, 0).pageNames, ["beta"]);
+  assert.deepEqual(listWindow(names, "amm", 10, 0).pageNames, ["GAMMA"]);
+});
+
+check("stale high pageIndex clamps to last page", () => {
+  const names = Array.from({ length: 45 }, (_, i) => `n${i}`);
+  const w = listWindow(names, "", 30, 99);
+  assert.equal(w.pageIndex, 1);
+  assert.equal(w.pageCount, 2);
+  assert.deepEqual(w.pageNames, names.slice(30, 45));
+});
+
+check("zero matches: empty page, pageCount 0, pageIndex 0", () => {
+  const w = listWindow(["a", "b"], "zzz", 30, 3);
+  assert.equal(w.totalMatched, 0);
+  assert.equal(w.pageCount, 0);
+  assert.equal(w.pageIndex, 0);
+  assert.deepEqual(w.pageNames, []);
+});
+
+check("pageForIndex maps absolute indexes to page numbers", () => {
+  assert.equal(pageForIndex(0, 30), 0);
+  assert.equal(pageForIndex(29, 30), 0);
+  assert.equal(pageForIndex(30, 30), 1);
+  assert.equal(pageForIndex(159, 30), 5);
+});
+
+if (failed) {
+  console.error(`list_window_helpers.mjs: ${failed} check(s) failed`);
+  process.exit(1);
+}
+console.log("list_window_helpers.mjs: all checks passed");

--- a/admin/spa/tests/run.mjs
+++ b/admin/spa/tests/run.mjs
@@ -25,6 +25,7 @@ const SUITES = [
   "mission_identity.mjs",
   "alerts.mjs",
   "design_tokens.mjs",
+  "list_window_helpers.mjs",
   "settings.mjs",
   "tasks.mjs",
   "hierarchy.mjs",


### PR DESCRIPTION
## Intent

On `#/repos`, a hard `CARD_CAP = 30` silently truncated the filtered repository cards, so with 160+ repos a newly added card never appeared unless the filter narrowed matches to ≤30. This PR replaces that silent slice with client-side pagination (page size 30) over the existing name filter, and jumps to the new card’s page on Add.

Mission: https://linear.app/fidecastro/issue/CAKE-145/repo-list-cant-reach-all-repos-add-pagination

## What changed

- New pure helper `admin/spa/src/lib/listWindow.js` (`listWindow` + `pageForIndex`) with hermetic tests (`list_window_helpers.mjs`, wired into `test:helpers` / `check:ui`).
- `ReposPage.jsx`: page window instead of `matchedNames.slice(0, CARD_CAP)`; Runs-page-style Prev/Next + “A–B of M” copy; secrets-check still batches **visible page only**; Add clears the filter and opens the page that holds the new index.
- Name filter was already present past 5 repos — kept; mission “add search” is satisfied by keeping it and making matches beyond 30 reachable via pages.

## Sibling adapter-list audit (mission bullet 3)

| Surface | Cap? | Action |
|---|---|---|
| Repositories | Was hard slice @ 30 | **Fixed** |
| PMO instances | Filter, no hard slice | No change |
| Dev Types | Full roster table | No change |
| Skill sources | Maps all sources | No change |

Related residual (out of scope): `SelectionChips` `matchCap=30` is a chip-picker ceiling, not this adapter list.

## How to verify

```bash
npm run test:helpers --prefix admin/spa
# includes list_window_helpers: 160 names × pageSize 30, every name on exactly one page
docker build -f admin/Dockerfile -t devcake/admin:latest ./admin   # or: docker buildx bake admin
```

Live: Admin → Repositories with ≥160 repos — page through past index 30; filter a late name; Add and confirm the new card is on-screen expanded.

## Out of scope

- Server-side config pagination
- Converting repo cards to a table
- SelectionChips pagination
- Internal-forge inventory table pagination

## Deviations

None material. Agent host has no Bake/compose stack; proof used hermetic helpers + `npm run build` + `docker build -f admin/Dockerfile` (image served HTTP 200). Full 160-repo live UI not exercised here — CI + hermetic 160-name suite cover reachability math.