### PR TITLE
[CAKE-183] Runs table: merge the five token/cost cells into one centered placeholder on running rows

### DIFF
--- a/admin/spa/src/pages/RunsPage.jsx
+++ b/admin/spa/src/pages/RunsPage.jsx
@@ -21,10 +21,15 @@ import { runHoverDetail } from "../lib/runHover.js";
 // CAKE-171/174: muted italic placeholder when a token/cost scalar was not
 // measured. Copy comes only from the tokenCostAbsence phrasebook — never a
 // second phrase string here.
-function AbsenceNote({ copy }) {
+// CAKE-183: layout="merged" drops the per-cell max-w cap and centers a single
+// nowrap line across the five token/cost columns.
+function AbsenceNote({ copy, layout = "cell" }) {
+  const merged = layout === "merged";
   return (
     <span
-      className="inline-block max-w-[9rem] text-left text-[11px] italic leading-snug text-neutral-500 dark:text-neutral-400"
+      className={merged
+        ? "inline-block whitespace-nowrap text-center text-[11px] italic text-neutral-500 dark:text-neutral-400"
+        : "inline-block max-w-[9rem] text-left text-[11px] italic leading-snug text-neutral-500 dark:text-neutral-400"}
       title={copy}
       aria-label={copy}>
       {copy}
@@ -137,11 +142,20 @@ export default function RunsPage() {
     value != null ? tokens(value) : aggregateAbsence();
   const aggregateUsdOrAbsence = (value) =>
     value != null ? usd(value) : aggregateAbsence();
-  const costCell = (r) => {
+  // Effective displayed cost scalar (null → absence path). Same ADR-0021
+  // override/estimate rules as costCell — kept as a pure helper so the
+  // CAKE-183 merge predicate can compare copy without re-deriving showEst.
+  const effectiveCostUsd = (r) => {
     const showEst = overrideOn
       ? r.cost_usd_estimated != null
       : r.cost_usd == null && r.cost_usd_estimated != null;
-    const eff = showEst ? r.cost_usd_estimated : r.cost_usd;
+    return {
+      showEst,
+      eff: showEst ? r.cost_usd_estimated : r.cost_usd,
+    };
+  };
+  const costCell = (r) => {
+    const { showEst, eff } = effectiveCostUsd(r);
     if (eff == null) {
       return (
         <AbsenceNote
@@ -161,6 +175,32 @@ export default function RunsPage() {
         ~{usd(eff)}
       </span>
     );
+  };
+
+  // CAKE-183: when all five token/cost display paths are absence notes with
+  // the same phrasebook copy, merge into one colspan=5 cell. Mixed rows
+  // (numbers + "not extracted" on CACHE W alone) stay per-cell.
+  const uniformTokenCostAbsence = (r) => {
+    const tokenAbs = (value) =>
+      value != null ? null : absenceCopy({ state: r.state, source: r.token_source });
+    const { eff } = effectiveCostUsd(r);
+    const costAbs = eff == null
+      ? costAbsenceCopy({
+          state: r.state,
+          source: r.token_source,
+          emptyRateCard,
+        })
+      : null;
+    const copies = [
+      tokenAbs(r.input_tokens),
+      tokenAbs(r.output_tokens),
+      tokenAbs(r.cache_read_tokens),
+      tokenAbs(r.cache_write_tokens),
+      costAbs,
+    ];
+    if (copies.some((c) => c == null)) return null;
+    const first = copies[0];
+    return copies.every((c) => c === first) ? first : null;
   };
 
   const sortableTh = (key, label, extra = "") => {
@@ -263,74 +303,85 @@ export default function RunsPage() {
   // multi-line cells. It lives in the stage glyph's popup, the icon
   // aria-labels, the run terminal's header — and always in the CSV export.
   const iconAction = "rounded p-0.5 text-neutral-500 transition hover:text-accent-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500/60 dark:text-neutral-400 dark:hover:text-accent-300";
-  const runRow = (r) => (
-    <tr key={r.run_id} onClick={() => setOpenRun(r)}
-      title="Click to open the run terminal"
-      className="cursor-pointer border-t border-neutral-100 hover:bg-stone-50 dark:border-neutral-800 dark:hover:bg-neutral-900">
-      <td className="py-2 pr-2">
-        <span className="flex items-center gap-1 whitespace-nowrap">
-          <StageGlyph stage={r.mission_type} detail={`run ${r.run_id}`} />
-          <button type="button"
-            onClick={(e) => { e.stopPropagation(); setOpenRun(r); }}
-            title="Open the run terminal"
-            aria-label={`Open the terminal for run ${r.run_id}`}
-            className={iconAction}>
-            <ScrollText size={14} aria-hidden />
-          </button>
-          <a href={traceUrl(r.run_id)}
-            onClick={(e) => e.stopPropagation()}
-            target="_blank" rel="noopener"
-            title="Open traces in OpenObserve"
-            aria-label={`Open traces for run ${r.run_id}`}
-            className={iconAction}>
-            <Activity size={14} aria-hidden />
-          </a>
-        </span>
-      </td>
-      <td className="pr-2">{missionCell(r)}</td>
-      <td className="pr-2">{harnessCell(r)}</td>
-      <td className="pr-2">{telCell(r.model)}</td>
-      <td className="pr-2">
-        <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-          <StatusPill state={r.state} verdict={r.verdict} />
-          {/* the old second line, folded to a popup — one-line rows */}
-          {(r.error || r.verdict) && (
-            <span role="img"
-              title={r.error || r.verdict}
-              aria-label={r.error ? `error: ${r.error}` : `verdict: ${r.verdict}`}
-              className={r.error
-                ? "text-red-500 dark:text-red-400"
-                : "text-amber-500 dark:text-amber-400"}>
-              <TriangleAlert size={13} aria-hidden />
-            </span>
-          )}
-        </span>
-      </td>
-      <td className="whitespace-nowrap pr-2 text-xs text-neutral-500 dark:text-neutral-400"
-        title={fullTime(r.started_at)}>
-        {relTime(r.started_at)}
-      </td>
-      <td className="whitespace-nowrap pr-2 text-xs tabular-nums text-neutral-500 dark:text-neutral-400">
-        {duration(r.started_at, r.ended_at)}
-      </td>
-      <td className="pr-2 text-right text-xs tabular-nums" title={tokenCellTitle(r)}>{tokenOrAbsence(r.input_tokens, r)}</td>
-      <td className="pr-2 text-right text-xs tabular-nums" title={outCellTitle(r)}>{tokenOrAbsence(r.output_tokens, r)}</td>
-      <td className="pr-2 text-right text-xs tabular-nums" title={tokenCellTitle(r)}>{tokenOrAbsence(r.cache_read_tokens, r)}</td>
-      <td className="pr-2 text-right text-xs tabular-nums" title={tokenCellTitle(r)}>{tokenOrAbsence(r.cache_write_tokens, r)}</td>
-      <td className="pr-2 text-right text-xs tabular-nums">{costCell(r)}</td>
-      <td className="pl-2 text-right">
-        {/* dispatched/running only — finalizing hides Stop too: the Dev has
-            already exited and the backend 409s a stop there by design */}
-        {["dispatched", "running"].includes(r.state) && (
-          <Button size="sm" kind="danger-ghost"
-            aria-label={`Stop run ${r.run_id}`}
-            onClick={(e) => { e.stopPropagation(); setStopOneErr(""); setStopTarget(r); }}>
-            Stop
-          </Button>
+  const runRow = (r) => {
+    const mergedCopy = uniformTokenCostAbsence(r);
+    return (
+      <tr key={r.run_id} onClick={() => setOpenRun(r)}
+        title="Click to open the run terminal"
+        className="cursor-pointer border-t border-neutral-100 hover:bg-stone-50 dark:border-neutral-800 dark:hover:bg-neutral-900">
+        <td className="py-2 pr-2">
+          <span className="flex items-center gap-1 whitespace-nowrap">
+            <StageGlyph stage={r.mission_type} detail={`run ${r.run_id}`} />
+            <button type="button"
+              onClick={(e) => { e.stopPropagation(); setOpenRun(r); }}
+              title="Open the run terminal"
+              aria-label={`Open the terminal for run ${r.run_id}`}
+              className={iconAction}>
+              <ScrollText size={14} aria-hidden />
+            </button>
+            <a href={traceUrl(r.run_id)}
+              onClick={(e) => e.stopPropagation()}
+              target="_blank" rel="noopener"
+              title="Open traces in OpenObserve"
+              aria-label={`Open traces for run ${r.run_id}`}
+              className={iconAction}>
+              <Activity size={14} aria-hidden />
+            </a>
+          </span>
+        </td>
+        <td className="pr-2">{missionCell(r)}</td>
+        <td className="pr-2">{harnessCell(r)}</td>
+        <td className="pr-2">{telCell(r.model)}</td>
+        <td className="pr-2">
+          <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+            <StatusPill state={r.state} verdict={r.verdict} />
+            {/* the old second line, folded to a popup — one-line rows */}
+            {(r.error || r.verdict) && (
+              <span role="img"
+                title={r.error || r.verdict}
+                aria-label={r.error ? `error: ${r.error}` : `verdict: ${r.verdict}`}
+                className={r.error
+                  ? "text-red-500 dark:text-red-400"
+                  : "text-amber-500 dark:text-amber-400"}>
+                <TriangleAlert size={13} aria-hidden />
+              </span>
+            )}
+          </span>
+        </td>
+        <td className="whitespace-nowrap pr-2 text-xs text-neutral-500 dark:text-neutral-400"
+          title={fullTime(r.started_at)}>
+          {relTime(r.started_at)}
+        </td>
+        <td className="whitespace-nowrap pr-2 text-xs tabular-nums text-neutral-500 dark:text-neutral-400">
+          {duration(r.started_at, r.ended_at)}
+        </td>
+        {mergedCopy != null ? (
+          <td colSpan={5} className="pr-2 text-center text-xs">
+            <AbsenceNote copy={mergedCopy} layout="merged" />
+          </td>
+        ) : (
+          <>
+            <td className="pr-2 text-right text-xs tabular-nums" title={tokenCellTitle(r)}>{tokenOrAbsence(r.input_tokens, r)}</td>
+            <td className="pr-2 text-right text-xs tabular-nums" title={outCellTitle(r)}>{tokenOrAbsence(r.output_tokens, r)}</td>
+            <td className="pr-2 text-right text-xs tabular-nums" title={tokenCellTitle(r)}>{tokenOrAbsence(r.cache_read_tokens, r)}</td>
+            <td className="pr-2 text-right text-xs tabular-nums" title={tokenCellTitle(r)}>{tokenOrAbsence(r.cache_write_tokens, r)}</td>
+            <td className="pr-2 text-right text-xs tabular-nums">{costCell(r)}</td>
+          </>
         )}
-      </td>
-    </tr>
-  );
+        <td className="pl-2 text-right">
+          {/* dispatched/running only — finalizing hides Stop too: the Dev has
+              already exited and the backend 409s a stop there by design */}
+          {["dispatched", "running"].includes(r.state) && (
+            <Button size="sm" kind="danger-ghost"
+              aria-label={`Stop run ${r.run_id}`}
+              onClick={(e) => { e.stopPropagation(); setStopOneErr(""); setStopTarget(r); }}>
+              Stop
+            </Button>
+          )}
+        </td>
+      </tr>
+    );
+  };
 
   const doClear = async () => {
     setClearing(true);

--- a/admin/spa/tests/costs.mjs
+++ b/admin/spa/tests/costs.mjs
@@ -185,11 +185,19 @@ await withPage(async (page) => {
       cache_write_tokens: 0, cost_usd: 0, cost_usd_estimated: null,
       started_at: new Date(Date.now() - 300000).toISOString(),
       ended_at: new Date(Date.now() - 240000).toISOString() },
+    // Mixed finished: numbers + null CACHE W — must NOT colspan-merge
+    { run_id: "A-5-1-EXECUTE-MIXEDX", mission_key: "A-5", mission_type: "EXECUTE",
+      dev_type: "senior-dev", seq: 1, state: "finished",
+      token_source: "end_event",
+      input_tokens: 1200, output_tokens: 340, cache_read_tokens: 80,
+      cache_write_tokens: null, cost_usd: 0.42, cost_usd_estimated: null,
+      started_at: new Date(Date.now() - 360000).toISOString(),
+      ended_at: new Date(Date.now() - 300000).toISOString() },
   ];
   await page.route(/\/api\/v1\/runs(?:\?.*)?$/, (route) =>
     route.fulfill({ status: 200, contentType: "application/json",
       body: JSON.stringify({
-        total: 4, total_runs: 4, runs,
+        total: 5, total_runs: 5, runs,
         totals: {
           runtime_seconds: 180,
           input_tokens: 0, output_tokens: 0,
@@ -205,9 +213,24 @@ await withPage(async (page) => {
   await gotoFresh(page, "#/runs");
   await page.waitForSelector("table tbody tr");
   const body = await page.innerText("tbody");
+  // Totals row is first in tbody when present — locate data rows by content.
+  const runningRow = page.locator("table tbody tr").filter({
+    has: page.locator('button[aria-label="Stop run A-1-1-EXECUTE-WAITXX"]'),
+  });
+  const mixedRow = page.locator("table tbody tr").filter({ hasText: "A-5" });
 
-  check("running null cells say available after the run ends",
-    body.includes("available after the run ends"));
+  // CAKE-183: uniform interim placeholder merges into one colspan=5 cell
+  const waitPhrase = "available after the run ends";
+  await checked("running row shows the interim placeholder exactly once",
+    async () => (await runningRow.locator(`[aria-label="${waitPhrase}"]`).count()) === 1);
+  await checked("running interim placeholder spans the five token/cost columns",
+    async () => {
+      const mergedCell = runningRow.locator(`td[colspan="5"]:has([aria-label="${waitPhrase}"])`);
+      return (await mergedCell.count()) === 1;
+    });
+  check("running row keeps its Stop control after the merged token/cost cell",
+    (await runningRow.locator('button[aria-label="Stop run A-1-1-EXECUTE-WAITXX"]').count()) === 1);
+
   check("failed null cells say not extracted (run failed)",
     body.includes("not extracted (run failed)"));
   check("finished + unavailable source says not extracted (unavailable)",
@@ -216,6 +239,26 @@ await withPage(async (page) => {
     /\b0\b/.test(body) && body.includes("$0.00"));
   check("null aggregate cache-write column says not extracted (not a fabricated 0)",
     (await page.locator('[data-testid="runs-totals"] [aria-label="not extracted"]').count()) >= 1);
+
+  // Mixed finished row: per-column cells, no colspan merge
+  check("mixed finished row has no colspan=5 token/cost merge",
+    (await mixedRow.locator("td[colspan='5']").count()) === 0);
+  const mixedCells = mixedRow.locator("td");
+  // 7 leading + 5 token/cost + 1 actions = 13
+  check("mixed finished row keeps five separate token/cost cells",
+    (await mixedCells.count()) === 13);
+  check("mixed finished CACHE W alone shows not extracted",
+    (await mixedCells.nth(10).innerText()).includes("not extracted"));
+  check("mixed finished cost still shows its dollar amount",
+    (await mixedCells.nth(11).innerText()).includes("$0.42"));
+
+  // One-line discipline at the suite's default viewport (1280): the merged
+  // phrase must not force document-level horizontal overflow.
+  const docOver = await page.evaluate(() =>
+    Math.ceil(document.documentElement.scrollWidth)
+      - document.documentElement.clientWidth);
+  check(`running merged placeholder does not force document horizontal overflow (${docOver}px)`,
+    docOver <= 1);
 });
 
 
@@ -253,16 +296,21 @@ await withPage(async (page) => {
       }) }));
   await gotoFresh(page, "#/runs");
   await page.waitForSelector("table tbody tr");
-  const rows = page.locator("table tbody tr");
-  const runningCost = await rows.nth(0).locator("td").nth(-2).innerText();
-  const failedCost = await rows.nth(1).locator("td").nth(-2).innerText();
-  const finishedCost = await rows.nth(2).locator("td").nth(-2).innerText();
-  check("empty card + running cost still says available after the run ends",
-    runningCost.includes("available after the run ends"));
-  check("empty card + failed cost still says not extracted (run failed)",
-    failedCost.includes("not extracted (run failed)"));
+  // No totals in this fixture — still locate by mission key so row order
+  // from server sort cannot silently retarget assertions. After CAKE-183,
+  // uniform-absence rows use one colspan=5 cell (not five token tds).
+  const waitPhrase = "available after the run ends";
+  const failedPhrase = "not extracted (run failed)";
+  const noRatePhrase = "no rate card — add rates under Cost inputs";
+  const runningRow = page.locator("table tbody tr").filter({ hasText: "E-1" });
+  const failedRow = page.locator("table tbody tr").filter({ hasText: "E-2" });
+  const finishedRow = page.locator("table tbody tr").filter({ hasText: "E-3" });
+  check("empty card + running still shows interim phrase once across token/cost",
+    (await runningRow.locator(`[aria-label="${waitPhrase}"]`).count()) === 1);
+  check("empty card + failed still shows run-failed phrase once across token/cost",
+    (await failedRow.locator(`[aria-label="${failedPhrase}"]`).count()) === 1);
   check("empty card + finished unpriced cost shows no-rate-card taxonomy",
-    finishedCost.includes("no rate card — add rates under Cost inputs"));
+    (await finishedRow.locator(`[aria-label="${noRatePhrase}"]`).count()) === 1);
 });
 
 summary("costs");


### PR DESCRIPTION
## Intent
On the Admin SPA Runs table, when a run’s five token/cost cells (in / out / cache r / cache w / cost) would all show the **same** absence placeholder, render **one** `colSpan={5}` centered, italic, single-line cell instead of five wrapping copies. The Stop / actions cell stays separate. Mixed-value rows, filtered totals, aggregate-by-mission, and CSV exports are unchanged (display-only).

## Mission
https://linear.app/fidecastro/issue/CAKE-183/runs-table-merge-the-five-tokencost-cells-into-one-centered

## How to verify
- `node tests/costs.mjs` (with vite on `:5199`): CAKE-171/174/183 mocked blocks — running row shows the interim phrase **exactly once** with `colspan=5`; Stop still present; mixed finished row keeps five separate cells (CACHE W `"not extracted"`, cost dollars).
- Phrasebook helpers / design tokens unchanged: `npm run test:helpers --prefix admin/spa` (or the token_cost_absence + design_tokens suites).
- Image: `docker build -f admin/Dockerfile -t localhost/devcake/admin:latest admin` (Bake unavailable on this agent host); nginx-health via `docker run --network host`.

## Risk / rollout
SPA-only layout. No API or export shape change. Merge predicate is uniform absence **copy**, not `state === "running"` alone (covers `dispatched` / `finalizing` and other uniform full-set phrases).

## Out of scope
Placeholder copy / CAKE-171 phrasebook edits; Overview or other tables.