### PR TITLE
[CAKE-156] Discoverable adapter rename via card … menu and PromptDialog

### DIFF
--- a/admin/spa/package.json
+++ b/admin/spa/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "check:ui": "node tests/run.mjs",
-    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs && node tests/config_draft.mjs && node tests/contracts.mjs && node tests/req_seq.mjs && node tests/mission_identity.mjs && node tests/alerts.mjs && node tests/design_tokens.mjs && node tests/unused_repos.mjs && node tests/fleet_expand.mjs && node tests/services_helpers.mjs && node tests/memory_notebook.mjs && node tests/banner_copy.mjs && node tests/list_window_helpers.mjs"
+    "test:helpers": "node tests/markdown_helpers.mjs && node tests/format_helpers.mjs && node tests/deps_helpers.mjs && node tests/board_helpers.mjs && node tests/config_draft.mjs && node tests/contracts.mjs && node tests/req_seq.mjs && node tests/mission_identity.mjs && node tests/alerts.mjs && node tests/design_tokens.mjs && node tests/unused_repos.mjs && node tests/fleet_expand.mjs && node tests/services_helpers.mjs && node tests/memory_notebook.mjs && node tests/banner_copy.mjs && node tests/list_window_helpers.mjs && node tests/repo_rename_cascade.mjs && node tests/adapter_rename_menu.mjs"
   },
   "dependencies": {
     "@fontsource-variable/bricolage-grotesque": "^5.2.10",

--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -12,6 +12,7 @@ import MoreMenu from "./MoreMenu.jsx";
 import RepoChips from "./RepoChips.jsx";
 import ClearSecretsDialog, { CLEAR_SECRETS_ENTRY } from "./ClearSecretsDialog.jsx";
 import { ADOPTION_COPY } from "../lib/configLabels.js";
+import { INSTANCE_NAME_RE, INSTANCE_NAME_RULE } from "../lib/draftErrors.js";
 import { useSharedDraft } from "../lib/ConfigDraftContext.jsx";
 import { getRegistry, loadRegistry } from "../lib/registry.js";
 import { nextFreeName, useNewNames } from "../lib/instanceNames.js";
@@ -556,6 +557,16 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
         onConfirm={(nn) => {
           if (!renameFor) return;
           if (nn === renameFor.name) { setRenameFor(null); setRenameErr(""); return; }
+          // draft rename has no server round-trip to reject a bad name —
+          // validate HERE so the dialog never closes over a doomed Save
+          if (!INSTANCE_NAME_RE.test(nn)) {
+            setRenameErr(`Not a valid instance name: ${INSTANCE_NAME_RULE}.`);
+            return;
+          }
+          if (cfg.pmos.some((p, i) => i !== renameFor.idx && p.name === nn)) {
+            setRenameErr(`A PMO instance named "${nn}" already exists.`);
+            return;
+          }
           setRenameErr("");
           applyPmoNameChange(renameFor.idx, renameFor.name, nn);
           setRenameFor(null);

--- a/admin/spa/src/components/PmoSection.jsx
+++ b/admin/spa/src/components/PmoSection.jsx
@@ -5,7 +5,7 @@ import { Field, Help, SecretField, Input } from "./Field.jsx";
 import SettingRow from "./SettingRow.jsx";
 import Button from "./Button.jsx";
 import Toggle from "./Toggle.jsx";
-import { ConfirmDialog } from "./Modal.jsx";
+import { ConfirmDialog, PromptDialog } from "./Modal.jsx";
 import ImmediateBadge from "./ImmediateBadge.jsx";
 import InstantZone from "./InstantZone.jsx";
 import MoreMenu from "./MoreMenu.jsx";
@@ -28,6 +28,9 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
   const [clearSecrets, setClearSecrets] = useState(false);
   const [secretsEpoch, setSecretsEpoch] = useState(0);
   const [clearReloadErr, setClearReloadErr] = useState("");
+  // CAKE-156: discoverable draft rename (PromptDialog → setField; applies on Save)
+  const [renameFor, setRenameFor] = useState(null); // { idx, name } | null
+  const [renameErr, setRenameErr] = useState("");
   // per-PMO intake: App-owned /health (like the sidebar master), never the
   // config draft — Discard must not desync a safety switch from the server.
   const [intakeOverride, setIntakeOverride] = useState({}); // name → bool optimistic
@@ -106,6 +109,56 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
       title, body, confirmLabel: "I understand — proceed",
       action: () => { setField(path, value); setConfirm(null); },
     });
+
+  // Shared by the inline name Input and the Rename adapter PromptDialog.
+  const applyPmoNameChange = (idx, prev, next) => {
+    newPmoNames.rename(prev, next);
+    setField(`cfg.pmos.${idx}.name`, next);
+    if (prev && next && prev !== next) {
+      (cfg.crons || []).forEach((c, ci) => {
+        if (!c.reserved && c.pmo === prev)
+          setField(`cfg.crons.${ci}.pmo`, next);
+      });
+    }
+  };
+
+  const requestRemovePmo = (inst, idx) => {
+    const doRemove = () => {
+      newPmoNames.untrack(inst.name);
+      setField("cfg.pmos", cfg.pmos.filter((_, i) => i !== idx));
+    };
+    if (savedPmoNames.has(inst.name)) {
+      setConfirm({
+        title: `Remove PMO instance "${inst.name}"?`,
+        body: "Removing it and saving permanently deletes its stored API key; in-flight runs of this instance fail cleanly. Nothing changes until you Save.",
+        confirmLabel: "Remove from draft",
+        action: () => { doRemove(); setConfirm(null); },
+      });
+    } else doRemove();
+  };
+
+  // Per-card ⋯: Rename (non-managed) + Remove. Empty when managed board is
+  // also non-removable — never a one-item menu for a lone visible action
+  // that isn't secondary to something else; here both are secondary.
+  const pmoCardMenuItems = (inst, idx) => {
+    const items = [];
+    if (!inst.managed) {
+      items.push({
+        label: "Rename adapter",
+        desc: "Applies on Save — secrets and cron board targets follow; past runs keep the old name.",
+        onClick: () => { setRenameErr(""); setRenameFor({ idx, name: inst.name }); },
+      });
+    }
+    if (cfg.pmos.length > 1 && !(inst.managed && health.internal_forge)) {
+      items.push({
+        label: "Remove",
+        danger: true,
+        desc: "Removes the card from the draft; saving deletes its stored API key.",
+        onClick: () => requestRemovePmo(inst, idx),
+      });
+    }
+    return items;
+  };
 
   // per-instance tests (schema v3 / M10): keyed pmo:{name} / forge:{name}
   const testPmo = async (name) => {
@@ -202,33 +255,43 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
           const fq = cfg.pmos.length > 5 ? pmoFilter.trim().toLowerCase() : "";
           if (fq && !(inst.name || "").toLowerCase().includes(fq)) return null;
           const tr = testResult[`pmo:${inst.name}`];
+          const cardMenu = pmoCardMenuItems(inst, idx);
           if (!expandedPmos.has(idx)) {
             return (
-              <button key={`${idx}-${secretsEpoch}`} type="button"
-                data-testid="pmo-summary-row"
-                aria-label={`Expand PMO instance ${inst.name}`}
-                onClick={() => togglePmoCard(idx)}
-                className="flex w-full flex-wrap items-center gap-x-3 gap-y-1 rounded-card border border-neutral-200 px-4 py-2.5 text-left transition hover:bg-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/60 dark:border-neutral-800 dark:hover:bg-neutral-900">
-                <span className="font-mono text-sm font-semibold">{inst.name || "(unnamed)"}</span>
-                <span className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">{inst.system}</span>
-                {inst.managed && (
-                  <span className="rounded bg-stone-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
-                    Bundled board
-                  </span>
-                )}
-                {inst.team_key && (
-                  <span className="text-xs text-neutral-500 dark:text-neutral-400">{inst.team_key}</span>
-                )}
-                <span className="ml-auto flex shrink-0 items-center gap-3">
-                  <span className="text-[11px] text-neutral-400 dark:text-neutral-500">
-                    {(inst.repos || []).length} repo{(inst.repos || []).length === 1 ? "" : "s"}
-                  </span>
-                  {(health.pmo_instances || {})[inst.name]?.intake_paused && (
-                    <span className="text-[11px] text-amber-600 dark:text-amber-400">intake paused</span>
+              <div key={`${idx}-${secretsEpoch}`}
+                className="flex items-stretch rounded-card border border-neutral-200 dark:border-neutral-800">
+                <button type="button"
+                  data-testid="pmo-summary-row"
+                  aria-label={`Expand PMO instance ${inst.name}`}
+                  onClick={() => togglePmoCard(idx)}
+                  className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2.5 text-left transition hover:bg-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/60 dark:hover:bg-neutral-900">
+                  <span className="font-mono text-sm font-semibold">{inst.name || "(unnamed)"}</span>
+                  <span className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">{inst.system}</span>
+                  {inst.managed && (
+                    <span className="rounded bg-stone-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
+                      Bundled board
+                    </span>
                   )}
-                  <span aria-hidden className="text-xs text-neutral-400">▸</span>
-                </span>
-              </button>
+                  {inst.team_key && (
+                    <span className="text-xs text-neutral-500 dark:text-neutral-400">{inst.team_key}</span>
+                  )}
+                  <span className="ml-auto flex shrink-0 items-center gap-3">
+                    <span className="text-[11px] text-neutral-400 dark:text-neutral-500">
+                      {(inst.repos || []).length} repo{(inst.repos || []).length === 1 ? "" : "s"}
+                    </span>
+                    {(health.pmo_instances || {})[inst.name]?.intake_paused && (
+                      <span className="text-[11px] text-amber-600 dark:text-amber-400">intake paused</span>
+                    )}
+                    <span aria-hidden className="text-xs text-neutral-400">▸</span>
+                  </span>
+                </button>
+                {cardMenu.length > 0 && (
+                  <span className="flex shrink-0 items-center pr-2"
+                    onClick={(e) => e.stopPropagation()}>
+                    <MoreMenu label={`More actions for ${inst.name || "PMO"}`} items={cardMenu} />
+                  </span>
+                )}
+              </div>
             );
           }
           const sysMeta = (registry.pmo_systems || []).find((s) => s.id === inst.system)
@@ -263,28 +326,11 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
                     </span>
                   )}
                 </span>
-                {/* the managed board is not removable while the bundled
-                    provisioner exists — the next boot would resurrect it and
-                    deleting would orphan its app-minted PAT (ADR-0030) */}
-                {cfg.pmos.length > 1 && !(inst.managed && health.internal_forge) && (
-                  <Button kind="danger-ghost" onClick={() => {
-                    const doRemove = () => {
-                      newPmoNames.untrack(inst.name);
-                      setField("cfg.pmos", cfg.pmos.filter((_, i) => i !== idx));
-                    };
-                    if (savedPmoNames.has(inst.name)) {
-                      // saving the removal permanently deletes the stored
-                      // secret — worth an explicit confirm (audit A21)
-                      setConfirm({
-                        title: `Remove PMO instance "${inst.name}"?`,
-                        body: "Removing it and saving permanently deletes its stored API key; in-flight runs of this instance fail cleanly. Nothing changes until you Save.",
-                        confirmLabel: "Remove from draft",
-                        action: () => { doRemove(); setConfirm(null); },
-                      });
-                    } else doRemove();
-                  }}>
-                    Remove
-                  </Button>
+                {/* Rename + Remove share the card ⋯ (DESIGN.md §3). Managed
+                    board stays name-locked and non-removable while the
+                    bundled provisioner exists (ADR-0030 / CAKE-157). */}
+                {cardMenu.length > 0 && (
+                  <MoreMenu label={`More actions for ${inst.name || "PMO"}`} items={cardMenu} />
                 )}
               </div>
               {saved ? (
@@ -318,18 +364,7 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
                 <Field label="Instance name"
                   help="Operator-chosen identity (lowercase letters/digits/underscores, ≤39, no hyphens). Uppercased, it prefixes this instance's branches and run ids (run ids truncate the prefix to 12 chars). Renaming on Save moves stored secrets with the card and updates scheduled-task board targets; past run records and board markers keep the old name.">
                   <Input value={inst.name} disabled={!!inst.managed}
-                  onChange={(e) => {
-                    const prev = inst.name;
-                    const next = e.target.value;
-                    newPmoNames.rename(prev, next);
-                    setField(`cfg.pmos.${idx}.name`, next);
-                    if (prev && next && prev !== next) {
-                      (cfg.crons || []).forEach((c, ci) => {
-                        if (!c.reserved && c.pmo === prev)
-                          setField(`cfg.crons.${ci}.pmo`, next);
-                      });
-                    }
-                  }} />
+                  onChange={(e) => applyPmoNameChange(idx, inst.name, e.target.value)} />
                   {dr.errors[`cfg.pmos.${idx}.name`] && (
                     <span className="mt-1 block text-xs text-red-600 dark:text-red-400">
                       ✗ {dr.errors[`cfg.pmos.${idx}.name`]}
@@ -513,6 +548,19 @@ export default function PmoSection({ newNamesState, health = {}, healthError = f
       <ConfirmDialog open={!!confirm} {...(confirm || {})}
         onConfirm={() => confirm.action()}
         onCancel={() => setConfirm(null)} />
+      <PromptDialog open={!!renameFor}
+        title={`Rename adapter "${renameFor?.name || ""}"`}
+        label="New name" initial={renameFor?.name || ""}
+        hint="Renaming applies on Save: stored secrets move with the card and scheduled-task board targets update; past run records and board markers keep the old name."
+        confirmLabel="Rename" error={renameErr}
+        onConfirm={(nn) => {
+          if (!renameFor) return;
+          if (nn === renameFor.name) { setRenameFor(null); setRenameErr(""); return; }
+          setRenameErr("");
+          applyPmoNameChange(renameFor.idx, renameFor.name, nn);
+          setRenameFor(null);
+        }}
+        onCancel={() => { setRenameFor(null); setRenameErr(""); }} />
       {clearSecrets && (
         <ClearSecretsDialog
           context="pmo"

--- a/admin/spa/src/pages/ReposPage.jsx
+++ b/admin/spa/src/pages/ReposPage.jsx
@@ -8,7 +8,7 @@ import { Field, SecretField, Input, Select } from "../components/Field.jsx";
 import SettingRow from "../components/SettingRow.jsx";
 import Button from "../components/Button.jsx";
 import Toggle from "../components/Toggle.jsx";
-import { ConfirmDialog, Modal } from "../components/Modal.jsx";
+import { ConfirmDialog, Modal, PromptDialog } from "../components/Modal.jsx";
 import ImmediateBadge from "../components/ImmediateBadge.jsx";
 import MoreMenu from "../components/MoreMenu.jsx";
 import ClearSecretsDialog, { CLEAR_SECRETS_ENTRY } from "../components/ClearSecretsDialog.jsx";
@@ -216,6 +216,9 @@ export default function ReposPage({ onHealthChange }) {
   const [createFor, setCreateFor] = useState(null);       // card idx | null
   const [clearSecrets, setClearSecrets] = useState(false);
   const [secretsEpoch, setSecretsEpoch] = useState(0);
+  // CAKE-156: discoverable draft rename (PromptDialog → setField; applies on Save)
+  const [renameFor, setRenameFor] = useState(null); // { idx, name } | null
+  const [renameErr, setRenameErr] = useState("");
   // cards added/renamed this session stay name-editable even when their name
   // collides with a still-saved one (the delete-then-re-add / mid-typing trap)
   // the Set lives in the provider (2026-08-02): an internal Set was lost on
@@ -307,6 +310,80 @@ export default function ReposPage({ onHealthChange }) {
       title, body, confirmLabel: "I understand — proceed",
       action: () => { setField(path, value); setConfirm(null); },
     });
+
+  // Shared by the inline name Input and the Rename adapter PromptDialog.
+  // Cascade PMO citations only — never draft Dev Type memory_repos
+  // (CAKE-152 / DraftChrome Dev-Types-first Save hazard).
+  const applyRepoNameChange = (idx, prev, next) => {
+    newNames.rename(prev, next);
+    setField(`cfg.repos.${idx}.name`, next);
+    if (prev && next && prev !== next) {
+      cfg.pmos.forEach((p, pi) => {
+        for (const field of ["repos", "reference_repos", "memory_repos"]) {
+          if ((p[field] || []).includes(prev))
+            setField(`cfg.pmos.${pi}.${field}`,
+              p[field].map((n) => (n === prev ? next : n)));
+        }
+      });
+    }
+  };
+
+  const requestRemoveRepo = (repo, idx) => {
+    const doRemove = () => {
+      newNames.untrack(repo.name);
+      setField("cfg.repos", cfg.repos.filter((_, i) => i !== idx));
+      cfg.pmos.forEach((p, pi) => {
+        if ((p.repos || []).includes(repo.name))
+          setField(`cfg.pmos.${pi}.repos`,
+            p.repos.filter((n) => n !== repo.name));
+        if ((p.reference_repos || []).includes(repo.name))
+          setField(`cfg.pmos.${pi}.reference_repos`,
+            p.reference_repos.filter((n) => n !== repo.name));
+        if ((p.memory_repos || []).includes(repo.name))
+          setField(`cfg.pmos.${pi}.memory_repos`,
+            p.memory_repos.filter((n) => n !== repo.name));
+      });
+      Object.entries(dr.draft.devTypes || {}).forEach(([nm, dt]) => {
+        if ((dt.memory_repos || []).includes(repo.name))
+          setField(`devTypes.${nm}.memory_repos`,
+            dt.memory_repos.filter((n) => n !== repo.name));
+      });
+    };
+    const refPmos = cfg.pmos
+      .filter((p) => (p.repos || []).includes(repo.name)
+                  || (p.reference_repos || []).includes(repo.name)
+                  || (p.memory_repos || []).includes(repo.name))
+      .map((p) => p.name);
+    if (savedRepoNames.has(repo.name)) {
+      setConfirm({
+        title: `Remove repository "${repo.name}"?`,
+        body: "Removing it and saving permanently deletes its stored tokens (write / read-only / reviewer); missions that used this repo gate until a human closes them out."
+          + (refPmos.length
+              ? ` It is also deselected from PMO connection${refPmos.length > 1 ? "s" : ""} ${refPmos.join(", ")}.`
+              : "")
+          + " Nothing changes until you Save.",
+        confirmLabel: "Remove from draft",
+        action: () => { doRemove(); setConfirm(null); },
+      });
+    } else doRemove();
+  };
+
+  const repoCardMenuItems = (repo, idx) => {
+    const items = [{
+      label: "Rename adapter",
+      desc: "Applies on Save — tokens, PMO citations, and the local mirror follow; past runs keep the old name.",
+      onClick: () => { setRenameErr(""); setRenameFor({ idx, name: repo.name }); },
+    }];
+    if (cfg.repos.length > 0) {
+      items.push({
+        label: "Remove",
+        danger: true,
+        desc: "Removes the card from the draft; saving deletes its stored tokens.",
+        onClick: () => requestRemoveRepo(repo, idx),
+      });
+    }
+    return items;
+  };
 
   // computed from the DRAFT, so unsaved PMO (de)selections count. Predicate
   // matches /health.unused_repos (work + reference + memory; no skills).
@@ -420,30 +497,40 @@ export default function ReposPage({ onHealthChange }) {
         {cfg.repos.map((repo, idx) => {
           if (!visibleSet.has(repo.name)) return null;
           const tr = testResult[`forge:${repo.name}`];
+          const cardMenu = repoCardMenuItems(repo, idx);
           if (!expandedRepos.has(idx)) {
             let host = "";
             try { host = repo.url ? new URL(repo.url).host : ""; } catch { host = ""; }
             return (
-              <button key={`${idx}-${secretsEpoch}`} type="button"
-                data-testid="repo-summary-row"
-                aria-label={`Expand repository ${repo.name}`}
-                onClick={() => toggleRepoCard(idx)}
-                className="flex w-full flex-wrap items-center gap-x-3 gap-y-1 rounded-card border border-neutral-200 px-4 py-2.5 text-left transition hover:bg-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/60 dark:border-neutral-800 dark:hover:bg-neutral-900">
-                <span className="font-mono text-sm font-semibold">{repo.name || "(unnamed)"}</span>
-                <span className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">{repo.forge}</span>
-                {host && <span className="min-w-0 truncate text-xs text-neutral-500 dark:text-neutral-400">{host}</span>}
-                <span className="ml-auto flex shrink-0 items-center gap-3">
-                  <span className="text-[11px] text-neutral-400 dark:text-neutral-500">
-                    {repo.auto_merge ? "auto-merge" : "merge hand-off"}
-                  </span>
-                  {tr && (
-                    <span className={`text-xs ${tr.ok ? "text-green-700 dark:text-green-400" : "text-red-600"}`}>
-                      {tr.ok ? "✓" : "✗"}
+              <div key={`${idx}-${secretsEpoch}`}
+                className="flex items-stretch rounded-card border border-neutral-200 dark:border-neutral-800">
+                <button type="button"
+                  data-testid="repo-summary-row"
+                  aria-label={`Expand repository ${repo.name}`}
+                  onClick={() => toggleRepoCard(idx)}
+                  className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2.5 text-left transition hover:bg-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/60 dark:hover:bg-neutral-900">
+                  <span className="font-mono text-sm font-semibold">{repo.name || "(unnamed)"}</span>
+                  <span className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">{repo.forge}</span>
+                  {host && <span className="min-w-0 truncate text-xs text-neutral-500 dark:text-neutral-400">{host}</span>}
+                  <span className="ml-auto flex shrink-0 items-center gap-3">
+                    <span className="text-[11px] text-neutral-400 dark:text-neutral-500">
+                      {repo.auto_merge ? "auto-merge" : "merge hand-off"}
                     </span>
-                  )}
-                  <span aria-hidden className="text-xs text-neutral-400">▸</span>
-                </span>
-              </button>
+                    {tr && (
+                      <span className={`text-xs ${tr.ok ? "text-green-700 dark:text-green-400" : "text-red-600"}`}>
+                        {tr.ok ? "✓" : "✗"}
+                      </span>
+                    )}
+                    <span aria-hidden className="text-xs text-neutral-400">▸</span>
+                  </span>
+                </button>
+                {cardMenu.length > 0 && (
+                  <span className="flex shrink-0 items-center pr-2"
+                    onClick={(e) => e.stopPropagation()}>
+                    <MoreMenu label={`More actions for ${repo.name || "repository"}`} items={cardMenu} />
+                  </span>
+                )}
+              </div>
             );
           }
           return (
@@ -462,79 +549,15 @@ export default function ReposPage({ onHealthChange }) {
                     devTypes={dr.draft.devTypes}
                     depth={(healthInfo?.claims_depth || {})[repo.name]} />
                 </span>
-                {cfg.repos.length > 0 && (
-                  <Button kind="danger-ghost" onClick={() => {
-                    const doRemove = () => {
-                      newNames.untrack(repo.name);
-                      setField("cfg.repos", cfg.repos.filter((_, i) => i !== idx));
-                      // cascade: the server refuses a PMO that still lists a
-                      // repo name with no card — deselect it everywhere too
-                      cfg.pmos.forEach((p, pi) => {
-                        if ((p.repos || []).includes(repo.name))
-                          setField(`cfg.pmos.${pi}.repos`,
-                            p.repos.filter((n) => n !== repo.name));
-                        if ((p.reference_repos || []).includes(repo.name))
-                          setField(`cfg.pmos.${pi}.reference_repos`,
-                            p.reference_repos.filter((n) => n !== repo.name));
-                        if ((p.memory_repos || []).includes(repo.name))
-                          setField(`cfg.pmos.${pi}.memory_repos`,
-                            p.memory_repos.filter((n) => n !== repo.name));
-                      });
-                      Object.entries(dr.draft.devTypes || {}).forEach(([nm, dt]) => {
-                        if ((dt.memory_repos || []).includes(repo.name))
-                          setField(`devTypes.${nm}.memory_repos`,
-                            dt.memory_repos.filter((n) => n !== repo.name));
-                      });
-                    };
-                    const refPmos = cfg.pmos
-                      .filter((p) => (p.repos || []).includes(repo.name)
-                                  || (p.reference_repos || []).includes(repo.name)
-                                  || (p.memory_repos || []).includes(repo.name))
-                      .map((p) => p.name);
-                    if (savedRepoNames.has(repo.name)) {
-                      setConfirm({
-                        title: `Remove repository "${repo.name}"?`,
-                        body: "Removing it and saving permanently deletes its stored tokens (write / read-only / reviewer); missions that used this repo gate until a human closes them out."
-                          + (refPmos.length
-                              ? ` It is also deselected from PMO connection${refPmos.length > 1 ? "s" : ""} ${refPmos.join(", ")}.`
-                              : "")
-                          + " Nothing changes until you Save.",
-                        confirmLabel: "Remove from draft",
-                        action: () => { doRemove(); setConfirm(null); },
-                      });
-                    } else doRemove();
-                  }}>
-                    Remove
-                  </Button>
+                {cardMenu.length > 0 && (
+                  <MoreMenu label={`More actions for ${repo.name || "repository"}`} items={cardMenu} />
                 )}
               </div>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
                 <Field label="Repo name"
                   help="Operator-chosen identity (lowercase letters/digits/underscores, ≤39, no hyphens). Missions reference it in `devcake-repo:` markers and PMO default-repo settings. Renaming on Save moves stored tokens, updates PMO/Dev Type citations, and migrates the local mirror; past run records and `devcake-repo:` markers already on the board keep the old name.">
                   <Input value={repo.name}
-                  onChange={(e) => {
-                    const prev = repo.name;
-                    const next = e.target.value;
-                    newNames.rename(prev, next);
-                    setField(`cfg.repos.${idx}.name`, next);
-                    if (prev && next && prev !== next) {
-                      // Cascade PMO citations in the same config draft so
-                      // inline validation does not block Save. Do NOT touch
-                      // draft Dev Type memory_repos here: DraftChrome saves
-                      // Dev Types before PUT /config, and a successful Dev
-                      // Type PUT + failed config rename would leave disk
-                      // citing the new name while AppConfig still has the
-                      // old one. Server _rewrite_repo_citations + post-reload
-                      // persist owns Dev Type citations.
-                      cfg.pmos.forEach((p, pi) => {
-                        for (const field of ["repos", "reference_repos", "memory_repos"]) {
-                          if ((p[field] || []).includes(prev))
-                            setField(`cfg.pmos.${pi}.${field}`,
-                              p[field].map((n) => (n === prev ? next : n)));
-                        }
-                      });
-                    }
-                  }} />
+                  onChange={(e) => applyRepoNameChange(idx, repo.name, e.target.value)} />
                   {dr.errors[`cfg.repos.${idx}.name`] && (
                     <span className="mt-1 block text-xs text-red-600 dark:text-red-400">
                       ✗ {dr.errors[`cfg.repos.${idx}.name`]}
@@ -753,6 +776,19 @@ export default function ReposPage({ onHealthChange }) {
       <ConfirmDialog open={!!confirm} {...(confirm || {})}
         onConfirm={() => confirm.action()}
         onCancel={() => setConfirm(null)} />
+      <PromptDialog open={!!renameFor}
+        title={`Rename adapter "${renameFor?.name || ""}"`}
+        label="New name" initial={renameFor?.name || ""}
+        hint="Renaming applies on Save: stored tokens move, PMO citations update, and the local mirror migrates; past run records and `devcake-repo:` markers already on the board keep the old name."
+        confirmLabel="Rename" error={renameErr}
+        onConfirm={(nn) => {
+          if (!renameFor) return;
+          if (nn === renameFor.name) { setRenameFor(null); setRenameErr(""); return; }
+          setRenameErr("");
+          applyRepoNameChange(renameFor.idx, renameFor.name, nn);
+          setRenameFor(null);
+        }}
+        onCancel={() => { setRenameFor(null); setRenameErr(""); }} />
       {clearSecrets && (
         <ClearSecretsDialog
           context="repos"

--- a/admin/spa/src/pages/ReposPage.jsx
+++ b/admin/spa/src/pages/ReposPage.jsx
@@ -21,6 +21,7 @@ import { unusedRepoNames } from "../lib/unusedRepos.js";
 import { isMemoryNotebookCard } from "../lib/memoryNotebook.js";
 import { fleetSeedIndexes } from "../lib/fleetExpand.js";
 import { CONNECTION_FIELDS, connRef } from "../lib/connectionFields.js";
+import { INSTANCE_NAME_RE, INSTANCE_NAME_RULE } from "../lib/draftErrors.js";
 import { listWindow, pageForIndex } from "../lib/listWindow.js";
 
 // Repositories page (v0.1.1 B4, founder request): the repository cards +
@@ -784,6 +785,16 @@ export default function ReposPage({ onHealthChange }) {
         onConfirm={(nn) => {
           if (!renameFor) return;
           if (nn === renameFor.name) { setRenameFor(null); setRenameErr(""); return; }
+          // draft rename has no server round-trip to reject a bad name —
+          // validate HERE so the dialog never closes over a doomed Save
+          if (!INSTANCE_NAME_RE.test(nn)) {
+            setRenameErr(`Not a valid repo name: ${INSTANCE_NAME_RULE}.`);
+            return;
+          }
+          if (cfg.repos.some((r, i) => i !== renameFor.idx && r.name === nn)) {
+            setRenameErr(`A repository card named "${nn}" already exists.`);
+            return;
+          }
           setRenameErr("");
           applyRepoNameChange(renameFor.idx, renameFor.name, nn);
           setRenameFor(null);

--- a/admin/spa/tests/adapter_rename_menu.mjs
+++ b/admin/spa/tests/adapter_rename_menu.mjs
@@ -1,0 +1,69 @@
+// CAKE-156: PMO / repository adapter rename must be discoverable via a
+// per-card MoreMenu → PromptDialog that applies through the draft setField
+// path (not Dev Types' immediate POST /dev-types/{name}/rename).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pmoSrc = readFileSync(join(root, "src/components/PmoSection.jsx"), "utf8");
+const reposSrc = readFileSync(join(root, "src/pages/ReposPage.jsx"), "utf8");
+
+let failed = 0;
+const check = (name, fn) => {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed += 1;
+    console.log(`  ✗ ${name}: ${e.message}`);
+  }
+};
+
+check("PmoSection exposes Rename adapter via PromptDialog", () => {
+  assert.match(pmoSrc, /PromptDialog/, "PmoSection must import/use PromptDialog");
+  assert.match(pmoSrc, /label:\s*"Rename adapter"/, "PmoSection MoreMenu must offer Rename adapter");
+  assert.match(pmoSrc, /applyPmoNameChange|applyNameChange/,
+    "PmoSection must factor rename apply for Input + PromptDialog");
+});
+
+check("ReposPage exposes Rename adapter via PromptDialog", () => {
+  assert.match(reposSrc, /PromptDialog/, "ReposPage must import/use PromptDialog");
+  assert.match(reposSrc, /label:\s*"Rename adapter"/, "ReposPage MoreMenu must offer Rename adapter");
+  assert.match(reposSrc, /applyRepoNameChange|applyNameChange/,
+    "ReposPage must factor rename apply for Input + PromptDialog");
+});
+
+check("adapter rename hints do not claim immediate rename", () => {
+  assert.doesNotMatch(pmoSrc, /Renames immediately/,
+    "PMO adapter PromptDialog must not copy Dev Types' immediate-rename hint");
+  assert.doesNotMatch(reposSrc, /Renames immediately/,
+    "Repo adapter PromptDialog must not copy Dev Types' immediate-rename hint");
+  assert.match(pmoSrc, /applies on Save/i, "PMO rename copy must say applies on Save");
+  assert.match(reposSrc, /applies on Save/i, "Repo rename copy must say applies on Save");
+});
+
+check("adapter rename does not POST a rename endpoint", () => {
+  assert.doesNotMatch(pmoSrc, /POST["'].*\/rename/,
+    "PMO rename must stay draft setField — no POST rename");
+  assert.doesNotMatch(reposSrc, /POST["'].*\/rename/,
+    "Repo rename must stay draft setField — no POST rename");
+});
+
+check("ReposPage rename still avoids draft Dev Type memory_repos cascade", () => {
+  assert.doesNotMatch(
+    reposSrc,
+    /setField\(`devTypes\.\$\{nm\}\.memory_repos`,\s*\n?\s*dt\.memory_repos\.map/,
+    "ReposPage must not cascade repo rename into draft Dev Type memory_repos");
+  assert.match(
+    reposSrc,
+    /for \(const field of \["repos", "reference_repos", "memory_repos"\]\)/,
+    "PMO citation cascades on rename must remain");
+});
+
+if (failed) {
+  console.error(`adapter_rename_menu.mjs: ${failed} check(s) failed`);
+  process.exit(1);
+}
+console.log("adapter_rename_menu.mjs: all checks passed");

--- a/admin/spa/tests/adapter_rename_ui.mjs
+++ b/admin/spa/tests/adapter_rename_ui.mjs
@@ -1,0 +1,273 @@
+// CAKE-156: route-mocked UI — per-card MoreMenu → PromptDialog rename
+// dirties the draft and SaveReview shows the name change. No live backend.
+import { check, checked, gotoFresh, summary, withPage } from "./harness.mjs";
+
+const REPO = {
+  name: "notes",
+  forge: "gitea",
+  url: "http://gitea:3000/devcake-repos/notes.git",
+  api_base: null,
+  default_branch: "main",
+  auto_merge: false,
+  auto_resolve_merge_conflicts: true,
+  merge_retry_window_minutes: 30,
+  merge_settle_minutes: 0,
+};
+
+const PMO = {
+  name: "linear1",
+  system: "linear",
+  team_key: "DEV",
+  api_base: null,
+  repos: ["notes"],
+  reference_repos: [],
+  memory_repos: [],
+  intake_paused: false,
+  discovery_routing: true,
+  assignments: {},
+  managed: false,
+};
+
+const MANAGED = {
+  ...PMO,
+  name: "board",
+  system: "gitea_issues",
+  team_key: "devcake",
+  managed: true,
+  repos: [],
+};
+
+let liveCfg = {
+  pmos: [PMO, MANAGED],
+  repos: [REPO],
+  crons: [],
+  dismissed_alerts: [],
+  poll_interval_seconds: 30,
+  adoption_mode: "opt_in",
+};
+
+async function mockApis(page) {
+  await page.route(/\/api\/v1\/config$/, async (route) => {
+    if (route.request().method() === "PUT") {
+      const patch = route.request().postDataJSON() || {};
+      liveCfg = { ...liveCfg, ...patch };
+      return route.fulfill({
+        status: 200, contentType: "application/json",
+        body: JSON.stringify(liveCfg),
+      });
+    }
+    return route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify(liveCfg),
+    });
+  });
+  await page.route(/\/api\/v1\/dev-types$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify([]),
+    }));
+  await page.route(/\/api\/v1\/assignments$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({}),
+    }));
+  await page.route(/\/api\/v1\/harnesses$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({}),
+    }));
+  await page.route(/\/api\/v1\/health$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        intake_paused: false,
+        pmo_instances: {
+          linear1: { intake_paused: false },
+          board: { intake_paused: false },
+        },
+        internal_forge: true,
+        harness_pins: {},
+        active_runs: 0,
+      }),
+    }));
+  await page.route(/\/api\/v1\/connections\/registry$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        pmo_systems: [
+          { id: "linear", display_name: "Linear", supports_priority: true },
+          { id: "gitea_issues", display_name: "Gitea Issues", supports_priority: false },
+        ],
+        forges: [
+          { id: "github", display_name: "GitHub" },
+          { id: "gitea", display_name: "Gitea" },
+        ],
+        secret_shape_prefixes: ["ghp_"],
+        managed_labels_expected: 11,
+      }),
+    }));
+  await page.route(/\/api\/v1\/secrets-check/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({ conn: {} }),
+    }));
+  await page.route(/\/api\/v1\/internal-repos$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({ repos: [] }),
+    }));
+  await page.route(/\/api\/v1\/runs(?:\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        total: 0, total_runs: 0, runs: [], totals: null,
+        pmo_refs: [], rate_card: {},
+      }),
+    }));
+}
+
+async function renameViaCardMenu(page, cardName, newName) {
+  const more = page.locator(`button[aria-label="More actions for ${cardName}"]`).first();
+  await more.click();
+  await page.locator('[role="menuitem"]:has-text("Rename adapter")').click();
+  const dialog = page.locator('[role="dialog"]:has-text("Rename adapter")');
+  await dialog.waitFor({ timeout: 8000 });
+  const hint = await dialog.locator("span.text-xs, label span").allInnerTexts();
+  const hintText = hint.join(" ");
+  await dialog.locator("input").fill(newName);
+  await dialog.locator('button:has-text("Rename")').click();
+  await dialog.waitFor({ state: "detached", timeout: 8000 }).catch(() => {});
+  return hintText;
+}
+
+// ── 1. Repo: collapsed ⋯ → Rename → DirtyBar → SaveReview → Save ───────────
+await withPage(async (page) => {
+  liveCfg = {
+    pmos: [PMO, MANAGED],
+    repos: [REPO],
+    crons: [],
+    dismissed_alerts: [],
+    poll_interval_seconds: 30,
+    adoption_mode: "opt_in",
+  };
+  await mockApis(page);
+  await gotoFresh(page, "#/repos");
+  await page.waitForSelector('h1:has-text("Repositories")');
+
+  // Force collapsed summary so the sibling ⋯ is exercised.
+  const collapse = page.locator('button[aria-label^="Collapse repository"]');
+  if (await collapse.count()) await collapse.first().click();
+  await page.waitForSelector('[data-testid="repo-summary-row"]');
+
+  const hint = await renameViaCardMenu(page, "notes", "notebook");
+  check("repo PromptDialog hint says applies on Save (not immediately)",
+    /applies on Save/i.test(hint) && !/Renames immediately/i.test(hint));
+
+  await checked("repo rename dirties the draft (DirtyBar)", async () => {
+    await page.waitForSelector(':text("Unsaved changes")', { timeout: 8000 });
+    return (await page.locator(':text("Unsaved changes")').count()) >= 1;
+  });
+
+  await page.locator('button:has-text("Save changes…")').click();
+  await page.waitForSelector('[role="dialog"]:has-text("Review")', { timeout: 8000 });
+  const reviewText = await page.locator('[role="dialog"]').innerText();
+  check("SaveReview shows repo name notes → notebook",
+    /notes/.test(reviewText) && /notebook/.test(reviewText));
+
+  await page.locator('[role="dialog"] button:has-text("Save")').click();
+  await checked("repo rename Save completes (saved flash or clean draft)", async () => {
+    await page.waitForTimeout(500);
+    const saved = (await page.locator(':text("All changes saved")').count()) >= 1;
+    const dirty = (await page.locator(':text("Unsaved changes")').count()) >= 1;
+    return saved || !dirty;
+  });
+  check("config PUT carried renamed repo", liveCfg.repos?.[0]?.name === "notebook");
+});
+
+// ── 2. Non-managed PMO rename; managed board has no Rename item ────────────
+await withPage(async (page) => {
+  liveCfg = {
+    pmos: [
+      { ...PMO, name: "linear1", repos: [] },
+      { ...MANAGED },
+    ],
+    repos: [{ ...REPO, name: "notes" }],
+    crons: [{ id: "sweep", reserved: false, pmo: "linear1", enabled: true,
+      interval_minutes: 60, description_template: "sweep" }],
+    dismissed_alerts: [],
+    poll_interval_seconds: 30,
+    adoption_mode: "opt_in",
+  };
+  await mockApis(page);
+  await gotoFresh(page, "#/pmo");
+  await page.waitForSelector("#pmo");
+
+  // Managed board: no Rename (and no Remove while internal_forge) → no empty ⋯.
+  check("managed board has no per-card MoreMenu",
+    (await page.locator('button[aria-label="More actions for board"]').count()) === 0);
+
+  // Prefer expanded-card menu (≤3 PMOs start expanded); still covers the seam.
+  const hint = await renameViaCardMenu(page, "linear1", "team_a");
+  check("PMO PromptDialog hint says applies on Save (not immediately)",
+    /applies on Save/i.test(hint) && !/Renames immediately/i.test(hint));
+
+  await checked("PMO rename dirties the draft (DirtyBar)", async () => {
+    await page.waitForSelector(':text("Unsaved changes")', { timeout: 8000 });
+    return (await page.locator(':text("Unsaved changes")').count()) >= 1;
+  });
+
+  await page.locator('button:has-text("Save changes…")').click();
+  await page.waitForSelector('[role="dialog"]:has-text("Review")', { timeout: 8000 });
+  const reviewText = await page.locator('[role="dialog"]').innerText();
+  check("SaveReview shows PMO name linear1 → team_a",
+    /linear1/.test(reviewText) && /team_a/.test(reviewText));
+
+  check("SaveReview mentions cascaded cron board target or PMO rename",
+    /team_a/.test(reviewText));
+
+  await page.locator('[role="dialog"] button:has-text("Save")').click();
+  await checked("PMO rename Save completes", async () => {
+    await page.waitForTimeout(500);
+    const saved = (await page.locator(':text("All changes saved")').count()) >= 1;
+    const dirty = (await page.locator(':text("Unsaved changes")').count()) >= 1;
+    return saved || !dirty;
+  });
+  check("config PUT carried renamed PMO",
+    (liveCfg.pmos || []).some((p) => p.name === "team_a"));
+  check("cron pmo citation cascaded on Save payload",
+    (liveCfg.crons || []).some((c) => c.pmo === "team_a"));
+});
+
+// ── 3. Collapsed PMO summary ⋯ opens rename without expand-only dead-end ───
+await withPage(async (page) => {
+  liveCfg = {
+    pmos: [
+      { ...PMO, name: "alpha", repos: [] },
+      { ...PMO, name: "beta", repos: [] },
+      { ...PMO, name: "gamma", repos: [] },
+      { ...PMO, name: "delta", repos: [] },
+    ],
+    repos: [{ ...REPO, name: "notes" }],
+    crons: [],
+    dismissed_alerts: [],
+    poll_interval_seconds: 30,
+    adoption_mode: "opt_in",
+  };
+  await mockApis(page);
+  await gotoFresh(page, "#/pmo");
+  await page.waitForSelector('[data-testid="pmo-summary-row"]', { timeout: 8000 });
+  check("4+ PMOs seed collapsed summary rows",
+    (await page.locator('[data-testid="pmo-summary-row"]').count()) >= 4);
+
+  const beforeExpand = await page.locator('button[aria-label^="Collapse PMO"]').count();
+  await page.locator('button[aria-label="More actions for alpha"]').first().click();
+  await page.locator('[role="menuitem"]:has-text("Rename adapter")').click();
+  await page.waitForSelector('[role="dialog"]:has-text("Rename adapter")', { timeout: 8000 });
+  const afterExpand = await page.locator('button[aria-label^="Collapse PMO"]').count();
+  check("collapsed-row ⋯ opens PromptDialog without expanding the card",
+    (await page.locator('[role="dialog"]:has-text("Rename adapter")').count()) === 1
+    && afterExpand === beforeExpand);
+  await page.locator('[role="dialog"] button:has-text("Cancel")').click();
+});
+
+summary("adapter_rename_ui.mjs");

--- a/admin/spa/tests/adapter_rename_ui.mjs
+++ b/admin/spa/tests/adapter_rename_ui.mjs
@@ -159,6 +159,24 @@ await withPage(async (page) => {
   if (await collapse.count()) await collapse.first().click();
   await page.waitForSelector('[data-testid="repo-summary-row"]');
 
+  // Dialog-side validation (review round): a draft rename has no server
+  // round-trip to reject a bad name — the dialog itself must refuse and
+  // stay open, never close over a doomed Save.
+  await page.locator('button[aria-label="More actions for notes"]').first().click();
+  await page.locator('[role="menuitem"]:has-text("Rename adapter")').click();
+  const vDialog = page.locator('[role="dialog"]:has-text("Rename adapter")');
+  await vDialog.waitFor({ timeout: 8000 });
+  await vDialog.locator("input").fill("Not-Valid");
+  await vDialog.locator('button:has-text("Rename")').click();
+  await checked("invalid name keeps dialog open with the name rule", async () => {
+    await page.waitForTimeout(200);
+    const open = (await vDialog.count()) >= 1;
+    const err = await vDialog.innerText();
+    return open && /lowercase letter/.test(err);
+  });
+  await vDialog.locator('button:has-text("Cancel")').click();
+  await vDialog.waitFor({ state: "detached", timeout: 8000 }).catch(() => {});
+
   const hint = await renameViaCardMenu(page, "notes", "notebook");
   check("repo PromptDialog hint says applies on Save (not immediately)",
     /applies on Save/i.test(hint) && !/Renames immediately/i.test(hint));

--- a/admin/spa/tests/run.mjs
+++ b/admin/spa/tests/run.mjs
@@ -42,6 +42,7 @@ const SUITES = [
   "costs.mjs",
   "error_surface.mjs",
   "honesty_leftovers.mjs",
+  "adapter_rename_ui.mjs",
 ];
 
 // pick up admin credentials from the repo-root .env when not already set


### PR DESCRIPTION
## Intent

Make in-place PMO / repository adapter rename discoverable. Backend + draft `setField` rename already work (CAKE-152); operators still had no Rename affordance — only an ordinary name Field and static collapsed mono text.

## What changed

- Per-card `MoreMenu` (⋯) on non-managed PMO cards and all repository cards with **Rename adapter** → `PromptDialog`
- Applies via the existing draft path (`applyPmoNameChange` / `applyRepoNameChange`: `setField` + cascades). Remains draft until page Save — does **not** copy Dev Types’ immediate `POST …/rename`
- Honest consequence copy: applies on Save (secrets/tokens, cron board targets / PMO citations, repo mirror); historical runs and board markers keep the old name
- Once Rename exists, **Remove** moves into the same card ⋯ (DESIGN.md §3). Managed/bundled board stays name-locked and has no empty ⋯ (CAKE-157)
- Collapsed summary rows: flex split (expand region + sibling menu cell) so ⋯ works without nested-button traps
- Inline name Field kept

## Verify

- `npm run test:helpers --prefix admin/spa` (includes `adapter_rename_menu.mjs` + `repo_rename_cascade.mjs`)
- Route-mocked UI: `adapter_rename_ui.mjs` in `check:ui` — Rename → DirtyBar → SaveReview → Save; managed board has no Rename; collapsed-row ⋯ does not expand the card
- Agent host: `docker build -f admin/Dockerfile` (bake unavailable on buildah shim) + nginx-health `ok`; vite `npm run build`

## Out of scope

- Managed board identity rename (CAKE-157)
- Backend rename / secrets / mirror / citation rewrite (already on tip)

Mission: https://linear.app/fidecastro/issue/CAKE-156/discoverable-adapter-rename-via-card-menu-and-promptdialog