### PR TITLE
test(context): enforce cache protocol compatibility with mypy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,12 @@ tree. Prefer `./scripts/pytest_app.sh` or `PYTHONPATH=app` on Python 3.12.
 New behavior is **test-first** at public seams (`app/tests/`, port fakes). See
 [`AGENTS.md`](AGENTS.md) (TDD, SOLID, Always Works™).
 
+The ordinary app suite also runs a focused mypy gate for repository-context
+preparation and its cache Protocol. Static witnesses cover `RepoCache` and
+`NullRepoCache`; a negative case proves an incompatible failure-map signature
+is rejected. This is a scoped contract check, not whole-tree type coverage.
+Run it with `./scripts/pytest_app.sh -k repository_context_types`.
+
 ## Pull requests
 
 - **One intent per PR.** Prefer small, reviewable diffs.

--- a/app/devcake/domain/repo_mirror.py
+++ b/app/devcake/domain/repo_mirror.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import stat
 import time
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -273,7 +274,7 @@ class RepoCache:
         return ""
 
     def needed_for(self, *, work_repo: str, mission_type: str, instance,
-                   blocker_entries: list[dict],
+                   blocker_entries: list[dict] | None,
                    dev_type=None, config=None) -> list[str]:
         """The mirror-eligible repo set one run must have fresh (docs/07 §5a).
         Sourcing comes from THE shared rule (repo_sourcing.sourced_repo_names,
@@ -331,7 +332,7 @@ class RepoCache:
             self._synced_mono.pop(physical, None)
             log.debug("mirror %s: freshness dropped after an own write", physical)
 
-    async def ensure_fresh(self, names) -> tuple[bool, dict[str, str]]:
+    async def ensure_fresh(self, names: Iterable[str]) -> tuple[bool, dict[str, str]]:
         """Sync every named mirror unless already fresh. (all_ok, {name:
         reason}) — reasons only for failures. NEVER raises; the caller's
         poll segment must survive anything this does."""
@@ -845,7 +846,7 @@ class NullRepoCache:
     def needed_for(self, **_kw) -> list[str]:
         return []
 
-    async def ensure_fresh(self, names) -> tuple[bool, dict[str, str]]:
+    async def ensure_fresh(self, names: Iterable[str]) -> tuple[bool, dict[str, str]]:
         return True, {}
 
     async def tree_head(self, name: str) -> str | None:

--- a/app/requirements-dev.txt
+++ b/app/requirements-dev.txt
@@ -2,6 +2,7 @@
 # Runtime image uses requirements.txt alone.
 pytest==9.0.3
 ruff==0.12.2
+mypy==1.18.2
 pip-audit==2.10.1
 # starlette 1.x's TestClient rides httpx2 (encode's next-gen httpx successor,
 # same author — NOT a typosquat); the app's own adapters keep classic httpx

--- a/app/tests/test_repository_context_types.py
+++ b/app/tests/test_repository_context_types.py
@@ -1,0 +1,41 @@
+"""Focused static contract gate, run by the ordinary fresh-image pytest path."""
+from pathlib import Path
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def check(*paths: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "mypy", "--follow-imports=silent",
+         "--ignore-missing-imports", "--check-untyped-defs",
+         "--disallow-incomplete-defs", "--warn-unused-ignores",
+         "--cache-dir=/tmp/devcake-mypy", *(str(p) for p in paths)],
+        cwd=ROOT, text=True, capture_output=True, timeout=120)
+
+
+def test_repository_context_port_and_implementations_typecheck():
+    result = check(
+        ROOT / "devcake/ports/repository_context.py",
+        ROOT / "devcake/domain/repository_context.py",
+        ROOT / "tests/typechecks/repository_context.py")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_type_gate_rejects_an_incompatible_cache(tmp_path):
+    bad = tmp_path / "incompatible_cache.py"
+    bad.write_text('''from devcake.domain.repo_mirror import NullRepoCache
+from devcake.ports.repository_context import RepositoryContextCache
+
+class BrokenCache(NullRepoCache):
+    async def ensure_fresh(self, names: list[str]) -> tuple[bool, list[str]]:
+        return False, ["missing failure keys"]
+
+cache: RepositoryContextCache = BrokenCache()
+''')
+    result = check(bad)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "RepositoryContextCache" in result.stdout
+    assert "ensure_fresh" in result.stdout

--- a/app/tests/typechecks/repository_context.py
+++ b/app/tests/typechecks/repository_context.py
@@ -1,0 +1,9 @@
+"""Static witnesses: concrete caches must satisfy the preparation port."""
+from devcake.domain.repo_mirror import NullRepoCache, RepoCache
+from devcake.ports.repository_context import RepositoryContextCache
+
+
+def implementations(real: RepoCache, null: NullRepoCache) -> None:
+    production: RepositoryContextCache = real
+    fallback: RepositoryContextCache = null
+    del production, fallback


### PR DESCRIPTION
Relands #404 on `main`. #404 was based on the `refactor/repository-context` branch and merged into that branch after #402 had already been squash-merged to `main`, so its changes never reached `main`. This is #404's squash commit cherry-picked onto `main`, unchanged: the focused mypy contract gate for repository-context preparation and its cache Protocol, the corrected `needed_for` annotation, the typed `ensure_fresh` iterable, mypy pinned in test-only dependencies, and the CONTRIBUTING note.

Verified on the merged tree: full app suite 3265 passed, 2 skipped, with the static gate; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBKLwFrkny8udrVSc8fNXH