### PR TITLE
[CAKE-165] Two-way links between Skill sources and the built-in skills store

### DIFF
--- a/admin/spa/src/App.jsx
+++ b/admin/spa/src/App.jsx
@@ -77,8 +77,11 @@ function parseHash() {
   }
   const m = window.location.hash.match(/^#\/([^/]+)(?:\/(.+))?/);
   const page = m && PAGES.includes(m[1]) ? m[1] : "overview";
+  // Peel ?query / #fragment off the section segment before allowlist checks
+  // so deep-link flags like #/fleet/skills?add=1 stay on Skills (CAKE-165).
+  const sectionId = (raw) => (raw || "").split(/[?#]/, 1)[0] || "";
   if (page === "fleet") {
-    const sec = m?.[2];
+    const sec = sectionId(m?.[2]);
     if (!sec || !FLEET_IDS.includes(sec)) {
       window.location.replace(`#/fleet/${FLEET_IDS[0]}`);
       return { page: "fleet", section: FLEET_IDS[0] };
@@ -86,7 +89,7 @@ function parseHash() {
     return { page, section: sec };
   }
   if (page === "settings") {
-    const sec = m?.[2];
+    const sec = sectionId(m?.[2]);
     if (!sec || !SETTINGS_IDS.includes(sec)) {
       window.location.replace(`#/settings/${SETTINGS_IDS[0]}`);
       return { page: "settings", section: SETTINGS_IDS[0] };

--- a/admin/spa/src/components/SkillSourcesSection.jsx
+++ b/admin/spa/src/components/SkillSourcesSection.jsx
@@ -84,6 +84,13 @@ export default function SkillSourcesSection({
       {refreshMsg && (
         <p className="mb-3 text-sm text-green-700 dark:text-green-400">{refreshMsg}</p>
       )}
+      <p className="mb-3 text-sm text-neutral-500 dark:text-neutral-400">
+        Keeping skills in DevCake itself?{" "}
+        <a href="#/fleet/skills?add=1"
+          className="font-medium text-accent-700 underline underline-offset-2 dark:text-accent-300">
+          Add them to the built-in store
+        </a>
+      </p>
       {sources.length === 0 && (
         <p className="text-sm text-neutral-500 dark:text-neutral-400">
           No skill sources yet — Fleet → Skills lists the bundled

--- a/admin/spa/src/components/SkillsSection.jsx
+++ b/admin/spa/src/components/SkillsSection.jsx
@@ -17,6 +17,21 @@ import { isMarkdownPath, stripYamlFrontmatter } from "../lib/markdown.js";
 
 // ── skill authoring (docs/11 Skills section) ─────────────────────────────────
 
+// CAKE-165 deep-link: #/fleet/skills?add=1 auto-opens Add skill (then clears).
+function hashWantsAddSkill() {
+  const hash = window.location.hash || "";
+  const q = hash.includes("?") ? hash.slice(hash.indexOf("?") + 1) : "";
+  return new URLSearchParams(q.split("#")[0]).get("add") === "1";
+}
+
+function clearAddSkillFlag() {
+  const hash = window.location.hash || "";
+  if (!hash.includes("?")) return;
+  const next = "#/fleet/skills";
+  if (hash.split("?")[0] !== next && !hash.startsWith("#/fleet/skills")) return;
+  window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}${next}`);
+}
+
 // "Add skill" dialog: Write (name + trigger + markdown; the app generates
 // the frontmatter — the operator never sees YAML) or Import (upload a
 // SKILL.md + optional supporting files). 409 flips into an explicit
@@ -125,6 +140,13 @@ function AddSkillDialog({ onClose, onSaved }) {
           {err}
         </p>
       )}
+      <p className="mt-4 text-sm text-neutral-500 dark:text-neutral-400">
+        Skills live in an external repository?{" "}
+        <a href="#/skill-sources"
+          className="font-medium text-accent-700 underline underline-offset-2 dark:text-accent-300">
+          Connect it as a skill source
+        </a>
+      </p>
       <div className="mt-5 flex justify-end gap-2">
         <Button kind="ghost" disabled={busy} onClick={onClose}>Cancel</Button>
         {askOverwrite ? (
@@ -268,6 +290,29 @@ export default function SkillsSection({ setPageErr }) {
   };
   const [addSkill, setAddSkill] = useState(false);
   const [viewSkill, setViewSkill] = useState(null);
+  // Remember deep-link intent across the async /skills load so we can open
+  // only when the store is enabled, and clear the flag either way.
+  const [pendingAdd, setPendingAdd] = useState(() => hashWantsAddSkill());
+  useEffect(() => {
+    const onHash = () => {
+      if (hashWantsAddSkill()) setPendingAdd(true);
+    };
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
+  useEffect(() => {
+    if (!pendingAdd) return;
+    if (skillsErr) {
+      clearAddSkillFlag();
+      setPendingAdd(false);
+      return;
+    }
+    // Wait until store status is known (null = still loading).
+    if (skillsCatalog.store == null) return;
+    clearAddSkillFlag();
+    if (skillsCatalog.store.enabled) setAddSkill(true);
+    setPendingAdd(false);
+  }, [pendingAdd, skillsCatalog.store, skillsErr]);
 
   return (
     <>

--- a/admin/spa/tests/run.mjs
+++ b/admin/spa/tests/run.mjs
@@ -28,6 +28,7 @@ const SUITES = [
   "list_window_helpers.mjs",
   "cake162_polish.mjs",
   "cake162_ui.mjs",
+  "skill_sources_links.mjs",
   "settings.mjs",
   "tasks.mjs",
   "hierarchy.mjs",

--- a/admin/spa/tests/skill_sources_links.mjs
+++ b/admin/spa/tests/skill_sources_links.mjs
@@ -1,0 +1,184 @@
+// CAKE-165 — two-way links between Skill sources and the built-in store.
+// Public seam: hash route + visible navigation/modals (mocked store-enabled).
+import { checked, gotoFresh, summary, withPage } from "./harness.mjs";
+
+const PMO = {
+  name: "linear1",
+  system: "linear",
+  team_key: "DEV",
+  api_base: null,
+  repos: [],
+  reference_repos: [],
+  memory_repos: [],
+  intake_paused: false,
+  discovery_routing: true,
+  assignments: {},
+  managed: false,
+};
+
+async function mockApis(page, { storeEnabled = true } = {}) {
+  const body = {
+    pmos: [PMO],
+    repos: [],
+    skill_sources: [],
+    dismissed_alerts: [],
+    poll_interval_sec: 30,
+    adoption_mode: "manual",
+    attach_merged_changeset_to_pmo: false,
+  };
+  await page.route(/\/api\/v1\/config$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify(body),
+    }));
+  await page.route(/\/api\/v1\/dev-types$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify([]),
+    }));
+  await page.route(/\/api\/v1\/assignments$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({}),
+    }));
+  await page.route(/\/api\/v1\/harnesses$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({}),
+    }));
+  await page.route(/\/api\/v1\/health$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        intake_paused: false,
+        pmo_instances: {},
+        harness_pins: {},
+        active_runs: 0,
+        internal_forge: true,
+      }),
+    }));
+  await page.route(/\/api\/v1\/connections\/registry$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        pmo_systems: [{ id: "linear", display_name: "Linear", supports_priority: true }],
+        forges: [
+          { id: "github", display_name: "GitHub" },
+          { id: "gitea", display_name: "Gitea" },
+        ],
+        secret_shape_prefixes: ["ghp_"],
+        managed_labels_expected: 11,
+      }),
+    }));
+  await page.route(/\/api\/v1\/secrets-check/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({ conn: {} }),
+    }));
+  await page.route(/\/api\/v1\/internal-repos$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({ repos: [] }),
+    }));
+  await page.route(/\/api\/v1\/runs(?:\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        total: 0, total_runs: 0, runs: [], totals: null,
+        pmo_refs: [], rate_card: {},
+      }),
+    }));
+  await page.route(/\/api\/v1\/skills$/, (route) =>
+    route.fulfill({
+      status: 200, contentType: "application/json",
+      body: JSON.stringify({
+        skills: [
+          {
+            name: "pr-hygiene",
+            description: "PR discipline",
+            source: "store",
+            builtin: true,
+            origin: null,
+          },
+        ],
+        store: storeEnabled
+          ? { enabled: true, ok: true, detail: "", html_url: "http://gitea/skills" }
+          : { enabled: false, ok: false, detail: "disabled", html_url: "" },
+      }),
+    }));
+}
+
+await withPage(async (page) => {
+  await mockApis(page, { storeEnabled: true });
+
+  // 1: Skill sources CTA → Fleet Skills with Add-skill auto-open
+  await gotoFresh(page, "#/skill-sources");
+  await page.waitForSelector("#skills-sources");
+
+  const cta = page.locator('a[href="#/fleet/skills?add=1"]');
+  await checked("Skill sources shows built-in-store CTA to #/fleet/skills?add=1", async () => {
+    if ((await cta.count()) !== 1) return false;
+    const text = ((await cta.evaluate((el) => el.closest("p")?.textContent
+      || el.parentElement?.textContent || el.textContent)) || "");
+    return /Keeping skills in DevCake itself\?/i.test(text)
+      && /built-in store/i.test(text)
+      && !/\blocal\b/i.test(text);
+  });
+
+  await cta.click();
+  await page.waitForSelector("#skills", { timeout: 8000 });
+  await checked("CTA lands on Fleet → Skills (flag cleared from URL)", async () => {
+    const u = page.url();
+    return u.includes("#/fleet/skills") && !u.includes("add=1");
+  });
+  await checked("Add-skill modal opens automatically after CTA", async () => {
+    await page.waitForSelector('[role="dialog"] h4:has-text("Add skill")', { timeout: 8000 });
+    return (await page.locator('[role="dialog"] h4:has-text("Add skill")').count()) === 1;
+  });
+
+  // 2: Reverse link inside Add-skill → Skill sources
+  const reverse = page.locator('[role="dialog"] a[href="#/skill-sources"]');
+  await checked("Add-skill modal links to Skill sources (external repository copy)", async () => {
+    if ((await reverse.count()) < 1) return false;
+    const text = ((await reverse.first().evaluate((el) =>
+      el.closest("p")?.textContent || el.parentElement?.textContent || el.textContent)) || "");
+    return /Skills live in an external repository\?/i.test(text)
+      && /skill source/i.test(text)
+      && !/\blocal\b/i.test(text);
+  });
+
+  await reverse.first().click();
+  await page.waitForSelector("#skills-sources", { timeout: 8000 });
+  await checked("Modal reverse link lands on Skill sources", async () => {
+    return page.url().endsWith("#/skill-sources")
+      && (await page.locator("#skills-sources").count()) === 1;
+  });
+
+  // 3: Deep-link peel — query flag must not redirect away from Skills
+  await gotoFresh(page, "#/fleet/skills?add=1");
+  await page.waitForSelector("#skills", { timeout: 8000 });
+  await checked("#/fleet/skills?add=1 stays on Skills (router peels query)", async () => {
+    return (await page.locator("#skills").count()) === 1
+      && !page.url().includes("#/fleet/dev-types");
+  });
+  await checked("Deep-link auto-opens Add skill and clears add=1", async () => {
+    await page.waitForSelector('[role="dialog"] h4:has-text("Add skill")', { timeout: 8000 });
+    return (await page.locator('[role="dialog"] h4:has-text("Add skill")').count()) === 1
+      && !page.url().includes("add=1");
+  });
+});
+
+await withPage(async (page) => {
+  // Store disabled: deep-link stays on Skills but does not force the modal
+  await mockApis(page, { storeEnabled: false });
+  await gotoFresh(page, "#/fleet/skills?add=1");
+  await page.waitForSelector("#skills", { timeout: 8000 });
+  await checked("store-disabled deep-link stays on Skills without Add-skill modal", async () => {
+    await page.waitForTimeout(400);
+    return (await page.locator("#skills").count()) === 1
+      && (await page.locator('button:has-text("Add skill")').count()) === 0
+      && (await page.locator('[role="dialog"] h4:has-text("Add skill")').count()) === 0;
+  });
+});
+
+summary("skill_sources_links");


### PR DESCRIPTION
## Intent
Operators can hop between Connections → Skill sources and Fleet → Skills (built-in store) in one click. Arriving from Skill sources via the new CTA opens the Add-skill modal automatically.

## Mission
https://linear.app/fidecastro/issue/CAKE-165/two-way-links-between-skill-sources-and-the-built-in-skills-store

## Changes
- `parseHash` peels `?query` / `#fragment` off Fleet/Settings section ids so `#/fleet/skills?add=1` stays on Skills.
- Skill sources page CTA: “Keeping skills in DevCake itself? Add them to the built-in store” → `#/fleet/skills?add=1`.
- `SkillsSection` consumes `add=1`, opens Add skill when the store is enabled, clears the flag.
- Add-skill modal reverse link: “Skills live in an external repository? Connect it as a skill source” → `#/skill-sources`.
- Playwright suite `skill_sources_links.mjs` covers both directions + store-disabled gate.

## How to verify
- `npm run check:ui --prefix admin/spa` (or the new suite alone against vite with mocked APIs).
- Manual: Skill sources → CTA → Add skill open; modal link → Skill sources. Copy never says “local”.

## Out of scope
Backend/skill-store behavior; removing the existing Skills header “Skill sources” chip.