### PR TITLE
feat(cli): devcake up --release [TAG] and devcake prune [--devs]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,7 @@ a development build overrides it from the process environment:
 ```bash
 DEVCAKE_TAG=$(git rev-parse --short HEAD) devcake up --bake all   # scratch build
 devcake up --bake all            # a release checkout: VERSION pins the tag
+devcake up --release             # a host re-pin: newest v* tag, bake all, up, image tidy-up
 # or without devcake up:
 export DEVCAKE_TAG=$(cat VERSION); docker buildx bake all; docker compose up -d
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ added here without copying the full roadmap.
 See the living log and open candidates in
 [`docs/16-roadmap.md`](docs/16-roadmap.md).
 
+- **Added — `devcake up --release [TAG]` and `devcake prune`.** A host
+  re-pin is one command: fetch tags, check the newest release (or the
+  one named) out, bake all, bring the stack up in the safe order, and
+  remove stale control-plane images and dangling leftovers. It refuses
+  before touching anything when the tree has modified tracked files,
+  when the CLI runs from inside the checkout, or when the release ships
+  a newer CLI than the one running. `devcake prune` does the tidy-up on
+  demand; `--devs` asks the app for the host baker's Dev-image prune,
+  the admin button's chokepoint — the CLI never removes a Dev image
+  itself. Ships as `devcake-cli` 0.1.6.
+
 Community surface added for public-repo hygiene (no LICENSE change in this
 track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,10 @@ host deploys a release by checking out its tag and running `devcake up`
    a `v*` tag whose name differs from `VERSION` on the tagged commit. When
    the CLI was bumped, also push `cli-v<version>` on the same commit — that
    tag publishes to PyPI.
-3. Hosts: `git checkout vX.Y.Z && devcake up --bake all`. Nothing to edit.
+3. Hosts: `devcake up --release` (or `--release vX.Y.Z`); by hand,
+   `git checkout vX.Y.Z && devcake up --bake all`. Nothing to edit. When the
+   release bumped the CLI, `uv tool upgrade devcake-cli` first — `--release`
+   refuses an older CLI.
    `devcake status` and `devcake doctor` report a drift between the
    checkout's pin and the tag the stack runs under, with that command as
    the remedy.

--- a/app/tests/test_devcake_cli_release_prune.py
+++ b/app/tests/test_devcake_cli_release_prune.py
@@ -1,0 +1,264 @@
+"""``devcake up --release [TAG]`` and ``devcake prune`` (ADR-0038 addendum):
+the release checkout with its guards, the implied bake, the post-up image
+tidy-up, and the prune verb's two owners (CLI: control plane + dangling;
+baker: Dev images through the app's prune request)."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from test_devcake_cli_up_down_status import _ensure_cli_importable, _fake_checkout
+
+
+# ── a throwaway git repo with release tags ───────────────────────────────────
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(["git", *args], cwd=str(root), text=True,
+                          capture_output=True, check=True).stdout
+
+
+def _head_tags(root: Path) -> set[str]:
+    """Every tag at HEAD (a release commit also carries its cli-v tag)."""
+    return set(_git(root, "tag", "--points-at", "HEAD").split())
+
+
+def _release_repo(tmp_path: Path, *, cli_versions: dict[str, str]) -> Path:
+    """Tags v0.1.0 and v0.2.0 (plus a cli-v9.9.9 that must be ignored); each
+    release commit carries cli/devcake_cli/__init__.py with the version
+    given, and a VERSION file naming the tag."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.invalid")
+    _git(root, "config", "user.name", "t")
+    (root / "cli" / "devcake_cli").mkdir(parents=True)
+    for tag in ("v0.1.0", "v0.2.0"):
+        (root / "cli" / "devcake_cli" / "__init__.py").write_text(
+            f'__version__ = "{cli_versions[tag]}"\n')
+        (root / "VERSION").write_text(tag + "\n")
+        _git(root, "add", "-A")
+        _git(root, "commit", "-q", "-m", tag)
+        _git(root, "tag", "-a", tag, "-m", tag)
+    _git(root, "tag", "-a", "cli-v9.9.9", "-m", "cli")
+    # a local "origin" so `git fetch --tags origin` works offline
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(root), str(origin)],
+                   check=True, capture_output=True)
+    _git(root, "remote", "add", "origin", str(origin))
+    return root
+
+
+def test_release_tags_are_v_semver_newest_first(tmp_path):
+    _ensure_cli_importable()
+    from devcake_cli import release
+    root = _release_repo(tmp_path, cli_versions={"v0.1.0": "0.1.0", "v0.2.0": "0.1.0"})
+    assert release.release_tags(root) == ["v0.2.0", "v0.1.0"]
+    assert release.resolve_release_tag(root, "latest") == "v0.2.0"
+    assert release.resolve_release_tag(root, "v0.1.0") == "v0.1.0"
+    with pytest.raises(release.ReleaseRefused, match="not found"):
+        release.resolve_release_tag(root, "v9.9.9")
+    with pytest.raises(release.ReleaseRefused, match="not a release tag"):
+        release.resolve_release_tag(root, "cli-v9.9.9")
+
+
+def test_checkout_release_lands_detached_on_the_tag(tmp_path, capsys):
+    _ensure_cli_importable()
+    from devcake_cli import release
+    root = _release_repo(tmp_path, cli_versions={"v0.1.0": "0.1.0", "v0.2.0": "0.1.0"})
+    assert release.checkout_release(root, "v0.1.0") == "v0.1.0"
+    assert "v0.1.0" in _head_tags(root)
+    assert (root / "VERSION").read_text().strip() == "v0.1.0"
+    assert "checked out release v0.1.0" in capsys.readouterr().out
+
+
+def test_dirty_tree_refuses_before_touching_anything(tmp_path):
+    _ensure_cli_importable()
+    from devcake_cli import release
+    root = _release_repo(tmp_path, cli_versions={"v0.1.0": "0.1.0", "v0.2.0": "0.1.0"})
+    (root / "VERSION").write_text("edited\n")          # modified tracked file
+    (root / "scratch.txt").write_text("untracked is fine\n")
+    with pytest.raises(release.ReleaseRefused, match="modified tracked files"):
+        release.checkout_release(root, "v0.1.0")
+    assert "v0.2.0" in _head_tags(root)
+    (root / "VERSION").write_text("v0.2.0\n")
+    assert release.checkout_release(root, "v0.1.0") == "v0.1.0"   # untracked never blocks
+
+
+def test_older_cli_than_the_release_ships_refuses_with_the_upgrade_command(tmp_path):
+    _ensure_cli_importable()
+    from devcake_cli import release
+    root = _release_repo(tmp_path, cli_versions={"v0.1.0": "0.1.0", "v0.2.0": "9.9.9"})
+    with pytest.raises(release.ReleaseRefused, match="uv tool upgrade devcake-cli"):
+        release.checkout_release(root, "latest")
+    assert "v0.2.0" in _head_tags(root)
+    # read from the tag, never from the working tree
+    assert release.release_cli_version(root, "v0.1.0") == "0.1.0"
+    assert release.release_cli_version(root, "v0.2.0") == "9.9.9"
+    # an equal or newer CLI passes
+    release.check_cli_matches_release(root, "v0.2.0", running="9.9.9")
+    release.check_cli_matches_release(root, "v0.2.0", running="10.0.0")
+
+
+def test_editable_cli_inside_the_checkout_refuses(tmp_path):
+    _ensure_cli_importable()
+    from devcake_cli import release
+    root = _release_repo(tmp_path, cli_versions={"v0.1.0": "0.1.0", "v0.2.0": "0.1.0"})
+    with pytest.raises(release.ReleaseRefused, match="editable"):
+        release.check_cli_not_editable_from(root, root / "cli" / "devcake_cli" / "release.py")
+    release.check_cli_not_editable_from(root, tmp_path / "elsewhere" / "release.py")
+
+
+def test_dry_run_resolves_a_named_tag_without_fetching_or_checking_out(tmp_path, capsys):
+    _ensure_cli_importable()
+    from devcake_cli import release
+    root = _release_repo(tmp_path, cli_versions={"v0.1.0": "0.1.0", "v0.2.0": "0.1.0"})
+    _git(root, "remote", "remove", "origin")            # a fetch would fail
+    assert release.checkout_release(root, "v0.1.0", dry_run=True) == "v0.1.0"
+    assert release.checkout_release(root, "latest", dry_run=True) == "latest"
+    out = capsys.readouterr().out
+    assert "would: git fetch --tags origin && git checkout v0.1.0" in out
+    assert "v0.2.0" in _head_tags(root)
+
+
+# ── up --release: order, implied bake all, tidy-up last ──────────────────────
+
+def test_up_release_checks_out_first_implies_bake_all_and_prunes_last(monkeypatch, tmp_path):
+    _ensure_cli_importable()
+    import devcake_cli.up as up_mod
+    from devcake_cli import release as release_mod
+    sock = _fake_checkout(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DOCKER_SOCK", str(sock))
+    order = []
+    monkeypatch.setattr(release_mod, "checkout_release",
+                        lambda root, wanted, **kw: order.append(("release", wanted)) or "v0.2.0")
+    for name in ("_bake", "_compose_up", "_health_gate", "_hello_smoke",
+                 "_start_baker", "_prune_after_release"):
+        monkeypatch.setattr(up_mod, name,
+                            lambda *a, _n=name, **k: order.append((_n, getattr(a[1], "bake_targets", None) if len(a) > 1 else None)))
+    opts = up_mod.UpOptions(release="latest")
+    assert up_mod.run_up(opts, repo=tmp_path) == 0
+    assert order[0] == ("release", "latest")
+    assert [n for n, _ in order] == ["release", "_bake", "_start_baker", "_compose_up",
+                                     "_health_gate", "_hello_smoke", "_prune_after_release"]
+    assert dict(order)["_bake"] == ["all"]              # implied --bake all
+    # an explicit --bake wins
+    order.clear()
+    assert up_mod.run_up(up_mod.UpOptions(release="v0.2.0", bake=True,
+                                          bake_targets=["app"]), repo=tmp_path) == 0
+    assert dict(order)["_bake"] == ["app"]
+
+
+def test_up_release_refusal_is_exit_6_and_touches_nothing(monkeypatch, tmp_path):
+    _ensure_cli_importable()
+    import devcake_cli.up as up_mod
+    from devcake_cli import release as release_mod
+    sock = _fake_checkout(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DOCKER_SOCK", str(sock))
+    called = []
+    monkeypatch.setattr(up_mod, "_bake", lambda *a, **k: called.append("bake"))
+
+    def refuse(root, wanted, **kw):
+        raise release_mod.ReleaseRefused("the checkout has modified tracked files")
+    monkeypatch.setattr(release_mod, "checkout_release", refuse)
+    assert up_mod.run_up(up_mod.UpOptions(release="latest"), repo=tmp_path) == 6
+    assert called == []
+    assert not (tmp_path / ".env").exists()
+
+
+def test_up_flags_parse_release(monkeypatch):
+    _ensure_cli_importable()
+    import devcake_cli.main as cli_main
+    opts = cli_main.parse_up_flags(["--release"])
+    assert opts.release == "latest" and opts.bake is False
+    opts = cli_main.parse_up_flags(["--release", "v0.5.11", "--no-hello-smoke"])
+    assert opts.release == "v0.5.11" and opts.no_hello_smoke
+    opts = cli_main.parse_up_flags(["--release", "--bake", "app", "admin"])
+    assert opts.release == "latest" and opts.bake_targets == ["app", "admin"]
+    opts = cli_main.parse_up_flags(["--bake"])
+    assert opts.release is None
+
+
+# ── prune: the planner and the executor ─────────────────────────────────────
+
+IMAGES = [
+    ("devcake/app", "v0.5.11", "aaa111"), ("devcake/app", "v0.5.10", "aaa110"),
+    ("devcake/app", "latest", "aaa000"), ("devcake/admin", "v0.5.10", "bbb110"),
+    ("devcake/app-test", "latest", "ccc000"), ("devcake/dev-hello", "v0.5.9", "ddd009"),
+    ("devcake/dev-hello", "v0.5.11", "ddd011"),
+    ("devcake/dev-grok-build", "v0.5.9-1.0.13", "eee009"),
+    ("devcake/dev-claude-code", "v0.5.10-2.1.258", "fff010"),
+    ("gitea/gitea", "1.27.1-rootless", "ggg000"), ("<none>", "<none>", "hhh000"),
+    ("<none>", "<none>", "iii000"),
+]
+
+
+def test_plan_removes_stale_control_plane_and_dangling_never_devs():
+    _ensure_cli_importable()
+    from devcake_cli.prune import plan_image_prune
+    plan = plan_image_prune(IMAGES, tag="v0.5.11", in_use={"devcake/app:v0.5.10", "iii000"})
+    assert sorted(plan.remove) == sorted([
+        "devcake/app:latest", "devcake/admin:v0.5.10", "devcake/app-test:latest",
+        "devcake/dev-hello:v0.5.9", "hhh000"])
+    kept = dict(plan.keep)
+    assert kept["devcake/app:v0.5.11"] == "current release"
+    assert kept["devcake/app:v0.5.10"] == "in use"
+    assert kept["iii000"] == "in use"
+    assert "the baker" in kept["devcake/dev-grok-build:v0.5.9-1.0.13"]
+    assert "the baker" in kept["devcake/dev-claude-code:v0.5.10-2.1.258"]
+    assert kept["gitea/gitea:1.27.1-rootless"] == "not a DevCake image"
+    assert not any(r.startswith("devcake/dev-grok") or r.startswith("devcake/dev-claude")
+                   for r in plan.remove)
+
+
+def test_prune_verb_rmis_only_the_plan_and_asks_the_app_for_devs(monkeypatch, tmp_path, capsys):
+    _ensure_cli_importable()
+    import devcake_cli.main as cli_main
+    import devcake_cli.prune as prune_mod
+    _fake_checkout(tmp_path)
+    (tmp_path / ".env").write_text("DEVCAKE_TAG=v0.5.11\n")
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def fake_run(argv, **kw):
+        calls.append(argv)
+        if argv[:2] == ["docker", "images"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="\n".join(
+                f"{r} {t} {i}" for r, t, i in IMAGES) + "\n", stderr="")
+        if argv[:2] == ["docker", "ps"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="devcake/app:v0.5.11 sha256:aaa111\n", stderr="")
+        if argv[:2] == ["docker", "rmi"]:
+            if argv[2] == "hhh000":
+                return subprocess.CompletedProcess(argv, 1, stdout="", stderr="conflict: image is being used")
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+        raise AssertionError(argv)
+    monkeypatch.setattr(prune_mod.subprocess, "run", fake_run)
+    posted = []
+    monkeypatch.setattr(prune_mod.admin_api, "request",
+                        lambda root, method, path, **kw: posted.append((method, path)) or (200, {"ok": True}))
+    rc = cli_main.main(["prune", "--devs"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    rmis = sorted(a[2] for a in calls if a[:2] == ["docker", "rmi"])
+    # the fake `ps` shows only the v0.5.11 app in use, so v0.5.10 goes too
+    assert rmis == sorted(["devcake/app:latest", "devcake/app:v0.5.10",
+                           "devcake/admin:v0.5.10", "devcake/app-test:latest",
+                           "devcake/dev-hello:v0.5.9", "hhh000", "iii000"])
+    assert not any(a[:2] == ["docker", "rmi"] and "-f" in a for a in calls)
+    assert posted == [("POST", "/api/v1/harness/prune")]
+    assert "removed 6 of 7 stale image(s)" in out
+    assert "kept hhh000: conflict" in out
+    assert "Dev-image prune requested" in out
+    # dry run: nothing removed, nothing posted
+    calls.clear(); posted.clear()
+    rc = cli_main.main(["--json", "prune", "--devs", "--dry-run"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0 and payload["images"]["removed"] == [] and posted == []
+    assert len(payload["images"]["planned"]) == 7
+    assert cli_main.main(["prune", "--help"]) == 0
+    assert cli_main.main(["prune", "--bogus"]) == 2

--- a/cli/devcake_cli/__init__.py
+++ b/cli/devcake_cli/__init__.py
@@ -7,4 +7,4 @@ cannot shadow ``app/devcake``. Distribution / project name is ``devcake-cli``
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/cli/devcake_cli/main.py
+++ b/cli/devcake_cli/main.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import sys
 from typing import Sequence
 
-from . import baker, doctor, down, setup, status, up
+from . import baker, doctor, down, prune, setup, status, up
 
 
 _USAGE = """\
@@ -19,8 +19,9 @@ usage: devcake [--json] <verb> …
 Implemented:
   baker run     Host baker foreground / supervisor entry
                 (same loop as python -m dev_factory)
-  up            Bring up the compose stack (+ optional --bake)
+  up            Bring up the compose stack (+ optional --bake; --release [TAG])
   down          Stop the compose stack (no volume wipe)
+  prune         Remove stale DevCake images (--devs: ask the baker for Dev images)
   status        Compose + baker readiness snapshot
   doctor        Named preflight checks (+ remedies; --json)
   setup         First-setup / connections / settings-bundle import
@@ -36,10 +37,14 @@ Docs:    docs/adr/0038-devcake-cli-scope-command-surface-and-agent-operability.m
 """
 
 _UP_HELP = """\
-usage: devcake up [--bake [targets…]] [--dry-run] [--foreground-baker]
-                  [--no-hello-smoke] [--] [service…]
+usage: devcake up [--release [TAG]] [--bake [targets…]] [--dry-run]
+                  [--foreground-baker] [--no-hello-smoke] [--] [service…]
 
 Bring up the DevCake stack with discovered DOCKER_GID.
+  --release [TAG]        check the release out first (newest v* tag, or TAG),
+                         then bake all + up, then remove stale control-plane
+                         and dangling images; refuses a dirty tree or a CLI
+                         older than the release ships
   --bake [targets…]     bake before up (default targets: app admin hello)
   --dry-run              print discovered GID + planned actions
   --foreground-baker     up, then run baker in foreground (no supervisor)
@@ -48,7 +53,7 @@ Bring up the DevCake stack with discovered DOCKER_GID.
 """
 
 _VERBS = frozenset(
-    {"baker", "up", "down", "status", "doctor", "bake", "setup", "mcp"}
+    {"baker", "up", "down", "status", "doctor", "bake", "setup", "mcp", "prune"}
 )
 
 
@@ -63,6 +68,7 @@ def parse_up_flags(argv: Sequence[str]) -> up.UpOptions | int:
     do_bake = False
     bake_targets: list[str] = []
     compose_args: list[str] = []
+    release: str | None = None
     tokens = list(argv)
 
     i = 0
@@ -90,6 +96,13 @@ def parse_up_flags(argv: Sequence[str]) -> up.UpOptions | int:
                 bake_targets.append(tokens[i])
                 i += 1
             continue
+        if tok == "--release":
+            release = "latest"
+            i += 1
+            if i < len(tokens) and not tokens[i].startswith("--"):
+                release = tokens[i]
+                i += 1
+            continue
         if tok == "--":
             compose_args.extend(tokens[i + 1 :])
             break
@@ -102,6 +115,7 @@ def parse_up_flags(argv: Sequence[str]) -> up.UpOptions | int:
     return up.UpOptions(
         bake=do_bake,
         bake_targets=bake_targets,
+        release=release,
         dry_run=dry_run,
         foreground_baker=foreground,
         no_hello_smoke=no_hello,
@@ -166,6 +180,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stderr.write(f"devcake down: unknown option {rest[0]!r}\n")
             return 2
         return down.run_down(as_json=as_json)
+
+    if verb == "prune":
+        if rest and rest[0] in ("-h", "--help"):
+            sys.stdout.write(
+                "usage: devcake prune [--devs] [--dry-run] [--json]\n"
+                "Remove stale DevCake control-plane images (app/admin/app-test/hello "
+                "not on the current tag) and dangling build leftovers. Never a Dev "
+                "image: --devs asks the app for the host baker's Dev-image prune "
+                "(the admin button's chokepoint).\n"
+            )
+            return 0
+        devs = "--devs" in rest
+        dry = "--dry-run" in rest
+        extra = [a for a in rest if a not in ("--devs", "--dry-run")]
+        if extra:
+            sys.stderr.write(f"devcake prune: unknown option {extra[0]!r}\n")
+            return 2
+        return prune.run_prune(devs=devs, dry_run=dry, as_json=as_json)
 
     if verb == "status":
         if rest and rest[0] in ("-h", "--help"):

--- a/cli/devcake_cli/prune.py
+++ b/cli/devcake_cli/prune.py
@@ -1,0 +1,177 @@
+"""``devcake prune [--devs] [--dry-run]`` and the image tidy-up
+``devcake up --release`` runs after a successful bring-up (ADR-0038 addendum).
+
+Two owners, two paths. DevCake's **control-plane** images (app, admin,
+app-test, hello) and **dangling** build leftovers are the CLI's to remove:
+it already holds the docker socket for bake and compose. **Dev images**
+(``devcake/dev-*`` other than hello) belong to the host baker — the
+keep-set is the order and receipts are the registrar — so ``--devs`` asks
+the app for the same prune the admin button requests and the baker acts on
+its next tick; the CLI never ``rmi``s a Dev image itself. Third-party
+images are not ours and are left alone.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import admin_api
+from .paths import require_checkout_root
+
+CONTROL_PLANE_REPOS = frozenset({
+    "devcake/app", "devcake/admin", "devcake/app-test", "devcake/dev-hello"})
+
+
+@dataclass
+class PrunePlan:
+    remove: list[str] = field(default_factory=list)   # image refs / ids to rmi
+    keep: list[tuple[str, str]] = field(default_factory=list)   # (ref, why)
+
+
+def plan_image_prune(images: list[tuple[str, str, str]], *, tag: str,
+                     in_use: set[str]) -> PrunePlan:
+    """``images`` = (repository, tag, id) rows as ``docker images`` lists
+    them; ``in_use`` = refs and ids of every container (running or not).
+    Pure — the executor and ``up --release`` share it."""
+    plan = PrunePlan()
+    for repo, itag, iid in images:
+        ref = f"{repo}:{itag}"
+        if repo == "<none>" or itag == "<none>":
+            if iid in in_use:
+                plan.keep.append((iid, "in use"))
+            else:
+                plan.remove.append(iid)
+            continue
+        if repo.startswith("devcake/dev-") and repo not in CONTROL_PLANE_REPOS:
+            plan.keep.append((ref, "Dev image — the baker's (devcake prune --devs)"))
+            continue
+        if repo not in CONTROL_PLANE_REPOS:
+            plan.keep.append((ref, "not a DevCake image"))
+            continue
+        if itag == tag:
+            plan.keep.append((ref, "current release"))
+        elif ref in in_use or iid in in_use:
+            plan.keep.append((ref, "in use"))
+        else:
+            plan.remove.append(ref)
+    return plan
+
+
+def _docker(argv: list[str], root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(["docker", *argv], cwd=str(root), text=True,
+                          capture_output=True, timeout=120)
+
+
+def list_images(root: Path) -> list[tuple[str, str, str]]:
+    proc = _docker(["images", "--format", "{{.Repository}} {{.Tag}} {{.ID}}"], root)
+    if proc.returncode != 0:
+        raise RuntimeError(f"docker images failed: {(proc.stderr or '').strip()}")
+    rows = []
+    for ln in proc.stdout.splitlines():
+        parts = ln.split()
+        if len(parts) == 3:
+            rows.append((parts[0], parts[1], parts[2]))
+    return rows
+
+
+def images_in_use(root: Path) -> set[str]:
+    proc = _docker(["ps", "-a", "--format", "{{.Image}} {{.ImageID}}"], root)
+    used: set[str] = set()
+    if proc.returncode == 0:
+        for ln in proc.stdout.splitlines():
+            for tok in ln.split():
+                used.add(tok)
+                used.add(tok.removeprefix("sha256:")[:12])
+    return used
+
+
+def prune_images(root: Path, *, tag: str, dry_run: bool = False,
+                 as_json: bool = False) -> dict:
+    """Remove stale control-plane images and dangling leftovers; never a Dev
+    image. Returns the receipt the callers print or embed."""
+    plan = plan_image_prune(list_images(root), tag=tag, in_use=images_in_use(root))
+    removed, failed = [], []
+    for ref in plan.remove:
+        if dry_run:
+            continue
+        proc = _docker(["rmi", ref], root)          # never -f: a conflict is a keep
+        (removed if proc.returncode == 0 else failed).append(
+            ref if proc.returncode == 0 else (ref, (proc.stderr or "").strip()[:120]))
+    receipt = {"tag": tag, "dry_run": dry_run,
+               "planned": list(plan.remove), "removed": removed,
+               "failed": failed,
+               "kept": [{"ref": r, "why": w} for r, w in plan.keep
+                        if w in ("in use",)]}
+    if not as_json:
+        if plan.remove:
+            if dry_run:
+                head = f"would remove {len(plan.remove)}"
+            elif failed:
+                head = f"removed {len(removed)} of {len(plan.remove)}"
+            else:
+                head = f"removed {len(removed)}"
+            sys.stdout.write(f"── {head} stale image(s) "
+                             f"(control plane not on {tag}, dangling): "
+                             + ", ".join(plan.remove[:6])
+                             + ("…" if len(plan.remove) > 6 else "") + "\n")
+        else:
+            sys.stdout.write(f"── no stale image to remove (everything on {tag} or in use)\n")
+        for ref, why in failed:
+            sys.stdout.write(f"   kept {ref}: {why}\n")
+    return receipt
+
+
+def request_dev_prune(root: Path) -> tuple[int, object]:
+    """Ask the app for the baker's Dev-image prune — the admin button's
+    chokepoint (`POST /api/v1/harness/prune`)."""
+    return admin_api.request(root, "POST", "/api/v1/harness/prune")
+
+
+def run_prune(*, devs: bool = False, dry_run: bool = False,
+              as_json: bool = False, repo: Path | None = None) -> int:
+    try:
+        root = repo or require_checkout_root()
+    except FileNotFoundError as exc:
+        sys.stderr.write(f"devcake prune: {exc}\n")
+        return 3
+    from .envfile import parse_env_file
+    tag = (parse_env_file(root / ".env").get("DEVCAKE_TAG") or "").strip() \
+        if (root / ".env").is_file() else ""
+    if not tag:
+        from .paths import read_version_pin
+        tag = read_version_pin(root) or "latest"
+    try:
+        receipt = prune_images(root, tag=tag, dry_run=dry_run, as_json=as_json)
+    except RuntimeError as exc:
+        sys.stderr.write(f"devcake prune: {exc}\n")
+        return 4
+    payload = {"ok": True, "schema_version": 1, "images": receipt, "devs": None}
+    if devs:
+        if dry_run:
+            payload["devs"] = {"requested": False, "detail": "dry run"}
+            if not as_json:
+                sys.stdout.write("── would: ask the app for the baker's Dev-image prune\n")
+        else:
+            try:
+                status, body = request_dev_prune(root)
+            except admin_api.AdminUnreachable as exc:
+                sys.stderr.write(f"devcake prune --devs: {exc}\n")
+                payload["devs"] = {"requested": False, "detail": str(exc)}
+                payload["ok"] = False
+            else:
+                ok = status == 200
+                payload["devs"] = {"requested": ok, "status": status}
+                if not ok:
+                    payload["ok"] = False
+                if not as_json:
+                    sys.stdout.write(
+                        "── Dev-image prune requested; the host baker removes Dev "
+                        "images outside the keep-set on its next tick\n" if ok else
+                        f"── the app refused the Dev-image prune request (HTTP {status}): {body}\n")
+    if as_json:
+        sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+    return 0 if payload["ok"] else 4

--- a/cli/devcake_cli/release.py
+++ b/cli/devcake_cli/release.py
@@ -1,0 +1,133 @@
+"""``devcake up --release [TAG]`` — check the release tag out before the
+bring-up, with the guards a re-pin needs (docs/13; ADR-0038 addendum).
+
+The tag resolution of ``up`` reads the checkout's ``VERSION``, so the
+checkout happens first. Nothing is changed until every guard has passed:
+a clean tree (modified tracked files refuse; untracked files are fine), a
+CLI that is not running from inside this checkout (an editable install
+would swap its own source mid-run), and a CLI at least as new as the one
+the release ships (the tree's ``cli/devcake_cli/__init__.py``) — the
+bring-up order that makes a re-pin safe lives in the CLI, so an older CLI
+must not perform it.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from . import __version__
+
+RELEASE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+_VERSION_RE = re.compile(r'__version__\s*=\s*"([^"]+)"')
+
+
+class ReleaseRefused(RuntimeError):
+    """A guard refused the release checkout; the message names the remedy."""
+
+
+def _git(root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    proc = subprocess.run(["git", *args], cwd=str(root), text=True,
+                          capture_output=True)
+    if check and proc.returncode != 0:
+        raise ReleaseRefused(
+            f"git {' '.join(args)} failed: {(proc.stderr or proc.stdout).strip()}")
+    return proc
+
+
+def _vtuple(version: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in re.findall(r"\d+", version)[:3])
+
+
+def release_tags(root: Path) -> list[str]:
+    """Release tags of this checkout, newest first (``v*`` semver only —
+    ``cli-v*`` and anything else are not releases)."""
+    proc = _git(root, "tag", "--list", "v*", "--sort=-v:refname")
+    return [t.strip() for t in proc.stdout.splitlines()
+            if RELEASE_TAG_RE.match(t.strip())]
+
+
+def resolve_release_tag(root: Path, wanted: str, *, fetch: bool = True) -> str:
+    """``latest`` → the newest release tag after a tag fetch; a named tag
+    must exist. Never a partial match."""
+    if fetch:
+        _git(root, "fetch", "--tags", "--quiet", "origin")
+    tags = release_tags(root)
+    if wanted in ("", "latest"):
+        if not tags:
+            raise ReleaseRefused("no release tag (v*) found — is origin reachable?")
+        return tags[0]
+    if not RELEASE_TAG_RE.match(wanted):
+        raise ReleaseRefused(
+            f"{wanted!r} is not a release tag (expected vX.Y.Z or 'latest')")
+    if wanted not in tags:
+        raise ReleaseRefused(f"release tag {wanted} not found after fetching tags")
+    return wanted
+
+
+def check_clean_tree(root: Path) -> None:
+    proc = _git(root, "status", "--porcelain", "--untracked-files=no")
+    dirty = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    if dirty:
+        raise ReleaseRefused(
+            "the checkout has modified tracked files — commit, stash or "
+            f"discard them first ({len(dirty)} file(s): "
+            f"{', '.join(ln[3:] for ln in dirty[:3])}{'…' if len(dirty) > 3 else ''})")
+
+
+def check_cli_not_editable_from(root: Path, cli_file: Path | None = None) -> None:
+    here = (cli_file or Path(__file__)).resolve()
+    try:
+        here.relative_to(root.resolve())
+    except ValueError:
+        return
+    raise ReleaseRefused(
+        "this CLI runs from inside the checkout (editable install) — checking "
+        "out another release would swap its own source mid-run; use a tool "
+        "install (`uv tool install devcake-cli`) or check the tag out by hand")
+
+
+def release_cli_version(root: Path, tag: str) -> str | None:
+    """The CLI version the release ships, read from the tag without
+    touching the working tree. None when the tag carries no CLI."""
+    proc = _git(root, "show", f"{tag}:cli/devcake_cli/__init__.py", check=False)
+    if proc.returncode != 0:
+        return None
+    m = _VERSION_RE.search(proc.stdout)
+    return m.group(1) if m else None
+
+
+def check_cli_matches_release(root: Path, tag: str,
+                              running: str = __version__) -> None:
+    shipped = release_cli_version(root, tag)
+    if shipped and _vtuple(shipped) > _vtuple(running):
+        raise ReleaseRefused(
+            f"{tag} ships devcake-cli {shipped} but this CLI is {running}; "
+            "the bring-up order that makes a re-pin safe lives in the CLI. "
+            "Run: uv tool upgrade devcake-cli   (then re-run devcake up --release)")
+
+
+def checkout_release(root: Path, wanted: str, *, dry_run: bool = False,
+                     as_json: bool = False) -> str:
+    """Resolve, guard, and check the release tag out (detached, exactly the
+    manual recipe). Dry run resolves a named tag without fetching and
+    changes nothing. Returns the tag."""
+    def log(msg: str) -> None:
+        if not as_json:
+            sys.stdout.write(msg + "\n")
+    check_cli_not_editable_from(root)
+    if dry_run:
+        if wanted in ("", "latest"):
+            log("── would: git fetch --tags origin && git checkout <newest v* tag>")
+            return "latest"
+        tag = resolve_release_tag(root, wanted, fetch=False)
+        log(f"── would: git fetch --tags origin && git checkout {tag}")
+        return tag
+    check_clean_tree(root)
+    tag = resolve_release_tag(root, wanted)
+    check_cli_matches_release(root, tag)
+    _git(root, "checkout", "--quiet", tag)
+    log(f"── checked out release {tag} (detached HEAD)")
+    return tag

--- a/cli/devcake_cli/up.py
+++ b/cli/devcake_cli/up.py
@@ -23,6 +23,10 @@ class UpOptions:
     no_hello_smoke: bool = False
     compose_services: list[str] = field(default_factory=list)
     as_json: bool = False
+    # --release [TAG]: check the release out first (None = not requested);
+    # implies --bake all unless --bake was given, and a stale-image tidy-up
+    # after a successful bring-up (never Dev images — the baker's)
+    release: str | None = None
 
 
 @dataclass
@@ -38,6 +42,7 @@ class UpPlan:
     no_hello_smoke: bool
     env_seeded: bool
     env_generated: list[str]
+    release_requested: bool = False
 
 
 def discover_docker_gid(repo: Path, sock: str) -> tuple[str, str]:
@@ -235,6 +240,7 @@ def prepare_env(
         no_hello_smoke=opts.no_hello_smoke,
         env_seeded=env_seeded,
         env_generated=env_generated,
+        release_requested=opts.release is not None,
     )
     return plan, gid_line
 
@@ -287,6 +293,9 @@ def _print_dry_run(plan: UpPlan, *, as_json: bool) -> None:
             as_json=False,
         )
     _log(f"── would: docker compose up -d {services}".rstrip(), as_json=False)
+    if plan.release_requested:
+        _log(f"── would: remove stale control-plane images not on {plan.tag} and "
+             "dangling leftovers (never Dev images)", as_json=False)
     if plan.foreground_baker:
         _log(
             "── would: run host baker in foreground (exec `devcake baker run`; no supervisor)",
@@ -543,6 +552,14 @@ def _hello_smoke(repo: Path, plan: UpPlan, *, as_json: bool) -> None:
         raise SystemExit(4)
 
 
+def _prune_after_release(repo: Path, plan: UpPlan, *, as_json: bool) -> None:
+    from .prune import prune_images
+    try:
+        prune_images(repo, tag=plan.tag, as_json=as_json)
+    except RuntimeError as exc:   # a failed listing never fails the bring-up
+        _log(f"── image tidy-up skipped: {exc}", as_json=as_json)
+
+
 def _start_baker(repo: Path, plan: UpPlan, *, as_json: bool) -> None:
     factory = repo / ".factory"
     factory.mkdir(parents=True, exist_ok=True)
@@ -667,6 +684,20 @@ def run_up(opts: UpOptions, *, repo: Path | None = None) -> int:
         sys.stderr.write(f"devcake up: {exc}\n")
         return 3
 
+    if opts.release is not None:
+        # before anything else: the tag resolution below reads the
+        # checkout's VERSION, so the release must be checked out first
+        from . import release as release_mod
+        try:
+            release_mod.checkout_release(root, opts.release, dry_run=opts.dry_run,
+                                         as_json=opts.as_json)
+        except release_mod.ReleaseRefused as exc:
+            sys.stderr.write(f"devcake up --release: {exc}\n")
+            return 6
+        if not opts.bake:
+            opts.bake = True
+            opts.bake_targets = ["all"]
+
     try:
         plan, _ = prepare_env(root, opts, mutate=not opts.dry_run)
     except SystemExit as exc:
@@ -697,6 +728,10 @@ def run_up(opts: UpOptions, *, repo: Path | None = None) -> int:
         _health_gate(root, plan, as_json=opts.as_json)
         if plan.bake:
             _hello_smoke(root, plan, as_json=opts.as_json)
+        if opts.release is not None:
+            # only after a successful bring-up: stale control-plane images
+            # and dangling leftovers; Dev images stay the baker's
+            _prune_after_release(root, plan, as_json=opts.as_json)
         if plan.foreground_baker:
             _start_baker(root, plan, as_json=opts.as_json)
     except SystemExit as exc:

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -333,11 +333,16 @@ DAG's `name:` keys (ADR-0025), with the human-readable run id format of
 The release pin is **the checkout's `VERSION` file** (a release tag such as `v0.5.9`), bumped together with the changelog when a release is cut (`CONTRIBUTING.md`, "Cutting a release"; CI refuses a drift between the two). `devcake up` resolves the tag once — a `DEVCAKE_TAG` in the process environment for development builds, else `VERSION`, else `latest` — exports it for bake + compose, and **writes it into `.env`** so a later plain `docker compose up -d` stays lockstep. `.env` is never a source for it: a value set there by hand is rewritten on the next `devcake up`, and `up` says so. Deploying a release is therefore:
 
 ```bash
+devcake up --release           # newest v* tag: fetch tags, check it out, bake all, up, tidy images
+devcake up --release v0.5.9    # a specific release
+# by hand (what --release does):
 git checkout v0.5.9            # the release checkout carries its own pin
 devcake up --bake all          # bake + compose under that tag; .env updated
 # without the CLI:
 export DEVCAKE_TAG=$(cat VERSION); docker buildx bake all; docker compose up -d
 ```
+
+`--release` refuses before touching anything when the tree has modified tracked files, when the CLI runs from inside the checkout (an editable install would swap its own source mid-run), or when the release ships a newer `devcake-cli` than the one running — the bring-up order that makes a re-pin safe lives in the CLI, so upgrade it first (`uv tool upgrade devcake-cli`). After a successful bring-up it removes DevCake's stale control-plane images (app, admin, app-test, hello not on the new tag) and dangling build leftovers; Dev images are the baker's and are never touched. `devcake prune [--devs] [--dry-run]` does the same tidy-up on demand, and `--devs` asks the app for the host baker's Dev-image prune — the admin button's chokepoint — so the baker removes Dev images outside the keep-set on its next tick.
 
 A development build tags itself explicitly: `DEVCAKE_TAG=$(git rev-parse --short HEAD) devcake up --bake all`.
 

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -859,6 +859,13 @@ until that run exists, field evidence below stays operator-self-reported.
   Now the baker is replaced first, a tag move is itself a bake order
   (dropped pins with an image under another tag are rebaked), and `devcake
   status` prints the staffing with the remedy. CLI 0.1.5. Docs 13.
+- **One-command re-pin** (2026-09-08, founder ask, ADR-0038 addendum):
+  `devcake up --release [TAG]` fetches tags, checks the release out, bakes
+  all, brings the stack up in the safe order and removes stale
+  control-plane and dangling images; refuses a dirty tree, an editable
+  CLI, or a CLI older than the release ships. `devcake prune [--devs]`
+  tidies on demand, Dev images only through the baker's own prune
+  request. CLI 0.1.6. Docs 13, CONTRIBUTING, AGENTS.
 ### Field evidence (receipted)
 
 - **DevCake audits DevCake** (2026-08-17/18) — one board prompt became 54

--- a/docs/adr/0038-devcake-cli-scope-command-surface-and-agent-operability.md
+++ b/docs/adr/0038-devcake-cli-scope-command-surface-and-agent-operability.md
@@ -396,3 +396,11 @@ extra (`devcake-cli[mcp]`); Decision 3's zero-dependency base stays.
   stronger posture)
 - `admin/spa/src/components/FirstSetupDialog.jsx` +
   `POST /api/v1/dev-types/first-setup` (same-for-all roster seed to mirror)
+
+## Addendum — `devcake up --release [TAG]` and `devcake prune` (2026-09-08)
+
+**Why.** A host re-pin was three commands with an ordering rule a person had to remember (upgrade the CLI, check the tag out, `up --bake all`), and one of them — the order in which the app and the host baker come back — turned out to matter enough to freeze a fleet for a day. Stale images also piled up: every re-pin leaves the previous tag's control-plane images and the bake's dangling layers behind, and Dev images have an owner (the baker) that the operator could only reach through a button.
+
+**`devcake up --release [TAG]`.** Before anything else, fetch tags and check the release out (the newest `v*` tag, or the one named; `cli-v*` tags are not releases), detached, exactly as the manual recipe does; then proceed as `up --bake all` (an explicit `--bake` wins), and after a successful bring-up remove stale control-plane images and dangling leftovers. Three refusals, all before any change: modified tracked files in the tree (untracked files are fine); a CLI running from inside the checkout (an editable install would swap its own source mid-run); a CLI older than the one the release ships (read from the tag, never from the tree) — the safe bring-up order lives in the CLI, so an older one must not perform the re-pin; the message names the upgrade command. `--dry-run` prints the plan and changes nothing.
+
+**`devcake prune [--devs] [--dry-run]`.** Two owners, two paths, one verb. DevCake's control-plane images (app, admin, app-test, hello) not on the current tag, and dangling build leftovers, are the CLI's to remove — it already holds the docker socket for bake and compose; a removal the engine refuses (an image in use) is a keep, never a `-f`. Dev images are the baker's: the keep-set is the order and receipts are the registrar, so the CLI never `rmi`s one; `--devs` asks the app for the baker's Dev-image prune through the same request the admin button files, and the baker acts on its next tick. Third-party images are not DevCake's and are left alone. The verb table gains `prune`; `--json` and `--help` hold as on every verb.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "devcake-cli"
-version = "0.1.5"
+version = "0.1.6"
 description = "DevCake host CLI (up/down/status/doctor/setup/baker run)"
 readme = "README.md"
 license = {text = "GPL-3.0-only"}


### PR DESCRIPTION
## `devcake up --release [TAG]` and `devcake prune [--devs]`

### Why

A host re-pin was three commands with an ordering rule a person had to remember (upgrade the CLI, check the tag out, `up --bake all`), and one of them, which of the app and the host baker comes back first, froze a fleet for a day. Stale images pile up after every re-pin (the previous tag's control-plane images, the bake's dangling layers), and Dev images have an owner, the baker, that the operator could only reach through an admin button.

### `devcake up --release [TAG]`

Before anything else: fetch tags and check the release out, the newest `v*` tag or the one named (`cli-v*` tags are not releases), detached, exactly what the manual recipe does. Then proceed as `up --bake all` (an explicit `--bake` wins), in the safe bring-up order, and after a successful bring-up remove stale control-plane images and dangling leftovers. Three refusals, all before any change, exit 6:

- modified tracked files in the tree (untracked files are fine);
- a CLI running from inside the checkout: an editable install would swap its own source mid-run;
- a CLI older than the one the release ships, read from the tag and never from the working tree. The safe bring-up order lives in the CLI, so an older one must not perform the re-pin; the message names `uv tool upgrade devcake-cli`.

`--dry-run` prints the plan and changes nothing; a named tag is validated without a fetch.

### `devcake prune [--devs] [--dry-run]`

Two owners, two paths, one verb. DevCake's control-plane images (app, admin, app-test, hello) not on the current tag, and dangling build leftovers, are the CLI's to remove: it already holds the docker socket for bake and compose. Never `-f`; a removal the engine refuses is a keep, reported. Dev images are the baker's, with the keep-set as the order and receipts as the registrar, so the CLI never removes one itself: `--devs` files the same prune request the admin button files, and the baker acts on its next tick. Third-party images are left alone. `--json` carries the plan, what was removed, what was kept in use, and the Dev request's outcome.

### Tests

A throwaway git repo with release tags: resolution of `latest` and a named tag, non-release tags ignored, the checkout landing on the tag, the dirty-tree refusal (untracked never blocks), the older-CLI refusal read from the tag, the editable refusal, the dry run without a fetch. The `up` order with `--release` first and the tidy-up last, the implied `bake all` and an explicit `--bake` winning, refusal as exit 6 touching nothing, flag parsing. The pure planner, and the verb against a fake docker: the exact `rmi` set, no `-f`, a conflict kept, the app asked for Dev images, the dry run. Full app suite green; the editable guard smoke-tested from this checkout.

### Docs

docs/13 (the recipe becomes `devcake up --release`, with the manual form kept), CONTRIBUTING, AGENTS, ADR-0038 addendum, CHANGELOG, docs/16. Ships as `devcake-cli` 0.1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBKLwFrkny8udrVSc8fNXH
