### PR TITLE
[CAKE-153] Decomposition children are permanently gated when their body mentions repo-routing markers

### DIFF
--- a/app/devcake/domain/orchestrator/decomposition.py
+++ b/app/devcake/domain/orchestrator/decomposition.py
@@ -11,7 +11,7 @@ from ..model import (LABEL_CREATED, LABEL_NEEDS_HUMAN, LABEL_OPTIN, LABEL_SKIP,
                      LABEL_TRACKING, MissionRef)
 from ..run import Run
 from . import steps
-from .markers import (COMMENT_SENTINEL, at_decomposition_limit,
+from .markers import (COMMENT_SENTINEL, at_decomposition_limit, defang,
                       decomposition_depth, decomposition_marker)
 
 log = logging.getLogger("devcake.missions")
@@ -63,13 +63,13 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
                 f"of EARLIER parts, got {deps!r}")
     # Redact agent-generated fields before hashing and create_mission so
     # redelivery and secrets scrubbing stay consistent. Marker syntax in the
-    # untrusted body is defanged (opening backtick stripped) BEFORE hashing: a
-    # Dev quoting a decomposition marker would otherwise shadow the child's
-    # own footer and confuse the replay child-scan.
+    # untrusted body is neutralized via defang() BEFORE hashing: a Dev quoting
+    # any marker family (decomposition footer shadow, or a repo-routing token
+    # that would gate as unparseable) must lose its teeth without changing the
+    # manifest that replay/top-up keys on.
     normalized = [{
         "title": redact(str(d.get("title") or f"part {i}")),
-        "description": redact(str(d.get("description") or "")).replace(
-            "`devcake:decomposition:v1", "devcake:decomposition:v1"),
+        "description": defang(redact(str(d.get("description") or ""))),
         "priority": str(d.get("priority") or "medium"),
         "blocked_by": list(d.get("blocked_by") or []),
     } for i, d in enumerate(drafts, start=1)]

--- a/app/tests/test_decomposition_depth.py
+++ b/app/tests/test_decomposition_depth.py
@@ -5,11 +5,14 @@ unlimited). Depth is read from the mission's own record only: the app-managed
 `DEVCAKE-CREATED` label gates it, so a forged marker in an untrusted
 description is inert."""
 
-from devcake.config import AppConfig
+from devcake.config import AppConfig, PMOInstance
 from devcake.domain.orchestrator import decomposition
 from devcake.domain.orchestrator.markers import (DECOMPOSITION_MARKER_RE,
+                                                 RAW_REPO_MARKER,
+                                                 REPO_MARKER,
                                                  at_decomposition_limit,
                                                  decomposition_depth)
+from devcake.domain.repo_routing import resolve_repo
 
 from fakes import make_mission_manager
 from test_transitions import FakePMO, NullMessaging, _run, mission, run_coro
@@ -153,6 +156,26 @@ def test_child_bodies_are_defanged_against_marker_injection(tmp_path):
     decompose(mgr, [{"title": "a", "description": poison}, {"title": "b"}])
     assert len(fake.created) == 2
     assert "DEVCAKE-NEEDS-HUMAN" not in m.labels
+
+
+def test_child_bodies_quoting_repo_marker_do_not_gate(tmp_path):
+    """CAKE-152 / CAKE-153: a draft that quotes a repo-routing token in
+    backticks must be neutralized before create — otherwise RAW_REPO_MARKER
+    treats the empty/malformed shape as an unparseable routing intent and
+    gates the child forever. Tokens are written here as live board syntax
+    because this is the input under test; do not paste that form into PR
+    copy or comments."""
+    m = mission("in_progress", {"DEVCAKE"})
+    mgr, fake = make_depth_mgr(tmp_path, m)
+    # empty-name shape that RAW_REPO_MARKER matches and resolve_repo gates
+    poison = "docs mention " + "`devcake-repo:`" + " as the override syntax"
+    decompose(mgr, [{"title": "a", "description": poison}, {"title": "b"}])
+    child = fake.all_missions[1]
+    assert REPO_MARKER.search(child.description) is None
+    assert RAW_REPO_MARKER.search(child.description) is None
+    instance = PMOInstance(name="linear", team_key="DEV", repos=["alpha"])
+    name, reason = resolve_repo(child, instance, {"alpha"}, [])
+    assert name == "alpha" and reason is None
 
 
 def test_at_decomposition_limit_predicate():


### PR DESCRIPTION
## Intent

Decomposition draft normalization kept a partial `.replace` that only stripped the opening backtick from the decomposition token. Quoted repo-routing tokens (devcake-repo:…) stayed live, so `RAW_REPO_MARKER` / `resolve_repo` treated them as unparseable routing intent and gated the child forever (live: CAKE-152).

This PR routes draft neutralization through the canonical `defang()` chokepoint before the manifest hash, and adds a regression covering the empty-name repo-marker quote case.

## Mission

https://linear.app/fidecastro/issue/CAKE-153/decomposition-children-are-permanently-gated-when-their-body-mentions

## Changes

- `decomposition.py`: call `defang()` on redacted draft descriptions at the same pre-hash site (ordering preserved for replay/top-up).
- `test_decomposition_depth.py`: assert child body matches neither `REPO_MARKER` nor `RAW_REPO_MARKER`, and `resolve_repo` returns the instance default with `reason is None`.

## How to verify

```bash
./scripts/pytest_app.sh app/tests/test_decomposition_depth.py
# or (fresh app-test image):
docker run --rm -e OTEL_SDK_DISABLED=true localhost/devcake/app-test:latest \
  python -m pytest tests/test_decomposition_depth.py \
  tests/test_handoff_notes.py::test_defang_neutralizes_both_marker_families -v
```

Evidence from this run: fresh `docker build -f app/Dockerfile --target test` → 16 passed (full `test_decomposition_depth.py` + defang helper contract).

## Risk / rollout

None beyond new decompositions. Already-gated live children are out of scope (operator already unblocked CAKE-152 by hand-edit). No change to `defang()`, gate semantics, or parent-repo inheritance.

## Out of scope

- Retrofits of already-gated children
- Changing `RAW_REPO_MARKER` / `resolve_repo` semantics
- Docs/ADR edits beyond the call-site comment