### PR TITLE
feat(pmo): edit_feed port operation + feed_collapsible capability (ADR-0042 PR-1)

### DIFF
--- a/app/devcake/adapters/gitea_issues/adapter.py
+++ b/app/devcake/adapters/gitea_issues/adapter.py
@@ -19,7 +19,8 @@ import httpx
 from ...domain.model import (ALL_LABELS, Activity, ActivityEntry, AttachmentRef,
                              FeedChange, FeedDelta, Mission, MissionRef,
                              NormalizedStatus, canonicalize_labels)
-from ...ports.pmo import PMOCapabilities, PMOHealth, PMOTransient, get_many_via_get
+from ...ports.pmo import (FOLD_DETAILS, PMOCapabilities, PMOHealth, PMOTransient,
+                          get_many_via_get)
 from .._toolkit import gitea_internal_tracker_enable_deps, label_write_lock
 from ..forge_issue import CANCEL_FOOTER, apply_cancel_footer, strip_cancel_footer
 from .mapping import (mission_key, normalize_priority,
@@ -496,6 +497,16 @@ class GiteaIssuesAdapter:
         cid = created.get("id") if isinstance(created, dict) else None
         return str(cid) if cid is not None else None
 
+    async def edit_feed(self, ref: MissionRef, entry_id: str, markdown: str) -> None:
+        # whole-body replace of DevCake's own comment (ADR-0042 §3): Gitea
+        # addresses a comment by repository + comment id, so the issue in
+        # `ref` only gates the kind; id and created_at survive the edit. A
+        # vanished comment is a 404 → GiteaIssuesHTTPError (permanent).
+        self._require_issue(ref)
+        await self._req(
+            "PATCH", self._repo_path(f"/issues/comments/{entry_id}"),
+            json={"body": markdown})
+
     async def set_status(self, ref: MissionRef, status: NormalizedStatus) -> None:
         self._require_issue(ref)
         if status in ("done", "canceled"):
@@ -899,4 +910,5 @@ class GiteaIssuesAdapter:
             attachments_supported=True,
             global_ids=False,  # issue numbers collide across Gitea instances
             feed_delta=True,   # repository-wide issues/comments?since= listing
+            feed_collapsible=FOLD_DETAILS,  # <details> renders collapsed (ADR-0042 §3)
         )

--- a/app/devcake/adapters/github_issues/adapter.py
+++ b/app/devcake/adapters/github_issues/adapter.py
@@ -19,7 +19,8 @@ from ...domain.model import (ALL_LABELS, Activity, ActivityEntry,
                              Mission, MissionRef, NormalizedStatus,
                              canonicalize_labels)
 from ...domain.model import FeedDelta
-from ...ports.pmo import PMOCapabilities, PMOHealth, PMOTransient, get_many_via_get
+from ...ports.pmo import (FOLD_DETAILS, PMOCapabilities, PMOHealth, PMOTransient,
+                          get_many_via_get)
 from .._toolkit import label_write_lock
 from ..forge_issue import CANCEL_FOOTER, apply_cancel_footer, strip_cancel_footer
 from .mapping import (mission_key, normalize_priority,
@@ -320,6 +321,16 @@ class GitHubIssuesAdapter:
         cid = created.get("id") if isinstance(created, dict) else None
         return str(cid) if cid is not None else None
 
+    async def edit_feed(self, ref: MissionRef, entry_id: str, markdown: str) -> None:
+        # whole-body replace of DevCake's own comment (ADR-0042 §3): GitHub
+        # addresses a comment by repository + comment id, so the issue in
+        # `ref` only gates the kind; id and created_at survive the edit. A
+        # vanished comment is a 404 → RuntimeError (permanent).
+        self._require_issue(ref)
+        await self._req(
+            "PATCH", self._repo_path(f"/issues/comments/{entry_id}"),
+            json={"body": markdown})
+
     async def set_status(self, ref: MissionRef, status: NormalizedStatus) -> None:
         self._require_issue(ref)
         state = "closed" if status in ("done", "canceled") else "open"
@@ -470,4 +481,5 @@ class GitHubIssuesAdapter:
             attachments_supported=False,
             comment_max_chars=65536,
             global_ids=False,
+            feed_collapsible=FOLD_DETAILS,  # <details> renders collapsed (ADR-0042 §3)
         )

--- a/app/devcake/adapters/gitlab_issues/adapter.py
+++ b/app/devcake/adapters/gitlab_issues/adapter.py
@@ -18,7 +18,8 @@ from ...domain.model import (ALL_LABELS, Activity, ActivityEntry, AttachmentRef,
                              Mission, MissionRef, NormalizedStatus,
                              canonicalize_labels)
 from ...domain.model import FeedDelta
-from ...ports.pmo import PMOCapabilities, PMOHealth, PMOTransient, get_many_via_get
+from ...ports.pmo import (FOLD_DETAILS, PMOCapabilities, PMOHealth, PMOTransient,
+                          get_many_via_get)
 from .._toolkit import label_write_lock
 from ..forge_issue import CANCEL_FOOTER, apply_cancel_footer, strip_cancel_footer
 from .mapping import (mission_key, normalize_priority,
@@ -383,6 +384,17 @@ class GitLabIssuesAdapter:
         cid = created.get("id") if isinstance(created, dict) else None
         return str(cid) if cid is not None else None
 
+    async def edit_feed(self, ref: MissionRef, entry_id: str, markdown: str) -> None:
+        # whole-body replace of DevCake's own note (ADR-0042 §3): GitLab
+        # addresses a note by project + issue iid + note id — the one vendor
+        # where `ref` is part of the address, which is why the port carries
+        # it; id and created_at survive the edit. A vanished note is a
+        # 404 → GitLabHTTPError (permanent).
+        self._require_issue(ref)
+        await self._req(
+            "PUT", self._proj(f"/issues/{ref.pmo_id}/notes/{entry_id}"),
+            json={"body": markdown})
+
     async def set_status(self, ref: MissionRef, status: NormalizedStatus) -> None:
         self._require_issue(ref)
         if status in ("done", "canceled"):
@@ -653,4 +665,5 @@ class GitLabIssuesAdapter:
             relations_supported=self._relations_write is not False,
             attachments_supported=True,
             global_ids=False,
+            feed_collapsible=FOLD_DETAILS,  # <details> renders collapsed (ADR-0042 §3)
         )

--- a/app/devcake/adapters/linear/adapter.py
+++ b/app/devcake/adapters/linear/adapter.py
@@ -18,7 +18,7 @@ from ...domain.model import (ALL_LABELS, Activity, ActivityEntry, AttachmentRef,
                              FeedChange, FeedDelta, Mission, MissionDocument,
                              MissionRef, NormalizedStatus, Priority,
                              canonicalize_labels)
-from ...ports.pmo import PMOCapabilities, PMOHealth, PMOTransient
+from ...ports.pmo import FOLD_PLUS, PMOCapabilities, PMOHealth, PMOTransient
 from .._toolkit import label_write_lock
 from ..budget import (RateSignal, bind_principal, budget_for, header_float,
                       header_int)
@@ -868,6 +868,29 @@ class LinearAdapter:
         return ((data.get("commentCreate") or {})
                 .get("comment") or {}).get("id") or None
 
+    async def edit_feed(self, ref: MissionRef, entry_id: str, markdown: str) -> None:
+        """Issue → `commentUpdate`; project → `projectUpdateUpdate` (ADR-0042
+        §3). Whole-body replace: the id and `createdAt` survive the edit and
+        a `+++ Title … +++` body round-trips byte-identical (verified live).
+        A comment Linear no longer has comes back as a GraphQL error →
+        RuntimeError (permanent, never PMOTransient); so does a falsy
+        `success`, which must not read as a silent no-op."""
+        if ref.kind == "project":
+            data = await self._gql(
+                """mutation($id: String!, $b: String!) {
+                     projectUpdateUpdate(id: $id, input: {body: $b}) { success } }""",
+                {"id": entry_id, "b": markdown})
+            ok = (data.get("projectUpdateUpdate") or {}).get("success")
+        else:
+            data = await self._gql(
+                """mutation($id: String!, $b: String!) {
+                     commentUpdate(id: $id, input: {body: $b}) { success } }""",
+                {"id": entry_id, "b": markdown})
+            ok = (data.get("commentUpdate") or {}).get("success")
+        if not ok:
+            raise RuntimeError(
+                f"linear: edit of {ref.kind} feed entry {entry_id} not applied")
+
     async def set_status(self, ref: MissionRef, status: NormalizedStatus) -> None:
         if ref.kind == "project":
             await self._set_project_status(ref.pmo_id, status)
@@ -1256,7 +1279,11 @@ class LinearAdapter:
                                # safety rescan here
                                updated_at_tracks_comments=True,
                                feed_delta=True,   # root comments(filter:) read
-                               feed_threads=True)  # commentCreate parentId
+                               feed_threads=True,  # commentCreate parentId
+                               # `+++ Title … +++` renders as a native
+                               # toggle; a <details> block renders as
+                               # literal text (verified live, ADR-0042 §3)
+                               feed_collapsible=FOLD_PLUS)
 
     # ── normalization ────────────────────────────────────────────────────────
 

--- a/app/devcake/ports/pmo.py
+++ b/app/devcake/ports/pmo.py
@@ -115,6 +115,14 @@ class PMOHealth(BaseModel):
     detail: str = ""
 
 
+# ── fold syntax families (ADR-0042 §3) — port-level constants; the domain
+# compares against THESE, never a vendor name (test_agnosticism) ──
+FOLD_NONE = ""            # no collapsible syntax: the fold renders as a plain section
+FOLD_DETAILS = "details"  # HTML <details><summary> … </details>
+FOLD_PLUS = "plus"        # `+++ Title` … `+++` fenced collapsible section
+FoldSyntax = Literal["", "details", "plus"]
+
+
 class PMOCapabilities(BaseModel):
     """Adapter self-description consumed by the feed chokepoint, blocker
     locator, health probe, and admin mission-action paths (attachments,
@@ -160,6 +168,11 @@ class PMOCapabilities(BaseModel):
     # of finished siblings costs a handful of requests, not hundreds. False
     # ⇒ the locator loops `get`.
     batch_get: bool = False
+    # The vendor's collapsible-block syntax for the feed fold (ADR-0042 §3):
+    # the ONE vendor-specific rendering decision, taken by the feed
+    # chokepoint's fold renderer. "" ⇒ the fold renders flat (headed
+    # section, no wrapper) — every marker still rides inline and unquoted.
+    feed_collapsible: FoldSyntax = FOLD_NONE
 
 
 async def get_many_via_get(pmo, refs: list[MissionRef]) -> dict[str, Mission]:
@@ -253,6 +266,21 @@ class PMOPort(Protocol):
         can re-find them. ADF/rich-text PMOs (e.g. Jira) need an explicit
         fidelity strategy — multi-PMO is not “just another adapter” for this
         reason."""
+        ...
+    async def edit_feed(self, ref: MissionRef, entry_id: str, markdown: str) -> None:
+        """Replace the WHOLE body of a feed entry DevCake posted earlier
+        (ADR-0042 §3, §5). `entry_id` is what `post_feed` returned / what
+        `get_activity(full=True)` reports for it; `ref` is the entry's mission
+        (some vendors address an entry by item + entry). Kind-dispatched like
+        `post_feed`: issue → comment edit, project → project-update edit.
+        Markdown fidelity is the same port requirement as `post_feed`
+        (backticked markers must round-trip). The adapter never composes:
+        the domain sends the full new body, so there is no vendor-side
+        read-modify-write window. An entry the vendor no longer has (a
+        person deleted it) is a PERMANENT failure (never PMOTransient) —
+        the caller falls back to a new post. Edits keep the entry's
+        creation time and id: the entry never moves in the feed and never
+        becomes "new" to any watermark reader."""
         ...
     async def set_status(self, ref: MissionRef, status: NormalizedStatus) -> None: ...
     async def cancel_mission(self, ref: MissionRef) -> None:

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -9,6 +9,7 @@ from typing import Any
 from devcake.config import (AppConfig, CostInputs, DevType, ModelRate,
                             PMOInstance, RepoInstance)
 from devcake.domain.orchestrator import MissionManager
+from devcake.ports.pmo import FOLD_DETAILS
 
 
 # Former shipped DEFAULT_MODEL_RATES (builtin-v2). Production seed is empty
@@ -272,12 +273,13 @@ def fake_pmo_capabilities(*, global_ids=True, relations_supported=True,
                           comment_max_chars=None,
                           updated_at_tracks_comments=True,
                           feed_delta=False, feed_threads=False,
-                          batch_get=False):
+                          batch_get=False, feed_collapsible=FOLD_DETAILS):
     """Shared capability row for the test fakes. Default is Linear-shaped
     (global ids ON, so peer-resolution tests exercise the allowed path;
     `updated_at` tracks comments, so the feed memo has no safety rescan);
     colliding-id scenarios pass global_ids=False — the capability replaced
-    GLOBAL_ID_SYSTEMS in the 2026-08 cleanups."""
+    GLOBAL_ID_SYSTEMS in the 2026-08 cleanups. `feed_collapsible` defaults
+    to the issue-vendor fold family (ADR-0042 §3)."""
     from devcake.ports.pmo import PMOCapabilities
     return PMOCapabilities(
         projects_supported=True, project_labels_supported=True,
@@ -288,7 +290,7 @@ def fake_pmo_capabilities(*, global_ids=True, relations_supported=True,
         global_ids=global_ids,
         updated_at_tracks_comments=updated_at_tracks_comments,
         feed_delta=feed_delta, feed_threads=feed_threads,
-        batch_get=batch_get)
+        batch_get=batch_get, feed_collapsible=feed_collapsible)
 
 
 # ── ADR-0028: the test-side service graph ────────────────────────────────────

--- a/app/tests/test_contract_battery_honesty.py
+++ b/app/tests/test_contract_battery_honesty.py
@@ -20,7 +20,7 @@ _SCRIPTS = next((p for p in _SCRIPT_ROOTS if p.is_dir()), None)
 # Documented check-id sets (plan lock). Counts are independent literals —
 # not recomputed from the scripts' check() call sites.
 EXPECTED_FORGE_ROWS = 14  # CAKE-181 adds apply_default_branch_protection round-trip
-EXPECTED_PMO_ROWS = 14  # 1,2,3,4,5,5b,8,9,10,11,12,13,14,15
+EXPECTED_PMO_ROWS = 15  # 1,2,3,4,5,5b,8,9,10,11,12,13,14,15,16
 
 
 def _script(name: str) -> Path:
@@ -57,7 +57,7 @@ def test_forge_expected_rows_pinned_at_14():
     assert ns["EXPECTED_ROWS"] == EXPECTED_FORGE_ROWS
 
 
-def test_pmo_expected_rows_pinned_at_14():
+def test_pmo_expected_rows_pinned_at_15():
     ns = _extract(_script("contract_tests_pmo.py"))
     assert ns["EXPECTED_ROWS"] == EXPECTED_PMO_ROWS
 
@@ -95,6 +95,7 @@ def test_pmo_grader_counts_skips_toward_expected_without_failing():
         ("10", "i", "PASS"), ("11", "j", "PASS"), ("12", "k", "PASS"),
         ("13", "l", "SKIP — attachments_supported=False"),
         ("14", "m", "PASS"), ("15", "n", "SKIP — no project"),
+        ("16", "o", "PASS"),
     ]
     assert len(rows) == EXPECTED_PMO_ROWS
     assert pmo["grade_contract_battery"](rows, EXPECTED_PMO_ROWS) == 0

--- a/app/tests/test_gitea_issues_contract.py
+++ b/app/tests/test_gitea_issues_contract.py
@@ -13,7 +13,7 @@ import pytest
 from devcake.adapters.gitea_issues.adapter import GiteaIssuesAdapter
 from devcake.adapters.gitea_issues.mapping import CANCEL_FOOTER
 from devcake.domain.model import ALL_LABELS, MissionRef
-from devcake.ports.pmo import PMOPort, PMOTransient
+from devcake.ports.pmo import FOLD_DETAILS, PMOPort, PMOTransient
 
 PORT_METHODS = [n for n, v in vars(PMOPort).items()
                 if callable(v) and not n.startswith("_")]
@@ -140,6 +140,16 @@ class Router:
                 self.comments[n] = []
                 self.deps[n] = []
                 return httpx.Response(201, json=iss)
+
+        # comment by id (repository-scoped: the issue is not in the path)
+        if path.startswith("/api/v1/repos/o/r/issues/comments/") and method == "PATCH":
+            cid = int(path.rsplit("/", 1)[1])
+            for cs in self.comments.values():
+                for c in cs:
+                    if c["id"] == cid:
+                        c["body"] = body.get("body") or ""
+                        return httpx.Response(200, json=c)
+            return httpx.Response(404, json={"message": "comment not found"})
 
         # issue by number
         m = match_issue(path)
@@ -357,6 +367,31 @@ def test_post_feed_and_activity_marker_body():
     run(pmo.post_feed(MissionRef("1", "issue"), marker))
     act = run(pmo.get_activity(MissionRef("1", "issue")))
     assert act.entries[-1].body == marker
+
+
+def test_edit_feed_replaces_the_body_in_place():
+    """ADR-0042 §3: an edit is a whole-body replace of DevCake's own comment
+    through `PATCH …/issues/comments/{id}` — same entry_id, same ts, the
+    feed has no new entry, and a fold with a marker inside round-trips. A
+    vanished comment is the adapter's permanent error, never PMOTransient."""
+    r = Router()
+    pmo = make_pmo(r)
+    assert pmo.capabilities().feed_collapsible == FOLD_DETAILS
+    ref = MissionRef("1", "issue")
+    cid = run(pmo.post_feed(ref, "card `devcake:v1`"))
+    before = run(pmo.get_activity(ref, full=True))
+    new = ("card\n\n<details><summary>Details</summary>\n\n"
+           "`devcake:discovery-routed:v1 step=1 to=-`\n\n</details>\n\n`devcake:v1`")
+    run(pmo.edit_feed(ref, cid, new))
+    assert r.calls[-1] == f"PATCH /api/v1/repos/o/r/issues/comments/{cid}"
+    after = run(pmo.get_activity(ref, full=True))
+    assert len(after.entries) == len(before.entries)
+    (entry,) = [e for e in after.entries if e.entry_id == cid]
+    assert entry.body == new
+    assert entry.ts == before.entries[-1].ts
+    with pytest.raises(RuntimeError) as ei:
+        run(pmo.edit_feed(ref, "999", "gone"))
+    assert not isinstance(ei.value, PMOTransient)
 
 
 def test_create_mission_returns_key_and_id():

--- a/app/tests/test_github_issues_contract.py
+++ b/app/tests/test_github_issues_contract.py
@@ -13,7 +13,7 @@ import pytest
 from devcake.adapters.github_issues.adapter import GitHubIssuesAdapter
 from devcake.adapters.github_issues.mapping import CANCEL_FOOTER
 from devcake.domain.model import ALL_LABELS, MissionRef
-from devcake.ports.pmo import PMOPort, PMOTransient
+from devcake.ports.pmo import FOLD_DETAILS, PMOPort, PMOTransient
 
 PORT_METHODS = [n for n, v in vars(PMOPort).items()
                 if callable(v) and not n.startswith("_")]
@@ -105,6 +105,16 @@ class Router:
                 self.comments[n] = []
                 self.deps[n] = []
                 return httpx.Response(201, json=iss)
+
+        # comment by id (repository-scoped: the issue is not in the path)
+        if path.startswith("/repos/o/r/issues/comments/") and method == "PATCH":
+            cid = int(path.rsplit("/", 1)[1])
+            for cs in self.comments.values():
+                for c in cs:
+                    if c["id"] == cid:
+                        c["body"] = body.get("body") or ""
+                        return httpx.Response(200, json=c)
+            return httpx.Response(404, json={"message": "Not Found"})
 
         m = re.match(r"^/repos/o/r/issues/(\d+)(.*)$", path)
         if m:
@@ -240,6 +250,31 @@ def test_post_feed_marker_round_trip():
     run(pmo.post_feed(MissionRef("1", "issue"), marker))
     act = run(pmo.get_activity(MissionRef("1", "issue")))
     assert act.entries[-1].body == marker
+
+
+def test_edit_feed_replaces_the_body_in_place():
+    """ADR-0042 §3: an edit is a whole-body replace of DevCake's own comment
+    through `PATCH …/issues/comments/{id}` — same entry_id, same ts, the
+    feed has no new entry, and a fold with a marker inside round-trips. A
+    vanished comment is the adapter's permanent error, never PMOTransient."""
+    r = Router()
+    pmo = make_pmo(r)
+    assert pmo.capabilities().feed_collapsible == FOLD_DETAILS
+    ref = MissionRef("1", "issue")
+    cid = run(pmo.post_feed(ref, "card `devcake:v1`"))
+    before = run(pmo.get_activity(ref, full=True))
+    new = ("card\n\n<details><summary>Details</summary>\n\n"
+           "`devcake:discovery-routed:v1 step=1 to=-`\n\n</details>\n\n`devcake:v1`")
+    run(pmo.edit_feed(ref, cid, new))
+    assert r.calls[-1] == f"PATCH /repos/o/r/issues/comments/{cid}"
+    after = run(pmo.get_activity(ref, full=True))
+    assert len(after.entries) == len(before.entries)
+    (entry,) = [e for e in after.entries if e.entry_id == cid]
+    assert entry.body == new
+    assert entry.ts == before.entries[-1].ts
+    with pytest.raises(RuntimeError) as ei:
+        run(pmo.edit_feed(ref, "999", "gone"))
+    assert not isinstance(ei.value, PMOTransient)
 
 
 def test_create_relation_uses_global_id_and_is_duplicate_tolerant():

--- a/app/tests/test_gitlab_issues_contract.py
+++ b/app/tests/test_gitlab_issues_contract.py
@@ -13,7 +13,7 @@ import pytest
 from devcake.adapters.gitlab_issues.adapter import GitLabIssuesAdapter
 from devcake.adapters.gitlab_issues.mapping import CANCEL_FOOTER
 from devcake.domain.model import ALL_LABELS, MissionRef
-from devcake.ports.pmo import PMOPort, PMOTransient
+from devcake.ports.pmo import FOLD_DETAILS, PMOPort, PMOTransient
 
 PORT_METHODS = [n for n, v in vars(PMOPort).items()
                 if callable(v) and not n.startswith("_")]
@@ -158,6 +158,14 @@ class Router:
                 self.next_note += 1
                 self.notes.setdefault(iid, []).append(c)
                 return httpx.Response(201, json=c)
+            nm = re.match(r"^/notes/(\d+)$", rest)
+            if nm and method == "PUT":
+                nid = int(nm.group(1))
+                for c in self.notes.get(iid, []):
+                    if c["id"] == nid:
+                        c["body"] = body.get("body") or ""
+                        return httpx.Response(200, json=c)
+                return httpx.Response(404, json={"message": "404 Note Not Found"})
             if rest == "/links" and method == "GET":
                 status = self.links_status.get(iid, 200)
                 if status != 200:
@@ -280,6 +288,32 @@ def test_post_feed_and_activity_marker_body():
     run(pmo.post_feed(MissionRef("1", "issue"), marker))
     act = run(pmo.get_activity(MissionRef("1", "issue")))
     assert act.entries[-1].body == marker
+
+
+def test_edit_feed_replaces_the_body_in_place():
+    """ADR-0042 §3: an edit is a whole-body replace of DevCake's own note
+    through `PUT …/issues/{iid}/notes/{id}` (the note address carries the
+    issue — why the port takes `ref`) — same entry_id, same ts, the feed
+    has no new entry, and a fold with a marker inside round-trips. A
+    vanished note is the adapter's permanent error, never PMOTransient."""
+    r = Router()
+    pmo = make_pmo(r)
+    assert pmo.capabilities().feed_collapsible == FOLD_DETAILS
+    ref = MissionRef("1", "issue")
+    cid = run(pmo.post_feed(ref, "card `devcake:v1`"))
+    before = run(pmo.get_activity(ref, full=True))
+    new = ("card\n\n<details><summary>Details</summary>\n\n"
+           "`devcake:discovery-routed:v1 step=1 to=-`\n\n</details>\n\n`devcake:v1`")
+    run(pmo.edit_feed(ref, cid, new))
+    assert r.calls[-1] == f"PUT /api/v4/projects/o/r/issues/1/notes/{cid}"
+    after = run(pmo.get_activity(ref, full=True))
+    assert len(after.entries) == len(before.entries)
+    (entry,) = [e for e in after.entries if e.entry_id == cid]
+    assert entry.body == new
+    assert entry.ts == before.entries[-1].ts
+    with pytest.raises(RuntimeError) as ei:
+        run(pmo.edit_feed(ref, "999", "gone"))
+    assert not isinstance(ei.value, PMOTransient)
 
 
 def test_create_mission_returns_key_and_id():

--- a/app/tests/test_pmo_contract.py
+++ b/app/tests/test_pmo_contract.py
@@ -12,7 +12,7 @@ import pytest
 
 from devcake.adapters.linear.adapter import LinearAdapter
 from devcake.domain.model import ALL_LABELS, MissionRef
-from devcake.ports.pmo import PMOHealth, PMOPort, PMOTransient
+from devcake.ports.pmo import FOLD_PLUS, PMOHealth, PMOPort, PMOTransient
 
 PORT_METHODS = [n for n, v in vars(PMOPort).items()
                 if callable(v) and not n.startswith("_")]
@@ -27,7 +27,8 @@ def test_port_declares_expected_surface():
     assert sorted(PORT_METHODS) == sorted([
         "list_missions", "list_all", "get", "get_many", "get_activity", "children_of",
         "feed_changes_since",
-        "post_feed", "set_status", "cancel_mission", "swap_labels", "create_mission",
+        "post_feed", "edit_feed", "set_status", "cancel_mission", "swap_labels",
+        "create_mission",
         "create_relation", "ensure_labels", "append_description",
         "upload_attachment", "download_asset", "health_probe", "capabilities"])
 
@@ -110,6 +111,37 @@ def test_post_feed_dispatches_on_kind():
     run(pmo.post_feed(MissionRef("uuid-p1", "project"), "hi"))
     assert any("commentCreate" in q for q in rec.queries)
     assert any("projectUpdateCreate" in q for q in rec.queries)
+
+
+def test_edit_feed_dispatches_on_kind_and_a_refused_edit_is_permanent():
+    """ADR-0042 §3: an issue entry edits through `commentUpdate`, a project
+    entry through `projectUpdateUpdate` — both whole-body, addressed by the
+    entry id the post returned; a falsy `success` is a RuntimeError, never
+    PMOTransient (the caller falls back to a new post, not to a retry)."""
+    seen = []
+
+    def handler(req):
+        body = json.loads(req.content)
+        seen.append((body["query"], body["variables"]))
+        if "commentUpdate" in body["query"]:
+            return httpx.Response(200, json={"data": {"commentUpdate": {
+                "success": True}}})
+        return httpx.Response(200, json={"data": {"projectUpdateUpdate": {
+            "success": True}}})
+    pmo = LinearAdapter("k", transport=httpx.MockTransport(handler))
+    run(pmo.edit_feed(MissionRef("uuid-i1", "issue"), "cm-9", "new `devcake:v1`"))
+    assert "commentUpdate" in seen[-1][0]
+    assert seen[-1][1] == {"id": "cm-9", "b": "new `devcake:v1`"}
+    run(pmo.edit_feed(MissionRef("uuid-p1", "project"), "pu-1", "new `devcake:v1`"))
+    assert "projectUpdateUpdate" in seen[-1][0]
+    assert seen[-1][1] == {"id": "pu-1", "b": "new `devcake:v1`"}
+    assert pmo.capabilities().feed_collapsible == FOLD_PLUS
+
+    rec = Recorder({"commentUpdate": {"commentUpdate": {"success": False}}})
+    pmo = LinearAdapter("k", transport=httpx.MockTransport(rec.handler))
+    with pytest.raises(RuntimeError) as ei:
+        run(pmo.edit_feed(MissionRef("uuid-i1", "issue"), "cm-9", "new"))
+    assert not isinstance(ei.value, PMOTransient)
 
 
 def test_post_feed_reply_carries_parent_and_returns_the_comment_id():

--- a/app/tests/test_steward.py
+++ b/app/tests/test_steward.py
@@ -33,6 +33,7 @@ class MapPMO:
         self.activity = activity
         self.relations = []
         self.comments = []
+        self.edits = []                   # (pmo_id, entry_id, markdown)
         self.activity_calls = []
         self._relations_supported = relations_supported
 
@@ -48,6 +49,9 @@ class MapPMO:
 
     async def post_feed(self, ref, markdown, *, reply_to=None):
         self.comments.append((ref.pmo_id, markdown))
+
+    async def edit_feed(self, ref, entry_id, markdown):
+        self.edits.append((ref.pmo_id, entry_id, markdown))
 
     async def get_activity(self, ref, full=False):
         self.activity_calls.append(full)
@@ -914,6 +918,13 @@ class RoutePMO(MapPMO):
         ).entries.append(ActivityEntry(
             ts=NOW, author="devcake", kind="comment", body=markdown,
             entry_id=f"e{len(self.comments)}"))
+
+    async def edit_feed(self, ref, entry_id, markdown):
+        await super().edit_feed(ref, entry_id, markdown)
+        feed = self.feeds.get(ref.pmo_id)
+        for e in (feed.entries if feed else []):
+            if e.entry_id == entry_id:
+                e.body = markdown       # in place: same id, same ts (ADR-0042 §3)
 
     async def swap_labels(self, ref, remove, add):
         self.swaps.append((ref.pmo_id, set(remove), set(add)))

--- a/app/tests/test_transitions.py
+++ b/app/tests/test_transitions.py
@@ -21,6 +21,7 @@ from devcake.domain.run import Run
 from devcake.domain import backend_health
 from devcake.domain.orchestrator import dispatch, feed, sweeps
 from devcake.domain.orchestrator.markers import FEED_INLINE_MAX, REPLY_MARKER
+from devcake.ports.pmo import FOLD_DETAILS
 
 
 class FakePMO:
@@ -43,6 +44,7 @@ class FakePMO:
             comment_max_chars=getattr(self, "comment_max_chars", None),
             feed_delta=getattr(self, "feed_delta", False),
             feed_threads=getattr(self, "feed_threads", False),
+            feed_collapsible=getattr(self, "feed_collapsible", FOLD_DETAILS),
         )
 
     async def feed_changes_since(self, team_ref, since, *, limit_pages):
@@ -93,7 +95,29 @@ class FakePMO:
         cid = f"c{len(self.comments)}"
         self.threads = getattr(self, "threads", [])
         self.threads.append((cid, reply_to))
+        if getattr(self, "record_feed", False):
+            # opt-in: the post ALSO lands on the feed this fake serves, so a
+            # later edit_feed / get_activity(full=True) finds it (ADR-0042)
+            self.activity_entries.append(ActivityEntry(
+                ts=datetime.now(timezone.utc), author="devcake", kind="comment",
+                body=markdown, entry_id=cid, parent_id=reply_to))
         return cid
+
+    async def edit_feed(self, ref, entry_id, markdown):
+        self._check_ref(ref)
+        if ref.kind == "project":
+            self.project_update_edits = getattr(self, "project_update_edits", [])
+            self.project_update_edits.append((ref.pmo_id, entry_id, markdown))
+        else:
+            self.edits = getattr(self, "edits", [])
+            self.edits.append((ref.pmo_id, entry_id, markdown))
+        found = False
+        for e in self.activity_entries:
+            if e.entry_id == entry_id:
+                e.body = markdown       # ts unchanged: an edit never moves the entry
+                found = True
+        if not found and getattr(self, "strict_edits", False):
+            raise RuntimeError("entry not found")
 
     async def swap_labels(self, ref, remove, add):
         self._check_ref(ref)

--- a/docs/05-pmo-adapter.md
+++ b/docs/05-pmo-adapter.md
@@ -60,6 +60,11 @@ class PMOPort(Protocol):
         # (03 §8: threading is presentation, never content).
         # Feed POLICY (redaction, sentinel, suppression) is the orchestrator's
         # job; transport is the adapter's.
+    async def edit_feed(self, ref: MissionRef, entry_id: str, markdown: str) -> None: ...
+        # whole-body replace of an entry DevCake posted earlier (ADR-0042 §3, §5):
+        # kind-dispatched like post_feed, same markdown fidelity, the adapter
+        # never composes. A vanished entry is a PERMANENT failure (the caller
+        # posts anew); the id and creation time survive, so the entry never moves.
     async def set_status(self, ref: MissionRef, status: NormalizedStatus) -> None: ...
     async def cancel_mission(self, ref: MissionRef) -> None: ...
         # terminal cancel/archive — used by decomposition (issue children) and
@@ -121,6 +126,7 @@ class PMOCapabilities(BaseModel):
     updated_at_tracks_comments: bool = False  # the item's updated_at moves when a top-level comment is posted (Linear: True — a threaded reply does not move it; the feed-changes witness lists replies); False keeps the feed memo's safety rescan (04 §1)
     feed_delta: bool = False          # a team-wide feed-changes read exists (Linear, Gitea Issues: True); one read per cycle keeps memoized scans (04 §1)
     feed_threads: bool = False        # post_feed can nest an entry under an earlier one via reply_to (Linear: True); False ⇒ every post lands top level (03 §8)
+    feed_collapsible: FoldSyntax = "" # the feed fold's collapsible syntax family (ADR-0042 §3) — "" flat, "details" (`<details><summary>`: Gitea, GitHub, GitLab Issues), "plus" (`+++ Title … +++`: Linear); the one vendor-specific rendering decision, taken by the feed chokepoint
 
 class FeedChange(BaseModel):          # one changed feed entry — never its text
     pmo_id: str
@@ -167,7 +173,7 @@ One governor (`adapters/budget.py`) sits in front of every PMO adapter's wire ca
 
 ## 3. Normalization tables (normative)
 
-Everything below is **adapter internals behind the port** — the unified `get(ref)` dispatches to `_get_issue`/`_get_project`, `set_status` to `_set_issue_status`/`_set_project_status`, `swap_labels` to `_swap_issue_labels`/`_swap_project_labels`, and `post_feed` to `commentCreate`/`projectUpdateCreate`. The domain only ever sees the port surface of §1.
+Everything below is **adapter internals behind the port** — the unified `get(ref)` dispatches to `_get_issue`/`_get_project`, `set_status` to `_set_issue_status`/`_set_project_status`, `swap_labels` to `_swap_issue_labels`/`_swap_project_labels`, `post_feed` to `commentCreate`/`projectUpdateCreate`, and `edit_feed` to `commentUpdate`/`projectUpdateUpdate`. The domain only ever sees the port surface of §1.
 
 Linear workflow states carry a fixed `type` enum. DevCake maps by **type**, never by display name (teams rename states freely):
 
@@ -208,6 +214,7 @@ Projects: Linear Project statuses come in five fixed categories — Backlog, Pla
 ## 4. Feed posts, transcripts, and attachments
 
 - `post_feed(ref, markdown, reply_to=)` → issue: `commentCreate(input: {issueId, body[, parentId]})`, returning the created comment's id; project: `projectUpdateCreate(input: {projectId, body})` — Linear's project-native feed, no threads (the keyword is ignored there). Body is Markdown either way. Linear threads are one level deep — a reply is a `Comment` whose `parent` is set, listed in the issue's own comments connection with `parent { id }`, which the full activity read maps to `parent_id` — so `reply_to` always names a top-level comment (`feed_threads=True`).
+- `edit_feed(ref, entry_id, markdown)` → issue: `commentUpdate(id, input: {body})`; project: `projectUpdateUpdate(id, input: {body})` — a whole-body replace of DevCake's own entry (ADR-0042 §3). A falsy `success` raises (permanent); a comment Linear no longer has comes back as a GraphQL error, permanent too. Verified live: the comment keeps its id and `createdAt`, and a `+++ Title … +++` body round-trips byte-identical — Linear renders that fence as a native collapsible section and an HTML `<details>` block as literal text, hence `feed_collapsible="plus"`.
 - **Attachment-first feed policy (feed hygiene):** the activity feed is for *messages* — directives, short specifications, token reports, status notes. Bulk markdown always goes up as `.md` attachments referenced from a short sentinel-signed comment. This policy lives in the **orchestrator**, not the adapter (the port note in §1: policy above, transport below):
   - **Transcripts** (ADR-0014: the FULL session dump — every assistant-visible text block of the run) on the **issue mission-step** finalize path are uploaded as `{seq}_{TYPE}.md` attachments; the step comment keeps the backticked filename (the seq-derivation marker) + asset link **and carries the Dev's last message inline as a `>`-blockquote** (redacted, truncated at 2048 chars with a pointer to the attachment, posted with the externalization opt-out — the full text already rides the attachment). Quoting is the ADR-0014 D2 quarantine: `>`-quoted lines never count in any feed scan. Old-image payloads without a last message post the pointer-only comment. If the attachment upload fails (INV-5 on this path), the dump posts inline — blockquoted, with only the marker header unquoted. Truly FAILED / STEWARD / CURATOR are outside the feed-post requirement (`00-overview.md` INV-5); project-kind feed behavior is unchanged and not newly authorized by that ruling.
   - **Answer comment** (`<!-- DEVCAKE-REPLY -->`, producer half of a public answer-delivery contract for downstream feed consumers — consumers match on `startswith`, so a quoted or relayed copy of the marker never classifies as the real answer): finalize posts the Dev's last message as **its own issue comment**, marker first, body fully `>`-blockquoted (ADR-0014 D2), `externalize=False`, redacted before truncate at 2048 chars. Truncation points at the step transcript (this comment has no attachment of its own — it never claims one exists). Empty/missing last message ⇒ no post. Issues only (the contract is defined on the issue comment feed; project feeds are a different surface). **REVIEW + `reviewed` is suppressed** so a trailing approve/reject "LGTM" cannot displace the EXECUTE answer for consumers that take the newest REPLY as the mission's answer; `human_needed` on any type (including REVIEW) still posts. Intermediate ONBOARD/PLAN/EXECUTE replies are intentional progressive posts consumers may use or ignore. Constants live in `orchestrator/markers.py` (`REPLY_MARKER`) — the marker string is frozen; renaming breaks external consumers.
@@ -286,6 +293,7 @@ docker compose exec -T app python - < scripts/contract_tests_pmo.py
 | 13 | Attachment upload/download round-trip |
 | 14 | `create_relation` + `blocked_by` (duplicate-tolerant) when `relations_supported` |
 | 15 | Project full-mode mirrors the native feed (posted update round-trips; shallow stays `entries=[]`) when `projects_supported` — skips cleanly without a discoverable project |
+| 16 | `edit_feed` replaces DevCake's own entry in place: a posted card edited into one carrying a fold in the vendor's `feed_collapsible` family with a routed marker inside reads back as the same entry (one entry with that id, marker present, sentinel last) and the feed has not grown |
 
 The numbering is historical and stable (test files reference rows by number). The gaps are covered elsewhere: row 6 (attachment-first feed policy, > 2048-char externalization, inline fallback) is orchestrator policy, tested in `app/tests/test_transitions.py`; row 7 (`create_mission` labeling/priority/team scoping) is exercised through the decomposition tests; Linear-specific relation GraphQL parsing also has hermetic coverage in `app/tests/test_linear_relations.py`.
 
@@ -332,6 +340,7 @@ Internal vs external is **only** `api_base` + token + board path — one system,
 - **Feed:** issue comments; markdown markers round-trip byte-for-byte (live-verified). Gitea pages oldest-first; `paginate_rest_newest` keeps the newest pages at the ceiling (same newest-first survival as Linear).
 - **Feed changes:** `GET …/issues/comments?since=<RFC 3339>` lists the repository's issue comments changed after the moment, walked until an empty page or the header's last page (a server may clamp `limit`; a short page is not the last page) up to the caller's cap (`truncated` past it); pull-request comments are skipped, an unreadable timestamp skips its row, and the mission is the issue index at the end of the comment's `issue_url` (`feed_delta=True`). A removed comment is not listed — the feed memo's safety rescan, which this vendor keeps, catches it.
 - **Threads:** none (`feed_threads=False`) — `post_feed` accepts the port's `reply_to`, posts top level with the same body, and returns the comment id.
+- **Edits:** `PATCH …/issues/comments/{id}` with `{body}` — `edit_feed` replaces the whole body of DevCake's own comment (ADR-0042 §3); the comment is addressed by repository + id, so the issue in `ref` only gates the kind. Id and `created_at` survive; a vanished comment is a 404 → permanent error. `feed_collapsible="details"` (`<details><summary>` renders collapsed).
 - **Attachments:** multipart `POST …/issues/{index}/assets`. Gitea returns `browser_download_url` with **ROOT_URL** / `GITEA_UI_URL` (bundled: `localhost:3300`); the adapter rewrites **presentation hosts** (`api_base` host, `GITEA_UI_URL` host, loopback) onto `api_base` so the app container can download, pins path to `/attachments/` and origin netloc, and refuses off-allowlist redirects with the PMO token (docs/14 §11). Operator use of the Gitea UI and direct git remains unrestricted.
 
 ### 9.4 The default board (ADR-0030) — and manual setup for external Gitea
@@ -367,7 +376,7 @@ Expect all rows **PASS** (1–5, 5b, 8–14 when `relations_supported`). Same sc
 
 GitHub Issues and GitLab Issues ship as **launch-supported** forge-issue adapters (same profile: issue-only, label stages, open→backlog, markdown comments, dependency/links). Registry `PMOSystemInfo.experimental=False`; `operator_note` still surfaces vendor API gaps (GitHub attachments; GitLab Premium/EE blocked-by links). Live `scripts/contract_tests_pmo.py` batteries remain useful ops proof but are not a blocker for the admin `experimental` flag. Shared cancel footer lives in `adapters/forge_issue.py` (not a second Issues Port).
 
-Neither declares `feed_delta`: `feed_changes_since` raises and the poll keeps its per-mission feed reads. GitHub exposes a repository-wide `issues/comments?since=` listing that could implement it; GitLab lists notes per issue only. Neither threads issue comments (`feed_threads=False`): `post_feed` accepts `reply_to`, posts top level with the same body, and returns the comment/note id.
+Neither declares `feed_delta`: `feed_changes_since` raises and the poll keeps its per-mission feed reads. GitHub exposes a repository-wide `issues/comments?since=` listing that could implement it; GitLab lists notes per issue only. Neither threads issue comments (`feed_threads=False`): `post_feed` accepts `reply_to`, posts top level with the same body, and returns the comment/note id. Both edit their own entries in place (`edit_feed`, ADR-0042 §3): GitHub `PATCH /repos/{owner}/{repo}/issues/comments/{id}` (repository-scoped id), GitLab `PUT /projects/:id/issues/:iid/notes/:id` (the note's address carries the issue iid — the reason the port takes `ref`). Id and `created_at` survive; a vanished entry is a 404 → permanent error. Both declare `feed_collapsible="details"`.
 
 ### 9.7 GitLab Issues (`gitlab_issues`)
 
@@ -377,7 +386,7 @@ Launch-supported forge-issue adapter — registry `experimental=False`. `team_ke
 |---|---|
 | Status | `opened`→backlog; `closed`→done; cancel footer in description → canceled |
 | Labels | PUT issue `labels=A,B` replaces the set |
-| Feed | issue notes; `` `devcake:v1` `` byte-exact |
+| Feed | issue notes; `` `devcake:v1` `` byte-exact; edit `PUT …/issues/:iid/notes/:id` |
 | Attachments | POST `/projects/:id/uploads`; download `GET /api/v4/projects/:id/uploads/:secret/:filename` (web `/uploads/…` path is **403** with a PAT) |
 | Relations | `blocks` / `is_blocked_by` is **Premium**. Listing links is Free (top-level `iid` + `link_type`). Unprobed starts as "try the write" so the domain gate actually calls `create_relation`. Free gitlab.com → 403: no-op and latch `relations_supported=False`. Health reports `unprobed` / `on` / `off`. Row 14 of the contract battery records SKIP, not a vanished pass. |
 
@@ -391,7 +400,7 @@ Launch-supported forge-issue adapter — registry `experimental=False`. `team_ke
 |---|---|
 | Status | `open`→backlog; `closed`→done; cancel footer in body → canceled |
 | Labels | PUT `/issues/{n}/labels` replaces the set |
-| Feed | issue comments; `` `devcake:v1` `` byte-exact. Oldest-first pages; `paginate_rest_newest` keeps the newest at the ceiling. |
+| Feed | issue comments; `` `devcake:v1` `` byte-exact. Oldest-first pages; `paginate_rest_newest` keeps the newest at the ceiling. Edit `PATCH …/issues/comments/{id}`. |
 | Attachments | **No official API.** `attachments_supported=False` (founder option B). `upload_attachment` raises. `comment_max_chars=65536`. Feed chokepoint posts the full body as sequential `Part i of n` comments (each ≤ the cap, each sentinel-signed, at most `MAX_VENDOR_COMMENT_PARTS`). startswith-markers stay the first line of part 1. |
 | Relations | Works on personal repos if `issue_id` is the global numeric id. Duplicate → 422 `already been taken`. |
 

--- a/scripts/contract_tests_pmo.py
+++ b/scripts/contract_tests_pmo.py
@@ -3,7 +3,8 @@
 System-agnostic: builds the adapter via ``make_pmo``. Fixture create/cleanup
 use **only** port methods (``create_mission`` / ``cancel_mission``).
 
-Tests 1–5 & 8–10 (M2) + 11–14 (cancel, markers, attachments, relations).
+Tests 1–5 & 8–10 (M2) + 11–16 (cancel, markers, attachments, relations,
+project mirror, edit_feed in place).
 Forge-issue systems (``gitea_issues``) use the documented profile variants
 (open→backlog; no projects; priority always medium).
 
@@ -37,10 +38,10 @@ from devcake.domain.model import ALL_LABELS, MissionRef
 from devcake.ports.pmo import PMOTransient
 
 PASS, FAIL, SKIP = "PASS", "FAIL", "SKIP"
-# Pinned check count (ids 1,2,3,4,5,5b,8,9,10,11,12,13,14,15). A vanished
+# Pinned check count (ids 1,2,3,4,5,5b,8,9,10,11,12,13,14,15,16). A vanished
 # check must fail the battery — never self-grade N/N from len(results)
 # alone (CAKE-83). SKIP rows still count toward EXPECTED_ROWS.
-EXPECTED_ROWS = 14
+EXPECTED_ROWS = 15
 results: list[tuple[str, str, str]] = []
 
 GITEA_URL = os.environ.get("DEVCAKE_CONTRACT_GITEA_URL", "http://gitea:3000")
@@ -529,6 +530,39 @@ async def _run_battery(pmo, system: str, team: str) -> int:
                 ok15, note15 = False, str(e)[:160]
             check("15", "project full-mode mirrors the native feed",
                   ok15, note15)
+
+    # ── 16 edit_feed replaces DevCake's own entry in place (ADR-0042 §3) ─
+    # Post a card, edit it into one carrying a fold in the vendor's syntax
+    # family (`capabilities().feed_collapsible`) with a routed marker inside
+    # and the sentinel last; read back full: exactly one entry with that id,
+    # the marker present, the sentinel still the last bytes, and the feed
+    # still one entry long — an edit is never a new entry.
+    eid = await make_temp_issue(pmo, team, "[CONTRACT] edit_feed in place",
+                                {"DEVCAKE"})
+    ok16, note16 = True, ""
+    try:
+        ref16 = MissionRef(eid, "issue")
+        cid16 = await pmo.post_feed(ref16, "card `devcake:v1`")
+        routed = "`devcake:discovery-routed:v1 step=1 to=-`"
+        if caps.feed_collapsible == "details":
+            fold = f"<details><summary>Details</summary>\n\n{routed}\n\n</details>"
+        else:
+            fold = f"+++ Details\n\n{routed}\n\n+++"
+        await pmo.edit_feed(ref16, cid16, f"card\n\n{fold}\n\n`devcake:v1`")
+        act = await pmo.get_activity(ref16, full=True)
+        mine = [e for e in act.entries if e.entry_id == cid16]
+        ok16 = (cid16 is not None and len(mine) == 1 and len(act.entries) == 1
+                and routed in mine[0].body
+                and mine[0].body.rstrip().endswith("`devcake:v1`"))
+        note16 = "" if ok16 else (
+            f"id={cid16!r} matching={len(mine)} entries={len(act.entries)} "
+            f"marker={any(routed in e.body for e in act.entries)}")
+    except Exception as e:
+        ok16, note16 = False, str(e)[:160]
+    finally:
+        await cleanup_issue(pmo, eid)
+    check("16", "edit_feed replaces DevCake's own entry in place",
+          ok16, note16)
 
     width = max((len(n) for _, n, _ in results), default=0)
     failures = skips = 0


### PR DESCRIPTION
## Why

ADR-0042 ("the feed for readers") arranges the mission feed into step cards with a collapsed fold for the bookkeeping and one status comment edited in place. Both need two seams the PMO port did not have: a way to **replace the whole body of an entry DevCake posted earlier**, and a way for the feed chokepoint to learn **which collapsible syntax the vendor renders** without ever naming a vendor. This is PR-1 of the plan: the port, the capability, the four adapters and their contract gates — purely additive. No domain code calls `edit_feed` yet.

## What

- **Port** (`app/devcake/ports/pmo.py`): `edit_feed(ref, entry_id, markdown)` — whole-body replace, kind-dispatched like `post_feed`, same markdown-fidelity requirement, the adapter never composes (no vendor-side read-modify-write window). An entry the vendor no longer has is a **permanent** failure, never `PMOTransient` — the caller falls back to a new post. The id and creation time survive, so an edited entry never moves in the feed and never becomes "new" to a watermark reader. Port-level fold constants `FOLD_NONE` / `FOLD_DETAILS` / `FOLD_PLUS` + `FoldSyntax`, and `PMOCapabilities.feed_collapsible` (default `""`, the flat rendering).
- **Linear**: `commentUpdate(id, input:{body})` for issues, `projectUpdateUpdate` for projects; a falsy `success` raises `RuntimeError`. `feed_collapsible=FOLD_PLUS` — the `+++ Title … +++` fence is what Linear renders as a native toggle (a `<details>` block renders as literal text); verified live that the edit keeps the comment id and `createdAt` and the body round-trips byte-identical.
- **Gitea / GitHub**: `PATCH …/issues/comments/{id}` (repository-scoped comment id; the issue in `ref` only gates the kind). **GitLab**: `PUT …/issues/{iid}/notes/{id}` — the note's address carries the issue, which is why the port takes `ref`. All three declare `FOLD_DETAILS`. Errors ride each adapter's existing request helper: 429/5xx → `PMOTransient`, 4xx → the adapter's permanent error family (a vanished entry is a 404).

## Tests

- `test_pmo_contract.py`: the pinned port surface gains `edit_feed`; a Linear kind-dispatch test (`commentUpdate` gets `{"id", "b"}` for an issue ref, `projectUpdateUpdate` for a project ref) and a `{"success": false}` reply raises `RuntimeError`, not `PMOTransient`. `test_fakes_do_not_drift_from_port` now enforces the fake signatures.
- One round-trip test per issue vendor (`test_gitea_issues_contract.py`, `test_github_issues_contract.py`, `test_gitlab_issues_contract.py`): post → `edit_feed` with a `<details>` fold carrying a routed marker → `get_activity(full=True)`: same `entry_id`, same `ts`, new body, no new entry, the exact endpoint/method on the wire, and an unknown id is the permanent error.
- Fakes: `fake_pmo_capabilities(feed_collapsible=FOLD_DETAILS)`; `FakePMO.edit_feed` (records `edits` / `project_update_edits`, rewrites the matching `activity_entries` body in place, `strict_edits`) plus opt-in `record_feed` (posts land on the served feed as `ActivityEntry`s); `MapPMO.edit_feed` records, `RoutePMO.edit_feed` also rewrites the entry in its feed.
- Live battery `scripts/contract_tests_pmo.py`: row 16 — post a card, edit it into one carrying a fold in the vendor's `feed_collapsible` family with a routed marker inside and the sentinel last; read back: exactly one entry with that id, marker present, sentinel last, feed still one entry long. `EXPECTED_ROWS` 14 → 15; `test_contract_battery_honesty.py` re-pinned. CI proves it on the Gitea lane; the Linear lane is a one-off manual run on the local rig.
- `ruff check app` clean; targeted set 390 passed; full suite 3344 passed with only the 70 pre-existing environment failures (backup CLI, live messaging, image pins, …) that fail identically on `main`.

## Docs

`docs/05-pmo-adapter.md`: port listing gains `edit_feed`; capability table gains `feed_collapsible`; §3 dispatch sentence and §4 gain the two Linear mutations; §9.3 (Gitea), §9.6/9.7/9.8 (GitHub/GitLab) gain their edit endpoints; the battery table gains row 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVp9ty5CFCjT6PphDe24MH
