### PR TITLE
fix(steward): the discovery drain decides on the memoized scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ added here without copying the full roadmap.
 See the living log and open candidates in
 [`docs/16-roadmap.md`](docs/16-roadmap.md).
 
+- **Fixed — the discovery drain no longer starves itself.** Before
+  dispatching a steward run, the drain re-read every pending source of
+  the family live, bypassing the feed memo. On a large family that was
+  about a hundred tracker reads per cycle; the shared credential hit the
+  request budget's critical floor part-way, the next read was refused,
+  the drain deferred and restarted the same family a cycle later — two
+  thousand requests an hour and no dispatch. The drain now decides on
+  the same memoized, witnessed scan the sweep made this cycle, and a
+  refused read resumes next cycle instead of restarting.
+
 Community surface added for public-repo hygiene (no LICENSE change in this
 track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).
 

--- a/app/devcake/domain/orchestrator/discovery.py
+++ b/app/devcake/domain/orchestrator/discovery.py
@@ -235,10 +235,11 @@ async def scan_source(mgr, m, *, memo: bool = True) -> SourceState:
     write to=-. pending = posted − receipted when counts are known —
     restart-proof board arithmetic, no local ledger.
 
-    `memo` (ADR-0033 addendum): the per-cycle sweep reuses a recent scan
-    while nothing changed (`FeedScanMemo`); a caller about to WRITE on the
-    strength of the scan passes memo=False and pays the live read. A
-    truncated scan is never memoized."""
+    `memo` (ADR-0033 addendum): the per-cycle sweep and the discovery
+    drain reuse a recent scan while nothing changed (`FeedScanMemo`); a
+    caller about to WRITE on the strength of the scan (a label drop, a
+    `to=-` close, the steward's own apply) passes memo=False and pays the
+    live read. A truncated scan is never memoized."""
     fm = getattr(mgr, "feed_memo", None) if memo else None
     if fm is not None:
         hit = fm.get("discovery", m)

--- a/app/devcake/domain/steward_service.py
+++ b/app/devcake/domain/steward_service.py
@@ -246,10 +246,20 @@ class StewardService:
             pending: dict[str, list[tuple[int, int]]] = {}
             for s in group:
                 try:
-                    state = await discovery.scan_source(mgr, s, memo=False)   # a dispatch decides on a live read
+                    # the same memoized scan the sweep made this cycle
+                    # (ADR-0033 addendum: witnessed where the vendor lists
+                    # feed changes, invalidated by every DevCake write).
+                    # Re-reading the family live here cost a full feed read
+                    # per pending source per cycle and starved the very
+                    # dispatch it was meant to protect (field: ~100 reads
+                    # a cycle, refused mid-family at the budget floor, then
+                    # restarted from scratch the next cycle).
+                    state = await discovery.scan_source(mgr, s)
                 except PMOTransient as e:
                     # rate limit / thin budget: keep the pending ids, the
-                    # sweep re-drives next cycle — never abort the segment
+                    # sweep re-drives next cycle — never abort the segment.
+                    # Sources scanned so far are memoized, so the next
+                    # cycle resumes where this one stopped
                     log.warning("discovery lane deferred for %s: %s", s.key, e)
                     return
                 if state.truncated:

--- a/app/tests/test_discovery_trigger.py
+++ b/app/tests/test_discovery_trigger.py
@@ -101,6 +101,107 @@ def test_off_snapshot_pending_ids_are_dropped(tmp_path):
     assert calls == [] and mgr._discoveries_pending == set()
 
 
+# ── the drain decides on the memoized scan (ADR-0033 addendum) ───────────────
+
+def _family_setup(tmp_path):
+    """Three pending sources in ONE family (blocked_by edges), each feed
+    carrying one unrouted discovery batch."""
+    src = m("src", "T-S", status="in_progress")
+    src2 = m("src2", "T-S2", status="in_progress", blocked_by=["src"])
+    src3 = m("src3", "T-S3", status="in_progress", blocked_by=["src"])
+    other = m("oth", "T-O")
+    pmo = RoutePMO([src, src2, src3, other])
+    for s_ in (src, src2, src3):
+        pmo.feeds[s_.pmo_id] = Activity(
+            mission=s_, entries=[_ae(discovery_marker(2, 1))], truncated=False)
+    mgr = make_mgr(tmp_path, pmo)
+    mgr.instance.discovery_routing = True
+    mgr.steward_repo = lambda: "home"
+    # one finished EXECUTE run per source (distinct ids — the shared helper
+    # hard-codes one run id, which would make the runs overwrite each other)
+    from devcake.domain.run import Run
+    for s_ in (src, src2, src3):
+        r = Run(run_id=f"L-{s_.key}-2-EXECUTE-AAAAAA", mission_key=s_.key,
+                mission_pmo_id=s_.pmo_id, mission_type="EXECUTE",
+                dev_type="senior-dev", seq=2, state="finished",
+                pmo_ref=mgr.instance_name)
+        r.result = {"outcome": "executed", "summary": "s", "discoveries": [
+            {"finding": f"finding about {s_.key}", "evidence": "src/x.py:1; repro: pytest -k f1",
+             "scope": "scope 1"}]}
+        mgr.runs.store.save(r)
+    dt = DevType(name="steward", harness_template="claude-code")
+    svc = StewardService(AppConfig(), {"steward": dt}, mgr)
+    calls = []
+
+    async def fake_dispatch(dt_, fam, pending, **kw):
+        calls.append((sorted(fam.by_id), dict(pending), kw))
+        return object()
+    mgr.dispatch_steward_discovery = fake_dispatch
+    return pmo, mgr, svc, calls, [src, src2, src3, other]
+
+
+def _reads(pmo):
+    return [pid for pid, _full in pmo.activity_calls]
+
+
+def test_drain_reuses_the_sweeps_memoized_scan_and_reads_nothing(tmp_path):
+    # the sweep scanned the labelled sources through the memo this cycle;
+    # the drain's decision costs zero further feed reads
+    pmo, mgr, svc, calls, missions = _family_setup(tmp_path)
+    for s_ in missions[:3]:
+        s_.labels = s_.labels | {"DEVCAKE-DISCOVERY"}
+        run_coro(discovery.discovery_sweep(mgr, s_))
+    assert mgr._discoveries_pending == {"src", "src2", "src3"}
+    n = len(pmo.activity_calls)
+    run_coro(svc.maybe_dispatch_discovery(missions))
+    assert len(pmo.activity_calls) == n                 # memo hits only
+    assert len(calls) == 1
+    assert calls[0][1] == {"src": [(2, 1)], "src2": [(2, 1)], "src3": [(2, 1)]}
+    assert mgr._discoveries_pending == set()
+
+
+def test_refused_read_defers_and_the_next_cycle_resumes_where_it_stopped(tmp_path):
+    from devcake.ports.pmo import PMOBudgetExceeded
+    pmo, mgr, svc, calls, missions = _family_setup(tmp_path)
+    mgr._discoveries_pending |= {"src", "src2", "src3"}
+    real = pmo.get_activity
+    refuse = {"src3"}
+
+    async def budgeted(ref, full=False):
+        if ref.pmo_id in refuse:
+            refuse.discard(ref.pmo_id)
+            raise PMOBudgetExceeded("remaining quota is reserved for critical calls")
+        return await real(ref, full=full)
+    pmo.get_activity = budgeted
+    # cycle 1: two sources read, the third refused → deferred, nothing served
+    run_coro(svc.maybe_dispatch_discovery(missions))
+    assert calls == []
+    assert mgr._discoveries_pending == {"src", "src2", "src3"}
+    first = _reads(pmo)
+    assert sorted(first) == ["src", "src2"]           # src3 raised before the read counted
+    # cycle 2: only the refused source is read — the other two are memoized
+    run_coro(svc.maybe_dispatch_discovery(missions))
+    assert _reads(pmo)[len(first):] == ["src3"]
+    assert len(calls) == 1
+    assert calls[0][1] == {"src": [(2, 1)], "src2": [(2, 1)], "src3": [(2, 1)]}
+    assert mgr._discoveries_pending == set()
+
+
+def test_own_write_still_forces_the_drain_to_read_live(tmp_path):
+    # the memo is invalidated by every DevCake write to a feed: a source
+    # DevCake wrote to since the sweep is read again before the dispatch
+    from devcake.domain.orchestrator.feed import feed_written
+    pmo, mgr, svc, calls, missions = _family_setup(tmp_path)
+    for s_ in missions[:3]:
+        s_.labels = s_.labels | {"DEVCAKE-DISCOVERY"}
+        run_coro(discovery.discovery_sweep(mgr, s_))
+    feed_written(mgr, "src2")
+    n = len(pmo.activity_calls)
+    run_coro(svc.maybe_dispatch_discovery(missions))
+    assert _reads(pmo)[n:] == ["src2"]
+    assert len(calls) == 1
+
+
 # ── the label-gated sweep arm ────────────────────────────────────────────────
 
 def test_sweep_reseeds_pending_from_the_board(tmp_path):

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -839,6 +839,17 @@ until that run exists, field evidence below stays operator-self-reported.
   anchor so a redelivered finalize threads the same way. Docs 03 §8, 05,
   07.
 
+- **The discovery drain decides on the memoized scan** (2026-09-08, ADR-0033
+  addendum): before dispatching, the drain re-read every pending source of
+  the family live, bypassing the memo. Field receipt from a board whose
+  pending sources form one large decomposition family: about a hundred
+  feed reads a cycle, the shared credential at the budget's critical floor
+  part-way through, the next read refused, the drain deferred and restarted
+  the family a cycle later — two thousand requests an hour on that
+  instance and no dispatch, while the sweep's scans of the same missions
+  were memo hits. Unlatching the steward's degradation (v0.5.9) exposed
+  it. The drain now reuses the sweep's witnessed scan and resumes after a
+  refusal; the dispatch was already critical-class.
 ### Field evidence (receipted)
 
 - **DevCake audits DevCake** (2026-08-17/18) — one board prompt became 54

--- a/docs/adr/0033-discovery-routing-the-counterflow-lane.md
+++ b/docs/adr/0033-discovery-routing-the-counterflow-lane.md
@@ -465,3 +465,9 @@ The memo above re-reads a labeled feed whenever its mission's `updated_at` moved
   ADR-0031 (elevated markers, marker counting), ADR-0032 (handoff
   sibling lane, defang treatment), docs/19 §2 (impedance), §4
   (instrument), §6 (membrane).
+
+## Addendum — the drain decides on the memoized scan (2026-09-08)
+
+The discovery drain (`StewardService.maybe_dispatch_discovery`) used to re-read every pending source of the family it was about to serve **live**, bypassing the memo, on the reasoning that a dispatch should decide on the freshest feed. That rule predates the witness above. Field receipt from a board whose pending sources form one large decomposition family: the drain read about a hundred feeds per cycle, the shared tracker credential reached the request budget's critical floor part-way through the family, the next read was refused as routine, the drain deferred, kept nothing, and started the same family from scratch a cycle later — an instance demand of about two thousand requests an hour with zero dispatches, while the sweep's own scans of the same missions were memo hits. Unlatching the steward's degradation exposed it; while latched, the drain returned before its scan loop.
+
+Ruling: the drain decides on the **same memoized scan the sweep made this cycle**. That scan is invalidated by every DevCake write to the feed (the chokepoint), re-read when the mission changed, validated by the feed-changes witness where the vendor lists changes, and re-read after the safety window elsewhere — the memo decides *when*, pending stays posted − receipted from the feed. A source whose read is refused defers the drain as before, but the sources already read are memoized, so the next cycle resumes rather than restarts. The dispatch itself already runs as a critical call with a bounded wait. Live reads stay where a **write** is decided on the strength of a scan: the sweep's label drop and `to=-` close, and the steward run's own apply.


### PR DESCRIPTION
## The discovery drain decides on the memoized scan

### Why

Field receipt (2026-09-08) on a board whose pending discovery sources form one large decomposition family: the drain re-read every pending source of the family **live** before dispatching, bypassing the feed memo, on the rule "a dispatch decides on a live read". That rule predates the feed-changes witness. The cost was about a hundred feed reads per cycle; the shared tracker credential reached the request budget's critical floor part-way through the family, the next read was refused as routine, the drain deferred, kept nothing, and started the same family from scratch a cycle later. Measured: about two thousand requests an hour on that instance with zero dispatches, while the sweep's own scans of the same missions were memo hits (256 hits, 98 live reads per cycle). Unlatching the steward's degradation (v0.5.9) exposed it: while latched, the drain returned before its scan loop, which is why the earlier field receipt of about six hundred requests an hour looked fine.

### What changes

- The drain calls the same `scan_source` the sweep uses **through the memo**. That scan is invalidated by every DevCake write to the feed (the chokepoint), re-read when the mission changed, validated by the witness where the vendor lists feed changes, and re-read after the safety window elsewhere. The memo decides *when*; pending stays posted − receipted from the feed.
- A refused read still defers the drain, but the sources already read are memoized, so the next cycle resumes where this one stopped instead of restarting the family.
- The dispatch itself was already a critical-class call with a bounded wait; nothing changes there.
- Live reads stay where a **write** is decided on the strength of a scan: the sweep's label drop and `to=-` close, and the steward run's own apply.

### Tests

Three new tests in the trigger suite: the drain reads nothing when the sweep scanned the family this cycle and dispatches with the full pending map; a refused read on the third of three sources defers and the next cycle reads only that source; an own write to a source still forces one live read before the dispatch. Full app suite green.

### Docs

ADR-0033 addendum "the drain decides on the memoized scan", `scan_source` docstring, CHANGELOG Unreleased, docs/16 living log with the receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBKLwFrkny8udrVSc8fNXH
