### PR TITLE
feat(feed): folds, step cards, notices and the unfolding projection (ADR-0042 PR-3)

### DIFF
--- a/app/devcake/domain/orchestrator/feed.py
+++ b/app/devcake/domain/orchestrator/feed.py
@@ -4,19 +4,22 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import Iterator, Sequence
 
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
-from ...ports.pmo import PMOTransient
+from ...ports.pmo import FOLD_DETAILS, FOLD_PLUS, PMOTransient
 from ...security import redact
 from ..model import Mission, MissionRef, STAGE_LABELS
 from ..run import utcnow
 from . import markers
-from .markers import (COMMENT_SENTINEL, DELIVERABLE_MARKER, FEED_INLINE_MAX,
-                      PART_LINE, PLAN_FILE, REPLY_MARKER, SENTINEL_RE,
-                      STEP_MARKER)
+from .markers import (ANSWER_TOKEN_RE, COMMENT_SENTINEL, DELIVERABLE_MARKER,
+                      FEED_INLINE_MAX, PART_LINE, PLAN_FILE, REPLY_MARKER,
+                      SENTINEL_RE, STATUS_MARKER_RE, STEP_MARKER)
 
 log = logging.getLogger("devcake.missions")
 tracer = trace.get_tracer("devcake")
@@ -179,11 +182,19 @@ def _step_filename(reconstructed: str) -> str | None:
 
 
 def _substance(filename: str, reconstructed: str) -> str:
-    """Linear-shaped attachment bytes from a reconstructed feed comment."""
+    """Linear-shaped attachment bytes from a reconstructed feed comment.
+
+    A step card (ADR-0042) that had to carry its dump inline keeps it as
+    the fold's `Transcript (inline)` section: only that section's quoted
+    lines are the dump. A pre-card body (no such section) is read as it
+    always was — the quoted region from its first `>` line on."""
     if filename.startswith("PLAN_"):
         parts = reconstructed.split("\n\n", 1)
         return parts[1] if len(parts) > 1 else reconstructed
     lines = reconstructed.splitlines()
+    inline = _inline_transcript_lines(lines)
+    if inline is not None:
+        lines = inline
     i = 0
     while i < len(lines) and not (lines[i].startswith(">") or lines[i] == ">"):
         i += 1
@@ -203,22 +214,22 @@ def _substance(filename: str, reconstructed: str) -> str:
     return text
 
 
-def coalesced_step_files(entries) -> list[tuple[str, str, object]]:
-    """(filename, content, first_entry) from paginated or single inline steps.
-
-    The inverse of `_feed`'s vendor-cap split. activity_payload only calls
-    this — it must not re-parse Part labels.
-    """
-    out: list[tuple[str, str, object]] = []
+def _page_groups(entries) -> Iterator[tuple[list, str | None]]:
+    """Walk a feed grouping DevCake's `Part i of n` pages back into one
+    post: yields (entries_of_the_post, reconstructed_body). A non-DevCake
+    entry yields ([entry], None). A lone page whose siblings are missing
+    yields ([entry], None) too — a partial post is never reconstructed.
+    The ONE walk shared by `coalesced_step_files` and the projection
+    (`unfold_entries`)."""
     i = 0
     n = len(entries)
     while i < n:
         e = entries[i]
         body = e.body or ""
         if not is_devcake_comment(body):
+            yield [e], None
             i += 1
             continue
-        page = strip_vendor_page(body)
         coords = _part_coords(body)
         if coords and coords[0] == 1 and coords[1] >= 2:
             total = coords[1]
@@ -234,17 +245,29 @@ def coalesced_step_files(entries) -> list[tuple[str, str, object]]:
                 group.append(nxt)
                 j += 1
             if len(group) == total:
-                reconstructed = join_vendor_comments(
-                    [g.body or "" for g in group])
-                name = _step_filename(reconstructed)
-                if name:
-                    out.append((name, _substance(name, reconstructed), e))
+                yield group, join_vendor_comments([g.body or "" for g in group])
                 i = j
                 continue
-        name = _step_filename(page)
-        if name and coords is None:
-            out.append((name, _substance(name, page), e))
+        if coords is None:
+            yield [e], strip_vendor_page(body)
+        else:
+            yield [e], None
         i += 1
+
+
+def coalesced_step_files(entries) -> list[tuple[str, str, object]]:
+    """(filename, content, first_entry) from paginated or single inline steps.
+
+    The inverse of `_feed`'s vendor-cap split. activity_payload only calls
+    this — it must not re-parse Part labels.
+    """
+    out: list[tuple[str, str, object]] = []
+    for group, reconstructed in _page_groups(entries):
+        if reconstructed is None:
+            continue
+        name = _step_filename(reconstructed)
+        if name:
+            out.append((name, _substance(name, reconstructed), group[0]))
     return out
 
 
@@ -448,3 +471,572 @@ def stage_of(mission: Mission) -> str | None:
     stage = mission.labels & STAGE_LABELS
     return next(iter(stage)) if stage else None
 
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ADR-0042 — the feed for readers: folds, step cards, notices, and the
+# unfolding projection. The shapes live HERE (the chokepoint owns every
+# direction of every shape); activity_payload only calls `unfold_entries`.
+# Every rendered body is handed to `_feed`/`_edit`, which append the
+# sentinel LAST — the fold closes before it (SENTINEL_RE anchors at the end
+# of the unquoted body; anything after the sentinel would flip the card to
+# 🧑 HUMAN and trip the Freshness Gate on DevCake's own record).
+# ═══════════════════════════════════════════════════════════════════════════
+
+@dataclass(frozen=True)
+class FoldSection:
+    """One record section inside a fold: the LEGACY comment text verbatim
+    (sentinel-free) under a fixed title. `at` is None for a section as old
+    as its comment; a late append (routing receipts, a deliverable note)
+    carries the append time so the projection unfolds it as an entry at
+    ITS time, not the comment's."""
+    title: str
+    body: str
+    at: datetime | None = None
+
+
+# fixed section vocabulary — the projection keys on these titles
+SECTION_ANSWER = "Answer"
+SECTION_TOKEN_REPORT = "Token report"
+SECTION_DISCOVERIES = "Discoveries"
+SECTION_TRANSITION = "Transition"
+SECTION_TRANSCRIPT_INLINE = "Transcript (inline)"
+SECTION_RUN = "Run"
+SECTION_ROUTING_RECEIPTS = "Routing receipts"
+SECTION_DELIVERABLE = "Deliverable"
+SECTION_RECORD = "Record"
+# the projection never emits these as entries — they describe the card
+_SILENT_SECTIONS = frozenset({SECTION_ANSWER, SECTION_RUN,
+                              SECTION_TRANSCRIPT_INLINE})
+
+# A section line: a glyph the head never uses, the bold title, an optional
+# append time. The glyph keeps an ordinary bold line (`**Result:**`, a bold
+# sentence in a notice head) from ever reading as a section.
+SECTION_GLYPH = "▸"
+SECTION_RE = re.compile(
+    r"^▸ \*\*(?P<title>[A-Z][^*\n]{0,40})\*\*"
+    r"(?: · at=(?P<at>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z))?$")
+_AT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+# fold wrappers per syntax family (PMOCapabilities.feed_collapsible). The
+# `plus` fence and the `details` element are verified live on their
+# vendors; "" renders the fold flat under a headed rule.
+DETAILS_FOLD_OPEN = "<details>\n<summary>{summary}</summary>"
+DETAILS_FOLD_CLOSE = "</details>"
+PLUS_FOLD_OPEN = "+++ {summary}"
+PLUS_FOLD_CLOSE = "+++"
+PLAIN_FOLD_OPEN = "▾ {summary}"
+PLAIN_FOLD_CLOSE = ""
+DEFAULT_SUMMARY = "Details"
+
+
+def _section_line(section: FoldSection) -> str:
+    line = f"{SECTION_GLYPH} **{section.title}**"
+    if section.at is not None:
+        line += f" · at={section.at.astimezone(timezone.utc):{_AT_FORMAT}}"
+    return line
+
+
+def fold_summary(sections: Sequence[FoldSection]) -> str:
+    """`Details — answer · token report · run`: the collapsed line a reader
+    sees, naming what the fold holds."""
+    names = [s.title.lower() for s in sections]
+    return f"{DEFAULT_SUMMARY} — " + " · ".join(names) if names else DEFAULT_SUMMARY
+
+
+def render_fold(sections: Sequence[FoldSection], *, collapsible: str,
+                summary: str | None = None) -> str:
+    """THE vendor-specific rendering (one function, one capability value):
+    the fold's wrapper for the syntax family; the inner grammar is the same
+    everywhere. Section bodies ride verbatim, so every backticked marker a
+    scan reads sits on its own unquoted line inside the fold."""
+    summary = summary or fold_summary(sections)
+    if collapsible == FOLD_DETAILS:
+        open_, close = DETAILS_FOLD_OPEN, DETAILS_FOLD_CLOSE
+    elif collapsible == FOLD_PLUS:
+        open_, close = PLUS_FOLD_OPEN, PLUS_FOLD_CLOSE
+    else:
+        open_, close = PLAIN_FOLD_OPEN, PLAIN_FOLD_CLOSE
+    parts = [open_.format(summary=summary)]
+    for sec in sections:
+        parts.append(_section_line(sec))
+        body = sec.body.strip("\n")
+        if body:
+            parts.append(body)
+    if close:
+        parts.append(close)
+    return "\n\n".join(parts)
+
+
+def _fold_opener(line: str) -> str | None:
+    if line == "<details>":
+        return FOLD_DETAILS
+    if line.startswith("+++ ") or line == "+++":
+        return FOLD_PLUS
+    if line.startswith("▾ "):
+        return ""
+    return None
+
+
+def strip_fold(body: str) -> tuple[str, str | None]:
+    """(head, fold_inner) — the text before the fold and the fold's inner
+    text (section lines + bodies, wrapper and summary line removed), or
+    (body, None) when the body carries no fold. Parses every family by
+    CONTENT regardless of the vendor: a wrong wrapper constant could break
+    a vendor's rendering, never the projection or a scan."""
+    text = unseal(body)
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith(">"):
+            continue
+        fam = _fold_opener(line)
+        if fam is None:
+            continue
+        head = "\n".join(lines[:i]).rstrip()
+        rest = lines[i + 1:]
+        if fam == FOLD_DETAILS:
+            # summary line, then everything up to the LAST closing tag
+            if rest and rest[0].startswith("<summary>"):
+                rest = rest[1:]
+            end = _rfind(rest, DETAILS_FOLD_CLOSE)
+            inner = rest[:end] if end is not None else rest
+        elif fam == FOLD_PLUS:
+            end = _rfind(rest, PLUS_FOLD_CLOSE)
+            inner = rest[:end] if end is not None else rest
+        else:
+            inner = rest
+        return head, "\n".join(inner).strip("\n")
+    return text, None
+
+
+def _rfind(lines: list[str], needle: str) -> int | None:
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i] == needle:
+            return i
+    return None
+
+
+def fold_sections(inner: str | None) -> list[FoldSection]:
+    """Split a fold's inner text on its section lines. Text before the
+    first section line belongs to no section and is dropped (a rendered
+    fold never has any)."""
+    out: list[FoldSection] = []
+    title: str | None = None
+    at: datetime | None = None
+    buf: list[str] = []
+
+    def flush():
+        if title is not None:
+            out.append(FoldSection(title, "\n".join(buf).strip("\n"), at))
+
+    for line in (inner or "").splitlines():
+        hit = SECTION_RE.match(line)
+        if hit:
+            flush()
+            title = hit.group("title")
+            stamp = hit.group("at")
+            at = (datetime.strptime(stamp, _AT_FORMAT).replace(tzinfo=timezone.utc)
+                  if stamp else None)
+            buf = []
+        elif title is not None:
+            buf.append(line)
+    flush()
+    return out
+
+
+def append_fold_section(body: str, section: FoldSection, *,
+                        collapsible: str) -> str:
+    """The late-bookkeeping append (ADR-0042 §3): `body` is a posted comment
+    (sentinel or not), the result is the same comment with `section` added
+    to its fold — created when a pre-card anchor has none — and the
+    summary line re-rendered. Sentinel-free: `_edit` re-seals. A paged
+    body (a vendor-cap split) is refused: its fold spans several entries
+    and cannot be edited as one — the caller posts instead."""
+    if _part_coords(body) is not None:
+        raise ValueError("paged comment — a fold cannot be appended across pages")
+    head, inner = strip_fold(body)
+    sections = fold_sections(inner) + [section]
+    return head.rstrip() + "\n\n" + render_fold(sections, collapsible=collapsible)
+
+
+def unseal(body: str | None) -> str:
+    """The body without its trailing provenance sentinel (and the blank line
+    before it) — the inverse of the seal `_feed`/`_edit` apply."""
+    text = body or ""
+    idx = text.rfind(COMMENT_SENTINEL)
+    if idx >= 0 and not text[idx + len(COMMENT_SENTINEL):].strip():
+        text = text[:idx]
+        if text.endswith("\n\n"):
+            text = text[:-2]
+        elif text.endswith("\n"):
+            text = text[:-1]
+    return text
+
+
+def _inline_transcript_lines(lines: list[str]) -> list[str] | None:
+    """The `Transcript (inline)` section's lines of a card body, or None
+    when the body has no such section (a pre-card transcript comment)."""
+    start = None
+    for i, line in enumerate(lines):
+        hit = SECTION_RE.match(line)
+        if hit and hit.group("title") == SECTION_TRANSCRIPT_INLINE:
+            start = i + 1
+            break
+    if start is None:
+        return None
+    out: list[str] = []
+    for line in lines[start:]:
+        if SECTION_RE.match(line) or line in (DETAILS_FOLD_CLOSE, PLUS_FOLD_CLOSE):
+            break
+        out.append(line)
+    while out and not out[-1].strip():
+        out.pop()                     # the blank line before the next section
+    return out
+
+
+# ── the step card ─────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class StepCardParts:
+    """Everything a step card renders. `answer_md` is the Dev's last
+    message, already redacted; the renderer quotes it (ADR-0014 D2) and
+    cuts it at a boundary. `transcript_url` None ⇒ the dump rides inline
+    as a fold section (no-attachment vendor / upload failed) and
+    `transcript_md` must be given. `sections` are the fold's record
+    sections in order (token report, discoveries, transition, run …)."""
+    seq: int
+    mission_type: str
+    glyph: str
+    outcome_word: str
+    result_line: str
+    next_line: str
+    transcript_name: str
+    transcript_url: str | None
+    sections: list[FoldSection] = field(default_factory=list)
+    answer_md: str | None = None
+    transcript_md: str | None = None
+    duration_s: float | None = None
+    cost_usd: float | None = None
+
+
+CARD_RE = re.compile(
+    r"^(?P<glyph>\S+) Step (?P<seq>\d+) · (?P<type>ONBOARD|PLAN|EXECUTE|REVIEW)"
+    r" · (?P<outcome>[^·\n]+?)(?: · (?P<rest>[^\n]*))?$")
+TRANSCRIPT_LINE_RE = re.compile(
+    r"^Transcript: `(?P<name>\d+_(?:ONBOARD|PLAN|EXECUTE|REVIEW)\.md)`"
+    r"(?: — \[download\]\((?P<url>\S+)\)| \(inline, in the details below\))$")
+ANSWER_CUT_NOTE = "… (truncated — full text in the attachment)"
+_LEGACY_REPLY_CUT_NOTE = "… (truncated — full text in the step transcript on this issue)"
+_SENTENCE_END = re.compile(r"[.!?…](?=\s)")
+
+
+def format_duration(seconds: float | None) -> str | None:
+    if seconds is None or seconds < 0:
+        return None
+    if seconds < 60:
+        return f"{int(round(seconds))} s"
+    minutes = int(round(seconds / 60))
+    if minutes < 90:
+        return f"{minutes} min"
+    return f"{minutes // 60} h {minutes % 60:02d} min"
+
+
+def card_header(glyph: str, seq: int, mission_type: str, outcome_word: str,
+                duration_s: float | None = None,
+                cost_usd: float | None = None) -> str:
+    parts = [f"{glyph} Step {seq} · {mission_type} · {outcome_word}"]
+    dur = format_duration(duration_s)
+    if dur:
+        parts.append(dur)
+    if cost_usd is not None:
+        parts.append(f"${cost_usd:.2f}")
+    return " · ".join(parts)
+
+
+def cut_at_boundary(text: str, budget: int = FEED_INLINE_MAX) -> tuple[str, bool]:
+    """Cut `text` under `budget` at a paragraph break, else at a sentence
+    end, else hard — never mid-sentence when a boundary exists past a
+    quarter of the budget (the `_chunk_text` rule). (text, was_cut)."""
+    if len(text) <= budget:
+        return text, False
+    floor = budget // 4
+    window = text[:budget]
+    cut = window.rfind("\n\n")
+    if cut >= floor:
+        return text[:cut].rstrip(), True
+    last = None
+    for m in _SENTENCE_END.finditer(window):
+        if m.end() >= floor:
+            last = m.end()
+    if last is not None:
+        return text[:last].rstrip(), True
+    return window.rstrip(), True
+
+
+def render_step_card(parts: StepCardParts, *, collapsible: str) -> str:
+    """One top-level comment per step (ADR-0042 §2): header line, the
+    Dev's answer quoted and cut at a boundary, Result/Next, the transcript
+    line (its backticked file token is the seq-derivation surface — exactly
+    one per card), then the fold. Sentinel-free: `_feed` seals it."""
+    lines = [card_header(parts.glyph, parts.seq, parts.mission_type,
+                         parts.outcome_word, parts.duration_s, parts.cost_usd)]
+    answer = (parts.answer_md or "").strip()
+    if answer:
+        cut, was_cut = cut_at_boundary(answer)
+        if was_cut:
+            cut = cut + "\n\n" + ANSWER_CUT_NOTE
+        lines.append(blockquote(cut))
+    lines.append(f"**Result:** {parts.result_line}\n**Next:** {parts.next_line}")
+    if parts.transcript_url:
+        lines.append(f"Transcript: `{parts.transcript_name}` — "
+                     f"[download]({parts.transcript_url})")
+    else:
+        lines.append(f"Transcript: `{parts.transcript_name}` "
+                     "(inline, in the details below)")
+    sections = list(parts.sections)
+    if not parts.transcript_url:
+        dump = blockquote(f"---\n\n{parts.transcript_md or ''}")
+        inline = FoldSection(SECTION_TRANSCRIPT_INLINE, dump)
+        # before the Run section, after every marker-bearing section, so a
+        # paged card keeps its markers on the earliest pages
+        run_at = next((i for i, s in enumerate(sections)
+                       if s.title == SECTION_RUN), len(sections))
+        sections.insert(run_at, inline)
+    lines.append(render_fold(sections, collapsible=collapsible))
+    return "\n\n".join(lines)
+
+
+# ── notices ───────────────────────────────────────────────────────────────
+
+NEEDS_YOU = "✋ **Needs you.**"
+FOR_THE_RECORD = "⚠️ **For the record.**"
+INFO = "ℹ️"
+
+
+def directive_lead(glyph: str, title: str) -> str:
+    return f"{glyph} **{title}.**"
+
+
+def leads_lead(src_key: str, step: int) -> str:
+    return f"📨 **Leads from {src_key}, step {step}.**"
+
+
+def record_section(legacy_body: str, at: datetime | None = None) -> FoldSection:
+    """Today's comment text, verbatim minus the sentinel — the section the
+    projection emits as the Dev's entry (ADR-0042 amendment: the fold
+    always carries the record; the head is for people)."""
+    return FoldSection(SECTION_RECORD, unseal(legacy_body).strip("\n"), at)
+
+
+def render_notice(lead: str, what: str, *, todo: str = "",
+                  sections: Sequence[FoldSection] = (),
+                  collapsible: str) -> str:
+    """A comment written to a person: lead + one sentence + what to do,
+    then the fold with the record. Sentinel-free: `_feed` seals it."""
+    head = f"{lead} {what}".strip()
+    parts = [head]
+    if todo:
+        parts.append(todo)
+    if sections:
+        parts.append(render_fold(sections, collapsible=collapsible))
+    return "\n\n".join(parts)
+
+
+# ── the status comment (a view) ───────────────────────────────────────────
+
+def is_status_comment(body: str | None) -> bool:
+    return is_devcake_comment(body) and bool(STATUS_MARKER_RE.search(unquoted(body)))
+
+
+def find_status_entry(entries) -> str | None:
+    """The OLDEST DevCake entry carrying the status marker with an id —
+    oldest so two instances that both created one converge on the same."""
+    for e in entries:
+        if e.entry_id and is_status_comment(e.body):
+            return e.entry_id
+    return None
+
+
+# ── the projection: the Dev's folder is unfolded from the record ─────────
+
+@dataclass
+class Projected:
+    """An ACTIVITY.md entry as the mirror renders it — an ActivityEntry's
+    fields plus `source`, the raw first entry it came from (the identity
+    `coalesced_step_files` keys its step files on)."""
+    ts: datetime
+    author: str
+    kind: str
+    body: str
+    attachments: list
+    entry_id: str | None
+    parent_id: str | None
+    source: object
+
+
+def _seal(body: str) -> str:
+    return body.rstrip("\n") + "\n\n" + COMMENT_SENTINEL
+
+
+def _aware(ts: datetime) -> datetime:
+    return ts if ts.tzinfo is not None else ts.replace(tzinfo=timezone.utc)
+
+
+def _projected(entry, body: str, *, ts: datetime | None = None,
+               attachments: list | None = None) -> Projected:
+    return Projected(ts=ts or entry.ts, author=entry.author, kind=entry.kind,
+                     body=body,
+                     attachments=list(entry.attachments) if attachments is None
+                     else attachments,
+                     entry_id=entry.entry_id, parent_id=entry.parent_id,
+                     source=entry)
+
+
+def legacy_transcript_body(name: str, run_id: str, url: str | None,
+                           answer_bq: str, inline_bq: str) -> str:
+    """The pre-card transcript comment, byte for byte (finalize's
+    `_post_transcript`): pointer + quoted answer with an attachment, header
+    + quoted dump without one."""
+    if url:
+        body = (f"🧾 DevCake transcript `{name}` (run `{run_id}`) — "
+                f"attached: [{name}]({url})")
+        return body + ("\n\n" + answer_bq if answer_bq else "")
+    return f"🧾 DevCake transcript `{name}` (run `{run_id}`)\n\n" + inline_bq
+
+
+def legacy_answer_body(answer_bq: str) -> str:
+    """The pre-card answer comment (`_post_reply`): the reply marker and the
+    quoted answer, its cut note pointing at the transcript on the issue."""
+    return REPLY_MARKER + "\n\n" + answer_bq.replace(
+        ANSWER_CUT_NOTE, _LEGACY_REPLY_CUT_NOTE)
+
+
+def _split_attachments(entry, transcript_name: str):
+    """(transcript refs, discovery refs, others) by attachment name."""
+    tr, disc, other = [], [], []
+    for att in entry.attachments:
+        name = (att.name or "").rsplit("/", 1)[-1]
+        if name == transcript_name:
+            tr.append(att)
+        elif name.startswith("DISCOVERY_") and name.endswith(".md"):
+            disc.append(att)
+        else:
+            other.append(att)
+    return tr, disc, other
+
+
+def unfold_card(group: list, reconstructed: str) -> list[Projected] | None:
+    """A step card → the entries the folder carried before ADR-0042:
+    transcript (with the quoted answer and the step file), answer (when
+    the card carries the answer token), then one entry per record section
+    in fold order — each at the card's time unless the section is a late
+    append. None when the body is not a card."""
+    first = group[0]
+    lines = reconstructed.splitlines()
+    if not lines or not CARD_RE.match(lines[0]):
+        return None
+    head, inner = strip_fold(reconstructed)
+    head_lines = head.splitlines()
+    tline = next((TRANSCRIPT_LINE_RE.match(l) for l in head_lines
+                  if TRANSCRIPT_LINE_RE.match(l)), None)
+    if tline is None:
+        return None
+    name, url = tline.group("name"), tline.group("url")
+    # the quoted answer: the maximal run of `>` lines before **Result:**
+    quoted = []
+    for line in head_lines[1:]:
+        if line.startswith("**Result:**"):
+            break
+        if line.lstrip().startswith(">"):
+            quoted.append(line)
+    answer_bq = "\n".join(quoted)
+    sections = fold_sections(inner)
+    by_title = {s.title: s for s in sections}
+    run_id = ""
+    if SECTION_RUN in by_title:
+        run_id = by_title[SECTION_RUN].body.strip().strip("`")
+    inline_bq = (by_title[SECTION_TRANSCRIPT_INLINE].body
+                 if SECTION_TRANSCRIPT_INLINE in by_title else "")
+    tr_refs, disc_refs, other_refs = _split_attachments(first, name)
+    out = [_projected(first, _seal(legacy_transcript_body(
+        name, run_id, url, answer_bq, inline_bq)),
+        attachments=tr_refs + other_refs)]
+    if SECTION_ANSWER in by_title and answer_bq:
+        out.append(_projected(first, _seal(legacy_answer_body(answer_bq)),
+                              attachments=[]))
+    for sec in sections:
+        if sec.title in _SILENT_SECTIONS:
+            continue
+        refs = disc_refs if sec.title == SECTION_DISCOVERIES else []
+        out.append(_projected(first, _seal(sec.body), ts=sec.at, attachments=refs))
+    return out
+
+
+def unfold_notice(group: list, reconstructed: str) -> list[Projected]:
+    """A DevCake comment with a fold → its Record section as the entry (the
+    legacy body, verbatim) plus every late section as its own entry; a
+    fold without a Record section keeps the head as the entry. No fold ⇒
+    the comment passes through unchanged."""
+    first = group[0]
+    head, inner = strip_fold(reconstructed)
+    if inner is None:
+        return [_projected(first, first.body or "")] if len(group) == 1 else [
+            _projected(first, _seal(reconstructed))]
+    sections = fold_sections(inner)
+    record = next((s for s in sections if s.title == SECTION_RECORD), None)
+    out = [_projected(first, _seal(record.body if record is not None else head))]
+    for sec in sections:
+        if sec is record or sec.at is None:
+            continue
+        out.append(_projected(first, _seal(sec.body), ts=sec.at, attachments=[]))
+    return out
+
+
+def unfold_entries(entries) -> list[Projected]:
+    """The mirror's entry list (ADR-0042 §8): cards unfold into the legacy
+    sequence, folded notices into their record, the status comment is
+    omitted (a view — every fact in it is already here; it stays on the
+    watermark), everything else passes through. Late sections land at
+    their own time (stable sort — vendor entries are already ascending)."""
+    out: list[Projected] = []
+    for group, reconstructed in _page_groups(entries):
+        first = group[0]
+        if reconstructed is None:
+            out.extend(_projected(e, e.body or "") for e in group)
+            continue
+        if is_status_comment(first.body):
+            continue
+        card = unfold_card(group, reconstructed)
+        if card is not None:
+            out.extend(card)
+            continue
+        out.extend(unfold_notice(group, reconstructed))
+    out.sort(key=lambda p: _aware(p.ts))
+    return out
+
+
+# ── the multi-file attachment pipe ───────────────────────────────────────
+
+async def post_attachments_comment(mgr, pmo_id: str, kind: str, *,
+                                   files: Sequence[tuple[str, str]],
+                                   comment_of,
+                                   reply_to: str | None = None) -> str | None:
+    """`post_attachment_comment` for several files at once (a step card
+    carries the transcript AND the discovery record): uploads each in
+    order, then posts `comment_of(urls)` where `urls` maps filename → url
+    or None (that upload failed → the builder's inline form for it)."""
+    urls: dict[str, str | None] = {}
+    supported = _attachments_supported(mgr)
+    for filename, content in files:
+        url = None
+        if supported:
+            try:
+                url = await mgr.pmo.upload_attachment(pmo_id, filename,
+                                                      content.encode())
+            except Exception:  # noqa: BLE001 — fall back to the builder's inline form
+                log.exception("attachment upload failed for %s — inline fallback",
+                              filename)
+        urls[filename] = url
+    body, externalize = comment_of(urls)
+    return await mgr._feed(pmo_id, kind, body, externalize=externalize,
+                           reply_to=reply_to)

--- a/app/devcake/domain/orchestrator/markers.py
+++ b/app/devcake/domain/orchestrator/markers.py
@@ -72,6 +72,24 @@ REPLY_MARKER = "<!-- DEVCAKE-REPLY -->"
 # says the zip is the audit copy, not the answer (docs/05 §4).
 DELIVERABLE_MARKER = "<!-- DEVCAKE-DELIVERABLE -->"
 
+# ADR-0042 §7 — no marker rides as an HTML comment (one vendor renders them
+# as text). The answer and the deliverable note are marked by backticked
+# tokens inside the step card's / notice's fold instead; the two HTML
+# markers above survive only as the PROJECTION's legacy shapes (the Dev's
+# ACTIVITY.md is unfolded from the record byte for byte) and on pre-card
+# feeds.
+ANSWER_TOKEN_RE = re.compile(r"`devcake:answer:v1 step=(\d+)`")
+DELIVERABLE_TOKEN = "`devcake:deliverable:v1`"
+# ADR-0042 §5 — the one status comment per mission, found again by this
+# token (oldest marked DevCake entry wins). A VIEW: never elevated, never
+# counted, omitted from the Dev's folder by the projection.
+STATUS_MARKER = "`devcake:status:v1`"
+STATUS_MARKER_RE = re.compile(r"`devcake:status:v1`")
+
+
+def answer_token(seq: int) -> str:
+    return f"`devcake:answer:v1 step={seq}`"
+
 # docs/03 §4.1 — merge-failure state markers, counted/located from the feed
 # so the state stays fully PMO-derivable (no local clocks or counters). The
 # comments carrying them are short by construction (< FEED_INLINE_MAX): the

--- a/app/tests/test_feed_folds.py
+++ b/app/tests/test_feed_folds.py
@@ -1,0 +1,289 @@
+"""ADR-0042 primitives (PR-3 of the plan): folds, step cards, notices and
+the unfolding projection in feed.py. No call site changes yet — these
+tests pin the shapes and the two invariants every later PR rests on: the
+sentinel stays the last bytes of every rendered body, and every marker a
+scan reads is found inside a fold on every syntax family."""
+from datetime import datetime, timezone
+
+import pytest
+
+from devcake.domain.model import ActivityEntry, AttachmentRef
+from devcake.domain.orchestrator import feed, freshness
+from devcake.domain.orchestrator.feed import (FoldSection, StepCardParts,
+                                              append_fold_section,
+                                              card_header, cut_at_boundary,
+                                              fold_sections, is_devcake_comment,
+                                              record_section, render_fold,
+                                              render_notice, render_step_card,
+                                              strip_fold, unfold_entries,
+                                              unquoted)
+from devcake.domain.orchestrator.markers import (ANSWER_TOKEN_RE,
+                                                 COMMENT_SENTINEL,
+                                                 CONFLICT_MARKER,
+                                                 FRESHNESS_MARKER,
+                                                 MERGE_RETRY_MARKER,
+                                                 REPLY_MARKER, STATUS_MARKER,
+                                                 STEP_MARKER, answer_token,
+                                                 discovery_in_keys,
+                                                 discovery_posts,
+                                                 discovery_receipts)
+from devcake.ports.pmo import FOLD_DETAILS, FOLD_NONE, FOLD_PLUS
+
+FAMILIES = (FOLD_DETAILS, FOLD_PLUS, FOLD_NONE)
+NOW = datetime(2026, 9, 9, 12, 0, tzinfo=timezone.utc)
+LATER = datetime(2026, 9, 9, 15, 30, tzinfo=timezone.utc)
+
+TOKEN_REPORT = ("🧮 DevCake token report — step 2 (EXECUTE, senior-dev)\n"
+                "model: m · input: 1 · output: 2\ncache read/write: 3/4\n"
+                "cost: $3.0500\nextraction: end_event\nrun: T-1-2-EXECUTE-AAAAAA")
+HARVEST = ("`devcake:discovery:v1 step=2 n=1`\n\n🔎 1 discovery from step 2 "
+           "(EXECUTE) — leads for related missions, routed separately.\n\n"
+           "`devcake:finding:v1 sha=0123456789ab`\n\n"
+           "Full record attached: [DISCOVERY_2.md](https://files.example/DISCOVERY_2.md)\n\n"
+           "**1.**\n> the config default changed\n> Evidence: src/config.py:42")
+TRANSITION = ("🔀 DevCake opened/updated the pull request: "
+              "https://forge.example/pr/8 — awaiting REVIEW.")
+
+
+def _sections(*, run=True):
+    out = [FoldSection("Answer", answer_token(2)),
+           FoldSection("Token report", TOKEN_REPORT),
+           FoldSection("Discoveries", HARVEST),
+           FoldSection("Transition", TRANSITION)]
+    if run:
+        out.append(FoldSection("Run", "`T-1-2-EXECUTE-AAAAAA`"))
+    return out
+
+
+def _card(collapsible, *, url="https://files.example/2_EXECUTE.md",
+          answer="Root cause: the skip gate.\n\nFix in the PR.", dump=None):
+    return render_step_card(StepCardParts(
+        seq=2, mission_type="EXECUTE", glyph="🔀", outcome_word="executed",
+        result_line="Pull request https://forge.example/pr/8.",
+        next_line="DevCake — REVIEW.", transcript_name="2_EXECUTE.md",
+        transcript_url=url, sections=_sections(), answer_md=answer,
+        transcript_md=dump, duration_s=12 * 60, cost_usd=3.05),
+        collapsible=collapsible)
+
+
+def _seal(body):
+    return body + "\n\n" + COMMENT_SENTINEL
+
+
+def _entry(body, ts=NOW, eid="c1", attachments=()):
+    return ActivityEntry(ts=ts, author="cake", kind="comment", body=body,
+                         entry_id=eid, attachments=list(attachments))
+
+
+# ── fold grammar ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("fam", FAMILIES)
+def test_fold_round_trips_sections_on_every_family(fam):
+    secs = [FoldSection("Token report", TOKEN_REPORT),
+            FoldSection("Routing receipts",
+                        "🧭 Discovery routing receipts:\n`devcake:discovery-routed:v1 step=2 to=-`",
+                        at=LATER)]
+    body = "head line\n\n" + render_fold(secs, collapsible=fam)
+    head, inner = strip_fold(_seal(body))
+    assert head == "head line"
+    got = fold_sections(inner)
+    assert [(s.title, s.body, s.at) for s in got] == \
+        [(s.title, s.body, s.at) for s in secs]
+    assert "Details — token report · routing receipts" in body
+
+
+def test_section_line_never_matches_head_or_legacy_lines():
+    for line in ("**Result:** Pull request x.", "**Next:** DevCake — REVIEW.",
+                 "✋ **Needs you.** The plan needs approval.",
+                 "**1.**", "🧮 DevCake token report — step 2 (EXECUTE, d)",
+                 "▸ **lowercase**", "**Token report**"):
+        assert feed.SECTION_RE.match(line) is None, line
+    assert feed.SECTION_RE.match("▸ **Token report**")
+    hit = feed.SECTION_RE.match("▸ **Routing receipts** · at=2026-09-09T15:30:00Z")
+    assert hit and hit.group("at") == "2026-09-09T15:30:00Z"
+
+
+def test_append_fold_section_extends_creates_and_refuses_paged():
+    base = _card(FOLD_DETAILS)
+    late = FoldSection("Routing receipts",
+                       "`devcake:discovery-routed:v1 step=2 to=T-9`", at=LATER)
+    grown = append_fold_section(_seal(base), late, collapsible=FOLD_DETAILS)
+    assert COMMENT_SENTINEL not in grown          # sentinel-free: _edit re-seals
+    titles = [s.title for s in fold_sections(strip_fold(grown)[1])]
+    assert titles == ["Answer", "Token report", "Discoveries", "Transition",
+                      "Run", "Routing receipts"]
+    assert "· routing receipts" in grown           # summary re-rendered
+    # a pre-card anchor (no fold) gains one
+    legacy = _seal("🧾 DevCake transcript `1_ONBOARD.md` (run `r`) — attached: [1_ONBOARD.md](u)")
+    created = append_fold_section(legacy, late, collapsible=FOLD_PLUS)
+    assert created.startswith("🧾 DevCake transcript") and "+++ Details" in created
+    assert fold_sections(strip_fold(created)[1])[0].title == "Routing receipts"
+    with pytest.raises(ValueError):
+        append_fold_section("Part 1 of 2\n\n" + base, late, collapsible=FOLD_DETAILS)
+
+
+# ── the step card ───────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("fam", FAMILIES)
+def test_card_invariants_on_every_family(fam):
+    body = _seal(_card(fam))
+    assert is_devcake_comment(body)                         # sentinel last
+    assert not freshness._is_material(body)                 # never trips the gate
+    assert len(STEP_MARKER.findall(unquoted(body))) == 1    # one file token
+    text = unquoted(body)
+    assert discovery_posts(text) == [(2, 1)]
+    assert ANSWER_TOKEN_RE.search(text).group(1) == "2"
+    assert body.startswith("🔀 Step 2 · EXECUTE · executed · 12 min · $3.05\n\n> Root cause")
+    assert "Transcript: `2_EXECUTE.md` — [download](https://files.example/2_EXECUTE.md)" in body
+    assert "<!--" not in body                               # no HTML markers
+
+
+def test_every_scanner_finds_its_marker_inside_a_fold():
+    secs = [FoldSection("Markers", "\n".join([
+        "`devcake:conflict-resolve:2`", "`devcake:freshness-rereview:3`",
+        MERGE_RETRY_MARKER, "`devcake:discovery-routed:v1 step=1 to=T-4`",
+        "`devcake:discovery-in:v1 src=T-7 step=2`"]))]
+    for fam in FAMILIES:
+        text = unquoted(_seal("head\n\n" + render_fold(secs, collapsible=fam)))
+        assert max(int(m.group(1)) for m in CONFLICT_MARKER.finditer(text)) == 2
+        assert max(int(m.group(1)) for m in FRESHNESS_MARKER.finditer(text)) == 3
+        assert MERGE_RETRY_MARKER in text
+        assert discovery_receipts(text) == {(1, "T-4")}
+        assert discovery_in_keys(text) == {("T-7", 2)}
+
+
+def test_cut_at_boundary_prefers_paragraph_then_sentence():
+    text = "First paragraph. Still first.\n\nSecond paragraph is long. " * 40
+    cut, was_cut = cut_at_boundary(text, 300)
+    assert was_cut and cut.endswith("first.") or cut.endswith("long.")
+    assert len(cut) <= 300
+    no_para = "A sentence here. " * 40
+    cut, was_cut = cut_at_boundary(no_para, 200)
+    assert was_cut and cut.endswith(".") and len(cut) <= 200
+    assert cut_at_boundary("short", 100) == ("short", False)
+    cut, was_cut = cut_at_boundary("x" * 500, 100)
+    assert was_cut and len(cut) == 100
+
+
+def test_card_header_omits_unknowns():
+    assert card_header("✅", 3, "REVIEW", "approved") == "✅ Step 3 · REVIEW · approved"
+    assert card_header("✅", 3, "REVIEW", "approved", 42, None) == \
+        "✅ Step 3 · REVIEW · approved · 42 s"
+    assert card_header("✅", 3, "REVIEW", "approved", 100 * 60, 0.5) == \
+        "✅ Step 3 · REVIEW · approved · 1 h 40 min · $0.50"
+
+
+def test_inline_transcript_section_is_the_dump_for_step_files():
+    dump = "turn 1\n\nturn 2 with `devcake:discovery:v1 step=9 n=9` quoted"
+    body = _seal(_card(FOLD_DETAILS, url=None, dump=dump))
+    assert "Transcript: `2_EXECUTE.md` (inline, in the details below)" in body
+    assert discovery_posts(unquoted(body)) == [(2, 1)]    # the quoted dump never counts
+    files = feed.coalesced_step_files([_entry(body)])
+    assert [(n, c) for n, c, _ in files] == [("2_EXECUTE.md", dump)]
+    # a pre-card inline transcript still reconstructs as before
+    legacy = _seal("🧾 DevCake transcript `1_ONBOARD.md` (run `r`)\n\n"
+                   + feed.blockquote("---\n\n" + dump))
+    assert feed.coalesced_step_files([_entry(legacy)])[0][1] == dump
+
+
+# ── notices ─────────────────────────────────────────────────────────────────
+
+def test_notice_carries_the_record_and_unfolds_to_it():
+    legacy = ("🧩 Auto-merge hit a merge conflict on https://forge.example/pr/8 "
+              "— back to EXECUTE. `devcake:conflict-resolve:1`")
+    body = render_notice(feed.directive_lead("🧩", "Conflict-resolve directive"),
+                         "The merge conflicted; the next Dev syncs the branch.",
+                         sections=[record_section(_seal(legacy))],
+                         collapsible=FOLD_PLUS)
+    sealed = _seal(body)
+    assert is_devcake_comment(sealed)
+    assert CONFLICT_MARKER.search(unquoted(sealed)).group(1) == "1"
+    assert unquoted(sealed).count("conflict-resolve:1") == 1   # never doubled
+    [proj] = unfold_entries([_entry(sealed)])
+    assert proj.body == _seal(legacy)
+
+
+# ── the projection ──────────────────────────────────────────────────────────
+
+def _card_entry(fam, **kw):
+    refs = [AttachmentRef(url="https://files.example/2_EXECUTE.md", name="2_EXECUTE.md"),
+            AttachmentRef(url="https://files.example/DISCOVERY_2.md", name="DISCOVERY_2.md")]
+    return _entry(_seal(_card(fam, **kw)), attachments=refs)
+
+
+@pytest.mark.parametrize("fam", FAMILIES)
+def test_card_unfolds_into_the_legacy_sequence(fam):
+    out = unfold_entries([_card_entry(fam)])
+    assert [p.body for p in out] == [
+        _seal("🧾 DevCake transcript `2_EXECUTE.md` (run `T-1-2-EXECUTE-AAAAAA`) — "
+              "attached: [2_EXECUTE.md](https://files.example/2_EXECUTE.md)\n\n"
+              "> Root cause: the skip gate.\n>\n> Fix in the PR."),
+        _seal(REPLY_MARKER + "\n\n> Root cause: the skip gate.\n>\n> Fix in the PR."),
+        _seal(TOKEN_REPORT), _seal(HARVEST), _seal(TRANSITION)]
+    assert all(is_devcake_comment(p.body) for p in out)
+    assert all(p.ts == NOW and p.entry_id == "c1" for p in out)
+    assert [a.name for a in out[0].attachments] == ["2_EXECUTE.md"]
+    assert [a.name for a in out[3].attachments] == ["DISCOVERY_2.md"]
+    assert out[1].attachments == [] and out[2].attachments == []
+    assert out[0].source is not None
+
+
+def test_cut_answer_unfolds_with_the_legacy_cut_notes():
+    long = "Sentence one is here. " * 200
+    out = unfold_entries([_card_entry(FOLD_DETAILS, answer=long)])
+    assert out[0].body.count("… (truncated — full text in the attachment)") == 1
+    assert "full text in the step transcript on this issue" in out[1].body
+    assert "full text in the attachment" not in out[1].body
+
+
+def test_pointer_only_card_unfolds_without_an_answer_entry():
+    parts = StepCardParts(seq=1, mission_type="ONBOARD", glyph="📋",
+                          outcome_word="triaged", result_line="Needs a plan.",
+                          next_line="DevCake — PLAN.", transcript_name="1_ONBOARD.md",
+                          transcript_url="u", sections=[
+                              FoldSection("Token report", TOKEN_REPORT),
+                              FoldSection("Run", "`r`")])
+    body = _seal(render_step_card(parts, collapsible=FOLD_DETAILS))
+    out = unfold_entries([_entry(body)])
+    assert [p.body for p in out] == [
+        _seal("🧾 DevCake transcript `1_ONBOARD.md` (run `r`) — attached: [1_ONBOARD.md](u)"),
+        _seal(TOKEN_REPORT)]
+
+
+def test_late_sections_unfold_at_their_own_time_after_later_entries():
+    card = _seal(_card(FOLD_DETAILS))
+    grown = _seal(append_fold_section(card, FoldSection(
+        "Routing receipts", "🧭 receipts\n`devcake:discovery-routed:v1 step=2 to=-`",
+        at=LATER), collapsible=FOLD_DETAILS))
+    human = ActivityEntry(ts=datetime(2026, 9, 9, 13, 0, tzinfo=timezone.utc),
+                          author="felipe", kind="comment", body="please hurry",
+                          entry_id="h1")
+    out = unfold_entries([_entry(grown), human])
+    assert out[-2].body == "please hurry" and out[-1].body.startswith("🧭 receipts\n")
+    assert out[-1].ts == LATER and out[-1].entry_id == "c1"
+
+
+def test_status_comment_is_omitted_and_others_pass_through():
+    status = _seal("📌 **T-1 — status**\n\n" + render_fold(
+        [FoldSection("Record", STATUS_MARKER)], collapsible=FOLD_PLUS))
+    legacy = _seal("✅ REVIEW approved; PR merged (u). Mission done.")
+    human = ActivityEntry(ts=NOW, author="felipe", kind="comment",
+                          body="> quoting `devcake:v1`\n\nmy own words")
+    out = unfold_entries([_entry(status, eid="s1"), _entry(legacy, eid="c2"), human])
+    assert [p.body for p in out] == [legacy, human.body]
+    assert feed.is_status_comment(status) and feed.find_status_entry(
+        [_entry(legacy, eid="c2"), _entry(status, eid="s1")]) == "s1"
+
+
+def test_paged_card_unfolds_from_its_joined_pages():
+    dump = "line\n" * 400
+    body = _card(FOLD_DETAILS, url=None, dump=dump)
+    pages = feed.split_vendor_comments(body, 1200)
+    assert len(pages) >= 3
+    entries = [_entry(_seal(p), eid=f"p{i}") for i, p in enumerate(pages)]
+    out = unfold_entries(entries)
+    assert out[0].body.startswith("🧾 DevCake transcript `2_EXECUTE.md` (run `T-1-2-EXECUTE-AAAAAA`)\n\n> ---")
+    assert [p.entry_id for p in out] == ["p0"] * len(out)
+    files = feed.coalesced_step_files(entries)
+    assert [(n, c) for n, c, _ in files] == [("2_EXECUTE.md", dump.rstrip("\n"))] \
+        or [(n, c) for n, c, _ in files] == [("2_EXECUTE.md", dump)]

--- a/app/tests/test_structure_guards.py
+++ b/app/tests/test_structure_guards.py
@@ -593,6 +593,9 @@ def test_activity_payload_does_not_reimplement_feed_pagination():
         "_join_part_payloads", "_strip_part_and_sentinel", "_part_coords",
         "_substance", "_step_filename", "coalesced_step_files",
         "join_vendor_comments", "split_vendor_comments",
+        # ADR-0042: the unfolding projection is feed.py's too
+        "_page_groups", "strip_fold", "fold_sections", "unfold_card",
+        "unfold_notice", "unfold_entries",
     }
     defined = {n.name for n in tree.body
                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}


### PR DESCRIPTION
Third PR of the ADR-0042 plan (docs/adr/0042-feed-for-readers.md); primitives only, **no call-site change** — the feed DevCake posts today is byte-identical after this PR.

## What

- **Port**: `FOLD_NONE/FOLD_DETAILS/FOLD_PLUS` and `PMOCapabilities.feed_collapsible` (the fold's syntax family, never a vendor name). This hunk is shared with the `edit_feed` PR and drops out on rebase.
- **feed.py**: the fold grammar (`▸ **Title** · at=…` section lines), `render_fold` (the one vendor-specific function), `strip_fold`/`fold_sections` (parse every family by content), `append_fold_section` (late bookkeeping; refuses paged bodies), `unseal`; `render_step_card` with `cut_at_boundary` and `card_header`; notice leads, `render_notice`, `record_section`; `is_status_comment`/`find_status_entry`; the **projection** — `_page_groups` (lifted from `coalesced_step_files`), `unfold_card`, `unfold_notice`, `unfold_entries`; `_substance` reads a card's inline-transcript section; `post_attachments_comment`.
- **markers.py**: backticked answer/deliverable/status tokens; the two HTML-comment markers survive only as projection shapes.

## Verified live before this PR

On a scratch issue: both fold families round-trip byte-identical through the vendor APIs, an edit keeps the entry's id and creation time, the `+++` fence renders as a native toggle on the vendor that shows `<details>` as text, and HTML comments render as text there.

## Tests

`test_feed_folds.py` (21): fold round trip on every family; the section line never matches a head or legacy line; append/create/refuse-paged; card invariants (sentinel last, immaterial to the Freshness Gate, exactly one file token, no HTML marker); every real scanner finds its marker inside a fold; boundary cuts; header; inline transcript reconstructs the step file; a notice's record unfolds to the legacy body; a card unfolds into the legacy entry sequence with attachments split and the legacy cut notes; pointer-only card; late sections land at their own time; the status comment is omitted; a paged card unfolds from its joined pages. Structure guard bans the unfolders outside feed.py. Full suite: 3,361 passed; only the 70 known environment failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVp9ty5CFCjT6PphDe24MH