### PR TITLE
[CAKE-168] Baker liveness false-alarms after log rotation; sharpen the no-user-session remedy

### DIFF
--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -799,6 +799,11 @@ def test_up_sh_loud_degraded_gap_on_respawn_fallback():
     assert "respawn" in combined.lower()
     # Gap warning must mention linger / launchd so operators know the prefer path.
     assert "linger" in combined.lower() or "launchd" in combined.lower()
+    # Linux DEGRADED reason must consult the sharper probe — not only the
+    # hard-coded "user systemd unavailable" for every !systemd_available case.
+    assert "devcake_baker_linux_degraded_reason" in text
+    assert "devcake_baker_linux_degraded_reason" in helper
+    assert "devcake_baker_systemd_user_session_missing" in helper
 
 
 def test_up_sh_persists_devcake_tag_into_env():
@@ -991,6 +996,139 @@ main() {{
 """)
     assert result.returncode == 0, result.stderr + result.stdout
     assert "liveness confirmed" in result.stdout
+
+
+def test_baker_host_wait_liveness_resets_baseline_on_log_shrinkage(tmp_path):
+    """Copytruncate mid-wait must reset baseline; post-rotate growth confirms."""
+    logfile = tmp_path / "watch.log"
+    pidfile = tmp_path / "watch.pid"
+    # Oversized pre-upgrade log — baseline is this length before launch.
+    old = "OLD" * 1000
+    logfile.write_text(old)
+    baseline = len(old.encode())
+    pidfile.write_text("7\n")
+    result = _run_baker_host_driver(tmp_path, f"""
+kill() {{
+  if [[ "${{1:-}}" == "-0" ]]; then return 0; fi
+  return 0
+}}
+_sleeps=0
+sleep() {{
+  _sleeps=$((_sleeps + 1))
+  if [[ "$_sleeps" -eq 1 ]]; then
+    # Copytruncate shrinks below baseline — wait loop resets, does not succeed.
+    : > "{logfile}"
+  elif [[ "$_sleeps" -eq 2 ]]; then
+    # Post-rotate growth past the reset baseline confirms liveness.
+    echo "dev_factory: watching keep-set" >> "{logfile}"
+  fi
+}}
+main() {{
+  # 6s budget (step=2) so sleep1=shrink + sleep2=growth fit before timeout.
+  devcake_baker_wait_liveness 7 "{logfile}" "{pidfile}" "nohup python3 -m dev_factory &" 6 {baseline}
+}}
+""")
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "liveness confirmed" in result.stdout
+
+
+def test_baker_host_wait_liveness_failure_mentions_rotation_when_log_shrank(tmp_path):
+    """Timeout after shrink must name rotation and still tail the live path."""
+    logfile = tmp_path / "watch.log"
+    pidfile = tmp_path / "watch.pid"
+    old = "OLD" * 1000
+    logfile.write_text(old)
+    baseline = len(old.encode())
+    pidfile.write_text("8\n")
+    result = _run_baker_host_driver(tmp_path, f"""
+kill() {{
+  if [[ "${{1:-}}" == "-0" ]]; then return 0; fi
+  return 0
+}}
+_sleeps=0
+sleep() {{
+  _sleeps=$((_sleeps + 1))
+  if [[ "$_sleeps" -eq 1 ]]; then
+    : > "{logfile}"   # shrink only — no growth past the reset baseline
+  fi
+}}
+tail() {{ command tail "$@"; }}
+main() {{
+  set +e
+  devcake_baker_wait_liveness 8 "{logfile}" "{pidfile}" "nohup python3 -m dev_factory &" 4 {baseline}
+  echo "rc=$?"
+}}
+""")
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "rc=1" in result.stdout
+    assert "did not progress its log" in result.stderr
+    assert "rotat" in result.stderr.lower()
+    assert f"last log lines ({logfile}):" in result.stderr
+
+
+def test_baker_host_degraded_reason_distinguishes_no_user_session(tmp_path):
+    """systemctl present + dead user bus → enable-linger remedy, not generic."""
+    # Case A: binary present, user session missing → sharper linger path.
+    result_a = _run_baker_host_driver(tmp_path, """
+command() {
+  if [[ "${1:-}" == "-v" && "${2:-}" == "systemctl" ]]; then
+    echo "/usr/bin/systemctl"
+    return 0
+  fi
+  builtin command "$@"
+}
+systemctl() {
+  if [[ "${1:-}" == "--user" && "${2:-}" == "show-environment" ]]; then
+    return 1
+  fi
+  return 0
+}
+main() {
+  set +e
+  devcake_baker_systemd_user_session_missing
+  echo "missing_rc=$?"
+  reason="$(devcake_baker_linux_degraded_reason)"
+  echo "reason=$reason"
+  # Banner must name enable-linger for this case (stdout+stderr).
+  set +e
+  devcake_baker_degraded_gap "$reason" 2>banner.err
+  echo "banner<<EOF"
+  cat banner.err
+  echo "EOF"
+}
+""")
+    assert result_a.returncode == 0, result_a.stderr + result_a.stdout
+    assert "missing_rc=0" in result_a.stdout
+    reason_line = next(
+        ln for ln in result_a.stdout.splitlines() if ln.startswith("reason=")
+    )
+    reason = reason_line[len("reason=") :]
+    assert "user systemd unavailable" != reason
+    assert "enable-linger" in reason
+    assert "enable-linger" in result_a.stdout.lower() or "enable-linger" in result_a.stderr.lower()
+    # Banner body (captured) also carries the remedy by name.
+    assert "enable-linger" in result_a.stdout
+
+    # Case B: no systemctl at all → generic unavailable; do NOT prescribe linger
+    # as the primary reason (banner tip may still mention it).
+    result_b = _run_baker_host_driver(tmp_path, """
+command() {
+  if [[ "${1:-}" == "-v" && "${2:-}" == "systemctl" ]]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+main() {
+  set +e
+  devcake_baker_systemd_user_session_missing
+  echo "missing_rc=$?"
+  reason="$(devcake_baker_linux_degraded_reason)"
+  echo "reason=$reason"
+}
+""")
+    assert result_b.returncode == 0, result_b.stderr + result_b.stdout
+    assert "missing_rc=1" in result_b.stdout
+    assert "reason=user systemd unavailable" in result_b.stdout
 
 
 def test_up_sh_measures_baker_log_baseline_before_launch():

--- a/scripts/lib/baker_host.sh
+++ b/scripts/lib/baker_host.sh
@@ -26,6 +26,8 @@ devcake_baker_platform() {
 
 # Loud banner when falling back to the flock-guarded respawn loop.
 # Printed to stderr so operators cannot miss the degraded path.
+# When reason names enable-linger (no-user-session path), print the sharper
+# remedy by name so WSL-with-systemd operators are not left on the generic tip.
 devcake_baker_degraded_gap() {
   local reason="${1:-neither systemd nor launchd available}"
   echo "══════════════════════════════════════════════════════════════" >&2
@@ -36,6 +38,14 @@ devcake_baker_degraded_gap() {
   echo "     Linux:  systemd --user + loginctl enable-linger \"\$USER\"" >&2
   echo "     macOS:  launchd LaunchAgent (login session / Docker Desktop)" >&2
   echo "   Then re-run ./up.sh to install the native supervisor." >&2
+  case "$reason" in
+    *enable-linger*)
+      echo "   Sharper fix (systemd present, no user session manager):" >&2
+      echo "     loginctl enable-linger \"\$USER\"" >&2
+      echo "     then restart your session (or the host), then ./up.sh" >&2
+      echo "     — ./up.sh will install the native systemd user unit." >&2
+      ;;
+  esac
   echo "══════════════════════════════════════════════════════════════" >&2
 }
 
@@ -53,6 +63,28 @@ devcake_baker_systemd_available() {
   # show-environment talks to the user manager; fails without a user bus.
   systemctl --user show-environment >/dev/null 2>&1 || return 1
   return 0
+}
+
+# systemctl binary exists but the user session manager is unreachable
+# (typical: WSL systemd=true without linger / no user bus).
+# Usage: → 0 when that is the case, 1 otherwise (incl. no systemctl at all).
+devcake_baker_systemd_user_session_missing() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  systemctl --user show-environment >/dev/null 2>&1 && return 1
+  return 0
+}
+
+# Linux DEGRADED reason for up.sh fallthrough. Distinguishes:
+#   install/start failed | no user session (linger) | binary unavailable.
+# Echoes one reason line on stdout.
+devcake_baker_linux_degraded_reason() {
+  if devcake_baker_systemd_available; then
+    echo "systemd user unit install/start failed"
+  elif devcake_baker_systemd_user_session_missing; then
+    echo "systemd present but no user session — run: loginctl enable-linger \"\$USER\", restart session/host, then ./up.sh"
+  else
+    echo "user systemd unavailable"
+  fi
 }
 
 # macOS launchd is available when we are on Darwin and launchctl exists.
@@ -402,7 +434,7 @@ devcake_baker_wait_liveness() {
   local pid="$1" logfile="$2" pidfile="$3" launch_cmd="$4"
   local seconds="${5:-12}"
   local baseline="${6-}"
-  local size=0 elapsed=0 step=2
+  local size=0 elapsed=0 step=2 rotated=0
   [[ -f "$logfile" ]] || : >"$logfile"
   if [[ -z "$baseline" ]]; then
     baseline=$(wc -c <"$logfile" 2>/dev/null | tr -d ' ' || echo 0)
@@ -414,6 +446,9 @@ devcake_baker_wait_liveness() {
       echo "── host baker died during launch confirmation (pid ${pid})" >&2
       echo "   launch: ${launch_cmd}" >&2
       echo "   pidfile: ${pidfile}" >&2
+      if [[ "$rotated" -eq 1 ]]; then
+        echo "   note: watch.log was rotated (shrunk) mid-launch — tail is of the current file" >&2
+      fi
       echo "   last log lines (${logfile}):" >&2
       tail -n 40 "$logfile" 2>/dev/null >&2 || true
       echo "   tip: retry with ./up.sh --foreground-baker when the parent reaps detached children" >&2
@@ -421,6 +456,13 @@ devcake_baker_wait_liveness() {
       return 1
     fi
     size=$(wc -c <"$logfile" 2>/dev/null | tr -d ' ' || echo 0)
+    # Copytruncate (rotate_watch_log) shrinks the live inode below the
+    # pre-launch baseline — reset and keep waiting for post-rotate growth.
+    if [[ "$size" -lt "$baseline" ]]; then
+      rotated=1
+      baseline=$size
+      continue
+    fi
     if [[ "$size" -gt "$baseline" ]]; then
       echo "── host baker watching keep-set (pid ${pid} → ${logfile}; liveness confirmed)"
       return 0
@@ -429,6 +471,9 @@ devcake_baker_wait_liveness() {
   echo "── host baker did not progress its log within ~${seconds}s (pid ${pid})" >&2
   echo "   launch: ${launch_cmd}" >&2
   echo "   pidfile: ${pidfile}" >&2
+  if [[ "$rotated" -eq 1 ]]; then
+    echo "   note: watch.log was rotated (shrunk) mid-launch — tail is of the current file" >&2
+  fi
   echo "   last log lines (${logfile}):" >&2
   tail -n 40 "$logfile" 2>/dev/null >&2 || true
   echo "   tip: retry with ./up.sh --foreground-baker when the parent reaps detached children" >&2

--- a/up.sh
+++ b/up.sh
@@ -491,14 +491,8 @@ if [[ "$_BAKER_SUPERVISED" -eq 0 ]]; then
   # DEGRADED: flock-guarded respawn loop (never bare nohup of the baker).
   case "$_BAKER_PLAT" in
     darwin) devcake_baker_degraded_gap "launchd install/start failed" ;;
-    linux)
-      if devcake_baker_systemd_available; then
-        devcake_baker_degraded_gap "systemd user unit install/start failed"
-      else
-        devcake_baker_degraded_gap "user systemd unavailable"
-      fi
-      ;;
-    *) devcake_baker_degraded_gap "platform ${_BAKER_PLAT} has no native supervisor" ;;
+    linux)  devcake_baker_degraded_gap "$(devcake_baker_linux_degraded_reason)" ;;
+    *)      devcake_baker_degraded_gap "platform ${_BAKER_PLAT} has no native supervisor" ;;
   esac
   if ! devcake_baker_respawn_install "$(pwd)" "$_FACTORY_DIR" "$_BAKER_LOG" "$_BAKER_PIDFILE"; then
     echo "── failed to install flock-guarded baker respawn supervisor" >&2


### PR DESCRIPTION
## Intent

Fix the host-baker post-launch liveness false alarm that fires when `watch.log` is copytruncated mid-wait (oversized pre-upgrade logs), and sharpen the Linux DEGRADED banner when `systemctl` exists but the user session manager is missing (WSL `systemd=true` without linger).

Mission: https://linear.app/fidecastro/issue/CAKE-168/baker-liveness-false-alarms-after-log-rotation-sharpen-the-no-user

## What changed

- `devcake_baker_wait_liveness` (`scripts/lib/baker_host.sh`): when measured log size is **below** the pre-launch baseline, treat as rotation — reset baseline and keep waiting (still require later growth). Failure printout notes mid-launch rotation and tails the **current** logfile.
- New helpers: `devcake_baker_systemd_user_session_missing`, `devcake_baker_linux_degraded_reason` — distinguish no-`systemctl` vs systemd-present/no-user-session (`loginctl enable-linger` + restart + `./up.sh`).
- `up.sh` Linux DEGRADED branch forwards through `devcake_baker_linux_degraded_reason` (chokepoint stays in `baker_host.sh`).
- TDD stubs in `app/tests/test_dev_factory.py` for shrinkage success, rotation-named failure, and linger vs generic unavailable.

## How to verify

```bash
./scripts/pytest_app.sh app/tests/test_dev_factory.py -k 'baker_host_wait_liveness or baker_host_degraded or up_sh_loud_degraded or up_sh_confirms_baker or up_sh_measures_baker'
# or full file:
./scripts/pytest_app.sh app/tests/test_dev_factory.py
```

Observed here: fresh `app-test` image build, then `87 passed` for `tests/test_dev_factory.py` in that image (scripts/`up.sh` bind-mounted). Throwaway Redis for `pytest_app.sh` failed on this agent host (`netavark: iptables: No such file or directory`) — shell-stub baker tests do not need Redis; CI still grades the full suite.

**Not proven in-harness:** live host with pre-upgrade `watch.log` > 2 MiB rotation cap, or live WSL linger enable — field acceptance lines; unit stubs encode the contracts.

## Risk / rollout

Host-path shell only (`up.sh` / `baker_host.sh`). No app runtime or rotator change. First `./up.sh` after upgrade on noisy logs should confirm liveness instead of false-alarming.

## Out of scope

Rotation cap / idle-poll noise; app-side `baker_liveness()`; docs rewrite (no contradiction found in `docs/13-deployment.md`).