### PR TITLE
docs: lead install with uv tool install devcake-cli (now on PyPI)

### DIFF
--- a/.claude/skills/devcake-ops/SKILL.md
+++ b/.claude/skills/devcake-ops/SKILL.md
@@ -42,12 +42,14 @@ Ground rules before anything else:
 From the repository root:
 
 ```bash
-uv tool install .        # or: pipx install .
-devcake --help           # verify the console script resolves
+uv tool install devcake-cli   # from PyPI (or: pipx install devcake-cli)
+devcake --help                # verify the console script resolves
 ```
 
-The CLI is versioned with the checkout: after every `git pull`, run
-`uv tool install .` again so the installed CLI matches the tree.
+When operating a checkout day to day, prefer installing from it
+(`uv tool install .` at the repo root) and re-run that after every
+`git pull` — the CLI is versioned with the tree, and PyPI releases can
+lag it.
 
 ## 3. Preflight — `devcake doctor`
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ real EXECUTE: §9.
 ```bash
 # Clone the remote or fork you intend to run:
 git clone <this-repo-url> && cd devcake
-uv tool install .          # or: pipx install .  → console script `devcake`
+uv tool install devcake-cli   # from PyPI — or from this checkout: uv tool install .
 devcake doctor             # named preflight + one-time remedies (--json ok)
 devcake up --bake          # auto-inits .env secrets, DOCKER_GID, control plane + hello + baker
 # Later restarts (images already baked):  devcake up


### PR DESCRIPTION
devcake-cli 0.1.0 is live on PyPI via the trusted-publishing workflow (verified: fresh-venv install from PyPI resolves the console script). README quickstart and the devcake-ops skill now lead with the no-clone install, keeping the from-checkout lockstep guidance for day-to-day operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L644H93ePTasb3DAEVaViS