### PR TITLE
release(v0.5.2): changelog section + devcake-cli 0.1.1 version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ See the living log and open candidates in
 Community surface added for public-repo hygiene (no LICENSE change in this
 track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).
 
-- **Added — per-board plan approval.** A PMO card toggle (**Plan
+## v0.5.2 (2026-09-02)
+
+Patch release in the v0.5 "Java Lava" line.
+[Release notes](https://github.com/flieber-inc/devcake/releases/tag/v0.5.2).
+
+- **New — per-board plan approval** (#380). A PMO card toggle (**Plan
   approval**, `pmos[].plan_approval`, default off) that makes every fresh
   plan — from a PLAN run or attached at ONBOARD triage — park its mission
   under `DEVCAKE-NEEDS-HUMAN` next to `DEVCAKE-EXECUTE`, and every
@@ -29,9 +34,10 @@ track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).
   hand-off label and recovery path; not counted as a hand-off (docs/03
   §2a).
 - **Fixed — `/health` 500 (SPA "Backend unreachable") and aborted poll
-  sweeps once an internal mission repo is registered.** Internal (zero-repo)
-  repos are synthesized with hyphenated names the operator-card pattern
-  forbids; their token read-throughs went to the secrets store, whose name
+  sweeps once an internal mission repo is registered** (#378). Internal
+  (zero-repo) repos are synthesized with hyphenated names the operator-card
+  pattern forbids; their token read-throughs went to the secrets store,
+  whose name
   check raised — outside the branch-protection probe's try on `/health`,
   and outside `refresh_health`, where the cycle guard then dropped whole
   poll cycles whenever a breaker was latched. Such rows now carry a
@@ -43,14 +49,20 @@ track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).
   field (there is none): it re-probes on the registered service-token
   adapter and clears on ok instead of sticking until restart.
 - **Fixed — `devcake up` could leave the host baker dead on the degraded
-  (flock respawn) path.** The respawn loop's lock fd was inherited by its
-  children, so a stopped supervisor's orphans (the backoff `sleep`, the
-  baker) kept the lock; the install slept a fixed 0.3 s and the successor
+  (flock respawn) path** (#379). The respawn loop's lock fd was inherited
+  by its children, so a stopped supervisor's orphans (the backoff `sleep`,
+  the baker) kept the lock; the install slept a fixed 0.3 s and the
+  successor
   gave up on the busy lock at once ("respawn supervisor died at launch").
   The handoff is now ordered and waited — supervisor first, then baker,
   each waited for with SIGKILL escalation (`DEVCAKE_BAKER_EXIT_WAIT`) — the
   loop closes its lock fd for every child, and a successor waits up to
   `DEVCAKE_RESPAWN_LOCK_WAIT` seconds for a predecessor still releasing it.
+- **devcake-cli 0.1.1.** The CLI wheel carries the `devcake up` handoff
+  fix above (the launcher now stops a degraded respawn supervisor first);
+  PyPI installs upgrade with `uv tool upgrade devcake-cli`, checkout
+  installs with `uv tool install .` after pulling (lockstep with the
+  repo's `scripts/lib`).
 
 ## v0.5.1 (2026-08-31)
 

--- a/cli/devcake_cli/__init__.py
+++ b/cli/devcake_cli/__init__.py
@@ -7,4 +7,4 @@ cannot shadow ``app/devcake``. Distribution / project name is ``devcake-cli``
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "devcake-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "DevCake host CLI (up/down/status/doctor/setup/baker run)"
 readme = "README.md"
 license = {text = "GPL-3.0-only"}


### PR DESCRIPTION
## Intent

Cut v0.5.2: move the Unreleased entries (#380 plan approval, #378 internal-repo `/health` fix, #379 baker handoff fix) into a v0.5.2 changelog section, and bump devcake-cli to 0.1.1 so the `cli-v0.1.1` tag carries the launcher half of #379 to PyPI.

## Proof (Always Works™)

- [x] Docs / templates only — re-read for accuracy (changelog mirrors the v0.5.1 section; no line over 80 columns)
- [x] `pyproject.toml` + `cli/devcake_cli/__init__.py` version strings agree (the release-cli workflow guards tag == pyproject version)

## Checklist

- [x] **One intent** — release bookkeeping only
- [x] **Security claims** unchanged
- [x] **No secrets or local state**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiNvyWbpWrRNACCxJvF4YV