### PR TITLE
fix(admin): complete Save and leave navigation after retry

### DIFF
--- a/admin/spa/src/components/DraftChrome.jsx
+++ b/admin/spa/src/components/DraftChrome.jsx
@@ -100,7 +100,9 @@ export default function DraftChrome({ registerNavGuard, health }) {
   const confirmSave = async () => {
     const fromNav = review?.fromNav;
     const ok = await doSave();
-    if (fromNav) fromNav(ok); // proceed only on full success
+    // Keep navigation pending while the results dialog offers a retry.
+    // Closing the dialog cancels it; only a successful save proceeds.
+    if (fromNav && ok) fromNav(true);
   };
 
   const closeReview = () => {
@@ -144,7 +146,7 @@ export default function DraftChrome({ registerNavGuard, health }) {
         results={saveResults}
         onConfirm={confirmSave}
         onCancel={closeReview}
-        onRetry={doSave}
+        onRetry={confirmSave}
       />
       <NavGuardDialog
         open={!!navPrompt}

--- a/admin/spa/tests/draft_persistence.mjs
+++ b/admin/spa/tests/draft_persistence.mjs
@@ -1,0 +1,139 @@
+// Rendered draft behavior at the HTTP seam. Every API request is intercepted;
+// these tests never write the operator's configuration.
+import { check, checkedEventually, gotoFresh, summary, withPage } from "./harness.mjs";
+
+const POLL = 'input[aria-label="Poll interval (seconds)"]';
+const dirty = (page) => page.getByText(/^Unsaved changes/);
+
+async function board(page) {
+  const state = {
+    cfg: { pmos: [], repos: [], poll_interval_seconds: 30, dismissed_alerts: [] },
+    assignments: { ONBOARD: { dev_type: "alpha", extra_cli_args: "" } },
+    failing: new Set(), writes: [], unexpected: [],
+  };
+  await page.route(/\/api\/v1\//, async (route) => {
+    const req = route.request();
+    const path = new URL(req.url()).pathname.replace("/api/v1/", "");
+    const reply = (data, status = 200) => route.fulfill({
+      status, contentType: "application/json", body: JSON.stringify(data),
+    });
+    if (req.method() === "GET") {
+      if (path === "config") return reply(state.cfg);
+      if (path === "assignments") return reply(state.assignments);
+      if (path === "dev-types") return reply(["alpha", "beta"].map((name) => ({
+        name, harness_template: "claude-code", max_concurrency: 1, skills: [], memory_repos: [],
+      })));
+      if (path === "runs") return reply({ runs: [], total: 0, total_runs: 0, pmo_refs: [] });
+      return reply({});
+    }
+    state.writes.push({ path, body: req.postDataJSON() });
+    if (req.method() !== "PUT" || !["config", "assignments"].includes(path)) {
+      state.unexpected.push(path);
+      return reply({ detail: "unexpected write" }, 405);
+    }
+    if (state.failing.has(path)) return reply({ detail: `${path} temporarily unavailable` }, 503);
+    if (path === "config") Object.assign(state.cfg, req.postDataJSON());
+    else state.assignments = req.postDataJSON();
+    return reply({ ok: true });
+  });
+  return state;
+}
+
+async function review(page) {
+  await page.getByRole("button", { name: "Save changes…", exact: true }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByText(/^Review \d+ change/).waitFor();
+  return dialog;
+}
+
+await withPage(async (page) => {
+  const state = await board(page);
+  state.failing.add("config");
+  await gotoFresh(page, "#/pmo");
+  await page.locator(POLL).fill("45");
+  const dialog = await review(page);
+  check("editing and reviewing do not persist config", state.writes.length === 0);
+  await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+  check("cancel review preserves the edited value", await page.locator(POLL).inputValue() === "45");
+  await (await review(page)).getByRole("button", { name: /^Save 1 change/ }).click();
+  await checkedEventually("failed save shows its error and preserves the dirty draft", async () =>
+    (await page.getByRole("dialog").innerText()).includes("config temporarily unavailable") &&
+    await dirty(page).count() === 1 && await page.locator(POLL).inputValue() === "45");
+  check("failed config write did not alter persisted state", state.cfg.poll_interval_seconds === 30);
+  state.failing.clear();
+  await page.getByRole("button", { name: "Retry failed", exact: true }).click();
+  await checkedEventually("successful retry closes the dialog and clears the draft", async () =>
+    await page.getByRole("dialog").count() === 0 && await dirty(page).count() === 0);
+  check("retry persisted the requested scalar", state.cfg.poll_interval_seconds === 45);
+  await page.reload();
+  await checkedEventually("saved scalar survives a fresh mount", async () =>
+    await page.locator(POLL).inputValue() === "45" && await dirty(page).count() === 0);
+  check("single-unit scenario made no unexpected writes", state.unexpected.length === 0);
+});
+
+await withPage(async (page) => {
+  const state = await board(page);
+  state.failing.add("assignments");
+  await gotoFresh(page, "#/pmo");
+  await page.locator(POLL).fill("45");
+  await page.locator('aside a[href="#/fleet"]').click();
+  await page.locator('aside a[href="#/fleet/mission-types"]').click();
+  const onboard = page.locator("#mission-types tbody tr").filter({
+    has: page.locator('td:text-is("ONBOARD")'),
+  }).first().locator("select");
+  await onboard.selectOption("beta");
+  await (await review(page)).getByRole("button", { name: /^Save 2 changes/ }).click();
+  await checkedEventually("partial save retains only the failed assignment edit", async () =>
+    (await dirty(page).innerText()).includes("(1)") &&
+    (await page.getByRole("dialog").innerText()).includes("assignments temporarily unavailable"));
+  check("partial save landed config but left assignments unchanged",
+    state.cfg.poll_interval_seconds === 45 && state.assignments.ONBOARD.dev_type === "alpha");
+  const beforeRetry = state.writes.length;
+  state.failing.clear();
+  await page.getByRole("button", { name: "Retry failed", exact: true }).click();
+  await checkedEventually("retry converges to a clean draft", async () =>
+    await dirty(page).count() === 0 && await page.getByRole("dialog").count() === 0);
+  check("retry sends only the failed unit",
+    JSON.stringify(state.writes.slice(beforeRetry).map((w) => w.path)) === '["assignments"]');
+  check("retried assignment is persisted", state.assignments.ONBOARD.dev_type === "beta");
+  check("partial-save scenario made no unexpected writes", state.unexpected.length === 0);
+});
+
+await withPage(async (page) => {
+  const state = await board(page);
+  state.failing.add("config");
+  await gotoFresh(page, "#/pmo");
+  await page.locator(POLL).fill("45");
+  await page.locator('aside a[href="#/runs"]').click();
+  await page.getByRole("button", { name: "Save & leave…", exact: true }).click();
+  await page.getByRole("dialog").getByRole("button", { name: /^Save 1 change/ }).click();
+  await checkedEventually("failed Save and leave keeps the user on the draft page", async () =>
+    page.url().endsWith("#/pmo") &&
+    (await page.getByRole("dialog").innerText()).includes("config temporarily unavailable"));
+  state.failing.clear();
+  await page.getByRole("button", { name: "Retry failed", exact: true }).click();
+  await checkedEventually("successful retry completes the requested navigation", async () =>
+    page.url().endsWith("#/runs") && await page.getByRole("dialog").count() === 0);
+  check("Save and leave retry persisted config", state.cfg.poll_interval_seconds === 45);
+  check("navigation scenario made no unexpected writes", state.unexpected.length === 0);
+});
+
+await withPage(async (page) => {
+  const state = await board(page);
+  state.failing.add("config");
+  await gotoFresh(page, "#/pmo");
+  await page.locator(POLL).fill("45");
+  await page.locator('aside a[href="#/runs"]').click();
+  await page.getByRole("button", { name: "Save & leave…", exact: true }).click();
+  await page.getByRole("dialog").getByRole("button", { name: /^Save 1 change/ }).click();
+  await page.getByRole("button", { name: "Close", exact: true }).click();
+  check("closing failed save preserves the draft and cancels navigation",
+    page.url().endsWith("#/pmo") && await page.locator(POLL).inputValue() === "45");
+  await page.locator('aside a[href="#/runs"]').click();
+  await page.getByRole("button", { name: "Discard & leave", exact: true }).click();
+  await checkedEventually("a new navigation attempt can discard and leave", async () =>
+    page.url().endsWith("#/runs") && await page.getByRole("dialog").count() === 0);
+  check("discard after failure leaves server config untouched", state.cfg.poll_interval_seconds === 30);
+});
+
+summary("draft_persistence");

--- a/admin/spa/tests/run.mjs
+++ b/admin/spa/tests/run.mjs
@@ -36,6 +36,7 @@ const SUITES = [
   "skills_fetch_external.mjs",
   "repo_backed_skills.mjs",
   "settings.mjs",
+  "draft_persistence.mjs",
   "tasks.mjs",
   "hierarchy.mjs",
   "devtypes.mjs",

--- a/docs/11-admin-panel.md
+++ b/docs/11-admin-panel.md
@@ -173,6 +173,13 @@ Internal (zero-repo) missions always auto-merge; operators who want doctrine con
 
 ## 3. Config page — draft/Save model and sections
 
+If **Save & leave** encounters a failed save, the results dialog keeps the
+requested navigation pending. **Retry failed** saves the remaining dirty units
+and leaves only after success; **Close** cancels that navigation and preserves
+the draft. Successful units drop out after the server rebase and are not sent
+again on retry. `admin/spa/tests/draft_persistence.mjs` verifies these behaviors
+through the rendered UI and controlled HTTP responses.
+
 **Unified draft (founder decision, 2026-07-13):** every edit on this page lands in a client-side draft — *nothing* persists until the operator reviews and saves. A **DirtyBar** appears while the draft differs from the server state; **Save** opens a **SaveReviewDialog** listing every pending change (per section) for confirmation, then issues the PUTs (`/config`, `/dev-types/{name}`, `/assignments`) and reports per-section results inline. A **nav guard** intercepts hash navigation away from a dirty draft (revert-and-ask, then replay). Danger confirms (adoption mode, auto-merge) still appear at flip time but only write the draft — the real write happens at Save. The one exception is the sidebar's mission-intake switch, which is deliberately immediate (§0); `dismissed_alerts` writes also bypass the draft (they're UI state, not operator config).
 
 **Multi-select convention (mandatory for new fields):** every field that


### PR DESCRIPTION
## Intent

After **Save & leave** failed, **Retry failed** persisted the draft but never completed the requested navigation. Keep navigation pending while the results dialog offers retry, route retries through the same confirmation path, and cancel pending navigation only when the user closes the dialog.

Adds four browser scenarios with 21 behavioral assertions: no persistence before confirmation, canceled review preserves edits, failed saves retain the draft, successful retry survives reload, partial saves retry only failed units, Save & leave retries complete navigation, and closing a failed save permits another navigation attempt. All API traffic is intercepted; these scenarios do not write live configuration.

## Proof

- Observed red: 17 assertions passed, navigation-after-retry failed. After the fix: 21 passed.
- SPA build and hermetic helper suite passed.
- Inspected failed-save dialog in light, dark, and 390 px mobile views.
- [Disposable CI](https://github.com/flieber-inc/devcake/actions/runs/34005104083) passed production app/admin Bake and startup, the full browser suite including all four new scenarios, Python tests, hello dispatch, forge/PMO contracts, and audits. CodeQL passed.
- Followed DESIGN.md; draft/save regimes preserved and behavior documented in docs/11.

PR 7 of the improvement sequence; independent of the other drafts.
