### PR TITLE
fix(http): one shared bounded pool; never rebuild a mirror for a changed clone user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ See the living log and open candidates in
 Community surface added for public-repo hygiene (no LICENSE change in this
 track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).
 
+- **Fixed — one shared HTTP pool; the app no longer runs at its
+  descriptor ceiling.** One connection pool per repository card held
+  hundreds of idle keep-alive sockets on a large host, and every boot
+  fan-out (the forge probe of every card, the mirror warm-up) then
+  failed for minutes with "too many open files": git spawns refused,
+  secret files read as corrupt, mirrors deleted and re-cloned, the
+  health probe resetting behind the proxy. Every adapter now shares one
+  bounded pool per timeout, closed once at shutdown; the compose `app`
+  service raises its open-files limit; a mirror whose origin differs
+  only in the authority user (a credential that failed to load, or was
+  rotated) gets its remote URL updated instead of being rebuilt; and the
+  secrets reader logs the actual reason a file was unreadable.
+
 ## v0.5.14 (2026-09-08)
 
 Patch release in the v0.5 "Java Lava" line. Ships with `devcake-cli` 0.1.7.

--- a/app/devcake/adapters/http.py
+++ b/app/devcake/adapters/http.py
@@ -1,15 +1,26 @@
-"""Shared lazy HTTP client per adapter instance (2026-08 evaluation F16).
+"""One shared HTTP connection pool for the whole process (2026-09 field
+incident), behind the per-adapter `PooledClient` seam of the 2026-08
+evaluation (F16).
 
-Every adapter previously built a fresh `httpx.AsyncClient` per request — a
-full TCP+TLS handshake each time, the root cause of the 319-repo sweep
-incident that was mitigated with a semaphore + budget rather than fixed.
-`PooledClient` keeps ONE lazily-created client (connection keep-alive) for
-the adapter's hot `_req` path; special-purpose calls (large asset downloads
-with redirects, long-timeout uploads) deliberately stay per-call.
+F16 replaced a fresh `httpx.AsyncClient` per request with one lazily-created
+client per adapter instance — keep-alive instead of a TCP+TLS handshake per
+call. With one forge adapter per repository card that became one POOL per
+card: a host with 325 cards held 984 idle keep-alive sockets, sat at the
+container's 1,024-descriptor soft cap, and every boot fan-out (the forge
+probe of every card, the mirror warm-up) failed for two minutes with "too
+many open files" — git spawns refused, secret files read as corrupt,
+mirrors deleted and re-cloned, the health probe's accept() resetting behind
+the proxy. httpx reaps an expired keep-alive only on that client's next
+request, so 325 pools never drained.
 
-Lifecycle: `ForgeRuntime.rebuild` fire-and-forget-closes the outgoing
-adapter set's clients (`aclose_adapters`); an adapter that is simply GC'd
-(tests, PMO manager rebuilds) closes nothing — httpx finalizers cover it.
+Now every adapter without an injected transport shares ONE client per
+timeout value, with bounded limits (`SHARED_LIMITS`). Authentication rides
+per request as headers, so nothing about a connection is per-card; the
+pool is keyed by origin inside httpx. An adapter built with a `transport`
+(tests, ad-hoc probes) keeps a private client. `PooledClient.aclose()`
+closes a private client only; the shared clients outlive adapters and are
+closed once at app shutdown (`aclose_shared`). Special-purpose calls (large
+asset downloads with redirects, long-timeout uploads) stay per-call.
 """
 
 from __future__ import annotations
@@ -27,20 +38,61 @@ log = logging.getLogger("devcake.adapters.http")
 _CLOSE_TASKS: set = set()
 
 
+# Bounds for the process-wide pool: enough parallelism for a poll cycle's
+# fan-out, a keep-alive set that fits any descriptor cap by a wide margin,
+# and an expiry short enough that an idle set drains between cycles.
+SHARED_LIMITS = httpx.Limits(max_connections=64, max_keepalive_connections=16,
+                             keepalive_expiry=15.0)
+_SHARED: dict[float, httpx.AsyncClient] = {}       # keyed by timeout
+
+
+def shared_client(timeout: float) -> httpx.AsyncClient:
+    """The process-wide client for this timeout (created lazily; a closed
+    one is replaced — the lifespan closes them at shutdown, tests too)."""
+    client = _SHARED.get(timeout)
+    # getattr: a test double standing in for httpx.AsyncClient may not
+    # carry is_closed; treat it as open, exactly as the per-adapter client did
+    if client is None or getattr(client, "is_closed", False):
+        client = httpx.AsyncClient(timeout=timeout, limits=SHARED_LIMITS)
+        _SHARED[timeout] = client
+    return client
+
+
+async def aclose_shared() -> None:
+    """Close every shared client (app shutdown)."""
+    clients = list(_SHARED.values())
+    _SHARED.clear()
+    for client in clients:
+        if not getattr(client, "is_closed", False):
+            close = getattr(client, "aclose", None)
+            if close is not None:
+                await close()
+
+
 class PooledClient:
+    """The adapter-side seam: `get()` hands the shared client back unless
+    this adapter was built with its own transport."""
+
     def __init__(self, *, timeout: float = 20,
                  transport: "httpx.AsyncBaseTransport | None" = None):
         self._timeout = timeout
         self._transport = transport
         self._client: httpx.AsyncClient | None = None
 
+    @property
+    def shared(self) -> bool:
+        return self._transport is None
+
     def get(self) -> httpx.AsyncClient:
-        if self._client is None or self._client.is_closed:
+        if self.shared:
+            return shared_client(self._timeout)
+        if self._client is None or getattr(self._client, "is_closed", False):
             self._client = httpx.AsyncClient(
                 timeout=self._timeout, transport=self._transport)
         return self._client
 
     async def aclose(self) -> None:
+        # a private client is ours to close; the shared pool outlives us
         if self._client is not None and not self._client.is_closed:
             await self._client.aclose()
 

--- a/app/devcake/api/main.py
+++ b/app/devcake/api/main.py
@@ -252,6 +252,12 @@ async def lifespan(app: FastAPI):
     for t in tasks:
         with contextlib.suppress(asyncio.CancelledError):
             await t
+    # the process-wide HTTP pool (adapters/http): adapters never close it
+    try:
+        from ..adapters.http import aclose_shared
+        await aclose_shared()
+    except Exception:  # noqa: BLE001 — shutdown must proceed
+        log.exception("closing the shared HTTP pool on shutdown")
 
 
 def _operation_id(route, _seen: dict[str, int] = {}) -> str:  # noqa: B006 — the registration-order memo IS the point

--- a/app/devcake/domain/repo_mirror.py
+++ b/app/devcake/domain/repo_mirror.py
@@ -376,6 +376,21 @@ class RepoCache:
     # ── sync ─────────────────────────────────────────────────────────────────
 
     @staticmethod
+    def _remote_identity(url: str) -> str:
+        """The remote WITHOUT its authority user: what makes two origin URLs
+        the same repository. A credential that failed to load renders a
+        different clone user (2026-09 field incident: a descriptor shortage
+        made 53 mirrors read as "remote changed" and rebuild); a rotated
+        credential renders one too. Neither is a different repository."""
+        if "://" not in url:
+            return url
+        scheme, rest = url.split("://", 1)
+        authority, _, path = rest.partition("/")
+        if "@" in authority:
+            authority = authority.rsplit("@", 1)[1]
+        return f"{scheme}://{authority}/{path}" if path or rest.endswith("/") else f"{scheme}://{authority}"
+
+    @staticmethod
     def _origin_url(url: str, clone_user: str) -> str:
         """Embed ``clone_user@`` after the scheme for http(s) remotes that
         lack an authority user. Shared by ``sync_one`` and ``remote_head``
@@ -438,7 +453,20 @@ class RepoCache:
         else:
             r = await self.git(["-C", str(p), "remote", "get-url", "origin"],
                                env=env)
-            if r.returncode != 0 or r.stdout.strip() != expected_url:
+            stored = r.stdout.strip()
+            if (r.returncode == 0 and stored != expected_url
+                    and self._remote_identity(stored)
+                    == self._remote_identity(expected_url)):
+                # same repository, different authority user: point origin
+                # at the expected URL — never delete a mirror for a
+                # credential that failed to load or was rotated
+                log.info("mirror %s: origin user changed — updating the "
+                         "remote URL", name)
+                r2 = await self.git(["-C", str(p), "remote", "set-url",
+                                     "origin", expected_url], env=env)
+                if r2.returncode != 0:
+                    return await fail(f"remote set-url: {r2.stderr}")
+            elif r.returncode != 0 or stored != expected_url:
                 # URL changed (or corrupt config): the mirror is for a
                 # DIFFERENT repo now — rebuild rather than fetch into it
                 log.info("mirror %s: remote changed — re-initializing", name)

--- a/app/devcake/secrets.py
+++ b/app/devcake/secrets.py
@@ -155,8 +155,11 @@ def _read(path: Path) -> dict:
         if not isinstance(data, dict):
             raise ValueError("not a JSON object")
         return data
-    except Exception:  # noqa: BLE001 — lenient-read contract: corrupt file reads as absent (logged); redaction scanner alarms separately
-        log.error("unreadable secret file %s", path)
+    except Exception as e:  # noqa: BLE001 — lenient-read contract: corrupt file reads as absent (logged); redaction scanner alarms separately
+        # the reason matters: a descriptor shortage (EMFILE) reads exactly
+        # like a corrupt file without it (2026-09 field incident)
+        log.error("unreadable secret file %s: %s: %s", path,
+                  type(e).__name__, str(e)[:200])
         return {}
 
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -55,3 +55,14 @@ def _default_live_baker_for_staffing(monkeypatch):
         "devcake.domain.orchestrator.steward.require_staffed", _wrapped)
     monkeypatch.setattr(
         "devcake.domain.oauth.require_staffed", _wrapped)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_shared_http_pool():
+    """adapters/http keeps one shared client per timeout for the process;
+    a test that monkeypatches httpx.AsyncClient (or leaves a client open)
+    must not hand its double to the next test."""
+    yield
+    from devcake.adapters import http as http_mod
+    http_mod._SHARED.clear()
+

--- a/app/tests/test_http_shared_pool.py
+++ b/app/tests/test_http_shared_pool.py
@@ -1,0 +1,80 @@
+"""adapters/http: one shared, bounded HTTP pool for the process (2026-09
+field incident: one pool per repository card held 984 idle sockets against
+a 1,024-descriptor cap, and every boot fan-out failed with EMFILE)."""
+import asyncio
+
+import httpx
+
+from devcake.adapters import http as http_mod
+from devcake.adapters.http import PooledClient, SHARED_LIMITS, aclose_shared, shared_client
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def setup_function(_fn):
+    run(aclose_shared())
+
+
+def test_adapters_without_a_transport_share_one_client_per_timeout():
+    a, b, c = PooledClient(timeout=20), PooledClient(timeout=20), PooledClient(timeout=30)
+    assert a.shared and b.shared and c.shared
+    assert a.get() is b.get()                       # one pool, many adapters
+    assert a.get() is not c.get()                   # timeouts keep their own
+    assert a.get() is shared_client(20)
+    assert len(http_mod._SHARED) == 2
+
+
+def test_shared_client_is_bounded():
+    client = shared_client(20)
+    pool = client._transport._pool                  # httpcore's pool
+    assert pool._max_connections == SHARED_LIMITS.max_connections == 64
+    assert pool._max_keepalive_connections == SHARED_LIMITS.max_keepalive_connections == 16
+    assert pool._keepalive_expiry == SHARED_LIMITS.keepalive_expiry == 15.0
+
+
+def test_injected_transport_keeps_a_private_client():
+    seen = []
+
+    def handler(req):
+        seen.append(req.url.path)
+        return httpx.Response(200, json={})
+    private = PooledClient(timeout=20, transport=httpx.MockTransport(handler))
+    assert not private.shared
+    assert private.get() is not shared_client(20)
+    run(private.get().get("http://x.invalid/ping"))
+    assert seen == ["/ping"]
+    run(private.aclose())
+    assert private.get().is_closed is False         # a closed private client is replaced lazily
+
+
+def test_aclose_on_a_sharing_adapter_never_closes_the_pool():
+    a, b = PooledClient(timeout=20), PooledClient(timeout=20)
+    client = a.get()
+    run(a.aclose())
+    assert not client.is_closed
+    assert b.get() is client
+    run(aclose_shared())
+    assert client.is_closed
+    assert shared_client(20) is not client          # replaced on next use
+
+
+def test_close_adapters_on_rebuild_leaves_the_pool_alive():
+    """ForgeRuntime.rebuild fire-and-forget-closes the outgoing adapters
+    (F16): with a shared pool that must be a no-op for the pool itself."""
+    class Adapter:
+        def __init__(self):
+            self._http = PooledClient(timeout=20)
+
+        async def aclose(self):
+            await self._http.aclose()
+    adapters = [Adapter() for _ in range(5)]
+    client = adapters[0]._http.get()
+
+    async def scenario():
+        http_mod.aclose_adapters(adapters)
+        await asyncio.sleep(0)                      # let the close tasks run
+        await asyncio.sleep(0)
+    run(scenario())
+    assert not client.is_closed

--- a/app/tests/test_repo_mirror.py
+++ b/app/tests/test_repo_mirror.py
@@ -1246,3 +1246,45 @@ def test_invalidation_moment_follows_rename_and_leaves_with_delete(tmp_path):
     assert "beta" in cache._invalidated_at and "alpha" not in cache._invalidated_at
     cache.delete_mirror("beta")
     assert "beta" not in cache._invalidated_at
+
+
+# ── a changed authority user is never a rebuild (2026-09 field incident) ──
+
+def test_origin_user_change_updates_the_remote_url_instead_of_rebuilding(tmp_path):
+    """A credential that failed to load (or was rotated) renders a different
+    clone user in the origin URL; the mirror is the same repository and must
+    be kept — set-url, no delete, no re-init."""
+    from devcake.domain.repo_mirror import RepoCache
+
+    def script(args):
+        if "get-url" in args:
+            return GitResult(0, "https://someone-else@gitlab.com/o/alpha.git\n", "")
+        return None
+    cache, calls, forges = make_cache(tmp_path, [R1], script=script)
+    mirror = cache.mirror_path("alpha")
+    mirror.mkdir(parents=True, exist_ok=True)
+    (mirror / "HEAD").write_text("ref: refs/heads/main\n")
+    st = run_coro(cache.sync_one("alpha"))
+    assert st.ok, st.detail
+    expected = RepoCache._origin_url(R1.url, FakeForge.descriptor.clone_user)
+    assert any(c[:4] == ["-C", str(mirror), "remote", "set-url"] and c[-1] == expected
+               for c in calls)
+    assert not any(c[:1] == ["init"] for c in calls)
+    assert mirror.is_dir()
+    assert RepoCache._remote_identity("https://u@h/o/r.git") == "https://h/o/r.git"
+    assert RepoCache._remote_identity("https://h/o/r.git") == "https://h/o/r.git"
+    assert RepoCache._remote_identity("git@h:o/r.git") == "git@h:o/r.git"
+
+
+def test_a_different_repository_still_rebuilds_the_mirror(tmp_path):
+    def script(args):
+        if "get-url" in args:
+            return GitResult(0, "https://gitlab.com/o/beta.git\n", "")
+        return None
+    cache, calls, forges = make_cache(tmp_path, [R1], script=script)
+    mirror = cache.mirror_path("alpha")
+    mirror.mkdir(parents=True, exist_ok=True)
+    run_coro(cache.sync_one("alpha"))
+    assert any(c[:1] == ["init"] for c in calls)
+    assert not any("set-url" in c for c in calls)
+

--- a/app/tests/test_secrets_unreadable_reason.py
+++ b/app/tests/test_secrets_unreadable_reason.py
@@ -1,0 +1,32 @@
+"""secrets._read names WHY a file was unreadable: a descriptor shortage
+(EMFILE) reads exactly like a corrupt file otherwise (2026-09 incident:
+7,993 "unreadable secret file" lines that were all "too many open files")."""
+import logging
+from pathlib import Path
+
+from devcake import secrets
+
+
+def test_unreadable_secret_log_names_the_exception(tmp_path, caplog):
+    bad = tmp_path / "repo-x.json"
+    bad.write_text("{not json")
+    with caplog.at_level(logging.ERROR, logger="devcake.secrets"):
+        assert secrets._read(bad) == {}
+    msg = "\n".join(r.getMessage() for r in caplog.records)
+    assert "unreadable secret file" in msg and "JSONDecodeError" in msg
+
+
+def test_unreadable_secret_log_names_an_os_error(tmp_path, caplog, monkeypatch):
+    p = tmp_path / "repo-y.json"
+    p.write_text("{}")
+    real = Path.read_text
+
+    def boom(self, *a, **k):
+        if self == p:
+            raise OSError(24, "Too many open files")
+        return real(self, *a, **k)
+    monkeypatch.setattr(Path, "read_text", boom)
+    with caplog.at_level(logging.ERROR, logger="devcake.secrets"):
+        assert secrets._read(p) == {}
+    msg = "\n".join(r.getMessage() for r in caplog.records)
+    assert "OSError" in msg and "Too many open files" in msg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,15 @@ services:
       # (live-verified 2026-07-17) — same default as the gitea service below
       GITEA_ADMIN_USER: ${GITEA_ADMIN_USER:-devcakeadmin}
     restart: unless-stopped
+    # the container default (1,024 open files, soft) starved every boot
+    # fan-out into "too many open files" once the forge pools sat near it
+    # (2026-09 field incident); the hard cap is far higher, this is free.
+    # The shared HTTP pool (adapters/http) keeps the steady state small —
+    # this is the belt for the next fan-out nobody predicted.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     volumes:
       - devcake_data:/data              # note: NO docker.sock — kill/reconcile go via the Dagu API
       # ADR-0024: bare source mirrors, app-writable; the dev-run PROVISION

--- a/docs/13-deployment.md
+++ b/docs/13-deployment.md
@@ -38,7 +38,11 @@ from inside the Dev container.
 - Services: `app`, `dagu`, `redis`, `openobserve`, `admin`, `otel-collector`,
   `fluentbit`, `gitea` (internal fallback forge). Long-lived services carry
   `restart: unless-stopped` in compose — a compose fact, not an app knob
-  (there is deliberately no UI control for it).
+  (there is deliberately no UI control for it). The `app` service raises
+  its open-files limit to 65,536 (another compose fact): the app keeps one
+  shared, bounded HTTP pool for every forge and tracker call, and a boot
+  fan-out over hundreds of repositories must never hit the container's
+  1,024 default.
 - Volumes: `devcake_data` (→ `app:/data` — **secrets + config + state**),
   `devcake_mirrors` (→ `app:/mirrors` rw + the Dev **provision** container
   `:ro` — ADR-0024 source mirrors; DISPOSABLE cache, excluded from backups,

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -882,6 +882,18 @@ until that run exists, field evidence below stays operator-self-reported.
   on while the baker built the two pinned ones. `--bake` now accepts the
   control plane only and refuses harness targets; `--release` implies the
   control-plane bake. CLI 0.1.7. Docs 13, AGENTS, CONTRIBUTING.
+- **One shared HTTP pool; the descriptor ceiling** (2026-09-08, field
+  incident): after a re-pin the backend read "unreachable" for two
+  minutes — the app held 984 idle keep-alive sockets (one pool per
+  repository card, 325 cards) against the container's 1,024 soft cap, and
+  the boot fan-out failed with EMFILE 1,413 times: 51 git spawns refused,
+  7,993 secret reads logged as "unreadable" (the reader hid the errno),
+  53 mirrors deleted and re-cloned as "remote changed" because a
+  credential that failed to load renders a different clone user, and the
+  health probe's accept() resetting behind nginx. Now one bounded pool per
+  timeout shared by every adapter (closed at shutdown), `ulimits.nofile`
+  65,536 on the app service, a set-url instead of a rebuild when only the
+  origin's authority user differs, and the reader names the exception.
 ### Field evidence (receipted)
 
 - **DevCake audits DevCake** (2026-08-17/18) — one board prompt became 54


### PR DESCRIPTION
## One shared HTTP pool; the app no longer runs at its descriptor ceiling

### Why

Field incident (2026-09-08): after a re-pin the backend read "unreachable" for two minutes. The process held 984 idle keep-alive TCP sockets — one httpx pool per repository card, 325 cards — against the container's 1,024-descriptor soft cap. httpx reaps an expired keep-alive only on that client's next request, so 325 pools never drained between poll cycles. The boot fan-out (the forge probe of every card plus the mirror warm-up) then failed with `EMFILE`:

| In the boot minute | Count |
|---|---|
| "Too many open files" | 1,413 |
| git spawns refused | 51 |
| secret files logged "unreadable" (all readable; the reader hid the errno) | 7,993 |
| mirrors deleted and re-cloned as "remote changed" | 53 |

The health probe's `accept()` failing is what reset connections behind nginx. The 53 re-clones are a cascade of their own: a credential that fails to load renders a different clone user in the origin URL, and the mirror code read that as "a different repository".

### What changes

- **adapters/http**: every adapter without an injected transport shares one client per timeout, with bounded limits (64 connections, 16 keep-alive, 15 s expiry). Authentication rides per request, so nothing about a connection is per-card. An injected transport keeps a private client (tests, ad-hoc probes). `PooledClient.aclose` closes a private client only; the shared clients are closed once at app shutdown. A test double without `is_closed` is treated as open, as the per-adapter client did, and a conftest fixture clears the registry between tests.
- **docker-compose**: the `app` service raises `ulimits.nofile` to 65,536. The hard cap already allowed it. This is the belt for the next fan-out nobody predicted.
- **repo_mirror**: an origin URL that differs only in the authority user is the same repository: `remote set-url`, never delete and re-init. A different host or path still rebuilds.
- **secrets**: the lenient reader logs the exception class and message with the path, so a descriptor shortage no longer reads as a corrupt file.

### Tests

The shared pool: one client per timeout across adapters, bounds pinned against httpcore, a private client with a transport, `aclose` never closing the pool, rebuild's fire-and-forget close leaving it alive. The mirror guard: set-url on a user change, rebuild on a different repository, the identity helper. The reader naming a JSON error and an OS error. Full app suite green.

### Docs

docs/13 (the compose fact), CHANGELOG, docs/16 with the receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBKLwFrkny8udrVSc8fNXH
