### PR TITLE
fix(mirror): honor 'empty branch = repository default' on sync; delete skill-source mirrors on card removal

### DIFF
--- a/app/devcake/api/config_service.py
+++ b/app/devcake/api/config_service.py
@@ -338,14 +338,16 @@ def _apply_config_patch(body: dict, *, config, dev_types, managers,
         except Exception:  # noqa: BLE001 — cleanup is best-effort: the config change is APPLIED; a failure must not 500 it (audit A21); orphan named in the log
             log.exception("could not delete stored secrets of removed "
                           "%s instance %r", scope, name)
-        if scope == "repo" and repo_cache is not None:
+        if scope in ("repo", "skill") and repo_cache is not None:
             # ADR-0024: the removed card's mirror goes with it (same
-            # best-effort contract as the secret deletion above)
+            # best-effort contract as the secret deletion above). Skill
+            # sources maintain a mirror under the same namespace as repo
+            # cards, so both scopes clean up here.
             try:
                 repo_cache.delete_mirror(name)
             except Exception:  # noqa: BLE001 — cleanup only; the config change is APPLIED
-                log.exception("could not delete mirror of removed repo %r",
-                              name)
+                log.exception("could not delete mirror of removed %s %r",
+                              scope, name)
     # Per-repo auto_merge OFF→ON (founder request 2026-07-15, ADR-0020):
     # re-arm the deferred-merge window only for missions whose work repo
     # flipped — the next sweep posts a fresh window entry for those.

--- a/app/devcake/api/config_service.py
+++ b/app/devcake/api/config_service.py
@@ -24,6 +24,12 @@ from ..settings_bundle import (BundleError, dry_run_adapters,
 log = logging.getLogger("devcake")
 
 
+# Scopes whose cards own a name-keyed ADR-0024 mirror — the rename and
+# removal cleanups below must treat them identically or one path orphans
+# what the other migrates.
+_MIRRORED_SCOPES = ("repo", "skill")
+
+
 def _item_name(item) -> str:
     return item["name"] if isinstance(item, dict) else item.name
 
@@ -312,7 +318,7 @@ def _apply_config_patch(body: dict, *, config, dev_types, managers,
             except Exception:  # noqa: BLE001 — best-effort: config change is APPLIED; orphan named in the log
                 log.exception("could not rename %s secrets %r → %r",
                               scope, old_name, new_name)
-            if scope == "repo" and repo_cache is not None:
+            if scope in _MIRRORED_SCOPES and repo_cache is not None:
                 try:
                     repo_cache.rename_mirror(old_name, new_name)
                 except Exception:  # noqa: BLE001 — best-effort; config applied
@@ -332,17 +338,26 @@ def _apply_config_patch(body: dict, *, config, dev_types, managers,
             log.exception("post-rename adapter rebuild failed — renamed "
                           "instances may stay degraded until the next "
                           "config save or boot")
+    renamed_onto = {new_name
+                    for pairs in (skill_renames, pmo_renames, repo_renames)
+                    for _, new_name in pairs}
     for scope, name in removed:                  # only once the new config took
         try:
             secrets_store.delete_connection_instance(scope, name)
         except Exception:  # noqa: BLE001 — cleanup is best-effort: the config change is APPLIED; a failure must not 500 it (audit A21); orphan named in the log
             log.exception("could not delete stored secrets of removed "
                           "%s instance %r", scope, name)
-        if scope in ("repo", "skill") and repo_cache is not None:
+        if (scope in _MIRRORED_SCOPES and repo_cache is not None
+                and name not in renamed_onto):
             # ADR-0024: the removed card's mirror goes with it (same
             # best-effort contract as the secret deletion above). Skill
             # sources maintain a mirror under the same namespace as repo
-            # cards, so both scopes clean up here.
+            # cards, so both scopes clean up here. Never delete a name a
+            # rename just migrated ONTO in this same Save (remove skill X
+            # + rename repo Y→X would destroy Y's live mirror). A same-name
+            # same-scope card added later cold-clones by design: mirrors
+            # are name-keyed, and inheriting a removed card's freshness
+            # without a URL check is the riskier direction.
             try:
                 repo_cache.delete_mirror(name)
             except Exception:  # noqa: BLE001 — cleanup only; the config change is APPLIED

--- a/app/devcake/config.py
+++ b/app/devcake/config.py
@@ -309,6 +309,21 @@ class RepoInstance(BaseModel):
     def _url_shape(cls, v: str) -> str:
         return _validate_forge_url_shape(v)
 
+    @field_validator("default_branch")
+    @classmethod
+    def _branch_required(cls, v: str) -> str:
+        # Normalized at the boundary — sync, reads, DEVCAKE_DEFAULT_BRANCH,
+        # merge prompts, and claims must all compare ONE string — and
+        # NON-empty: unlike a skill source, a repo card's branch feeds
+        # container env and playbook instructions that break silently on
+        # "", so the sync-side default resolution must never mask it.
+        v = (v or "").strip()
+        if not v:
+            raise ValueError(
+                "default_branch must name a branch — repo cards have no "
+                "empty-means-remote-default contract")
+        return v
+
     @property
     def configured(self) -> bool:
         return bool(self.url.strip())
@@ -392,6 +407,13 @@ class SkillSource(BaseModel):
             raise ValueError(
                 f"subdir {v!r}: relative path inside the repo, no ..")
         return v
+
+    @field_validator("default_branch")
+    @classmethod
+    def _branch_stripped(cls, v: str) -> str:
+        # empty = the repository's default (the card contract); non-empty
+        # values normalize so sync and the mirror reads compare one string
+        return (v or "").strip()
 
     @property
     def configured(self) -> bool:

--- a/app/devcake/domain/repo_mirror.py
+++ b/app/devcake/domain/repo_mirror.py
@@ -58,6 +58,17 @@ def sync_error_class(stderr: str) -> str:
     return "auth" if any(m in lowered for m in _AUTH_MARKERS) else "transient"
 
 
+def _symref_head_branch(stdout: str) -> str:
+    """Branch name from `ls-remote --symref <url> HEAD` output ("" when the
+    remote has no HEAD symref — an empty repository, or a server that omits
+    the capability). Only `refs/heads/*` counts: a detached or non-branch
+    HEAD cannot seed a mirror's HEAD."""
+    for line in (stdout or "").splitlines():
+        if line.startswith("ref: refs/heads/") and line.rstrip().endswith("HEAD"):
+            return line[len("ref: refs/heads/"):].split("\t", 1)[0].strip()
+    return ""
+
+
 class MirrorStatus:
     """Ledger row for one mirror. Plain object — /health serializes as_dict."""
     __slots__ = ("ok", "synced_at", "attempted_at", "detail", "auth")
@@ -317,14 +328,28 @@ class RepoCache:
 
         # HEAD — load-bearing: a bare init defaults HEAD to main/master; a
         # wrong HEAD makes `git clone file://…` check out nothing
+        branch = (inst.default_branch or "").strip()
+        if not branch:
+            # The card contract is "empty branch = the repository's default"
+            # (skill sources default to empty; SPA hint says so) — resolve it
+            # from the remote's HEAD symref. Never write the empty ref: git
+            # refuses `refs/heads/` and the sync would fail every cycle.
+            r = await self.git(["ls-remote", "--symref", expected_url, "HEAD"],
+                               env=env)
+            branch = _symref_head_branch(r.stdout) if r.returncode == 0 else ""
+            if not branch:
+                return await fail(
+                    "default branch: the card's branch is empty and the "
+                    "remote's HEAD does not name one (empty repository?) — "
+                    "set Branch on the card")
         r = await self.git(["-C", str(p), "symbolic-ref", "HEAD",
-                            f"refs/heads/{inst.default_branch}"], env=env)
+                            f"refs/heads/{branch}"], env=env)
         if r.returncode != 0:
             return await fail(f"symbolic-ref: {r.stderr}")
 
         if self.config.repo_mirror.lfs:
             r = await self.git(["-C", str(p), "lfs", "fetch", "origin",
-                                inst.default_branch], env=env)
+                                branch], env=env)
             if r.returncode != 0:
                 return await fail(f"lfs fetch: {r.stderr or r.stdout}")
 

--- a/app/devcake/domain/repo_mirror.py
+++ b/app/devcake/domain/repo_mirror.py
@@ -336,12 +336,18 @@ class RepoCache:
             # refuses `refs/heads/` and the sync would fail every cycle.
             r = await self.git(["ls-remote", "--symref", expected_url, "HEAD"],
                                env=env)
-            branch = _symref_head_branch(r.stdout) if r.returncode == 0 else ""
+            if r.returncode != 0:
+                # a probe ERROR keeps its own stderr — an auth failure must
+                # latch the breaker, not read as "set Branch on the card"
+                return await fail(f"default-branch probe: "
+                                  f"{r.stderr or r.stdout}"
+                                  + (" (timeout)" if r.timed_out else ""))
+            branch = _symref_head_branch(r.stdout)
             if not branch:
                 return await fail(
                     "default branch: the card's branch is empty and the "
-                    "remote's HEAD does not name one (empty repository?) — "
-                    "set Branch on the card")
+                    "remote's HEAD does not name one (empty repository or "
+                    "detached HEAD) — set Branch on the card")
         r = await self.git(["-C", str(p), "symbolic-ref", "HEAD",
                             f"refs/heads/{branch}"], env=env)
         if r.returncode != 0:

--- a/app/devcake/domain/repo_mirror.py
+++ b/app/devcake/domain/repo_mirror.py
@@ -60,12 +60,17 @@ def sync_error_class(stderr: str) -> str:
 
 def _symref_head_branch(stdout: str) -> str:
     """Branch name from `ls-remote --symref <url> HEAD` output ("" when the
-    remote has no HEAD symref — an empty repository, or a server that omits
-    the capability). Only `refs/heads/*` counts: a detached or non-branch
-    HEAD cannot seed a mirror's HEAD."""
+    remote has no HEAD symref — an empty repository, a detached HEAD, or a
+    server that omits the capability). Only the line whose TARGET field is
+    exactly HEAD counts — a clone-shaped remote also advertises
+    `refs/remotes/origin/HEAD`, whose line merely ENDS with HEAD — and only
+    a `refs/heads/*` symref can seed a mirror's HEAD."""
     for line in (stdout or "").splitlines():
-        if line.startswith("ref: refs/heads/") and line.rstrip().endswith("HEAD"):
-            return line[len("ref: refs/heads/"):].split("\t", 1)[0].strip()
+        ref_part, _, target = line.partition("\t")
+        if target.strip() != "HEAD":
+            continue
+        if ref_part.startswith("ref: refs/heads/"):
+            return ref_part[len("ref: refs/heads/"):].strip()
     return ""
 
 
@@ -329,11 +334,15 @@ class RepoCache:
         # HEAD — load-bearing: a bare init defaults HEAD to main/master; a
         # wrong HEAD makes `git clone file://…` check out nothing
         branch = (inst.default_branch or "").strip()
-        if not branch:
+        probed = not branch
+        if probed:
             # The card contract is "empty branch = the repository's default"
             # (skill sources default to empty; SPA hint says so) — resolve it
             # from the remote's HEAD symref. Never write the empty ref: git
             # refuses `refs/heads/` and the sync would fail every cycle.
+            # Probed EVERY sync on purpose: caching the last answer would
+            # quietly turn "the repository's default" into "the default as
+            # of some earlier sync"; the RTT rides alongside the fetch's.
             r = await self.git(["ls-remote", "--symref", expected_url, "HEAD"],
                                env=env)
             if r.returncode != 0:
@@ -352,6 +361,19 @@ class RepoCache:
                             f"refs/heads/{branch}"], env=env)
         if r.returncode != 0:
             return await fail(f"symbolic-ref: {r.stderr}")
+        if probed:
+            # symbolic-ref succeeds on a DANGLING ref — a resolved branch
+            # the fetch never brought over (unborn HEAD advertisement, or
+            # the remote default changed between fetch and probe) must not
+            # ledger a green sync whose clones check out nothing
+            r = await self.git(["-C", str(p), "rev-parse", "--verify",
+                                "--quiet", f"refs/heads/{branch}^{{commit}}"])
+            if r.returncode != 0:
+                return await fail(
+                    f"default branch: the remote's HEAD names {branch!r} "
+                    f"but the fetch brought no such branch (unborn HEAD, "
+                    f"or it changed mid-sync) — retried next cycle; a "
+                    f"Branch on the card pins it")
 
         if self.config.repo_mirror.lfs:
             r = await self.git(["-C", str(p), "lfs", "fetch", "origin",
@@ -504,7 +526,13 @@ class RepoCache:
 
     def delete_mirror(self, name: str) -> None:
         """Best-effort removal (repo card deleted / re-init). Rename-aside
-        first so an in-flight Dev clone keeps its inode; then remove."""
+        first so an in-flight Dev clone keeps its inode; then remove.
+        Bookkeeping pops run even with NO on-disk dir: a card whose first
+        sync failed before init holds a ledger row too, and a removed card
+        must never keep a ghost /health entry until restart."""
+        self.ledger.pop(name, None)
+        self._synced_mono.pop(name, None)
+        self._locks.pop(name, None)
         p = self.mirror_path(name)
         if not p.exists():
             return
@@ -514,9 +542,6 @@ class RepoCache:
             shutil.rmtree(stale, ignore_errors=True)
         except OSError:
             log.exception("could not remove mirror %s", name)
-        self.ledger.pop(name, None)
-        self._synced_mono.pop(name, None)
-        self._locks.pop(name, None)
 
     def rename_mirror(self, old: str, new: str) -> None:
         """Migrate on-disk mirror + ledger key with a repo card rename.

--- a/app/tests/test_config_schema.py
+++ b/app/tests/test_config_schema.py
@@ -943,6 +943,25 @@ def test_skill_sources_round_trip_validation_and_name_disjointness():
         "skills_subdir")
 
 
+def test_default_branch_boundary_normalization():
+    """Branch values normalize at the model so sync, reads, container env,
+    and claims compare ONE string; a repo card refuses an EMPTY branch —
+    its value feeds DEVCAKE_DEFAULT_BRANCH and merge prompts, which break
+    silently on "" (skill sources keep empty = the remote's default)."""
+    from pydantic import ValidationError
+
+    from devcake.config import RepoInstance, SkillSource
+
+    assert RepoInstance(name="r", url="https://github.com/o/r",
+                        default_branch=" main ").default_branch == "main"
+    with pytest.raises(ValidationError, match="must name a branch"):
+        RepoInstance(name="r", url="https://github.com/o/r",
+                     default_branch="  ")
+    assert SkillSource(name="s", url="https://github.com/o/s",
+                       default_branch=" trunk ").default_branch == "trunk"
+    assert SkillSource(name="s", url="https://github.com/o/s").default_branch == ""
+
+
 def test_skill_source_url_and_forge_match_repo_instance():
     """CAKE-65: SkillSource rejects the same malformed URL / unknown forge
     literals as RepoInstance — empty URL still allowed (unconfigured card)."""

--- a/app/tests/test_repo_mirror.py
+++ b/app/tests/test_repo_mirror.py
@@ -771,3 +771,33 @@ def test_empty_branch_probe_error_keeps_stderr_and_latches_auth(tmp_path):
     assert "default-branch probe" in st.detail
     assert "shelf" in forges.breakers
     assert forges.breaker_fields["shelf"] == "token_ro"
+
+
+def test_resolved_branch_missing_from_fetch_fails_loud(tmp_path):
+    """symbolic-ref succeeds on a DANGLING ref — a probed default the fetch
+    never brought over (unborn HEAD / changed mid-sync) must not ledger a
+    green sync whose clones would check out nothing."""
+    def script(args):
+        if args[:1] == ["ls-remote"]:
+            return GitResult(0, "ref: refs/heads/main\tHEAD\nabc\tHEAD\n", "")
+        if "rev-parse" in args:
+            return GitResult(1, "", "")
+        return None
+    cache, _, _ = _skill_cache(tmp_path, script=script)
+    st = run_coro(cache.sync_one("shelf"))
+    assert not st.ok
+    assert "no such branch" in st.detail
+
+
+def test_delete_mirror_pops_bookkeeping_even_without_a_dir(tmp_path):
+    """A card whose first sync failed before init holds a ledger row but no
+    mirror dir — removal must still drop it, or /health keeps a ghost
+    failing row for a nonexistent card until restart."""
+    from devcake.domain.repo_mirror import MirrorStatus
+    cache, _, _ = make_cache(tmp_path, [R1])
+    cache.ledger["alpha"] = MirrorStatus(ok=False, detail="init failed")
+    cache._synced_mono["alpha"] = 1.0
+    assert not cache.mirror_path("alpha").exists()
+    cache.delete_mirror("alpha")
+    assert "alpha" not in cache.ledger
+    assert "alpha" not in cache._synced_mono

--- a/app/tests/test_repo_mirror.py
+++ b/app/tests/test_repo_mirror.py
@@ -721,3 +721,53 @@ def test_dispatch_without_external_skills_asks_for_no_cards(tmp_path):
     assert run is not None
     assert all("skillrepo" not in asked for asked in cache.asked)
     assert run.skill_repo_heads == {}
+
+
+# ── empty-branch default resolution (the card's "empty = remote default") ────
+
+def _skill_cache(tmp_path, *, script=None):
+    from devcake.config import SkillSource
+
+    class Skill(SkillSource):
+        @property
+        def token(self):  # type: ignore[override]
+            return ""
+
+        @property
+        def token_ro(self):  # type: ignore[override]
+            return "ro-s"
+
+    cache, calls, forges = make_cache(tmp_path, [], script=script)
+    cache.config.skill_sources = [
+        Skill(name="shelf", url="https://gitlab.com/o/skills")]
+    return cache, calls, forges
+
+
+def test_empty_branch_resolves_head_via_symref_probe(tmp_path):
+    def script(args):
+        if args[:1] == ["ls-remote"]:
+            return GitResult(0, "ref: refs/heads/trunk\tHEAD\nabc\tHEAD\n", "")
+        return None
+    cache, calls, _ = _skill_cache(tmp_path, script=script)
+    st = run_coro(cache.sync_one("shelf"))
+    assert st.ok, st.detail
+    probe = next(c for c in calls if c[:1] == ["ls-remote"])
+    assert "--symref" in probe and probe[-1] == "HEAD"
+    head = next(c for c in calls if "symbolic-ref" in c)
+    assert head[-1] == "refs/heads/trunk"
+
+
+def test_empty_branch_probe_error_keeps_stderr_and_latches_auth(tmp_path):
+    """A probe ERROR must never read as 'set Branch on the card': its own
+    stderr rides the ledger detail so an auth failure latches the breaker
+    exactly like a fetch auth failure would."""
+    def script(args):
+        if args[:1] == ["ls-remote"]:
+            return GitResult(128, "", "remote: … returned error: 401")
+        return None
+    cache, _, forges = _skill_cache(tmp_path, script=script)
+    st = run_coro(cache.sync_one("shelf"))
+    assert not st.ok and st.auth
+    assert "default-branch probe" in st.detail
+    assert "shelf" in forges.breakers
+    assert forges.breaker_fields["shelf"] == "token_ro"

--- a/app/tests/test_repo_mirror_git.py
+++ b/app/tests/test_repo_mirror_git.py
@@ -12,8 +12,8 @@ import subprocess
 
 import pytest
 
-from devcake.config import AppConfig, RepoInstance
-from devcake.domain.repo_mirror import RepoCache
+from devcake.config import AppConfig, RepoInstance, SkillSource
+from devcake.domain.repo_mirror import RepoCache, _symref_head_branch
 
 pytestmark = pytest.mark.skipif(shutil.which("git") is None,
                                 reason="no git binary")
@@ -240,3 +240,61 @@ def test_skill_reads_follow_upstream_commits_after_resync(rig):
     new = run_coro(cache.read_skill_file("alpha", "skills", sha2,
                                          "tdd", "SKILL.md"))
     assert b"body" in old and b"v2" in new
+
+
+# ── empty default_branch = "the repository's default" (the card contract) ────
+
+class LocalSkill(SkillSource):
+    """A skill-source card over a local origin — empty tokens, like LocalRepo."""
+
+    @property
+    def token(self):  # type: ignore[override]
+        return ""
+
+    @property
+    def token_ro(self):  # type: ignore[override]
+        return ""
+
+
+def _skill_rig(rig):
+    origin, cache, _ = rig
+    src = LocalSkill.model_construct(name="shelf", url=str(origin),
+                                     default_branch="", subdir="")
+    cache.config.skill_sources = [src]
+    return origin, cache
+
+
+def test_skill_source_empty_branch_resolves_the_remotes_head(rig):
+    """SPA hint 'Empty = the repository's default': HEAD must come from the
+    remote's symref — trunk here, NOT a git init default and NEVER the
+    invalid `refs/heads/` (which failed every sync after a good fetch)."""
+    origin, cache = _skill_rig(rig)
+    sh("git", "checkout", "-qb", "trunk", cwd=origin)
+    st = run_coro(cache.sync_one("shelf"))
+    assert st.ok, st.detail
+    head = sh("git", "-C", str(cache.mirror_path("shelf")),
+              "symbolic-ref", "HEAD").strip()
+    assert head == "refs/heads/trunk"
+    assert run_coro(cache.tree_head("shelf"))   # reads pin via mirror HEAD
+
+
+def test_skill_source_empty_branch_detached_remote_fails_actionably(rig):
+    """A remote with no HEAD symref (detached) cannot seed the mirror's
+    HEAD — the failure must name the card's Branch field, not surface
+    git's bare symbolic-ref refusal."""
+    origin, cache = _skill_rig(rig)
+    sh("git", "checkout", "-q", "--detach", cwd=origin)
+    st = run_coro(cache.sync_one("shelf"))
+    assert not st.ok
+    assert "default branch" in st.detail and "Branch" in st.detail
+
+
+def test_symref_head_branch_parser():
+    good = "ref: refs/heads/main\tHEAD\n0123abc\tHEAD\n"
+    assert _symref_head_branch(good) == "main"
+    assert _symref_head_branch("0123abc\tHEAD\n") == ""      # detached
+    assert _symref_head_branch("") == ""                     # empty remote
+    assert _symref_head_branch("ref: refs/tags/v1\tHEAD\n") == ""
+    # branch names may contain slashes
+    assert _symref_head_branch(
+        "ref: refs/heads/release/2.0\tHEAD\n") == "release/2.0"

--- a/app/tests/test_repo_mirror_git.py
+++ b/app/tests/test_repo_mirror_git.py
@@ -42,9 +42,10 @@ def sh(*args, cwd=None):
     return r.stdout
 
 
-class LocalRepo(RepoInstance):
-    """A config card whose URL is a local origin (file path) and whose
-    tokens are empty — sync goes unauthenticated, like a public repo."""
+class _EmptyTokens:
+    """Secrets-store bypass shared by the Local* cards — sync goes
+    unauthenticated, like a public repo. ONE copy: the two card kinds must
+    not drift when the token seam changes."""
 
     @property
     def token(self):  # type: ignore[override]
@@ -53,6 +54,10 @@ class LocalRepo(RepoInstance):
     @property
     def token_ro(self):  # type: ignore[override]
         return ""
+
+
+class LocalRepo(_EmptyTokens, RepoInstance):
+    """A config card whose URL is a local origin (file path)."""
 
 
 class Forges:
@@ -244,16 +249,8 @@ def test_skill_reads_follow_upstream_commits_after_resync(rig):
 
 # ── empty default_branch = "the repository's default" (the card contract) ────
 
-class LocalSkill(SkillSource):
-    """A skill-source card over a local origin — empty tokens, like LocalRepo."""
-
-    @property
-    def token(self):  # type: ignore[override]
-        return ""
-
-    @property
-    def token_ro(self):  # type: ignore[override]
-        return ""
+class LocalSkill(_EmptyTokens, SkillSource):
+    """A skill-source card over a local origin."""
 
 
 def _skill_rig(rig):
@@ -298,3 +295,8 @@ def test_symref_head_branch_parser():
     # branch names may contain slashes
     assert _symref_head_branch(
         "ref: refs/heads/release/2.0\tHEAD\n") == "release/2.0"
+    # a clone-shaped remote also advertises refs/remotes/origin/HEAD — its
+    # line merely ENDS with HEAD and must never seed the branch
+    assert _symref_head_branch(
+        "ref: refs/heads/master\trefs/remotes/origin/HEAD\n"
+        "0adc0adc\tHEAD\n") == ""

--- a/app/tests/test_settings_bundle.py
+++ b/app/tests/test_settings_bundle.py
@@ -1075,6 +1075,43 @@ def test_config_put_deletes_removed_skill_source_secrets(monkeypatch, tmp_path):
     assert secrets.read_connection_secret("skill", "shelf", "token_ro") == ""
 
 
+def test_config_put_deletes_removed_skill_source_mirror(monkeypatch, tmp_path):
+    """The removed card's ADR-0024 mirror goes with it — skill sources keep
+    a bare mirror in the SAME name namespace as repo cards, so leaving it
+    behind orphans <name>.git on the volume forever."""
+    import asyncio
+
+    from devcake.api import config_service
+
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, _dts = _world(config_mod, secrets, tpl)
+    cfg.skill_sources = [
+        config_mod.SkillSource(
+            name="shelf", url="https://github.com/acme/skills"),
+    ]
+    secrets.write_connection_secret("skill", "shelf", "token_ro",
+                                    "skill_ro_mirror_0062")
+
+    monkeypatch.setattr(config_service, "save_config", lambda c: None)
+    monkeypatch.setattr(config_service, "validate_config_semantics",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(config_service, "dry_run_adapters", lambda *a, **k: None)
+
+    class Cache:
+        def __init__(self):
+            self.deleted = []
+
+        def delete_mirror(self, name):
+            self.deleted.append(name)
+
+    cache = Cache()
+    asyncio.new_event_loop().run_until_complete(
+        config_service.apply_config_patch(
+            {"skill_sources": []}, config=cfg, dev_types={}, managers={},
+            reload=lambda: None, repo_cache=cache))
+    assert cache.deleted == ["shelf"]
+
+
 def test_config_put_renames_skill_source_moves_secrets(monkeypatch, tmp_path):
     """In-place rename (same card index, new name) moves the connection
     secret file — tokens follow the new name; no orphan under the old."""

--- a/app/tests/test_settings_bundle.py
+++ b/app/tests/test_settings_bundle.py
@@ -1089,8 +1089,8 @@ def test_config_put_deletes_removed_skill_source_mirror(monkeypatch, tmp_path):
         config_mod.SkillSource(
             name="shelf", url="https://github.com/acme/skills"),
     ]
-    secrets.write_connection_secret("skill", "shelf", "token_ro",
-                                    "skill_ro_mirror_0062")
+    # deliberately NO stored token: mirror cleanup keys on the CARD, not on
+    # secret files — a token-less public skills repo must clean up too
 
     monkeypatch.setattr(config_service, "save_config", lambda c: None)
     monkeypatch.setattr(config_service, "validate_config_semantics",
@@ -1840,3 +1840,92 @@ def test_config_put_rename_rebuilds_adapters_after_secret_move(
             {"poll_interval_seconds": 50}, config=cfg, dev_types={},
             managers={}, reload=reload))
     assert len(key_at_reload) == 1
+
+
+def test_config_put_renames_skill_source_migrates_its_mirror(
+        monkeypatch, tmp_path):
+    """A skill-source rename must migrate its mirror like a repo rename —
+    secrets moved but mirror left behind would orphan <old>.git forever
+    (renamed-from names never enter the removed-cleanup set)."""
+    import asyncio
+
+    from devcake.api import config_service
+
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, _dts = _world(config_mod, secrets, tpl)
+    cfg.skill_sources = [config_mod.SkillSource(
+        name="shelf", url="https://github.com/acme/skills")]
+
+    monkeypatch.setattr(config_service, "save_config", lambda c: None)
+    monkeypatch.setattr(config_service, "validate_config_semantics",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(config_service, "dry_run_adapters", lambda *a, **k: None)
+
+    class Cache:
+        def __init__(self):
+            self.renamed = []
+            self.deleted = []
+
+        def rename_mirror(self, old, new):
+            self.renamed.append((old, new))
+
+        def delete_mirror(self, name):
+            self.deleted.append(name)
+
+    cache = Cache()
+    body = {"skill_sources": [
+        {"name": "bookshelf", "forge": "github",
+         "url": "https://github.com/acme/skills",
+         "default_branch": "", "subdir": ""}]}
+    asyncio.new_event_loop().run_until_complete(
+        config_service.apply_config_patch(
+            body, config=cfg, dev_types={}, managers={},
+            reload=lambda: None, repo_cache=cache))
+    assert cache.renamed == [("shelf", "bookshelf")]
+    assert cache.deleted == []
+
+
+def test_config_put_remove_plus_rename_never_deletes_the_migrated_mirror(
+        monkeypatch, tmp_path):
+    """Remove skill source 'a' + rename repo 'b'→'a' in ONE Save: the
+    removed-cleanup must not destroy the mirror the rename just migrated
+    onto the surviving card's new name."""
+    import asyncio
+
+    from devcake.api import config_service
+
+    sb, _, secrets, config_mod, tpl = _env(monkeypatch, tmp_path)
+    cfg, _dts = _world(config_mod, secrets, tpl)
+    cfg.repos = list(cfg.repos) + [config_mod.RepoInstance(
+        name="b", url="https://github.com/acme/big")]
+    cfg.skill_sources = [config_mod.SkillSource(
+        name="a", url="https://github.com/acme/skills")]
+    base_repos = [r.model_dump() for r in cfg.repos]
+    for r in base_repos:
+        if r["name"] == "b":
+            r["name"] = "a"
+
+    monkeypatch.setattr(config_service, "save_config", lambda c: None)
+    monkeypatch.setattr(config_service, "validate_config_semantics",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(config_service, "dry_run_adapters", lambda *a, **k: None)
+
+    class Cache:
+        def __init__(self):
+            self.renamed = []
+            self.deleted = []
+
+        def rename_mirror(self, old, new):
+            self.renamed.append((old, new))
+
+        def delete_mirror(self, name):
+            self.deleted.append(name)
+
+    cache = Cache()
+    asyncio.new_event_loop().run_until_complete(
+        config_service.apply_config_patch(
+            {"repos": base_repos, "skill_sources": []}, config=cfg,
+            dev_types={}, managers={}, reload=lambda: None,
+            repo_cache=cache))
+    assert ("b", "a") in cache.renamed
+    assert "a" not in cache.deleted


### PR DESCRIPTION
## What

Two skill-source mirror lifecycle fixes, shipped together as a hotfix:

1. **Empty-branch sync fallback.** A skill-source card's Branch field promises "Empty = the repository's default" (the SPA hint says so, and `SkillSource.default_branch` defaults to `""`), but `sync_one` wrote `git symbolic-ref HEAD refs/heads/` verbatim — git refuses the empty ref, so **every sync failed after a successful fetch** with `symbolic-ref: fatal: Refusing to set 'HEAD' to invalid ref 'refs/heads/'` (the exact error observed in the field on seven GitLab-backed cards). The sync now resolves the branch from the remote's HEAD symref (`ls-remote --symref`), and fails actionably — naming the card's Branch field — when the remote has no HEAD to offer (empty repository / detached HEAD).

2. **Mirror cleanup on skill-source removal.** The config-PUT removed-card cleanup deleted stored secrets for every scope but the on-disk bare mirror only for scope `repo` — removing a skill-source card orphaned `<name>.git` on the mirror volume forever. The cleanup now covers scope `skill`. (Safe: repo-card/skill-source name collisions are already refused by `AppConfig` validation, so the widened delete can never hit a repo card's mirror.)

## Tests

- Real git: empty-branch sync sets mirror HEAD from the remote symref (a non-default `trunk`, proving no hardcoded fallback); detached remote HEAD fails with the actionable message; symref parser corner cases pinned.
- Config PUT: removing a skill source calls `delete_mirror`.
- `ruff` clean; affected suites green locally (the container suite runs in CI).

## Field remediation note

On the affected host, the immediate operator fix remains typing `main` into each card's Branch field — this PR makes the blank field work as documented from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018P4o2ofvFYEBecrtgZeoSy

---

## Skeptical review round (multi-agent + verification)

Additional fixes applied after a deep review of the PR itself:

- **Rename parity**: skill-source renames now migrate the mirror exactly like repo renames (shared `_MIRRORED_SCOPES` feeds both cleanups), and the removed-card cleanup never deletes a name a rename migrated onto in the same Save.
- **Probe honesty**: a failed `ls-remote` keeps its own stderr (an auth failure latches the breaker instead of reading as "set Branch on the card"); the symref parser anchors on the line whose target is exactly `HEAD` (a clone-shaped remote also advertises `refs/remotes/origin/HEAD`); a probed default branch is verified to exist post-fetch (symbolic-ref succeeds on a dangling ref).
- **Boundary-normalized branches**: `default_branch` strips at the model for both card kinds, and a **repo card refuses an empty branch** — its value feeds `DEVCAKE_DEFAULT_BRANCH`, merge prompts, and claims targets, which break silently on ""; empty-means-remote-default stays a skill-source-only contract.
- `delete_mirror` pops ledger/bookkeeping even when no dir exists (no ghost /health rows).

**Known residuals (deliberate, pre-existing)**: profile/bundle apply cleans secrets but not mirrors on card removal (true for repo cards before this PR too); `delete_mirror` can race an in-flight warm-up sync (pre-existing class). Both are follow-up candidates, not regressions.
