### PR TITLE
ci(cli): prove wheel and sdist installation in clean environments

### DIFF
--- a/.github/workflows/cli-install.yml
+++ b/.github/workflows/cli-install.yml
@@ -1,0 +1,44 @@
+name: CLI installation
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cli-install-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install:
+    name: Install CLI (${{ matrix.distribution }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        distribution: [wheel, sdist]
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Build release artifacts and install into a clean Python 3.12 environment
+        env:
+          DISTRIBUTION: ${{ matrix.distribution }}
+        run: |
+          set -euo pipefail
+          uv python install 3.12
+          uv build --out-dir "$RUNNER_TEMP/cli-dist"
+          uv venv --python 3.12 "$RUNNER_TEMP/cli-installed"
+          if [ "$DISTRIBUTION" = wheel ]; then
+            artifact=("$RUNNER_TEMP/cli-dist/"*.whl)
+          else
+            artifact=("$RUNNER_TEMP/cli-dist/"*.tar.gz)
+          fi
+          test "${#artifact[@]}" -eq 1
+          uv pip install --python "$RUNNER_TEMP/cli-installed/bin/python" "${artifact[0]}"
+      - name: Exercise installed commands outside the checkout
+        run: |
+          "$RUNNER_TEMP/cli-installed/bin/python" scripts/check_cli_install.py \
+            --python "$RUNNER_TEMP/cli-installed/bin/python"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,12 @@ reporting: [`SECURITY.md`](SECURITY.md).
 
 ## CI and forks
 
+`cli-install.yml` builds the release wheel and sdist and installs each in a
+clean Python 3.12 environment. It runs the installed entry points from outside
+the checkout, imports shipped modules, and checks help, JSON diagnostics,
+version agreement, and usage/checkout exit codes. It does not start a host
+baker or a production stack; those runtime paths have separate proof.
+
 GitHub Actions for this repository do **not** require custom private org
 secrets for pull-request CI.
 

--- a/scripts/check_cli_install.py
+++ b/scripts/check_cli_install.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Exercise an installed CLI from outside its source checkout (no Docker writes)."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import tomllib
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--python", required=True, type=Path)
+    args = parser.parse_args()
+    python = args.python.absolute()
+    console = python.parent / "devcake"
+    root = Path(__file__).resolve().parents[1]
+    expected = tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"]
+    env = {k: v for k, v in os.environ.items() if k not in {"PYTHONPATH", "PYTHONHOME"}}
+    with tempfile.TemporaryDirectory(prefix="devcake-installed-") as scratch:
+        def run(command: list[str], code: int = 0) -> subprocess.CompletedProcess:
+            result = subprocess.run(command, cwd=scratch, env=env, text=True,
+                                    capture_output=True, timeout=60)
+            assert result.returncode == code, result.stdout + result.stderr
+            return result
+
+        # Import every shipped module and prove it came from the installation.
+        result = run([str(python), "-I", "-c", '''
+import importlib, importlib.metadata, json, pathlib, pkgutil
+import devcake_cli
+for module in pkgutil.iter_modules(devcake_cli.__path__):
+    if module.name != "__main__":
+        importlib.import_module("devcake_cli." + module.name)
+print(json.dumps({"version": importlib.metadata.version("devcake-cli"),
+                  "module_version": devcake_cli.__version__,
+                  "path": str(pathlib.Path(devcake_cli.__file__).resolve())}))
+'''])
+        installed = json.loads(result.stdout)
+        assert installed["version"] == installed["module_version"] == expected
+        assert not Path(installed["path"]).is_relative_to(root)
+        for command in ([], ["up"], ["down"], ["status"], ["doctor"], ["setup"], ["baker"]):
+            output = run([str(console), *command, "--help"]).stdout
+            assert "usage:" in output.lower(), output
+        assert "usage:" in run([str(python), "-I", "-m", "devcake_cli", "--help"]).stdout
+        assert "unknown verb" in run([str(console), "not-a-command"], 2).stderr
+        assert "not a DevCake checkout" in run(
+            [str(console), "up", "--dry-run"], 3).stderr
+        doctor = json.loads(run([str(console), "doctor", "--json"], 3).stdout)
+        assert doctor["schema_version"] == 1 and doctor["ok"] is False
+        layout = next(c for c in doctor["checks"] if c["id"] == "checkout_layout")
+        assert layout["ok"] is False
+    print(f"installed CLI {expected}: imports, entry points, help, diagnostics and exit codes passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Intent

Existing CLI tests import checkout code; they do not prove that published artifacts include every module or that installed entry points work. Add a disposable CI matrix that builds the wheel and sdist with the release build tool, installs each into a fresh Python 3.12 environment, and runs commands from outside the checkout with source-path overrides removed.

The check verifies module imports, installed provenance, metadata/package version agreement, console and module entry points, help, JSON doctor diagnostics, and usage/checkout exit codes. It performs no stack or baker startup.

## Proof

- Wheel installation and installed-command checks passed locally in a clean Python 3.12 environment.
- Sdist installation and installed-command checks also passed locally. Both [CI installation lanes](https://github.com/flieber-inc/devcake/actions/runs/34004660573) passed. [Standard disposable CI](https://github.com/flieber-inc/devcake/actions/runs/34004660550) and CodeQL also passed.
- CONTRIBUTING documents the scope. PR 5 of the improvement sequence; independent of the other drafts.
