### PR TITLE
fix(review): preserve human stops and recorded merges on recovery

### DIFF
--- a/app/devcake/domain/orchestrator/review.py
+++ b/app/devcake/domain/orchestrator/review.py
@@ -22,6 +22,12 @@ async def _flag_out_of_pipeline_merge(mgr, run: Run) -> None:
     can merge unless branch protection forbids it. If the mission's PR turns
     up merged while the mission is still mid-pipeline, say so loudly —
     detection only; a human decides (they may have merged early themselves)."""
+    # A merge recorded by this run is our own completed side effect. A board
+    # outage can leave REVIEW finalizing after that merge; replay must not
+    # accuse it of an out-of-pipeline merge. Without a durable receipt the
+    # actor is still unknown, so retain the existing detection path.
+    if steps.REVIEW_MERGE in run.finalized_steps:
+        return
     forge = mgr.forges.get(run.repo_ref)
     if forge is None:
         # repo vanished: the detection cannot run — say so instead of going

--- a/app/devcake/domain/orchestrator/transitions.py
+++ b/app/devcake/domain/orchestrator/transitions.py
@@ -137,7 +137,11 @@ async def transition(mgr, run: Run, result: dict, plan_md: str | None) -> None:
     expected_stages.update(
         stage for marker, stage in _SWAP_MARKER_STAGE.items()
         if marker in run.finalized_steps)
-    if feed.stage_of(live) not in expected_stages:
+    # A human can cancel or SKIP a ticket without removing its REVIEW label.
+    # Neither stop may be overridden by approval, including artifact replay.
+    review_stopped = run.mission_type == "REVIEW" and (
+        live.status == "canceled" or LABEL_SKIP in live.labels)
+    if review_stopped or feed.stage_of(live) not in expected_stages:
         async def _external():
             await mgr._feed(
                 pmo_id, run.pmo_kind,

--- a/app/tests/test_review_restart.py
+++ b/app/tests/test_review_restart.py
@@ -1,0 +1,291 @@
+"""REVIEW recovery through artifact ingress and startup reconciliation.
+
+Remote PMO/forge state and pending messages survive; RunStore, RunManager,
+MissionManager, and FinalizerRouter are reconstructed from disk on restart.
+Faults occur at port operations, never at private checkpoints.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from devcake.adapters.files.run_store import RunStore
+from devcake.config import RepoInstance
+from devcake.domain.orchestrator import FinalizerRouter
+from devcake.domain.reconcile import reconcile_runs
+from devcake.domain.run import Run, auth_digest
+from devcake.domain.runs import RunManager
+from devcake.ports.forge import ForgeError, PullRequest
+from devcake.ports.pmo import PMOTransient
+from fakes import FakeExecutor, FakeForgeRuntime, NullMessaging, make_mission_manager
+from test_transitions import FakeForge, FakePMO, mission
+
+RUN_ID = "T-1-1-REVIEW-ABCDEF"
+AUTH = "obvious-fake-run-password"
+PAYLOAD = {
+    "result": {"outcome": "reviewed", "verdict": "approve",
+               "report_md": "The change satisfies the ticket."},
+    "transcript_md": "A synthetic REVIEW transcript.",
+    "token_report": {"input_tokens": 10, "output_tokens": 5},
+}
+
+
+class ProcessStopped(BaseException):
+    """A process exit bypasses production's recoverable Exception handlers."""
+
+
+class ReviewForge(FakeForge):
+    def __init__(self, *, fault_at: str = "approve",
+                 fault: BaseException | None = None) -> None:
+        super().__init__()
+        self.approved = False
+        self.merged = False
+        self.fault_at = fault_at
+        self.fault = fault if fault is not None else ProcessStopped(fault_at)
+
+    def after_write(self, operation: str) -> None:
+        if self.fault_at == operation:
+            self.fault_at = ""
+            raise self.fault
+
+    async def approve(self, pr_number: int) -> bool:
+        self.approved = True
+        self.after_write("approve")
+        return True
+
+    async def merge(self, pr_number: int) -> None:
+        self.merged = True
+        self.after_write("merge")
+
+    async def pr_state(self, pr_number: int) -> PullRequest:
+        return PullRequest(number=8, url="https://forge/pr/8",
+                           state="closed" if self.merged else "open",
+                           merged=self.merged)
+
+    async def get_pr_by_branch(self, branch: str) -> PullRequest:
+        return await self.pr_state(8)
+
+
+class PendingArtifacts(NullMessaging):
+    def __init__(self) -> None:
+        self.pending = {RUN_ID}
+        self.users = {RUN_ID}
+        self.reply_streams = {RUN_ID}
+
+    async def unresolved_run_ids(self) -> set[str]:
+        return set(self.pending)
+
+    async def reclaim_pending(self, handler, verify_auth) -> None:
+        for run_id in tuple(self.pending):
+            assert verify_auth(run_id, AUTH)
+            await handler(run_id, "run.artifacts", PAYLOAD)
+            self.pending.remove(run_id)  # ack only after successful handling
+
+    async def delete_run_user(self, run_id: str) -> None:
+        self.users.discard(run_id)
+
+    async def delete_reply_stream(self, run_id: str) -> None:
+        self.reply_streams.discard(run_id)
+
+    async def delete_runspec_result(self, run_id: str) -> None:
+        pass
+
+
+class CompletionPMO(FakePMO):
+    def __init__(self, *, accept_done: bool = False) -> None:
+        super().__init__(mission(labels={"DEVCAKE", "DEVCAKE-REVIEW"}))
+        self.accept_done = accept_done
+        self.fail_done = True
+
+    async def set_status(self, ref, status: str) -> None:
+        if status == "done" and self.fail_done:
+            self.fail_done = False
+            if self.accept_done:
+                await super().set_status(ref, status)
+                raise ProcessStopped("Done accepted; process stopped before response")
+            raise PMOTransient("board unavailable before Done")
+        await super().set_status(ref, status)
+
+
+def app(root: Path, pmo: FakePMO, forge: ReviewForge,
+        messaging: PendingArtifacts, *, auto_merge: bool = True) -> RunManager:
+    store = RunStore(root / "runs")
+    runs = RunManager(store, messaging, FakeExecutor())
+    repo = RepoInstance(name="main", url="https://forge/org/repo",
+                        auto_merge=auto_merge)
+    mgr = make_mission_manager(
+        pmo=pmo, forge_runtime=FakeForgeRuntime(forge, repo), runs=runs,
+        messaging=messaging, noop_audit=True)
+    runs.set_finalizer(FinalizerRouter({mgr.instance_name: mgr}, store, messaging))
+    return runs
+
+
+def seed(runs: RunManager) -> None:
+    runs.store.save(Run(
+        run_id=RUN_ID, mission_key="T-1", mission_pmo_id="p1",
+        mission_type="REVIEW", dev_type="judgment", seq=1,
+        pmo_ref="linear", repo_ref="main", state="running",
+        stage_label_at_dispatch="DEVCAKE-REVIEW", auth_digest=auth_digest(AUTH)))
+
+
+def run_scenario(coro) -> None:
+    # Do not install/clear the process-global loop: older suites still use it.
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+@pytest.mark.parametrize("auto_merge", [True, False])
+def test_cancellation_with_review_label_survives_approval_restart(tmp_path, auto_merge):
+    async def scenario():
+        pmo = FakePMO(mission(labels={"DEVCAKE", "DEVCAKE-REVIEW"}))
+        forge, messaging = ReviewForge(), PendingArtifacts()
+        runs = app(tmp_path, pmo, forge, messaging, auto_merge=auto_merge)
+        seed(runs)
+        with pytest.raises(ProcessStopped):
+            await runs.handle(RUN_ID, "run.artifacts", PAYLOAD)
+        assert forge.approved and not forge.merged
+        assert runs.store.get(RUN_ID).state == "finalizing"
+
+        # Trackers can cancel a ticket without removing its workflow labels.
+        pmo.mission.status = "canceled"
+        restarted = app(tmp_path, pmo, forge, messaging, auto_merge=auto_merge)
+        await reconcile_runs(restarted)
+
+        assert pmo.mission.status == "canceled"
+        assert pmo.mission.labels == {"DEVCAKE", "DEVCAKE-REVIEW"}
+        assert not forge.merged
+        assert restarted.store.get(RUN_ID).state == "finished"
+        assert "changed externally" in restarted.store.get(RUN_ID).verdict
+        assert messaging.pending == messaging.users == messaging.reply_streams == set()
+
+    run_scenario(scenario())
+
+
+@pytest.mark.parametrize("fault_at,auto_merge", [
+    ("approve", True), ("merge", True), ("approve", False),
+])
+def test_accepted_forge_write_recovers_after_restart(tmp_path, fault_at, auto_merge):
+    async def scenario():
+        pmo = FakePMO(mission(labels={"DEVCAKE", "DEVCAKE-REVIEW"}))
+        forge, messaging = ReviewForge(fault_at=fault_at), PendingArtifacts()
+        runs = app(tmp_path, pmo, forge, messaging, auto_merge=auto_merge)
+        seed(runs)
+        with pytest.raises(ProcessStopped):
+            await runs.handle(RUN_ID, "run.artifacts", PAYLOAD)
+        assert forge.approved
+        assert forge.merged is (fault_at == "merge")
+        assert runs.store.get(RUN_ID).state == "finalizing"
+        assert pmo.mission.status == "in_progress"
+
+        restarted = app(tmp_path, pmo, forge, messaging, auto_merge=auto_merge)
+        await reconcile_runs(restarted)
+
+        assert restarted.store.get(RUN_ID).state == "finished"
+        assert forge.merged is auto_merge
+        assert pmo.mission.status == ("done" if auto_merge else "in_progress")
+        assert pmo.mission.labels == (
+            {"DEVCAKE"} if auto_merge else {"DEVCAKE", "DEVCAKE-MERGE"})
+        assert messaging.pending == messaging.users == messaging.reply_streams == set()
+        assert any("token" in text.lower() for text in pmo.comments)
+        assert any(data == b"A synthetic REVIEW transcript." for _, data in pmo.uploads)
+        if fault_at == "merge":
+            # The process died before any local merge receipt: detection must
+            # remain active when the app cannot establish who merged remotely.
+            assert any("Out-of-pipeline merge detected" in text for text in pmo.comments)
+
+        # Completed artifact replay is a no-op even after another restart.
+        comments, pr_comments = list(pmo.comments), list(forge.pr_comments)
+        again = app(tmp_path, pmo, forge, messaging, auto_merge=auto_merge)
+        await reconcile_runs(again)
+        await again.handle(RUN_ID, "run.artifacts", PAYLOAD)
+        assert pmo.comments == comments
+        assert forge.pr_comments == pr_comments
+        assert forge.merged is auto_merge
+
+    run_scenario(scenario())
+
+
+@pytest.mark.parametrize("fault_at,auto_merge", [
+    ("approve", True), ("merge", True), ("approve", False),
+])
+def test_accepted_forge_write_with_lost_response_converges(tmp_path, fault_at, auto_merge):
+    async def scenario():
+        pmo = FakePMO(mission(labels={"DEVCAKE", "DEVCAKE-REVIEW"}))
+        forge = ReviewForge(fault_at=fault_at, fault=ForgeError("response lost"))
+        messaging = PendingArtifacts()
+        runs = app(tmp_path, pmo, forge, messaging, auto_merge=auto_merge)
+        seed(runs)
+        await messaging.reclaim_pending(runs.handle, runs.verify_auth)
+        restarted = app(tmp_path, pmo, forge, messaging, auto_merge=auto_merge)
+        await reconcile_runs(restarted)
+
+        assert forge.approved
+        assert forge.merged is auto_merge
+        assert pmo.mission.status == ("done" if auto_merge else "in_progress")
+        assert pmo.mission.labels == (
+            {"DEVCAKE"} if auto_merge else {"DEVCAKE", "DEVCAKE-MERGE"})
+        assert restarted.store.get(RUN_ID).state == "finished"
+        assert messaging.pending == messaging.users == messaging.reply_streams == set()
+        assert not any("auto-merge failed" in text for text in pmo.comments)
+
+    run_scenario(scenario())
+
+
+@pytest.mark.parametrize("accept_done", [False, True])
+def test_completion_recovers_without_misreporting_a_recorded_merge(tmp_path, accept_done):
+    async def scenario():
+        pmo = CompletionPMO(accept_done=accept_done)
+        forge, messaging = ReviewForge(fault_at=""), PendingArtifacts()
+        runs = app(tmp_path, pmo, forge, messaging)
+        seed(runs)
+        with pytest.raises(ProcessStopped if accept_done else PMOTransient):
+            await runs.handle(RUN_ID, "run.artifacts", PAYLOAD)
+        assert forge.merged
+        assert runs.store.get(RUN_ID).state == "finalizing"
+        assert pmo.mission.status == ("done" if accept_done else "in_progress")
+
+        restarted = app(tmp_path, pmo, forge, messaging)
+        await reconcile_runs(restarted)
+
+        assert pmo.mission.status == "done"
+        assert pmo.mission.labels == {"DEVCAKE"}
+        assert restarted.store.get(RUN_ID).state == "finished"
+        assert messaging.pending == messaging.users == messaging.reply_streams == set()
+        assert not any("auto-merge failed" in text for text in pmo.comments)
+        assert not any("Out-of-pipeline merge detected" in text for text in pmo.comments)
+
+    run_scenario(scenario())
+
+
+@pytest.mark.parametrize("labels", [
+    {"DEVCAKE", "DEVCAKE-EXECUTE"},
+    {"DEVCAKE", "DEVCAKE-REVIEW", "DEVCAKE-SKIP"},
+])
+@pytest.mark.parametrize("auto_merge", [True, False])
+def test_human_label_change_wins_over_replayed_approval(tmp_path, labels, auto_merge):
+    async def scenario():
+        pmo = FakePMO(mission(labels={"DEVCAKE", "DEVCAKE-REVIEW"}))
+        forge, messaging = ReviewForge(), PendingArtifacts()
+        runs = app(tmp_path, pmo, forge, messaging, auto_merge=auto_merge)
+        seed(runs)
+        with pytest.raises(ProcessStopped):
+            await runs.handle(RUN_ID, "run.artifacts", PAYLOAD)
+
+        pmo.mission.labels = set(labels)
+        restarted = app(tmp_path, pmo, forge, messaging, auto_merge=auto_merge)
+        await reconcile_runs(restarted)
+
+        assert pmo.mission.labels == labels
+        assert pmo.mission.status == "in_progress"
+        assert forge.approved and not forge.merged
+        assert restarted.store.get(RUN_ID).state == "finished"
+        assert "changed externally" in restarted.store.get(RUN_ID).verdict
+        assert messaging.pending == messaging.users == messaging.reply_streams == set()
+
+    run_scenario(scenario())

--- a/docs/03-mission-lifecycle.md
+++ b/docs/03-mission-lifecycle.md
@@ -10,6 +10,12 @@ Each Mission Type has a **playbook**: what the Dev receives, what it must do ins
 - **Finalization (app-side, always):** post the step comment (the Dev's last message, `>`-blockquoted) with the `{seq}_{TYPE}.md` full-session transcript attached (ADR-0014) → post token report (§8) → compare-and-transition (`04-orchestrator.md` §4) → forge side effects if any. **Exception:** on REVIEW-approve, the merge precedes the Done transition (§4.1) — Done must never overstate the repository.
 - **Failure:** nonzero exit or invalid `result.json` ⇒ no PMO transition; the Mission's label is untouched and it reschedules (attempt counting per `15-errors-and-retries.md`).
 
+On REVIEW finalization or replay, a live `canceled` ticket or a
+`DEVCAKE-SKIP` label is an external stop even if the ticket still carries
+`DEVCAKE-REVIEW`: publish the artifacts and external-transition notice, but
+do not merge or change its status/labels.
+An approval accepted before cancellation is not revoked (`04` §4).
+
 ## 1. ONBOARD
 
 **Goal:** assess a previously-untouched Mission's complexity and route it.

--- a/docs/04-orchestrator.md
+++ b/docs/04-orchestrator.md
@@ -181,7 +181,10 @@ def compare_and_transition(run, intended: Transition):
     # swap marker of ours (_SWAP_MARKER_STAGE) is accepted as our own prior
     # work — not an external change. A human change between deliveries still
     # halts further mutation.
-    if stage_label(live) not in expected_stages(run):
+    review_stopped = run.mission_type == "REVIEW" and (
+        live.status == "canceled" or "DEVCAKE-SKIP" in live.labels)
+    if review_stopped \
+            or stage_label(live) not in expected_stages(run):
         # A human (or another actor) changed state mid-run.
         pmo.post_feed(run.mission_ref,
             "DevCake completed a {type} run, but the mission's state was changed "
@@ -196,7 +199,20 @@ def compare_and_transition(run, intended: Transition):
 
 4. **Forge side effects** (EXECUTE/REVIEW only): PR comments/approval per `03-mission-lifecycle.md` and `06-forge-adapter.md`. **Exception to the ordering:** on REVIEW-approve, the merge (when the mission's repo has `auto_merge` on) runs *before* the status transition — Done is only declared after a real merge; a failed merge lands on `DEVCAKE-MERGE` instead (`03-mission-lifecycle.md` §4.1).
 
-Each completed side effect is appended to `run.finalized_steps` (keys from `orchestrator/steps.py` only — ADR-0034) and the Run file rewritten (atomic tmp+rename), so a crash mid-finalization resumes exactly where it stopped — already-done steps are skipped by their step keys.
+Each completed side effect is appended to `run.finalized_steps` (keys from `orchestrator/steps.py` only — ADR-0034) and the Run file rewritten (atomic tmp+rename). Replay skips durably recorded steps. Remote writes and local checkpoints are not one transaction: a remote write may succeed before its response or the checkpoint is recorded, so an unrecorded step can repeat after restart. Comments and approval requests are not promised exactly-once delivery; merge recovery uses the forge's already-merged handling and state probe.
+
+REVIEW treats a live `canceled` status or `DEVCAKE-SKIP` label as an external
+stop even if the tracker keeps the REVIEW label. After an approval-time crash,
+either stop prevents the resumed run from merging or changing the ticket's
+status/labels; an approval already accepted by the forge is not revoked. Artifacts remain
+available and the run finishes with an external-transition verdict.
+
+When the run has durably recorded its merge, replay does not report that
+merge as out-of-pipeline. Without that receipt, the existing detection still
+runs: a crash between remote merge and local persistence leaves the actor
+uncertain. `tests/test_review_restart.py` covers lost responses, process exits
+at remote writes, PMO completion failure, human stops, and completed replay
+through artifact ingress and startup reconciliation with real run files.
 
 Because the *label swap is the stage-advancing PMO mutation* and scheduling only derives work from live labels, a Mission can never be worked twice concurrently: until the swap lands, the Mission still derives as its old type, and the in-flight guard + grace cycle (§2) keep it out of candidates; after the swap, it derives as the next type. (Feed posts and other non-stage side effects may still land after the swap on some paths — the scheduler keys on the stage label, not on "last write wins.")
 
@@ -208,7 +224,7 @@ Runs every 10 s over all Runs in `dispatched | running`:
 - **Liveness:** a Run in `running` whose last `run.heartbeat` (`09-messaging.md`) is older than 5 minutes triggers a Dagu run-status query; a non-running Dagu status ⇒ Run `failed` (`DEV_KILLED` — the kill-chokepoint catch-all; exit 10/20 `DEV_CRASH` is only stamped when a Dev failure artifact or orphan post-mortem carries that code). A `dispatched` run that never starts within the startup grace (90 s) is treated the same way. Same unresolved + Dagu-dead promote-to-`finalizing` gate as timeout (Dagu is already known dead on this branch).
 
 - **Every kill branch re-reads before it kills.** The loop's snapshot of `store.active()` goes stale at every `await` (earlier kills, the Dagu status probe), so the timeout and liveness branches re-read the record and re-derive their verdict on the FRESH state immediately before killing — a run that finalized, entered finalize, or heartbeat mid-window is left alone. The same guard protects the stalled-finalize branch; `_kill_inner` (`domain/runs.py`) additionally aborts its save (and the mission-status restore) if the state moved during its own teardown awaits — the mover wins.
-- **No mid-run kill on mission terminal:** the watchdog does **not** poll the PMO for `done`/`canceled` mid-run. `EXTERNAL_TRANSITION` is decided only at **finalize**, when compare-and-transition re-reads the live stage label and finds it differs from `stage_label_at_dispatch` (artifacts still post; no further stage mutation).
+- **No mid-run kill on mission terminal:** the watchdog does **not** poll the PMO for `done`/`canceled` mid-run. `EXTERNAL_TRANSITION` is decided at **finalize** by the live stage comparison (§4); REVIEW also stops on a live `canceled` status or `DEVCAKE-SKIP` label even when its stage label remains. Artifacts still post; no further status/label mutation is applied on that external-transition path.
 - **Finalize-stall backstop:** Runs in `finalizing` are never wall-clock-killed while their `run.artifacts` entry can still be redelivered (crash+reclaim resumes them). But if a run is past `timeout_seconds + DEVCAKE_FINALIZE_STALL_SECONDS` (default 3600, age from `created_at`) **and** its entry is no longer on the ingress stream (poison dead-lettered per `15-errors-and-retries.md` §5, or lost), nothing can ever finish it — the watchdog fails it without re-entering finalize, so it stops blocking its mission and holding a concurrency slot.
 
 ## 6. Startup reconciliation (ordered checklist)


### PR DESCRIPTION
## Intent

REVIEW artifact replay could override a canceled ticket or `DEVCAKE-SKIP` when the REVIEW label remained, and could falsely report a previously recorded merge as out-of-pipeline after a board outage. Respect those human stops and skip the merge tripwire when this run has a durable merge receipt. Detection remains active without that receipt.

Add 14 recovery cases through `RunManager.handle` and `reconcile_runs`, reconstructing run storage, managers, and routing against the same persisted files and simulated remote state. Cover accepted approval/merge writes followed by response loss or process exit, board completion failure, human label changes, auto-merge off, and completed artifact replay. Update the lifecycle docs, including the possibility of repeated uncheckpointed remote writes.

This is PR 1 of the agreed seven-PR reliability and maintainability series. Decomposition recovery follows after this PR is reviewed and merged.

## Proof (Always Works™)

- [x] Red → green: cancellation reproduced `done` instead of `canceled`; SKIP replay changed labels; completion recovery emitted a false out-of-pipeline alert. Each was reproduced before its production fix.
- [x] Fresh Bake-backed `./scripts/pytest_app.sh --tb=short`: **3,229 passed, 2 skipped** (55.49s). The warning is the existing duplicate ZIP fixture.
- [x] Ruff in the freshly rebuilt app-test image: **all checks passed**.
- [x] Lifecycle documentation re-read; `git diff --check` clean.
- [x] [Disposable GitHub CI](https://github.com/flieber-inc/devcake/actions/runs/34002250010): production Bake, Compose startup/health, hello dispatch, Gitea contracts, and browser checks all passed (4m13s). CodeQL checks also passed. Verified commit: `fda2a906ac63f21df0ba77371382e43c51603907`; no deployment to the current running installation.

The new tests simulate failure at port operations; they do not claim a live provider outage or exactly-once remote delivery. Previously accepted approvals are not revoked by cancellation. Auto-merge off continues to constrain the app, with forge branch protection governing the Dev token.

## Checklist

- [x] One intent: REVIEW recovery; no decomposition or context-preparation refactor.
- [x] Security claims remain within `docs/14-security.md`.
- [x] Public lifecycle documentation updated in the same change.
- [x] No credentials, environment files, or local runtime state included.

## Links

- [Contributing](https://github.com/flieber-inc/devcake/blob/main/CONTRIBUTING.md)
- [Operator security contract](https://github.com/flieber-inc/devcake/blob/main/docs/14-security.md)
