### PR TITLE
feat(feed): the status comment — one per mission, edited in place (ADR-0042 PR-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ See the living log and open candidates in
 Community surface added for public-repo hygiene (no LICENSE change in this
 track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).
 
+- **Added — one status comment per mission, kept current.** The first
+  thing a reader sees: what is happening now, the pull request, the cost
+  so far, and the step ladder with outcomes, durations and costs. It is
+  created by whichever dispatch finds the feed without one, so a
+  scheduled task starting at EXECUTE or a mission a person ordered into
+  REVIEW gets one too, and it is edited in place at every step end, park,
+  hand-off, merge event and completion. A view, never an ask: it points
+  at the notice when a person is needed, counts for nothing, and the Dev's
+  activity folder omits it.
+
 - **Changed — one step card per step on the mission feed.** A step used
   to post its transcript, its answer (under an HTML marker one vendor
   renders as text), its token report and its discoveries as separate

--- a/app/devcake/domain/orchestrator/completion.py
+++ b/app/devcake/domain/orchestrator/completion.py
@@ -41,8 +41,7 @@ from ...ports.pmo import CRITICAL_BOUNDED_WAIT_S, pmo_call, pmo_call_ctx
 from ..model import (LABEL_EXECUTE, LABEL_MERGE, LABEL_REVIEW, Mission,
                      MissionRef)
 from ..run import Run
-from . import freshness, steps
-from . import feed
+from . import feed, freshness, status_comment, steps
 from .feed import unquoted
 from .markers import CONFLICT_MARKER, MAX_CONFLICT_RESOLVES
 
@@ -160,6 +159,12 @@ async def complete_merged(mgr, cause: MergedCause, *, ref: MissionRef,
                 await mgr._checkpoint(run, steps.REVIEW_DONE, _core)
             else:
                 await _core()
+            # ADR-0042 §5 — the status comment reads "done" (a view; never
+            # a gate; inside the write-back class so a starved key does
+            # not refuse it)
+            await status_comment.refresh(
+                mgr, ref.pmo_id, reason=spec.audit_action, run=run,
+                mission=mission, pr_url=pr_url)
         anchor = posted[0] if posted else None
         try:
             if run is not None:
@@ -235,6 +240,9 @@ async def route_conflict_to_execute(mgr, pmo_id: str, key: str, pr_url: str,
                                        remove={from_label}, add={LABEL_EXECUTE})
         mgr._audit(pmo_id, "conflict_resolve_dispatched",
                     f"attempt {n + 1} ({pr_url})")
+        with write_back_class():
+            await status_comment.refresh(mgr, pmo_id, reason="conflict_routed",
+                                         pr_url=pr_url)
         return True
     except Exception:  # noqa: BLE001 — degrade with record: conflict routing failure is logged; caller keeps the mission parked for a human
         log.exception("conflict auto-resolve routing failed for %s", key)

--- a/app/devcake/domain/orchestrator/dispatch.py
+++ b/app/devcake/domain/orchestrator/dispatch.py
@@ -736,6 +736,15 @@ async def _dispatch(mgr, mission: Mission, mtype: MissionType,
                         mgr.blocked_reasons[live.pmo_id])
             return None
 
+        # ADR-0042 §5 — the status comment: found by marker in the full read
+        # the mirror already paid, created when absent (whichever dispatch
+        # comes first — there is no privileged entry point), never
+        # refreshed here. Best-effort: the run is launched.
+        from . import status_comment
+        run.status_entry_id = await status_comment.ensure(
+            mgr, live, run, found=str(activity.get("status_entry_id") or ""))
+        mgr.runs.store.save(run)
+
         if live.status == "backlog":
             await mgr.pmo.set_status(mission.ref, "in_progress")
             mgr._audit(mission.pmo_id, "set_status", "in_progress")
@@ -1294,22 +1303,31 @@ def mission_cost(mgr, pmo_id: str, *,
     THE one cost-rollup (ADR-0034 PR-3 — review's loop warning carried a
     near-duplicate of this arithmetic): split_estimated=True additionally
     returns the estimated share, named rather than blended away."""
-    from .. import costing
     ci = mgr.config.cost_inputs
     total = est = 0.0
     for r in mgr.runs.store.all():
         if r.mission_pmo_id != pmo_id or not mgr._run_is_ours(r):
             continue
-        tr = r.token_report or {}
-        native = tr.get("cost_usd_native")
-        estimated = tr.get("cost_usd_estimated")
-        eff = costing.effective_cost(native, estimated, ci)
+        eff = run_cost(mgr, r)
         if eff is None:
             continue
+        tr = r.token_report or {}
         total += eff
-        if estimated is not None and (ci.override_native or native is None):
+        if tr.get("cost_usd_estimated") is not None and (
+                ci.override_native or tr.get("cost_usd_native") is None):
             est += eff
     return (total, est) if split_estimated else total
+
+
+def run_cost(mgr, r) -> float | None:
+    """One run's effective cost (ADR-0021 semantics) — the arithmetic
+    `mission_cost` sums, exposed so the status comment's ladder rows use
+    the ONE cost rule."""
+    from .. import costing
+    tr = r.token_report or {}
+    return costing.effective_cost(tr.get("cost_usd_native"),
+                                  tr.get("cost_usd_estimated"),
+                                  mgr.config.cost_inputs)
 
 
 async def _attempt_gate(mgr, mission: Mission, mtype: MissionType,

--- a/app/devcake/domain/orchestrator/finalize.py
+++ b/app/devcake/domain/orchestrator/finalize.py
@@ -12,7 +12,7 @@ from ...security import redact, redact_value
 from .. import backend_health, costing, failure_taxonomy
 from ..model import MissionRef
 from ..run import Run, is_pre_wipe, utcnow
-from . import discovery, steps, transitions
+from . import discovery, status_comment, steps, transitions
 from .feed import (SECTION_ANSWER, SECTION_DISCOVERIES, SECTION_RUN,
                    SECTION_TOKEN_REPORT, SECTION_TRANSITION, FoldSection,
                    StepCardParts, blockquote, collapsible_of,
@@ -214,6 +214,7 @@ async def _finalize(mgr, run: Run, payload: dict) -> None:
                 await restore_after_failure(mgr, run)
             log.warning("run %s failed (exit %s, attempt %d)",
                         run.run_id, exit_code, run.attempt_of_step)
+            await status_comment.refresh(mgr, pmo_id, reason="failed", run=run)
             return
 
         # 2b — ADR-0033 harvest bookkeeping (label, pending set, routing
@@ -262,6 +263,8 @@ async def _finalize(mgr, run: Run, payload: dict) -> None:
                     await restore_after_failure(mgr, run)
                 log.warning("run %s failed with DEV_BAD_OUTPUT: %s",
                             run.run_id, e)
+                await status_comment.refresh(mgr, pmo_id, reason="bad_output",
+                                             run=run)
                 return
             if _pre_wipe(mgr, run):
                 return
@@ -280,6 +283,9 @@ async def _finalize(mgr, run: Run, payload: dict) -> None:
             span.set_status(Status(StatusCode.ERROR, run.verdict))
             span.add_event("devcake.verdict", {"detail": run.verdict})
         log.info("finalized %s (%s)", run.run_id, outcome)
+        # ADR-0042 §5 — the LAST statement of the close: the status comment
+        # says what the record now says (best-effort, never a gate)
+        await status_comment.refresh(mgr, pmo_id, reason="finalize", run=run)
 
 
 def dev_failure_error(mgr, run: Run, payload: dict) -> str:

--- a/app/devcake/domain/orchestrator/manager.py
+++ b/app/devcake/domain/orchestrator/manager.py
@@ -149,6 +149,11 @@ class MissionManager:
         # a terminal answer on a memoized number is confirmed by the lookup
         # before the sweep writes.
         self._merge_pr_numbers: dict[str, int] = {}
+        # pmo_id → the mission's status comment entry id (ADR-0042 §5), for
+        # the run-less paths (sweeps); learnt at dispatch/refresh, dropped
+        # on a permanent edit failure. Process-local: the marker on the
+        # feed is the durable truth, found again at the next dispatch.
+        self._status_entries: dict[str, str] = {}
         # pmo_id → admitted attempts past the merge window that did not
         # merge (docs/03 §4.1): the second in a row hands off, so one
         # transient forge error cannot end a mission's automation. Process-

--- a/app/devcake/domain/orchestrator/status_comment.py
+++ b/app/devcake/domain/orchestrator/status_comment.py
@@ -1,0 +1,261 @@
+"""The mission's status comment (ADR-0042 §5): one per mission, a VIEW the
+reader opens first — the step ladder, what is happening now, the PR, the
+cost so far — edited in place at every step end, park, hand-off, merge
+event and completion. Created by WHICHEVER dispatch finds the feed without
+one (DevCake has no privileged entry point: a scheduled task starts at
+EXECUTE, a person can order a mission into any step by label, an older
+mission resumes mid-pipeline); found again by its marker, oldest wins, so
+a restart or a second instance converges on the same entry.
+
+Everything in it is derived from the record — the mission's runs, its
+labels and status, the recorded PR url — never the other way round: it
+carries no counted marker, it is immaterial to the Freshness Gate by
+construction (sentinel-signed, not elevated) and the Dev's folder omits
+it (its every fact is already there). It is never an ask: the ✋ notice
+is, and the Now line points at it. Best-effort by contract — a refused or
+failed write is audited and never gates a dispatch, a finalize or a sweep.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from ...ports.pmo import PMOTransient
+from ..model import (LABEL_EXECUTE, LABEL_FAILED, LABEL_MERGE,
+                     LABEL_NEEDS_HUMAN, LABEL_PLAN, LABEL_REVIEW, LABEL_SKIP,
+                     Mission, MissionRef)
+from ..run import Run, aware, utcnow
+from .feed import (SECTION_RECORD, FoldSection, collapsible_of, format_duration,
+                   render_fold)
+from .markers import STATUS_MARKER, decomposition_parent_ref
+
+log = logging.getLogger("devcake.missions")
+
+_IN_FLIGHT = ("dispatched", "running", "finalizing")
+_STAGE_STEP = {LABEL_PLAN: "PLAN", LABEL_EXECUTE: "EXECUTE",
+               LABEL_REVIEW: "REVIEW"}
+_OUTCOME_GLYPH = {
+    ("ONBOARD", "plan_needed"): ("📋", "triaged"),
+    ("ONBOARD", "decomposed"): ("🧩", "decomposed"),
+    ("PLAN", "planned"): ("📋", "planned"),
+    ("EXECUTE", "executed"): ("🔀", "PR opened"),
+}
+
+
+def runs_of(mgr, pmo_id: str) -> list[Run]:
+    """This instance's runs of the mission, oldest first — THE ladder's
+    source (a mission that entered at REVIEW has one row)."""
+    runs = [r for r in mgr.runs.store.all()
+            if r.mission_pmo_id == pmo_id and mgr._run_is_ours(r)
+            and r.mission_type not in ("STEWARD", "HELLO", "OAUTH")]
+    runs.sort(key=lambda r: aware(r.created_at))
+    return runs
+
+
+def _row_state(r: Run) -> tuple[str, str]:
+    """(glyph, word) for a ladder row."""
+    if r.state in _IN_FLIGHT:
+        return "⏳", "running"
+    if r.state != "finished":
+        return "⚠️", f"{r.state}" + (f" ({r.error_class})" if r.error_class else "")
+    outcome = str((r.result or {}).get("outcome") or "")
+    if outcome == "human_needed":
+        return "✋", "handed off"
+    if r.mission_type == "REVIEW" and outcome == "reviewed":
+        verdict = str((r.result or {}).get("verdict") or "").lower()
+        return ("✅", "approved") if verdict == "approve" else \
+            ("🔁", "rejected") if verdict == "reject" else ("⚠️", verdict or "reviewed")
+    return _OUTCOME_GLYPH.get((r.mission_type, outcome),
+                              ("⚠️", outcome or "no result"))
+
+
+def _duration_s(r: Run) -> float | None:
+    if r.started_at is None:
+        return None
+    end = r.ended_at if r.ended_at is not None else utcnow()
+    return (aware(end) - aware(r.started_at)).total_seconds()
+
+
+def _pr_url(runs: list[Run], given: str | None) -> str:
+    if given:
+        return given
+    for r in reversed(runs):
+        if r.pr_url:
+            return r.pr_url
+    for r in reversed(runs):
+        url = (r.result or {}).get("pr_url") if r.mission_type == "EXECUTE" else None
+        if url:
+            return str(url)
+    return ""
+
+
+def _now_line(mission: Mission, runs: list[Run], pr_url: str) -> str:
+    labels = mission.labels
+    if mission.status == "done":
+        return "✅ Done."
+    if mission.status == "canceled":
+        return "🚫 Canceled."
+    if LABEL_SKIP in labels:
+        return "⏸ Stopped by DEVCAKE-SKIP."
+    if LABEL_FAILED in labels:
+        return "⚠️ Gave up — needs a person (see the ✋ notice above)."
+    if LABEL_NEEDS_HUMAN in labels:
+        return "✋ Parked — needs a person (see the ✋ notice above)."
+    if LABEL_MERGE in labels:
+        return f"⏳ Awaiting merge of {pr_url}." if pr_url else "⏳ Awaiting merge."
+    live = next((r for r in reversed(runs) if r.state in _IN_FLIGHT), None)
+    if live is not None:
+        since = (f" since {aware(live.started_at):%Y-%m-%d %H:%M} UTC"
+                 if live.started_at else "")
+        return (f"⏳ Running step {live.seq} · {live.mission_type} "
+                f"(attempt {live.attempt_of_step}){since}.")
+    stage = next((_STAGE_STEP[l] for l in _STAGE_STEP if l in labels), None)
+    return f"⏳ Queued for {stage}." if stage else "⏳ Queued."
+
+
+def render(mgr, mission: Mission, runs: list[Run], *, pr_url: str | None,
+           collapsible: str) -> str:
+    """The comment body (sentinel-free; the chokepoints seal it). Pure —
+    everything comes from the record. Never a file token, never a
+    `Part i of n` line, no marker but the status marker (each pinned)."""
+    from .dispatch import mission_cost, run_cost
+    url = _pr_url(runs, pr_url)
+    latest: dict[int, Run] = {}
+    for r in runs:
+        latest[r.seq] = r                        # oldest first ⇒ last wins
+    total, est = mission_cost(mgr, mission.pmo_id, split_estimated=True)
+    minutes = sum((_duration_s(r) or 0) for r in latest.values()) / 60
+    lines = [f"📌 **{mission.key} — status** · a view DevCake keeps current; "
+             "the record is the entries above.", "",
+             f"**Now:** {_now_line(mission, runs, url)}"]
+    if url:
+        lines.append(f"**PR:** {url}")
+    cost = f"**Cost so far:** ${total:.2f}"
+    if est:
+        cost += f" (of which ${est:.2f} estimated)"
+    cost += f" across {len(latest)} step{'s' if len(latest) != 1 else ''}"
+    if minutes >= 1:
+        cost += f" · {format_duration(minutes * 60)} of Dev time"
+    lines.append(cost)
+    parent = decomposition_parent_ref(mission)
+    if parent:
+        lines.append(f"**Parent:** {_parent_label(mgr, parent)}")
+    if latest:
+        lines += ["", "| Step | Outcome | Duration | Cost |", "|---|---|---|---|"]
+        for seq in sorted(latest):
+            r = latest[seq]
+            glyph, word = _row_state(r)
+            attempt = (f" (attempt {r.attempt_of_step})"
+                       if r.attempt_of_step > 1 else "")
+            dur = format_duration(_duration_s(r)) or "—"
+            c = run_cost(mgr, r)
+            lines.append(f"| {seq} · {r.mission_type} | {glyph} {word}{attempt} "
+                         f"| {dur} | {'$%.2f' % c if c is not None else '—'} |")
+    record = FoldSection(SECTION_RECORD, (
+        f"{STATUS_MARKER}\nupdated {utcnow():%Y-%m-%d %H:%M} UTC · instance "
+        f"{getattr(mgr, 'instance_name', '')}"))
+    lines += ["", render_fold([record], collapsible=collapsible, summary="Record")]
+    return "\n".join(lines)
+
+
+def _parent_label(mgr, parent_ref: str) -> str:
+    snap = getattr(mgr, "snapshot", None)
+    for m in (getattr(snap, "missions", None) or []):
+        if m.pmo_id == parent_ref or m.key == parent_ref:
+            return f"{m.key} — {m.url}" if m.url else m.key
+    return parent_ref
+
+
+def _cache(mgr) -> dict[str, str]:
+    cache = getattr(mgr, "_status_entries", None)
+    if cache is None:
+        cache = {}
+        try:
+            mgr._status_entries = cache
+        except Exception:  # noqa: BLE001 — a frozen test double: the cache is optional
+            pass
+    return cache
+
+
+async def ensure(mgr, mission: Mission, run: Run, *, found: str) -> str:
+    """Dispatch-time (the only creation site): `found` is the marker hit
+    from the mirror's full read; when empty, the comment is created —
+    never refreshed here (finalize writes the next state). Returns the
+    entry id, "" when there is none (a project mission, a vendor that
+    returned no id, a refused write — audited, never raised)."""
+    if mission.pmo_kind != "issue":
+        return ""
+    cache = _cache(mgr)
+    if found:
+        cache[mission.pmo_id] = found
+        return found
+    try:
+        runs = runs_of(mgr, mission.pmo_id)
+        if all(r.run_id != run.run_id for r in runs):
+            runs.append(run)
+        body = render(mgr, mission, runs, pr_url=None,
+                      collapsible=collapsible_of(mgr))
+        cid = await mgr._feed(mission.pmo_id, "issue", body, externalize=False)
+    except Exception as e:  # noqa: BLE001 — a view never gates a dispatch: audited, the next dispatch tries again
+        mgr._audit(mission.pmo_id, "status_comment_failed", f"create: {str(e)[:160]}")
+        return ""
+    if cid:
+        cache[mission.pmo_id] = cid
+        mgr._audit(mission.pmo_id, "status_comment_created", cid)
+    return cid or ""
+
+
+def _known_entry(mgr, pmo_id: str, run: Run | None) -> str:
+    if run is not None and run.status_entry_id:
+        return run.status_entry_id
+    cache = _cache(mgr)
+    if cache.get(pmo_id):
+        return cache[pmo_id]
+    for r in reversed(runs_of(mgr, pmo_id)):
+        if r.status_entry_id:
+            return r.status_entry_id
+    return ""
+
+
+async def refresh(mgr, pmo_id: str, *, reason: str, run: Run | None = None,
+                  mission: Mission | None = None,
+                  pr_url: str | None = None) -> None:
+    """Rebuild the body from the record and edit it in place. At most ONE
+    cheap `pmo.get` when the caller has no fresh mission. Catches
+    everything: a refused budget, a transient, a vanished entry (the
+    cached id is dropped so the next dispatch re-creates it)."""
+    entry_id = _known_entry(mgr, pmo_id, run)
+    if not entry_id:
+        seen = getattr(mgr, "_status_unknown", None)
+        if seen is None:
+            seen = set()
+            try:
+                mgr._status_unknown = seen
+            except Exception:  # noqa: BLE001 — optional bookkeeping on a double
+                pass
+        if pmo_id not in seen:
+            seen.add(pmo_id)
+            mgr._audit(pmo_id, "status_comment_unknown", reason)
+        return
+    try:
+        if mission is None:
+            mission = await mgr.pmo.get(MissionRef(pmo_id, "issue"))
+        runs = runs_of(mgr, pmo_id)
+        if run is not None and all(r.run_id != run.run_id for r in runs):
+            runs.append(run)
+        body = render(mgr, mission, runs, pr_url=pr_url,
+                      collapsible=collapsible_of(mgr))
+        await mgr._edit(pmo_id, "issue", entry_id, body)
+        _cache(mgr)[pmo_id] = entry_id
+    except PMOTransient as e:
+        mgr._audit(pmo_id, "status_comment_failed", f"{reason}: {str(e)[:160]}")
+    except Exception as e:  # noqa: BLE001 — permanent (the entry is gone, the vendor refused): forget it; the next dispatch re-creates
+        mgr._audit(pmo_id, "status_comment_failed", f"{reason}: {str(e)[:160]}")
+        _cache(mgr).pop(pmo_id, None)
+        if run is not None and run.status_entry_id == entry_id:
+            run.status_entry_id = ""
+            try:
+                mgr.runs.store.save(run)
+            except Exception:  # noqa: BLE001 — best-effort bookkeeping
+                log.debug("status entry reset not saved for %s", run.run_id,
+                          exc_info=True)

--- a/app/devcake/domain/orchestrator/sweeps.py
+++ b/app/devcake/domain/orchestrator/sweeps.py
@@ -14,7 +14,7 @@ from ..model import (LABEL_MERGE, LABEL_NEEDS_HUMAN, LABEL_TRACKING, Mission,
                      STAGE_LABELS)
 from ..run import aware, utcnow
 from . import (board, completion, discovery, dispatch, feed, feed_memo,
-               freshness)
+               freshness, status_comment)
 from .markers import (MERGE_HANDOFF_MARKER, MERGE_RETRY_MARKER,
                       MERGE_SETTLE_MARKER)
 
@@ -253,6 +253,10 @@ async def merge_sweep(mgr, m: Mission) -> None:
                             f"🚫 PR {state.url} was closed without merging — "
                             f"mission canceled (merge sweep)."))
                 mgr._audit(m.pmo_id, "merge_sweep_canceled", state.url)
+                with completion.write_back_class():
+                    await status_comment.refresh(
+                        mgr, m.pmo_id, reason="merge_sweep_canceled",
+                        pr_url=state.url)
     else:
         # advisory banner (docs/11): an open PR on DEVCAKE-MERGE awaits a
         # human — unless the deferred-retry window is actively running
@@ -445,6 +449,10 @@ async def _deferred_merge_retry(mgr, m: Mission, pr,
                     mgr._merge_window_closed.add(m.pmo_id)
                     mgr.merge_handoffs[m.pmo_id] = (
                         f"{m.key}: awaiting human merge — {pr_url}")
+                    with completion.write_back_class():
+                        await status_comment.refresh(
+                            mgr, m.pmo_id, reason="conflict_handoff",
+                            mission=m, pr_url=pr_url)
             elif elapsed:
                 # a closing attempt that did not merge and was no conflict:
                 # the second in a row hands off
@@ -490,6 +498,9 @@ async def _hand_off_exhausted(mgr, m: Mission, pr_url: str,
                      "completes the mission once it lands."))
     mgr._audit(m.pmo_id, "merge_retry_exhausted", pr_url)
     mgr._merge_window_closed.add(m.pmo_id)
+    with completion.write_back_class():
+        await status_comment.refresh(mgr, m.pmo_id, reason="merge_handoff",
+                                     mission=m, pr_url=pr_url)
 
 
 async def _closing_attempt_failed(mgr, m: Mission, pr_url: str, window: int,

--- a/app/tests/test_status_comment.py
+++ b/app/tests/test_status_comment.py
@@ -1,0 +1,184 @@
+"""ADR-0042 §5 — the status comment: one per mission, created by whichever
+dispatch finds none, edited in place at the events of the record, a view
+that never gates and never counts."""
+from datetime import datetime, timedelta, timezone
+
+from devcake.domain.model import Activity, ActivityEntry
+from devcake.domain.orchestrator import dispatch, feed, freshness, status_comment
+from devcake.domain.orchestrator.feed import is_devcake_comment, unquoted
+from devcake.domain.orchestrator.markers import (PART_LINE, STATUS_MARKER,
+                                                 STEP_MARKER)
+from devcake.domain.run import Run
+from devcake.ports.pmo import PMOBudgetExceeded, PMOTransient
+
+from test_discovery_harvest import _exec_run, _payload
+from test_transitions import make_mgr, mission, run_coro
+
+NOW = datetime(2026, 9, 9, 12, 0, tzinfo=timezone.utc)
+
+
+def _run(store, seq, mtype, *, state="finished", outcome=None, attempt=1,
+         verdict=None, minutes=5, cost=None, status_entry_id=""):
+    r = Run(run_id=f"T-1-{seq}-{mtype}-AAAAAA{attempt}", mission_key="T-1",
+            mission_pmo_id="p1", mission_type=mtype, dev_type="senior-dev",
+            seq=seq, attempt_of_step=attempt, state=state,
+            status_entry_id=status_entry_id)
+    r.created_at = NOW + timedelta(minutes=seq * 10 + attempt)
+    r.started_at = r.created_at
+    if state == "finished":
+        r.ended_at = r.started_at + timedelta(minutes=minutes)
+        r.result = {"outcome": outcome, "summary": "s"}
+        if verdict:
+            r.result["verdict"] = verdict
+    if cost is not None:
+        r.token_report = {"cost_usd_native": cost}
+    store.save(r)
+    return r
+
+
+def _mgr(tmp_path, labels=frozenset({"DEVCAKE"}), status="in_progress"):
+    m = mission(status, set(labels))
+    mgr, fake, store = make_mgr(tmp_path, m)
+    fake.record_feed = True
+    return m, mgr, fake, store
+
+
+def _render(mgr, m, pr_url=None):
+    return status_comment.render(mgr, m, status_comment.runs_of(mgr, m.pmo_id),
+                                 pr_url=pr_url, collapsible="details")
+
+
+# ── invariants ──────────────────────────────────────────────────────────────
+
+def test_body_is_a_view_that_no_scan_counts(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path)
+    _run(store, 1, "ONBOARD", outcome="plan_needed", cost=0.5)
+    _run(store, 2, "EXECUTE", state="running")
+    body = _render(mgr, m) + "\n\n`devcake:v1`"
+    assert is_devcake_comment(body) and feed.is_status_comment(body)
+    assert STEP_MARKER.search(unquoted(body)) is None       # "1 · ONBOARD", never a file token
+    assert not any(PART_LINE.match(l) for l in body.splitlines())
+    assert not freshness._is_material(body)
+    entry = ActivityEntry(ts=NOW, author="cake", kind="comment", body=body, entry_id="s1")
+    assert dispatch._derive_seq(Activity(mission=m, entries=[entry])) == 1
+    assert unquoted(body).count("`devcake:") == 2            # status marker + sentinel only
+    assert "**Now:** ⏳ Running step 2 · EXECUTE (attempt 1) since" in body
+    assert "| 1 · ONBOARD | 📋 triaged | 5 min | $0.50 |" in body
+    assert "| 2 · EXECUTE | ⏳ running | " in body
+    assert "**Cost so far:** $0.50 across 2 steps" in body
+
+
+def test_ladder_is_the_runs_never_the_label_history(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path, {"DEVCAKE", "DEVCAKE-REVIEW"})
+    _run(store, 1, "REVIEW", outcome="reviewed", verdict="approve", cost=3.05)
+    body = _render(mgr, m, pr_url="https://forge.example/pr/8")
+    assert body.count("| 1 · REVIEW |") == 1 and "ONBOARD" not in body
+    assert "| 1 · REVIEW | ✅ approved | 5 min | $3.05 |" in body
+    assert "**PR:** https://forge.example/pr/8" in body
+    assert "**Now:** ⏳ Queued for REVIEW." in body           # nothing in flight
+
+
+def test_latest_attempt_per_step_and_now_lines(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path, {"DEVCAKE", "DEVCAKE-EXECUTE", "DEVCAKE-FAILED"})
+    _run(store, 1, "EXECUTE", state="failed", attempt=1)
+    _run(store, 1, "EXECUTE", state="failed", attempt=3)
+    body = _render(mgr, m)
+    assert body.count("| 1 · EXECUTE |") == 1 and "(attempt 3)" in body
+    assert "**Now:** ⚠️ Gave up — needs a person" in body
+    m.labels = {"DEVCAKE", "DEVCAKE-MERGE"}
+    assert "**Now:** ⏳ Awaiting merge of https://x." in _render(mgr, m, pr_url="https://x")
+    m.labels = {"DEVCAKE", "DEVCAKE-NEEDS-HUMAN"}
+    assert "✋ Parked — needs a person" in _render(mgr, m)
+    m.labels = {"DEVCAKE", "DEVCAKE-SKIP"}
+    assert "⏸ Stopped by DEVCAKE-SKIP" in _render(mgr, m)
+    m.status = "done"
+    assert "**Now:** ✅ Done." in _render(mgr, m)
+
+
+def test_cost_line_is_the_one_cost_rollup(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path)
+    _run(store, 1, "ONBOARD", outcome="plan_needed", cost=1.25)
+    _run(store, 2, "EXECUTE", outcome="executed", cost=2.0)
+    total = dispatch.mission_cost(mgr, "p1")
+    assert f"**Cost so far:** ${total:.2f}" in _render(mgr, m)
+
+
+# ── ensure / refresh ────────────────────────────────────────────────────────
+
+def test_ensure_creates_once_and_adopts_a_found_entry(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path)
+    run = _run(store, 1, "ONBOARD", state="running")
+    cid = run_coro(status_comment.ensure(mgr, m, run, found=""))
+    assert cid and len(fake.comments) == 1
+    body = fake.comments[0]
+    assert feed.is_status_comment(body) and STATUS_MARKER in unquoted(body)
+    assert mgr._status_entries["p1"] == cid
+    # a later dispatch finds it by marker: adopted, nothing posted
+    assert run_coro(status_comment.ensure(mgr, m, run, found="s-existing")) == "s-existing"
+    assert len(fake.comments) == 1
+    # a project mission never gets one
+    m.pmo_kind = "project"
+    assert run_coro(status_comment.ensure(mgr, m, run, found="")) == ""
+
+
+def test_refresh_edits_in_place_without_a_feed_read(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path)
+    fake.activity_entries = [ActivityEntry(ts=NOW, author="cake", kind="comment",
+                                           body="old `devcake:status:v1`\n\n`devcake:v1`",
+                                           entry_id="s1")]
+    run = _run(store, 1, "ONBOARD", outcome="plan_needed", status_entry_id="s1")
+    before = getattr(fake, "get_activity_full_calls", 0)
+    run_coro(status_comment.refresh(mgr, "p1", reason="finalize", run=run, mission=m))
+    (_pid, eid, body), = fake.edits
+    assert eid == "s1" and "📋 triaged" in body and body.endswith("`devcake:v1`")
+    assert getattr(fake, "get_activity_full_calls", 0) == before
+    assert fake.activity_entries[0].ts == NOW                # the entry never moves
+
+
+def test_refresh_without_an_id_audits_once_and_never_edits(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path)
+    audits = []
+    mgr._audit = lambda pid, action, detail="": audits.append(action)
+    run_coro(status_comment.refresh(mgr, "p1", reason="finalize", mission=m))
+    run_coro(status_comment.refresh(mgr, "p1", reason="finalize", mission=m))
+    assert audits == ["status_comment_unknown"]
+    assert getattr(fake, "edits", []) == []
+
+
+def test_refresh_failures_are_swallowed_and_audited(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path)
+    run = _run(store, 1, "ONBOARD", outcome="plan_needed", status_entry_id="gone")
+    fake.strict_edits = True
+    audits = []
+    mgr._audit = lambda pid, action, detail="": audits.append(action)
+    run_coro(status_comment.refresh(mgr, "p1", reason="finalize", run=run, mission=m))
+    assert audits == ["status_comment_failed"]
+    assert run.status_entry_id == "" and "p1" not in mgr._status_entries
+
+    async def starved(ref, entry_id, markdown):
+        raise PMOBudgetExceeded("reserve reached", retry_after=30)
+    fake.edit_feed = starved
+    run.status_entry_id = "s1"
+    run_coro(status_comment.refresh(mgr, "p1", reason="finalize", run=run, mission=m))
+    assert audits[-1] == "status_comment_failed"
+    assert run.status_entry_id == "s1"                        # a transient keeps the id
+    assert isinstance(PMOBudgetExceeded("x"), PMOTransient)
+
+
+def test_finalize_refreshes_the_status_comment_last(tmp_path):
+    m = mission("in_progress", {"DEVCAKE", "DEVCAKE-EXECUTE"})
+    mgr, fake, store = make_mgr(tmp_path, m)
+    fake.activity_entries = [ActivityEntry(ts=NOW, author="cake", kind="comment",
+                                           body="old `devcake:status:v1`\n\n`devcake:v1`",
+                                           entry_id="s1")]
+    run = _exec_run(store)
+    run.status_entry_id = "s1"
+    store.save(run)
+    run_coro(mgr.finalize(run, _payload(pr_url="https://forge.example/pr/8")))
+    assert run.state == "finished"
+    edits = [e for e in getattr(fake, "edits", []) if e[1] == "s1"]
+    assert len(edits) == 1
+    body = edits[0][2]
+    assert "| 1 · EXECUTE | 🔀 PR opened |" in body
+    assert "**PR:** https://forge.example/pr/8" in body
+    assert "**Now:** ⏳ Queued for REVIEW." in body           # labels moved on

--- a/docs/03-mission-lifecycle.md
+++ b/docs/03-mission-lifecycle.md
@@ -215,6 +215,33 @@ To approve and merge this PR yourself:
 
 rendered with the *concrete* URL/IID substituted — one paste must suffice. Each adapter emits only its own dialect (the `gh` line on GitHub, the `glab` line on GitLab). The same footer is the what-to-do of the `✋ **Needs you.**` notice posted on the mission feed when the merge is a person's (auto-merge off, or auto-merge failed), so one paste from the feed suffices too.
 
+## 5b. The status comment (ADR-0042)
+
+Each issue mission carries **one status comment**, a view the reader opens
+first: `📌 **KEY — status**`, a **Now** line (running step N · TYPE since …;
+✋ parked — needs a person, pointing at the ✋ notice; ⚠️ gave up; ⏸ stopped
+by `DEVCAKE-SKIP`; ⏳ awaiting merge of the PR; ✅ done; 🚫 canceled;
+⏳ queued for STEP), the **PR** as the record knows it, the **cost so far**
+(the one cost rollup, with the estimated share named), the decomposition
+**parent** when there is one, and the step ladder — one row per step from
+the mission's runs, latest attempt per step, glyph · outcome · duration ·
+cost. A mission that entered at REVIEW by label shows one row; the ladder is
+the runs, never the label history.
+
+It is **created by whichever dispatch finds the feed without one** — there
+is no privileged entry point — found again by the `` `devcake:status:v1` ``
+token in its `Record` fold (oldest marked entry wins, so a restart or a
+second instance converges on the same comment), and **edited in place** at
+every step end, park, hand-off, merge event and completion, never at
+dispatch. It carries no counted marker, is immaterial to the Freshness Gate
+(sentinel-signed, not elevated), never contains a file token or a
+`Part i of n` line, and the Dev's folder omits it (its every fact is
+already there; it still counts for the reading watermark). It is never an
+ask — the ✋ notice is. Every write is best-effort: a refused budget, a
+transient or a vanished entry is audited (`status_comment_failed`,
+`status_comment_unknown` once) and never gates a dispatch, a finalize or a
+sweep; a vanished entry is re-created at the next dispatch.
+
 ## 6. `result.json` schema (normative)
 
 ```jsonc

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -953,9 +953,17 @@ until that run exists, field evidence below stays operator-self-reported.
   deliveries, and routing receipts / the deliverable note appended to
   the harvesting card's / completion notice's fold by edit (fallback: the
   old post as a notice; audits `discovery_receipt_fold_failed`,
-  `deliverable_fold_failed`); the HTML deliverable marker retired. The
-  status comment follows (PR-6). Docs 03 §4.1/§4a/§4b/§4c/§5/§8/§8a, 04,
+  `deliverable_fold_failed`); the HTML deliverable marker retired. The status comment is PR-6 (below). Docs 03 §4.1/§4a/§4b/§4c/§5/§8/§8a, 04,
   05, 07, 15, ADR-0014 addendum.
+- **The feed for readers: the status comment** (2026-09-09, ADR-0042
+  PR-6): `orchestrator/status_comment.py` — `ensure` at dispatch (found by
+  marker in the mirror's full read, created when absent, never refreshed
+  there), `refresh` at finalize end and both failure branches, after a
+  completion, a conflict route, a merge hand-off and a closed PR (inside
+  the write-back class; every failure audited, never a gate);
+  `Run.status_entry_id` threads the id without a feed read; the ladder is
+  the runs (`dispatch.run_cost` factored out of `mission_cost`). Docs 03
+  §5b, CHANGELOG.
 - **DevCake audits DevCake** (2026-08-17/18) — one board prompt became 54
   self-decomposed tickets, 257 fresh-context runs, and 42 human-merged pull
   requests, with seven independently reproduced security-relevant findings,


### PR DESCRIPTION
Sixth PR of the ADR-0042 plan. **Stacked on #450 (PR-5) and, through it, on #445–#448** — merge in that order; this branch is rebased on #450.

## What a reader sees

One pinned-style comment per mission, kept current: a **Now** line (running step N since …; parked, needs a person, pointing at the ✋ notice; gave up; stopped; awaiting merge; done; canceled; queued), the **PR**, **cost so far** (the one cost rollup, estimated share named), the decomposition **parent**, and the step ladder (one row per step from the runs, latest attempt, glyph · outcome · duration · cost). A mission that entered at REVIEW by label shows one row.

## Mechanics

- Created by **whichever dispatch finds the feed without one** (found by the `devcake:status:v1` marker in the full read the mirror already pays; never refreshed at dispatch). Edited in place at finalize end and both failure branches, after a completion, after a conflict route, and on the sweeps' merge hand-off, conflict hand-off and PR-closed paths — inside the write-back class, every failure audited, never a gate.
- `Run.status_entry_id` threads the id so finalize never reads the feed for it; a process cache serves the run-less sweep paths; a permanent edit failure forgets the id so the next dispatch re-creates it.
- A view by construction: no counted marker, no file token, no `Part i of n` line; immaterial to the Freshness Gate; omitted from the Dev folder by the projection (PR-4).
- Also carries a test-isolation fix: each test manager gets its own PMO-instance copy (a steward test's `discovery_routing = False` leaked into the harvest suite through the shared default; order-dependent, previously hidden by alphabetical order).

## Tests

`test_status_comment.py` (9). Full suite: only the known environment failures.

## Docs

03 §5b (new), CHANGELOG, docs/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVp9ty5CFCjT6PphDe24MH
