### PR TITLE
Release workflow: devcake-cli to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,50 @@
+# Publish devcake-cli to PyPI via trusted publishing (OIDC — no stored token).
+#
+# Trigger: push a tag `cli-v<version>` where <version> matches
+# pyproject.toml's [project].version (guarded below). One-time PyPI setup by
+# the project owner: create/claim the `devcake-cli` project on pypi.org and
+# add this repo + workflow (environment `pypi`) as a trusted publisher.
+name: Release CLI
+
+on:
+  push:
+    tags: ["cli-v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Tag must match pyproject version
+        run: |
+          set -euo pipefail
+          want="${GITHUB_REF_NAME#cli-v}"
+          have="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          if [ "$want" != "$have" ]; then
+            echo "tag cli-v${want} does not match pyproject version ${have}" >&2
+            exit 1
+          fi
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Build sdist + wheel
+        run: uv build
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cli-dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # OIDC for PyPI trusted publishing
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: cli-dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1


### PR DESCRIPTION
Adds .github/workflows/release-cli.yml: pushing a tag cli-v<version> builds the sdist+wheel with uv (after a tag-matches-pyproject guard) and publishes to PyPI through OIDC trusted publishing in the pypi environment — no stored token. Actions pinned by SHA per repo convention (all four verified against their repos). Activation requires the one-time PyPI-side trusted-publisher registration by the project owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L644H93ePTasb3DAEVaViS