### PR TITLE
fix(audit): both audit writers scrub the actor label before the write

### DIFF
--- a/app/devcake/domain/orchestrator/feed.py
+++ b/app/devcake/domain/orchestrator/feed.py
@@ -256,11 +256,14 @@ def _audit(mgr, pmo_id: str, action: str, detail: str = "") -> None:
     detail = redact(detail)
     markers.AUDIT_PATH.parent.mkdir(parents=True, exist_ok=True)
     # redact(detail) already scrubbed; JSONL write is post-barrier (scanner cannot see MaD yet).
+    # the actor is an allowlisted label (auth.request_actor: [a-z0-9._-],
+    # 32 chars) — redact() is the same belt as for detail, so a caller that
+    # misuses the header can never park a secret shape in the audit file
     with open(markers.AUDIT_PATH, "a") as f:
         f.write(json.dumps({"ts": datetime.now(timezone.utc).isoformat(),
                             "instance": getattr(mgr, "instance_name", ""),
                             "pmo_id": pmo_id, "action": action, "detail": detail,
-                            "actor": _request_actor()}) + "\n")
+                            "actor": redact(_request_actor())}) + "\n")
     mgr._grace_next.add(pmo_id)
     # mirror every audit action as a span so OO alerts can fire on them
     # (`devcake_needs_human` was a file-only record no alert could ever see).

--- a/app/devcake/settings_bundle.py
+++ b/app/devcake/settings_bundle.py
@@ -128,7 +128,7 @@ def audit_event(action: str, detail: str = "") -> None:
     with open(path, "a") as f:
         f.write(json.dumps({"ts": _utcnow(), "instance": "", "pmo_id": "",
                             "action": action, "detail": redact(detail),
-                            "actor": _request_actor()}) + "\n")
+                            "actor": redact(_request_actor())}) + "\n")
     with tracer.start_as_current_span("audit.event") as span:
         span.set_attribute("devcake.audit.action", action)
         span.set_attribute("devcake.audit.detail", redact(detail)[:500])

--- a/app/tests/test_api_auth.py
+++ b/app/tests/test_api_auth.py
@@ -41,10 +41,15 @@ def test_every_admitted_mutation_writes_a_control_plane_audit_row(monkeypatch, t
     assert client.put("/api/v1/thing/refused", headers=intent).status_code == 409
     assert client.put("/api/v1/thing/a", headers=intent).status_code == 200
     assert client.put("/api/v1/thing/b", headers={**intent, "X-DevCake-Actor": "mcp"}).status_code == 200
+    # a caller that misuses the actor header cannot park a secret shape in
+    # the audit file: the label is allowlisted AND redacted at the write
+    leaked = {**intent, "X-DevCake-Actor": "glpat-abcdefghijklmnopqrstuv"}
+    assert client.put("/api/v1/thing/c", headers=leaked).status_code == 200
     rows = [json.loads(l) for l in (tmp_path / "state" / "events.jsonl").read_text().splitlines()]
     assert [(r["action"], r["detail"], r["actor"]) for r in rows] == [
         ("control_plane_write", "PUT /api/v1/thing/a 200", "admin"),
         ("control_plane_write", "PUT /api/v1/thing/b 200", "mcp"),
+        ("control_plane_write", "PUT /api/v1/thing/c 200", "«REDACTED»"),
     ]
 
 

--- a/app/tests/test_hygiene_audit_oauth_probe.py
+++ b/app/tests/test_hygiene_audit_oauth_probe.py
@@ -157,3 +157,24 @@ def test_register_all_reloads_credential_files(tmp_path, monkeypatch):
         assert secret not in redact(f"leak {secret} end")
     finally:
         unregister_runtime_secret("cred:coder:auth.txt")
+
+
+def test_mission_audit_actor_label_redacted_on_disk(tmp_path, monkeypatch):
+    """The audit row's actor is an allowlisted label; a caller that misuses
+    the actor header still cannot park a secret shape on disk — the writer
+    scrubs the label with the same redact() the detail gets."""
+    import devcake.domain.orchestrator.markers as markers
+    from devcake.api.auth import REQUEST_ACTOR
+    from devcake.domain.orchestrator import feed
+
+    audit = tmp_path / "events.jsonl"
+    monkeypatch.setattr(markers, "AUDIT_PATH", audit)
+    token = REQUEST_ACTOR.set("glpat-abcdefghijklmnopqrstuv")
+    try:
+        mgr = SimpleNamespace(instance_name="lin", _grace_next=set())
+        feed._audit(mgr, "ISSUE-1", "label_swap", "A→B")
+    finally:
+        REQUEST_ACTOR.reset(token)
+    line = json.loads(audit.read_text().strip().splitlines()[-1])
+    assert "abcdefghijklmnopqrstuv" not in line["actor"]
+    assert line["actor"] == MASK


### PR DESCRIPTION
## Why

Code-scanning alert 74 (clear-text storage of sensitive information) points at the audit row written by the feed chokepoint. The flagged value is the row's `actor` label, added with the operator MCP server: CodeQL taints it because the auth middleware reads it next to the Authorization header it validates. The label is allowlisted at the boundary (`auth.request_actor`: lowercase, stripped to `[a-z0-9._-]`, capped at 32 characters, default `admin`), so no credential can reach the write. Dismissed as a false positive per docs/14 §12 with that receipt.

## What changes

Belt-and-braces, the same one the `detail` field already has: both audit writers (`feed._audit` and `settings_bundle.audit_event`) pass the actor label through `redact()` before writing, so a caller that misuses the header cannot park a secret shape in the audit file.

## Tests

The middleware audit-row test posts a mutation with a token-shaped actor header and asserts the stored actor is the redaction mask; a feed-writer test does the same under a token-shaped actor context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBKLwFrkny8udrVSc8fNXH