### PR TITLE
fix(routing): devcake-repo markers accept the repository URL slug as an alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ See the living log and open candidates in
 Community surface added for public-repo hygiene (no LICENSE change in this
 track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).
 
+- **Fixed — `devcake-repo:` markers written as URL slugs gated every
+  child of a multi-repo decomposition.** The triage prompt lists each
+  repository as card name, workspace folder and URL on one line, and Devs
+  (humans too) reach for the folder or URL slug — whose hyphens make the
+  marker unparseable, so the children never dispatched. A marker that is
+  not a card name but equals exactly one work repository's URL slug now
+  resolves to that card (an exact secondary key on operator config, never
+  the default fall-through the marker doctrine forbids); zero or several
+  matches still gate, and the reason lists every card with its slug.
+  Decomposition inherits the parent's marker through the same resolver,
+  and the triage prompt says which value is the marker.
 - **Fixed — plan approval was invisible to the Dev and opaque to the
   human.** On a board with Plan approval on, a careful triage returned
   `human_needed` to ask for approval and the person received a hand-off

--- a/app/devcake/domain/orchestrator/decomposition.py
+++ b/app/devcake/domain/orchestrator/decomposition.py
@@ -90,8 +90,15 @@ async def finalize_decomposition(mgr, run: Run, result: dict) -> None:
                            ensure_ascii=True)
     manifest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     is_project = live.pmo_kind == "project"
-    from ..repo_routing import marker_repo
-    parent_repo_marker = marker_repo(live.description)
+    from ..repo_routing import marker_repo, repo_urls_of, resolve_marker
+    # the ONE marker→card rule (slug alias included), so a slug-marked
+    # parent stamps card names on its children; an unresolvable marker
+    # falls back to the raw parse and gates at the children's dispatch
+    # exactly as it would have gated the parent
+    parent_repo_marker = (resolve_marker(
+        live.description, set(mgr.forges.instances),
+        repo_urls_of(mgr.forges.instances))
+        or marker_repo(live.description))
 
     existing: dict[int, str] = {}
     existing_keys: dict[int, str] = {}

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -44,7 +44,7 @@ def resolve_repo(mgr, mission: Mission, all_runs: list | None = None):
     `all_runs`: pre-fetched store snapshot — the poll loop stamps every
     mission every cycle, so it reads the store ONCE per segment instead of
     once per mission; dispatch's live re-resolve reads fresh."""
-    from ..repo_routing import resolve_repo
+    from ..repo_routing import repo_urls_of, resolve_repo
     if all_runs is None:
         all_runs = mgr.runs.store.all()
     history = sorted(
@@ -53,7 +53,8 @@ def resolve_repo(mgr, mission: Mission, all_runs: list | None = None):
          and r.mission_type != "STEWARD"),
         key=lambda r: aware(r.created_at), reverse=True)
     return resolve_repo(mission, mgr.instance,
-                        set(mgr.forges.instances), history)
+                        set(mgr.forges.instances), history,
+                        repo_urls=repo_urls_of(mgr.forges.instances))
 
 
 def steward_repo(mgr) -> str | None:
@@ -310,9 +311,12 @@ def _onboard_repo_options(mgr, primary: str) -> str:
         "**Cross-repo work must never be one mission.** If completing this "
         "mission requires changes in more than one repository, take the "
         "high-complexity path: decompose into ONE child per repository, put "
-        "a `devcake-repo:<name>` line (backticked, exactly as written here) "
-        "in each child's description naming its repository, and order them "
-        "with blocked_by where one repository's change depends on another's. "
+        "a `devcake-repo:<name>` line (backticked) in each child's "
+        "description naming its repository, and order them with blocked_by "
+        "where one repository's change depends on another's. The marker "
+        "value is the card name in backticks at the START of each line "
+        "above; DevCake also accepts the repository URL's last path segment "
+        "as an alias. Nothing else routes. "
         f"A child without a marker lands on the default repository "
         f"(`{default}`).\n\n")
 

--- a/app/devcake/domain/repo_routing.py
+++ b/app/devcake/domain/repo_routing.py
@@ -35,25 +35,103 @@ def marker_repo(description: str) -> str | None:
     return m.group(1).lower() if m else None
 
 
+def repo_slug(url: str) -> str:
+    """The repository URL's last path segment, `.git`-stripped, lowercased —
+    the name Devs and humans reach for (it is the workspace folder and the
+    tail of the URL they just read)."""
+    return (url or "").rstrip("/").rsplit("/", 1)[-1].removesuffix(".git").lower()
+
+
+def _slug_candidates(token: str, repo_names: set[str],
+                     repo_urls: "dict[str, str] | None") -> list[str]:
+    """Configured cards whose URL slug equals `token` (case-insensitive)."""
+    if not repo_urls:
+        return []
+    return sorted(n for n, u in repo_urls.items()
+                  if n in repo_names and repo_slug(u) == token.lower())
+
+
+def _cards_with_slugs(repo_names: set[str],
+                      repo_urls: "dict[str, str] | None") -> str:
+    """`alpha (billing-api), beta (inventory-sync)` — the fix-the-
+    marker hint that shows the mapping instead of sending the human to the
+    admin panel."""
+    parts = []
+    for n in sorted(repo_names):
+        slug = repo_slug((repo_urls or {}).get(n, ""))
+        parts.append(f"{n} ({slug})" if slug and slug != n else n)
+    return ", ".join(parts) or "(none)"
+
+
+def repo_urls_of(instances) -> "dict[str, str] | None":
+    """Card name → URL from a forge registry's `instances` map; None when
+    the registry exposes names only (stubs), which disables the alias."""
+    items = getattr(instances, "items", None)
+    if items is None:
+        return None
+    return {n: getattr(i, "url", "") or "" for n, i in items()}
+
+
+def resolve_marker(description: str, repo_names: set[str],
+                   repo_urls: "dict[str, str] | None" = None) -> str | None:
+    """The CARD a description's marker names, or None: the card name itself,
+    or — field finding, hyphenated URL slugs written by triage Devs and
+    humans alike — the one configured card whose URL slug matches. Anything
+    ambiguous or unknown is None; `resolve_repo` owns the gate reasons. This
+    is the ONE marker→card rule, shared with decomposition's inheritance."""
+    strict = marker_repo(description)
+    if strict is not None and strict in repo_names:
+        return strict
+    raw = RAW_REPO_MARKER.search(description or "")
+    token = strict if strict is not None else (raw.group(1).strip() if raw else None)
+    if not token:
+        return None
+    cands = _slug_candidates(token, repo_names, repo_urls)
+    return cands[0] if len(cands) == 1 else None
+
+
 def resolve_repo(mission: "Mission", instance: "PMOInstance",
                  repo_names: set[str],
-                 run_history: "list[Run]") -> tuple[str | None, str | None]:
+                 run_history: "list[Run]",
+                 repo_urls: "dict[str, str] | None" = None
+                 ) -> tuple[str | None, str | None]:
     """→ (repo_name, None) when resolved; (None, reason) when gated.
 
     `run_history`: this mission's prior runs (any state), newest first —
     only their repo_ref is read. Steward/hello records never carry a
     mission's repo and must not be passed in.
+
+    `repo_urls`: card name → URL for the configured repos. Enables the slug
+    alias: a marker that is not a card name but equals exactly one work
+    repo's URL slug resolves to that card (an exact secondary key on
+    operator-owned config — NOT the silent default fall-through A26
+    forbids: zero or several matches still gate, with the mapping in the
+    reason). None = no aliasing (legacy callers, tests).
     """
     marker = marker_repo(mission.description)
+    raw = RAW_REPO_MARKER.search(mission.description or "")
+    token = marker if marker is not None else (
+        raw.group(1).strip() if raw else None)
+    if token is not None and marker not in repo_names:
+        # not a card name (unparseable, or parseable but unknown): try the
+        # slug alias before any gate
+        cands = _slug_candidates(token, repo_names, repo_urls)
+        if len(cands) == 1:
+            marker = cands[0]
+        elif len(cands) > 1:
+            return None, (f"ambiguous `devcake-repo:` marker {token[:40]!r} — "
+                          f"the URL slug matches several cards: "
+                          f"{', '.join(cands)}; use the card name")
     if marker is None:
-        raw = RAW_REPO_MARKER.search(mission.description or "")
         if raw:
             # devcake-repo:-shaped but unparseable = a typo'd routing intent
             # — silently landing on the default (and then latching sticky
             # there) is the exact hazard the marker exists to avoid (A26)
             return None, (f"unparseable `devcake-repo:` marker "
-                          f"{raw.group(1)[:40]!r} — repo names are lowercase "
-                          f"letters/digits/underscores, ≤39; fix the marker")
+                          f"{raw.group(1)[:40]!r} — the marker is the card "
+                          f"name (lowercase letters/digits/underscores, ≤39) "
+                          f"or the repository URL's last path segment; "
+                          f"configured: {_cards_with_slugs(repo_names, repo_urls)}")
 
     sticky = next((r.repo_ref for r in run_history if r.repo_ref), None)
     if sticky is not None:
@@ -74,8 +152,9 @@ def resolve_repo(mission: "Mission", instance: "PMOInstance",
     if marker is not None:
         if marker not in repo_names:
             return None, (f"unknown repo '{marker}' — fix the "
-                          f"`devcake-repo:` marker (configured: "
-                          f"{sorted(repo_names) or '(none)'})")
+                          f"`devcake-repo:` marker: the card name or the "
+                          f"repository URL's last path segment; configured: "
+                          f"{_cards_with_slugs(repo_names, repo_urls)}")
         if marker in (instance.reference_repos or []):
             # reference repos are read-only consultation material for every
             # stage (founder request 2026-07-15) — never a work target

--- a/app/tests/test_repo_routing.py
+++ b/app/tests/test_repo_routing.py
@@ -259,7 +259,7 @@ def test_resolve_repo_history_assembly(tmp_path):
     import devcake.domain.repo_routing as rr
     got = []
     orig = rr.resolve_repo
-    def spy(mission, instance, names, history):
+    def spy(mission, instance, names, history, **kw):
         got.append([r.run_id for r in history])
         return orig(mission, instance, {"alpha", "beta"}, history)
     rr.resolve_repo = spy
@@ -300,7 +300,7 @@ def test_resolve_repo_sticky_survives_mixed_naive_aware_created_at(tmp_path):
     )
     orig = rr.resolve_repo
 
-    def spy(mission, instance, names, history):
+    def spy(mission, instance, names, history, **kw):
         return orig(mission, instance, {"alpha", "beta"}, history)
 
     rr.resolve_repo = spy
@@ -1125,3 +1125,72 @@ def test_gitea_mission_repo_binding_row(monkeypatch):
     # the hyphenated name would otherwise raise in the secrets name check
     assert inst.internal is True
     assert inst.token == "" and inst.token_ro == ""
+
+
+REPO_URLS = {"alpha": "https://forge.example/team/billing-api.git",
+             "beta": "https://forge.example/team/Inventory-Sync"}
+
+
+def test_slug_alias_resolves_to_the_card():
+    """Field finding (a multi-repo decomposition on a field board): a triage Dev, shown the card name
+    next to the folder and the URL, wrote the URL slug — and a slug's
+    hyphens make the marker unparseable, so five children gated. A marker
+    that matches exactly one configured WORK repo's URL slug now resolves
+    to that card: an exact secondary key on operator-owned config, never a
+    fall-through to the default."""
+    assert resolve_repo(_m("`devcake-repo:billing-api`"), INST_SET, REPOS,
+                        [], repo_urls=REPO_URLS) == ("alpha", None)
+    # case- and .git-insensitive
+    assert resolve_repo(_m("`devcake-repo:inventory-sync`"), INST_SET,
+                        REPOS, [], repo_urls=REPO_URLS) == ("beta", None)
+    # a strictly parseable token that is not a card but IS a slug aliases too
+    urls = {"alpha": "https://forge.example/team/Ledger", "beta": "https://x/b"}
+    assert resolve_repo(_m("`devcake-repo:ledger`"), INST_SET, REPOS, [],
+                        repo_urls=urls) == ("alpha", None)
+    # the card name itself still wins outright
+    assert resolve_repo(_m("`devcake-repo:beta`"), INST_SET, REPOS, [],
+                        repo_urls=REPO_URLS) == ("beta", None)
+    # without URL knowledge nothing changes: today's unparseable gate
+    name, reason = resolve_repo(_m("`devcake-repo:billing-api`"), INST_SET,
+                                REPOS, [])
+    assert name is None and "unparseable" in reason
+    # sticky routing compares RESOLVED names: alias == sticky is fine,
+    # alias != sticky gates like any mid-mission marker change
+    assert resolve_repo(_m("`devcake-repo:billing-api`"), INST_SET, REPOS,
+                        [_run("alpha")], repo_urls=REPO_URLS) == ("alpha", None)
+    name, reason = resolve_repo(_m("`devcake-repo:billing-api`"), INST_SET,
+                                REPOS, [_run("beta")], repo_urls=REPO_URLS)
+    assert name is None and "changed mid-mission" in reason
+
+
+def test_slug_alias_gates_when_ambiguous_reference_or_unknown():
+    """Anything that does not map to exactly one work repo still gates,
+    and the reason names the cards so the fix on the ticket is immediate."""
+    dup = {"alpha": "https://forge.example/a/billing-api",
+           "beta": "https://forge.example/b/billing-api"}
+    name, reason = resolve_repo(_m("`devcake-repo:billing-api`"), INST_SET,
+                                REPOS, [], repo_urls=dup)
+    assert name is None and "ambiguous" in reason
+    assert "alpha" in reason and "beta" in reason
+    # slug of a REFERENCE repo: the reference gate, naming the card
+    inst_ref = PMOInstance(name="linear", team_key="DEV", repos=["alpha"],
+                           reference_repos=["beta"])
+    name, reason = resolve_repo(_m("`devcake-repo:inventory-sync`"),
+                                inst_ref, REPOS, [], repo_urls=REPO_URLS)
+    assert name is None and "REFERENCE" in reason and "beta" in reason
+    # unknown token: gate, and the hint lists each card WITH its slug
+    name, reason = resolve_repo(_m("`devcake-repo:core-svc`"), INST_SET,
+                                REPOS, [], repo_urls=REPO_URLS)
+    assert name is None and "unparseable" in reason
+    assert "alpha (billing-api)" in reason
+    assert "beta (inventory-sync)" in reason
+
+
+def test_resolve_marker_helper_for_inheritance():
+    """decomposition inherits the PARENT's marker onto every child through
+    the same resolver, so a slug-marked parent still stamps card names."""
+    from devcake.domain.repo_routing import resolve_marker
+    assert resolve_marker("`devcake-repo:billing-api`", REPOS, REPO_URLS) == "alpha"
+    assert resolve_marker("`devcake-repo:beta`", REPOS, REPO_URLS) == "beta"
+    assert resolve_marker("`devcake-repo:nope`", REPOS, REPO_URLS) is None
+    assert resolve_marker("no marker", REPOS, REPO_URLS) is None

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -887,6 +887,28 @@ def test_decomposition_children_inherit_repo_marker(tmp_path):
     assert len(fake.created) == 2
 
 
+def test_decomposition_children_inherit_resolved_card_from_slug_marker(
+        tmp_path, monkeypatch):
+    """A parent whose marker is the repo's URL slug (the field failure
+    shape) still stamps its children with the CARD name — inheritance goes
+    through the same resolver as dispatch."""
+    from devcake.config import RepoInstance
+    m = mission("in_progress", {"DEVCAKE"})
+    m.description = "Do the big thing\n\n`devcake-repo:billing-api`"
+    mgr, fake, _store = make_mgr(tmp_path, m)
+    cards = {"alpha": RepoInstance(name="alpha",
+                                   url="https://forge.example/team/billing-api.git"),
+             "beta": RepoInstance(name="beta", url="https://forge.example/team/beta")}
+    monkeypatch.setattr(type(mgr.forges), "instances",
+                        property(lambda self: cards))
+    run_coro(decomposition.finalize_decomposition(
+        mgr, _run("ONBOARD", None),
+        {"outcome": "decomposed", "decomposition": [{"title": "docs"}]}))
+    child = fake.all_missions[1]
+    assert "`devcake-repo:alpha`" in child.description
+    assert "`devcake-repo:billing-api`" not in child.description
+
+
 def test_decomposition_children_clean_without_marker(tmp_path):
     m = mission("in_progress", {"DEVCAKE"})
     mgr, fake, _store = make_mgr(tmp_path, m)

--- a/docs/tutorials/01-first-mission.md
+++ b/docs/tutorials/01-first-mission.md
@@ -64,7 +64,7 @@ Open **http://localhost:8080** (loopback; admin user/password from `.env`).
 
 1. **PMO** (`#/pmo`, under Connections) — Add PMO instance → team key → **Set** Linear API key → Test.
 2. **Repositories** (`#/repos`) — Add repository → choose a short card **name**
-   (lowercase letters/digits/underscores, ≤39 — this is the `devcake-repo:<name>` marker) →
+   (lowercase letters/digits/underscores, ≤39 — this is the `devcake-repo:<name>` marker; the URL's last path segment works as an alias) →
    URL → **Set** write token; prefer **RO** for non-EXECUTE and a **reviewer**
    token (app-only, different account) for formal forge approval → Test.
    Repositories, PMO, and Skill sources live under the sidebar's **Connections** group.
@@ -131,7 +131,7 @@ In your sandbox Linear team, create an issue:
 - **Title:** small and real — e.g. *"Add input validation to the parser, with tests"*.
 - **Description:** brief a competent contractor, and include a backticked
   work-repo marker matching the card name from step 1b, e.g.
-  `` `devcake-repo:sandbox` `` (lowercase letters/digits/underscores, ≤39). Resolution order is
+  `` `devcake-repo:sandbox` `` (the card name: lowercase letters/digits/underscores, ≤39; the repository URL's last path segment is accepted as an alias when it names exactly one work card). Resolution order is
   marker → instance default (first chip) → zero-repo; this tutorial needs the
   external card, so put the marker (or rely on the chip default from step 1b).
 - **Label:** **`DEVCAKE`** (opt-in adoption).


### PR DESCRIPTION
## Intent

Field finding: a multi-repo decomposition's children carried `devcake-repo:` markers written as the repository's URL slug (for example `devcake-repo:billing-api`) rather than the card name (`alpha`), so every child gated as unparseable and the family never started. The triage prompt shows the card name, the workspace folder and the URL on one line, and Devs (humans too) reach for the slug. Three fixes at the one routing chokepoint:

1. **Slug alias in `resolve_repo`.** A marker that is not a card name but equals exactly one configured card's URL slug (case- and `.git`-insensitive) resolves to that card. Zero matches gate as before; several matches gate as ambiguous naming the cards; a slug that resolves to a reference card hits the existing reference gate. Sticky routing compares resolved names. This is an exact secondary key on operator-owned config, not the silent default fall-through the marker doctrine (audit A26) forbids.
2. **Gate reasons show the mapping.** Unparseable and unknown markers now list every card with its slug (`alpha (billing-api), beta (inventory-sync)`), so the fix on a ticket takes seconds.
3. **Decomposition inherits through the same resolver** (`resolve_marker`), so a slug-marked parent stamps card names on its children, and the triage prompt states which value is the marker and that the URL slug is accepted as an alias.

Docs: tutorial marker rule, changelog.

## Proof (Always Works™)

- [x] `app/` — test-first: three routing tests and one decomposition test red before the change (unique slug, case/.git, unknown-but-slug token, sticky compare; ambiguous / reference / unknown gates with the mapping in the reason; inheritance from a slug-marked parent), then green. Two existing resolver spies accept the new keyword. `./scripts/pytest_app.sh` full suite green on a fresh `app-test` bake. Ruff clean.
- [x] No `admin/` or `images/` change.

## Checklist

- [x] **One intent** — marker → card resolution
- [x] **Security claims** unchanged (routing still fails closed on anything not uniquely resolvable)
- [x] **Docs drift** — tutorial + changelog in this PR
- [x] **No secrets or local state**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiNvyWbpWrRNACCxJvF4YV
