### PR TITLE
test(admin): a predicate over fetch-decorated text is re-read until it holds

### DIFF
--- a/admin/spa/DESIGN.md
+++ b/admin/spa/DESIGN.md
@@ -343,7 +343,11 @@ A UI change is done when you have personally seen:
    to as-found) to prove the save-revert regression; run it against
    stacks whose config you own. New interactions get
    real predicates added here (`checked(name, fn)` — never `check(name,
-   true)` after a bare wait), not just screenshots. CI runs the full
+   true)` after a bare wait), not just screenshots; a predicate over
+   text the page decorates after a later fetch (a stored-token suffix,
+   a presence-driven disabled state) uses `checkedEventually(name, fn)`,
+   which re-reads until it holds, so a slow runner cannot turn a
+   one-shot read into a flake. CI runs the full
    suite (`npm run check:ui`) against the compose-backed admin on
    `:8080` after hello dispatch + forge/PMO contract batteries (founder
    REVIEW_LEDGER item 9 — CI-minutes cost accepted). Local operators

--- a/admin/spa/tests/harness.mjs
+++ b/admin/spa/tests/harness.mjs
@@ -64,6 +64,29 @@ export async function checked(name, fn, detail = "") {
   }
 }
 
+// A predicate over DOM the page decorates AFTER a later fetch lands (a
+// select whose option labels gain their stored-token suffix once the
+// presence check answers) is read again until it holds or the budget is
+// spent: a one-shot read races the decoration and fails only on a slow
+// runner. The last predicate error, if any, becomes the failure detail.
+export async function checkedEventually(name, fn, { timeout = 8000, every = 150 } = {}) {
+  const deadline = Date.now() + timeout;
+  let lastErr = "";
+  for (;;) {
+    try {
+      if (await fn()) { check(name, true); return; }
+      lastErr = "";
+    } catch (e) {
+      lastErr = String(e).split("\n")[0];
+    }
+    if (Date.now() >= deadline) {
+      check(name, false, `still false after ${timeout} ms${lastErr ? ` — ${lastErr}` : ""}`);
+      return;
+    }
+    await new Promise((r) => setTimeout(r, every));
+  }
+}
+
 export function skip(name, why) {
   skips += 1;
   console.log(`  - ${name} (skipped: ${why})`);

--- a/admin/spa/tests/token_copy.mjs
+++ b/admin/spa/tests/token_copy.mjs
@@ -2,7 +2,7 @@
 // picking a source fires a dry_run whose rows drive the target list (no
 // client-side family table to drift); Copy is the only non-dry POST.
 // Values never appear anywhere — field names only.
-import { check, checked, gotoFresh, summary, withPage } from "./harness.mjs";
+import { check, checked, checkedEventually, gotoFresh, summary, withPage } from "./harness.mjs";
 
 const repo = (name, forge, host) => ({
   name, forge,
@@ -163,7 +163,9 @@ await withPage(async (page) => {
     dryPosts.length === 0 && copyPosts.length === 0);
 
   const select = modal.locator('select[aria-label="Token copy source"]');
-  await checked("source options show stored slots; empty cards disabled", async () => {
+  // the slot suffixes and the disabled state arrive with the presence
+  // check, after the modal is already open — read until they have
+  await checkedEventually("source options show stored slots; empty cards disabled", async () => {
     const opts = await select.locator("option").allInnerTexts();
     const alpha = opts.find((t) => t.startsWith("alpha"));
     const gammaDisabled = await select


### PR DESCRIPTION
## Why

The browser suite `token_copy.mjs` failed three times in CI on one check, "source options show stored slots; empty cards disabled", while every other check passed, most recently on the main-branch run for #396. The modal decorates its source options (the stored-token suffix and the disabled state) once the presence check answers, after the modal is already open. The suite read the options once, immediately after the modal appeared, so a slow runner lost the race.

## What

- `tests/harness.mjs` gains `checkedEventually(name, fn, { timeout = 8000, every = 150 })`: the predicate is re-read until it holds or the budget is spent, and the last predicate error becomes the failure detail.
- The token-copy check uses it. The product is unchanged: the picker is advisory by design and never waits on the presence check.
- `DESIGN.md` names the rule next to the existing predicate doctrine.

## Verification

- Reproduced the race locally by delaying the mocked presence answer by 1.5 s: the one-shot read fails the check, the re-read holds (10 of 10).
- `token_copy.mjs` green locally against vite without the delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBKLwFrkny8udrVSc8fNXH