### PR TITLE
feat(upstream): an issue placed in a project receives the project's activity (ADR-0036 addendum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ added here without copying the full roadmap.
 See the living log and open candidates in
 [`docs/16-roadmap.md`](docs/16-roadmap.md).
 
+- **Fixed — an issue placed in a project now sees the project's activity.**
+  A Dev working an issue a person added to a project received nothing
+  from the project: the upstream offer followed only the marker DevCake
+  writes when it splits a mission, so the project's brief, its updates and
+  its documents were invisible. The offer now ends at the project the
+  issue belongs to, mirrored under the upstream folder like a
+  decomposition parent, with the folder's relation and the project's
+  title named in the activity banner. A project the board does not poll
+  is read once; one that cannot be read is a named gap, never a silent
+  omission.
+
 Community surface added for public-repo hygiene (no LICENSE change in this
 track): [`CONTRIBUTING.md`](CONTRIBUTING.md), [`SECURITY.md`](SECURITY.md).
 

--- a/app/devcake/domain/orchestrator/activity_payload.py
+++ b/app/devcake/domain/orchestrator/activity_payload.py
@@ -273,7 +273,8 @@ async def _offer_upstream(mgr, mission, used: set[str]
                 mgr, anc.pmo_id, anc.pmo_kind or up.kind,
                 include_upstream=False)
         except Exception as e:  # noqa: BLE001 — one ancestor failure must not abort the offer
-            reason = f"{type(e).__name__}: {str(e)[:160]}"
+            reason = (f"{up.relation} activity unreadable: "
+                      f"{type(e).__name__}: {str(e)[:160]}")
             gaps.append({"key": key, "pmo_id": anc.pmo_id, "reason": reason})
             continue
 

--- a/app/devcake/domain/orchestrator/activity_payload.py
+++ b/app/devcake/domain/orchestrator/activity_payload.py
@@ -201,18 +201,23 @@ def _nested_snapshot_bytes(payload: dict) -> list[tuple[str, bytes]]:
 
 async def _offer_upstream(mgr, mission, used: set[str]
                           ) -> tuple[list[dict], list[dict], list[str], list[str]]:
-    """CAKE-124 / ADR-0036: mirror each decomposition ancestor under
+    """CAKE-124 / ADR-0036 (+ addendum): mirror each upstream mission —
+    every decomposition ancestor, then the containing project — under
     upstream/{KEY}/. Packs nearest-parent-first into a total byte budget
-    equal to `_attachment_cap()`; oldest (root-ward) ancestors truncate
-    first. Returns (attachment_dicts, gaps, truncated_keys, banner_lines)."""
+    equal to `_attachment_cap()`; the farthest (root-ward) ones truncate
+    first. A containing project the board snapshot does not hold (it may
+    carry no managed label) is read live; an unreadable one is a gap like
+    any ancestor. Returns (attachment_dicts, gaps, truncated_keys,
+    banner_lines)."""
     # Lazy import: family_graph → dispatch → activity_payload (cycle).
     from . import family_graph
     missions = await _missions_snapshot(mgr)
-    ancestors = family_graph.decomposition_ancestors(mission, missions)
+    chain = family_graph.upstream_chain(mission, missions)
     # A trusted parent_ref that does not resolve in the snapshot is a gap —
     # the Dev must not start believing the chain is empty when it is not.
     pref = decomposition_parent_ref(mission)
-    if pref and not ancestors:
+    if pref and not any(u.relation == family_graph.RELATION_PARENT
+                        for u in chain):
         pool = {m.pmo_id for m in missions}
         pool |= {m.key.upper() for m in missions if m.key}
         if pref not in pool and pref.upper() not in pool:
@@ -240,7 +245,23 @@ async def _offer_upstream(mgr, mission, used: set[str]
     # file lands, a later flat attachment named `upstream` takes the
     # docs/07 §2 `-2` suffix via `_unique_name` / `_tree_conflict`.
 
-    for i, anc in enumerate(ancestors):
+    def _label(u) -> str:
+        return (u.mission.key if u.mission is not None and u.mission.key
+                else u.ref)
+
+    for i, up in enumerate(chain):
+        anc = up.mission
+        if anc is None:
+            # not in the snapshot (an unlabeled project is never polled):
+            # one live read, under the caller's call class
+            try:
+                anc = await mgr.pmo.get(MissionRef(up.ref, up.kind))
+            except Exception as e:  # noqa: BLE001 — unreadable upstream = gap, never silent
+                reason = (f"{up.relation} unreadable: "
+                          f"{type(e).__name__}: {str(e)[:160]}")
+                gaps.append({"key": up.ref, "pmo_id": up.ref,
+                             "reason": reason})
+                continue
         key = anc.key or anc.pmo_id
         seg = _safe_upstream_key(key)
         if seg is None:
@@ -249,7 +270,7 @@ async def _offer_upstream(mgr, mission, used: set[str]
             continue
         try:
             nested = await activity_payload(
-                mgr, anc.pmo_id, anc.pmo_kind or "issue",
+                mgr, anc.pmo_id, anc.pmo_kind or up.kind,
                 include_upstream=False)
         except Exception as e:  # noqa: BLE001 — one ancestor failure must not abort the offer
             reason = f"{type(e).__name__}: {str(e)[:160]}"
@@ -260,8 +281,8 @@ async def _offer_upstream(mgr, mission, used: set[str]
         size = sum(len(b) for _, b in pairs)
         if used_bytes + size > budget:
             # This ancestor and every older (farther) one are omitted.
-            for rest in ancestors[i:]:
-                truncated.append(rest.key or rest.pmo_id)
+            for rest in chain[i:]:
+                truncated.append(_label(rest))
             break
 
         prefix = f"upstream/{seg}"
@@ -273,19 +294,24 @@ async def _offer_upstream(mgr, mission, used: set[str]
             files.append({"filename": full,
                           "content_b64": base64.b64encode(data).decode()})
         used_bytes += size
-        included.append(key)
+        included.append((key, up.relation, anc.title or ""))
 
     if included:
         banners.append(
-            "## Upstream mission activity (decomposition ancestors)")
+            "## Upstream mission activity (decomposition ancestors and "
+            "the containing project)")
         banners.append(
-            "Ancestor activity mirrors live under `upstream/{MISSION-KEY}/` "
-            "(nearest parent first, toward the graph root). Direct "
-            "`blocked_by` work-repo mounts remain a separate contract "
-            "(ADR-0017) — they are not mirrored here.")
-        for key in included:
+            "Upstream activity mirrors live under `upstream/{MISSION-KEY}/` "
+            "(nearest parent first, toward the graph root; the project "
+            "this mission belongs to comes last). Each holds that "
+            "mission's MISSION.md, ACTIVITY.md and attachments — consult "
+            "them for the brief and history this mission is part of. "
+            "Direct `blocked_by` work-repo mounts remain a separate "
+            "contract (ADR-0017) — they are not mirrored here.")
+        for key, relation, title in included:
             seg = _safe_upstream_key(key) or key
-            banners.append(f"- `upstream/{seg}/` — included")
+            tail = f": {title}" if title else ""
+            banners.append(f"- `upstream/{seg}/` — {relation}{tail}")
         banners.append("")
 
     if gaps:
@@ -409,9 +435,10 @@ async def activity_payload(mgr, pmo_id: str, kind: str = "issue",
     no resolved blockers and omits the section) render as a MISSION.md
     handoff block.
 
-    ADR-0036 / CAKE-124: when `include_upstream` is true (default), each
-    decomposition ancestor's activity mirror is nested under
-    `upstream/{MISSION-KEY}/` (nearest parent first; oldest truncated first
+    ADR-0036 / CAKE-124 (+ addendum): when `include_upstream` is true
+    (default), each upstream mission's activity mirror — every
+    decomposition ancestor, then the containing project — is nested under
+    `upstream/{MISSION-KEY}/` (nearest first; farthest truncated first
     under the attachment byte cap). Gaps land in `upstream_gaps` and as
     honest banners — never silent. Nested rebuilds pass
     `include_upstream=False` to avoid recursion."""

--- a/app/devcake/domain/orchestrator/family_graph.py
+++ b/app/devcake/domain/orchestrator/family_graph.py
@@ -10,8 +10,10 @@ PMO calls, no adapters.
 
 Also owns the *directed* decomposition ancestor walk
 (`decomposition_ancestors`, ADR-0036 / CAKE-124) — parent_ref chain toward
-the graph root only. That walk deliberately does NOT follow blocked_by
-edges (ADR-0017 stays the blocker-mount contract).
+the graph root only — and the upstream chain built on it (`upstream_chain`,
+ADR-0036 addendum): the same walk, then the containing project the vendor
+reports for the chain's last issue. Neither follows blocked_by edges
+(ADR-0017 stays the blocker-mount contract).
 """
 
 from __future__ import annotations
@@ -70,6 +72,59 @@ def decomposition_ancestors(source: Mission,
         seen.add(parent.pmo_id)
         cur = parent
     return out
+
+
+# How an upstream mission relates to the dispatched one (ADR-0036
+# addendum). Rendered in the ACTIVITY.md offer banner so the Dev knows why
+# each upstream/{KEY}/ folder is there.
+RELATION_PARENT = "decomposition parent"
+RELATION_PROJECT = "containing project"
+
+
+@dataclass(frozen=True)
+class Upstream:
+    """One upstream mission to mirror. `mission` is None when the board
+    snapshot does not hold it (a project without the managed label is
+    never polled) — the mirror builder then reads it live by `ref`."""
+    ref: str
+    kind: str                  # "issue" | "project"
+    relation: str              # RELATION_PARENT | RELATION_PROJECT
+    mission: Mission | None = None
+
+
+def containing_project_ref(mission: Mission) -> str | None:
+    """The containing project's pmo_id from the vendor's own record
+    (`parent_ref` on issue-kind missions; None on vendors without
+    projects). Trusted WITHOUT the LABEL_CREATED gate that guards the
+    decomposition marker: membership is set by a person or by DevCake on
+    the vendor, never by description text, so it cannot be forged."""
+    if (mission.pmo_kind or "issue") != "issue":
+        return None
+    return mission.parent_ref or None
+
+
+def upstream_chain(source: Mission, missions: list[Mission]) -> list[Upstream]:
+    """The missions whose activity a dispatched Dev is offered, nearest
+    first (ADR-0036 + addendum): the decomposition ancestors, then the
+    containing project of the chain's last issue (the source itself when
+    there is no chain). An issue a person places in a project therefore
+    gets the project's brief and feed exactly as a decomposition child
+    does; a chain that already ends at the project gains nothing twice.
+    The project is the farthest ancestor, so it truncates first under the
+    byte cap. Cycle-safe by construction of the walk plus the `seen` set."""
+    chain = [Upstream(m.pmo_id, m.pmo_kind or "issue", RELATION_PARENT, m)
+             for m in decomposition_ancestors(source, missions)]
+    last = chain[-1].mission if chain else source
+    seen = {source.pmo_id} | {u.ref for u in chain}
+    pid = containing_project_ref(last)
+    if not pid or pid in seen:
+        return chain
+    by_id = {m.pmo_id: m for m in missions if m.pmo_id}
+    proj = by_id.get(pid)
+    if proj is not None and (proj.pmo_kind or "issue") != "project":
+        return chain          # a parent_ref that is not a project: ignore
+    chain.append(Upstream(pid, "project", RELATION_PROJECT, proj))
+    return chain
 
 
 def family_of(source: Mission, missions: list[Mission]) -> Family:

--- a/app/devcake/prompts/__init__.py
+++ b/app/devcake/prompts/__init__.py
@@ -69,11 +69,12 @@ the EXECUTE step, from the plan you attach.
 - `/workspace/activity/` — the mission's knowledge base: MISSION.md (the
   brief), ACTIVITY.md (a faithful mirror of the mission's feed — full posts,
   replies, `[attachment: …]` markers), every attached file — including prior
-  steps' full session transcripts (`N_TYPE.md`) — and, when this mission is a
-  decomposition child, `upstream/{MISSION-KEY}/` mirrors of every ancestor
-  toward the graph root (parent, grandparent, …). Read upstream context from
-  those folders; do not assume a parent-delivered attachment lands at the
-  activity root. Reference material: grep or read what you need; do not
+  steps' full session transcripts (`N_TYPE.md`) — and, when this mission is
+  part of larger work, `upstream/{MISSION-KEY}/` mirrors of every upstream
+  mission: each decomposition ancestor toward the graph root (parent,
+  grandparent, …) and the project this mission belongs to. Read upstream
+  context from those folders; do not assume a parent-delivered attachment
+  lands at the activity root. Reference material: grep or read what you need; do not
   assume you must read all of it.
 - `/workspace/out/` — where your outputs go.
 
@@ -244,13 +245,14 @@ where they conflict with the mission description or with older comments, the
 most recent human comment wins.
 """
 
-# ADR-0036 / CAKE-124 — decomposition children receive ancestor activity under
-# upstream/{KEY}/. Appended next to the human-comments note so every playbook
-# (including operator template overrides that keep the epilogues) tells Devs
-# where parent/grandparent context lives.
+# ADR-0036 / CAKE-124 (+ addendum) — decomposition children and issues placed
+# in a project receive upstream activity under upstream/{KEY}/. Appended next
+# to the human-comments note so every playbook (including operator template
+# overrides that keep the epilogues) tells Devs where the context of the
+# larger work lives.
 UPSTREAM_ACTIVITY_NOTE = """
-### Upstream mission activity (decomposition ancestors)
-When this mission is a child in a decomposition graph, `/workspace/activity/upstream/{MISSION-KEY}/` holds a mirror of each ancestor's activity (MISSION.md, ACTIVITY.md, attachments) — nearest parent first, toward the graph root. Parent-delivered attachments (plans, ledgers, handoffs) live there, not necessarily at the activity root. ACTIVITY.md banners disclose gaps and oldest-first truncation under the payload byte cap. Direct `blocked_by` work-repo mounts are a separate contract under `/workspace/repo/`.
+### Upstream mission activity (decomposition ancestors and the containing project)
+When this mission is part of larger work — a child in a decomposition graph, or an issue that belongs to a project — `/workspace/activity/upstream/{MISSION-KEY}/` holds a mirror of each upstream mission's activity (MISSION.md, ACTIVITY.md, attachments): each ancestor nearest parent first toward the graph root, then the project this mission belongs to. The project's brief and feed are the context this mission is part of: consult them before deciding scope. Parent-delivered attachments (plans, ledgers, handoffs) live there, not necessarily at the activity root. ACTIVITY.md banners disclose gaps and farthest-first truncation under the payload byte cap. Direct `blocked_by` work-repo mounts are a separate contract under `/workspace/repo/`.
 """
 
 # Appended to every playbook that must WRITE result.json (all but PLAN, whose

--- a/app/devcake/prompts/customer_success.py
+++ b/app/devcake/prompts/customer_success.py
@@ -22,9 +22,10 @@ whether it is one deliverable or several.
   triage (the EXECUTE step produces the deliverables here, from your plan).
 - `/workspace/activity/` — the issue's knowledge base: MISSION.md (the
   brief), ACTIVITY.md (a faithful mirror of the issue's feed — posts,
-  replies, attachments), every attached file, and — when this issue is a
-  decomposition child — `upstream/{MISSION-KEY}/` mirrors of ancestor
-  activity toward the graph root. Read what you need.
+  replies, attachments), every attached file, and — when this issue is part
+  of larger work — `upstream/{MISSION-KEY}/` mirrors of each upstream
+  mission's activity: decomposition ancestors toward the graph root, then
+  the project this issue belongs to. Read what you need.
 - `/workspace/out/` — where your outputs go.
 
 ### The issue

--- a/app/tests/test_upstream_activity.py
+++ b/app/tests/test_upstream_activity.py
@@ -1,8 +1,10 @@
 """CAKE-124: offer every decomposition ancestor's activity under
-activity/upstream/{MISSION-KEY}/ (directed parent_ref chain to root).
+activity/upstream/{MISSION-KEY}/ (directed parent_ref chain to root), and
+(ADR-0036 addendum) the containing project's activity to any issue placed
+in a project.
 
 Public seams under test:
-- family_graph.decomposition_ancestors
+- family_graph.decomposition_ancestors / upstream_chain
 - activity_payload.activity_payload (upstream files + gaps + truncation)
 - dispatch gate via activity_payload upstream_gaps + context_sourcing_strict
 """
@@ -64,6 +66,72 @@ def test_decomposition_ancestors_ignores_blocked_by_only_neighbors():
     child.blocked_by = ["s"]
     got = family_graph.decomposition_ancestors(child, [root, child, sibling])
     assert [m.key for m in got] == ["ROOT-1"]
+
+
+def _project(pmo_id: str, key: str, *, labels: set | None = None) -> Mission:
+    return Mission(
+        instance="linear", pmo_id=pmo_id, pmo_kind="project", key=key,
+        title=f"project {key}", status="backlog",
+        labels=set(labels) if labels is not None else {"DEVCAKE"},
+        updated_at=NOW, description=f"project brief for {key}",
+    )
+
+
+def test_upstream_chain_issue_in_project_gets_the_project():
+    """ADR-0036 addendum: a hand-made issue placed in a project (no marker,
+    no DEVCAKE-CREATED) still gets the project as its upstream."""
+    proj = _project("p", "PRJ-1")
+    issue = _m("i", "ISSUE-1")
+    issue.parent_ref = "p"
+    got = family_graph.upstream_chain(issue, [proj, issue])
+    assert [(u.ref, u.relation) for u in got] == \
+        [("p", family_graph.RELATION_PROJECT)]
+    assert got[0].mission is proj and got[0].kind == "project"
+
+
+def test_upstream_chain_marker_chain_ending_at_project_is_not_doubled():
+    """A decomposition child of a project already reaches the project by
+    marker; the containment edge adds nothing twice."""
+    proj = _project("p", "PRJ-1")
+    child = _m("c", "CHILD-1", parent="p", depth=1)
+    child.parent_ref = "p"
+    got = family_graph.upstream_chain(child, [proj, child])
+    assert [(u.ref, u.relation) for u in got] == \
+        [("p", family_graph.RELATION_PARENT)]
+
+
+def test_upstream_chain_issue_chain_then_its_project():
+    """Root issue inside a project → child's chain = [root, project]."""
+    proj = _project("p", "PRJ-1")
+    root = _m("r", "ROOT-1")
+    root.parent_ref = "p"
+    child = _m("c", "CHILD-1", parent="r", depth=1)
+    child.parent_ref = "p"
+    got = family_graph.upstream_chain(child, [proj, root, child])
+    assert [(u.ref, u.relation) for u in got] == [
+        ("r", family_graph.RELATION_PARENT),
+        ("p", family_graph.RELATION_PROJECT)]
+
+
+def test_upstream_chain_project_absent_from_snapshot_is_offered_unresolved():
+    """A project without the managed label is never polled: the chain
+    names it with mission=None so the mirror builder reads it live."""
+    issue = _m("i", "ISSUE-1")
+    issue.parent_ref = "p-unlabeled"
+    got = family_graph.upstream_chain(issue, [issue])
+    assert len(got) == 1 and got[0].mission is None
+    assert got[0].ref == "p-unlabeled" and got[0].kind == "project"
+
+
+def test_upstream_chain_without_project_or_marker_is_empty():
+    issue = _m("i", "ISSUE-1")
+    assert family_graph.upstream_chain(issue, [issue]) == []
+
+
+def test_containing_project_ref_is_issue_only():
+    proj = _project("p", "PRJ-1")
+    proj.parent_ref = "x"
+    assert family_graph.containing_project_ref(proj) is None
 
 
 class MultiActivityPMO(MapPMO):
@@ -149,6 +217,92 @@ def test_grandchild_payload_includes_root_and_parent_upstream(tmp_path):
     assert by_name["upstream/CHILD-1/PLAN.md"] == b"bytes-of-PLAN.md"
     assert "upstream/ROOT-1/" in payload["activity_md"] or \
         "upstream/" in payload["activity_md"]
+
+
+def _project_act(proj: Mission, body: str) -> Activity:
+    entries = [ActivityEntry(ts=NOW, author="devcake", kind="comment",
+                             body=body, entry_id=f"u-{proj.pmo_id}")]
+    return Activity(mission=proj, entries=entries)
+
+
+def test_hand_made_issue_in_project_mirrors_the_project(tmp_path):
+    """The founder's case: an issue a person adds to a project must find
+    the project's brief and feed under upstream/, told what it is."""
+    proj = _project("p", "PRJ-1")
+    issue = _m("i", "ISSUE-1")
+    issue.parent_ref = "p"
+    activities = {
+        "p": _project_act(proj, "project update: scope agreed"),
+        "i": _act(issue, "issue feed"),
+    }
+    pmo = MultiActivityPMO([proj, issue], activities)
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [proj, issue]
+    payload = run_coro(mgr.activity_payload("i"))
+    by_name = {a["filename"]: base64.b64decode(a["content_b64"])
+               for a in payload["attachments"]}
+    assert b"project brief for PRJ-1" in by_name["upstream/PRJ-1/MISSION.md"]
+    assert b"scope agreed" in by_name["upstream/PRJ-1/ACTIVITY.md"]
+    assert payload["upstream_gaps"] == []
+    banner = payload["activity_md"]
+    assert "upstream/PRJ-1/" in banner and "containing project" in banner
+    assert "project PRJ-1" in banner            # the title, so the Dev knows
+    # the project was read from the snapshot, not fetched live
+    assert "p" not in pmo.get_calls
+
+
+def test_unlabeled_project_is_read_live(tmp_path):
+    """A project outside the board snapshot is fetched once by id."""
+    proj = _project("p", "PRJ-1", labels=set())
+    issue = _m("i", "ISSUE-1")
+    issue.parent_ref = "p"
+    activities = {
+        "p": _project_act(proj, "unlabeled project update"),
+        "i": _act(issue, "issue feed"),
+    }
+    pmo = MultiActivityPMO([proj, issue], activities)
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [issue]           # the poll never saw the project
+    payload = run_coro(mgr.activity_payload("i"))
+    names = [a["filename"] for a in payload["attachments"]]
+    assert "upstream/PRJ-1/MISSION.md" in names
+    assert pmo.get_calls == ["p"]
+    assert payload["upstream_gaps"] == []
+
+
+def test_unreadable_project_is_a_gap(tmp_path):
+    """The project cannot be read → a named gap, never a silent omission
+    (strict boards defer the dispatch on it like any ancestor gap)."""
+    issue = _m("i", "ISSUE-1")
+    issue.parent_ref = "p-gone"
+    pmo = MultiActivityPMO([issue], {"i": _act(issue, "issue feed")})
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [issue]
+    payload = run_coro(mgr.activity_payload("i"))
+    gaps = payload["upstream_gaps"]
+    assert len(gaps) == 1 and gaps[0]["key"] == "p-gone"
+    assert "containing project unreadable" in gaps[0]["reason"]
+    assert "UPSTREAM GAP" in payload["activity_md"]
+    assert not any(a["filename"].startswith("upstream/")
+                   for a in payload["attachments"])
+
+
+def test_project_child_by_marker_mirrors_the_project_once(tmp_path):
+    """A decomposition child of a project: one upstream folder, labeled as
+    the decomposition parent (unchanged behavior)."""
+    proj = _project("p", "PRJ-1")
+    child = _m("c", "CHILD-1", parent="p", depth=1)
+    child.parent_ref = "p"
+    activities = {"p": _project_act(proj, "project update"),
+                  "c": _act(child, "child feed")}
+    pmo = MultiActivityPMO([proj, child], activities)
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [proj, child]
+    payload = run_coro(mgr.activity_payload("c"))
+    names = [a["filename"] for a in payload["attachments"]]
+    assert names.count("upstream/PRJ-1/MISSION.md") == 1
+    assert "decomposition parent" in payload["activity_md"]
+    assert "containing project:" not in payload["activity_md"]
 
 
 def test_strict_unreadable_ancestor_reports_gap(tmp_path):

--- a/app/tests/test_upstream_activity.py
+++ b/app/tests/test_upstream_activity.py
@@ -362,6 +362,72 @@ def test_bundled_skills_never_include_review_ledger():
         assert "review-ledger" not in p.as_posix()
 
 
+def _dispatch_hand_made_issue_in_project(tmp_path, *, strict: bool,
+                                         readable: bool):
+    """Dispatch an issue a person placed in a project (no marker) whose
+    project may be unreadable — the ADR-0036 addendum's gate case."""
+    from devcake.config import AppConfig, Assignment, DevType, PMOInstance
+    from devcake.domain.model import MissionType
+    from fakes import FakeInternalForge, make_mission_manager
+    from test_prompt_templates import _ForgeWithDescriptor
+
+    proj = _project("p", "PRJ-1")
+    issue = _m("i", "ISSUE-1")
+    issue.parent_ref = "p"
+    issue.labels |= {"DEVCAKE-EXECUTE"}
+    issue.repo = "main"
+    activities = {"p": _project_act(proj, "project body"),
+                  "i": _act(issue, "issue body")}
+    pmo = MultiActivityPMO([proj, issue], activities)
+    if not readable:
+        pmo.fail_ids.add("p")
+    cfg = AppConfig(
+        context_sourcing_strict=strict,
+        assignments={mt: Assignment(dev_type="senior-dev")
+                     for mt in ("ONBOARD", "PLAN", "EXECUTE", "REVIEW")})
+    mgr = make_mission_manager(
+        tmp_path, pmo=pmo, forge=_ForgeWithDescriptor(), config=cfg,
+        dev_types={"senior-dev": DevType(name="senior-dev",
+                                         harness_template="claude-code")},
+        noop_audit=True)
+    mgr.internal_forge = FakeInternalForge()
+    mgr.instance = PMOInstance(name="linear", team_key="DEV", repos=["main"])
+    mgr._upstream_missions = [proj, issue]
+    launched = []
+
+    async def launch(run, image):
+        launched.append(run)
+    mgr.runs.bootstrap = type("B", (), {"launch": staticmethod(launch)})()
+    run = run_coro(mgr.dispatch(issue, MissionType.EXECUTE,
+                                mgr.dev_types["senior-dev"]))
+    return mgr, issue, run, launched, mgr.internal_forge
+
+
+def test_strict_unreadable_project_gates_dispatch(tmp_path):
+    """Strict on: the containing project cannot be read → fail-closed,
+    no attempt burned, the reason names the project."""
+    mgr, issue, run, launched, forge = _dispatch_hand_made_issue_in_project(
+        tmp_path, strict=True, readable=False)
+    assert run is None and launched == [] and forge.pushes == []
+    reason = mgr.blocked_reasons[issue.pmo_id]
+    assert "upstream activity unavailable" in reason
+    assert "PRJ-1" in reason and "containing project" in reason
+
+
+def test_readable_project_dispatches_with_its_mirror_in_the_snapshot(tmp_path):
+    """Strict on, project readable: the dispatch proceeds and the pushed
+    activity snapshot carries upstream/PRJ-1/ with the project's brief."""
+    mgr, issue, run, launched, forge = _dispatch_hand_made_issue_in_project(
+        tmp_path, strict=True, readable=True)
+    assert run is not None and launched
+    _repo, files, _msg = forge.pushes[0]
+    by_path = {f["path"]: base64.b64decode(f["content_b64"]).decode()
+               for f in files}
+    assert "project brief for PRJ-1" in by_path["upstream/PRJ-1/MISSION.md"]
+    assert "project body" in by_path["upstream/PRJ-1/ACTIVITY.md"]
+    assert "containing project: project PRJ-1" in by_path["ACTIVITY.md"]
+
+
 def _dispatch_with_ancestry(tmp_path, *, strict: bool, fail_root: bool = True):
     """Dispatch a child whose parent activity may be unreadable."""
     from devcake.config import AppConfig, Assignment, DevType, PMOInstance

--- a/docs/02-domain-model.md
+++ b/docs/02-domain-model.md
@@ -19,7 +19,7 @@ A **Mission** is a normalized DTO produced by the PMO adapter from a live Linear
 | `labels` | `set[str]` | Label names as they appear in the PMO System. Managed `DEVCAKE-*` names are canonicalized case-insensitively onto `ALL_LABELS` (`canonicalize_labels`) — Linear and the forge-issue adapters (GitHub/Gitea/GitLab) all emit that contract, and `derive()`/`swap_labels` are exact-string. |
 | `updated_at` | `datetime` | PMO-side last update. Scheduling tiebreaker. |
 | `url` | `str` | Deep link into the PMO System. |
-| `parent_ref` | `str \| None` | For Issues that belong to a Project: the project's `pmo_id` — also the tracking sweep's container link on the cycle snapshot (`BoardSnapshot.children_of`). `None` on forge-issue PMOs, which have no projects. |
+| `parent_ref` | `str \| None` | For Issues that belong to a Project: the project's `pmo_id` — also the tracking sweep's container link on the cycle snapshot (`BoardSnapshot.children_of`) and the upstream-offer's containment edge (`07-dev-runtime.md` §2, ADR-0036 addendum: the issue's Dev gets the project's activity under `upstream/`). `None` on forge-issue PMOs, which have no projects. |
 | `blocked_by` | `list[str]` | `pmo_id`s of Missions that block this one, read from the PMO System's native issue relations (`05-pmo-adapter.md` §3, `adr/0007`). Always `[]` for Projects (Linear relations are issue-scoped). Gates scheduling (`04-orchestrator.md` §2), not derivation. |
 | `instance` | `str` | Which configured PMO instance produced this Mission (schema v3) — stamped by the adapter at normalization so no fetch path can return an unstamped mission. |
 | `repo` | `str \| None` | Resolved work-repo instance name for this mission (poll-cycle stamp; never persisted). |

--- a/docs/07-dev-runtime.md
+++ b/docs/07-dev-runtime.md
@@ -41,13 +41,15 @@ Devs are **pure functions from (workspace, prompt) to artifacts**: they never wr
                          #   opens with the resumed-by-a-human banner (after a
                          #   hand-off, 03 §4a) and upstream-offer / gap /
                          #   truncation banners
-                         #   when this mission has decomposition ancestors (ADR-0036)
+                         #   when this mission has upstream work (ADR-0036)
     upstream/
-      {MISSION-KEY}/     # ZERO OR MORE decomposition-ancestor mirrors (ADR-0036 /
-                         #   CAKE-124): each holds that ancestor's MISSION.md,
-                         #   ACTIVITY.md, and attachments. Nearest parent first
-                         #   toward the graph root; oldest truncated first under
-                         #   the attachment byte cap. Direct blocked_by work-repo
+      {MISSION-KEY}/     # ZERO OR MORE upstream mirrors (ADR-0036 / CAKE-124 +
+                         #   addendum): each decomposition ancestor, then the
+                         #   project this mission belongs to; each holds that
+                         #   mission's MISSION.md, ACTIVITY.md, and attachments.
+                         #   Nearest parent first toward the graph root, the
+                         #   project last; farthest truncated first under the
+                         #   attachment byte cap. Direct blocked_by work-repo
                          #   mounts stay on ADR-0017 — they are not mirrored here.
     {attachment files}   # every attachment from the feed — including prior steps' full
                          #   session transcripts (`N_TYPE.md`, `PLAN_N.md`). When the
@@ -88,7 +90,7 @@ The workspace is prepared entirely by the container **entrypoint** (not the app)
 
 ## 2. `ACTIVITY.md` format
 
-**Intent (confirmed decision, revised by ADR-0014; amended by ADR-0036):** the `activity/` folder is a mini **knowledge base the harness taps into as needed** — queryable, greppable reference material. It is *never* inlined into the prompt; the playbook prompt carries only the mission title/description and points here (`03-mission-lifecycle.md` §7). The folder is four parts: **`MISSION.md`** (the brief — key/title/meta/labels, the FULL description, and mission-level attachments: description-embedded assets + the vendor's native attachment list, files downloaded / links rendered as links), **`ACTIVITY.md`** (a **faithful mirror of the feed as seen in the PMO** — every post and reply inline with its full body, `↳ reply to` nesting for people's replies (DevCake's own step bookkeeping is threaded on the board for readability and mirrored flat — the same file whether the vendor threads or not, `03-mission-lifecycle.md` §8), `[attachment: name]` markers at their feed positions; heavy content is naturally attachment-borne because DevCake's own long posts externalize at post time), the **sibling files** (every attachment's bytes, including prior steps' full session transcripts), and — when this mission is a decomposition child — **`upstream/{MISSION-KEY}/`** mirrors of every ancestor toward the graph root (ADR-0036 / CAKE-124; nearest parent first; oldest truncated first under the attachment byte cap; `blocked_by` work-repo mounts stay on ADR-0017). If the adapter's full-history hard stop ever trips, `ACTIVITY.md` opens with a loud `⚠ FEED TRUNCATED` banner — never silent. Upstream gaps and truncation use the same honest-banner doctrine (`⚠ UPSTREAM GAP` / `⚠ UPSTREAM TRUNCATED`). After a hand-off released by a person, `MISSION.md` opens with a one-line pointer and `ACTIVITY.md` with the `▶ RESUMED BY A HUMAN` banner (`03-mission-lifecycle.md` §4a); ancestor mirrors under `upstream/` never carry it.
+**Intent (confirmed decision, revised by ADR-0014; amended by ADR-0036):** the `activity/` folder is a mini **knowledge base the harness taps into as needed** — queryable, greppable reference material. It is *never* inlined into the prompt; the playbook prompt carries only the mission title/description and points here (`03-mission-lifecycle.md` §7). The folder is four parts: **`MISSION.md`** (the brief — key/title/meta/labels, the FULL description, and mission-level attachments: description-embedded assets + the vendor's native attachment list, files downloaded / links rendered as links), **`ACTIVITY.md`** (a **faithful mirror of the feed as seen in the PMO** — every post and reply inline with its full body, `↳ reply to` nesting for people's replies (DevCake's own step bookkeeping is threaded on the board for readability and mirrored flat — the same file whether the vendor threads or not, `03-mission-lifecycle.md` §8), `[attachment: name]` markers at their feed positions; heavy content is naturally attachment-borne because DevCake's own long posts externalize at post time), the **sibling files** (every attachment's bytes, including prior steps' full session transcripts), and — when this mission is part of larger work — **`upstream/{MISSION-KEY}/`** mirrors of every upstream mission: each decomposition ancestor toward the graph root, then the project the mission belongs to (ADR-0036 / CAKE-124 + addendum; nearest parent first, the project last; farthest truncated first under the attachment byte cap; an issue a person places in a project gets the project's brief and feed this way; `blocked_by` work-repo mounts stay on ADR-0017). If the adapter's full-history hard stop ever trips, `ACTIVITY.md` opens with a loud `⚠ FEED TRUNCATED` banner — never silent. Upstream gaps and truncation use the same honest-banner doctrine (`⚠ UPSTREAM GAP` / `⚠ UPSTREAM TRUNCATED`). After a hand-off released by a person, `MISSION.md` opens with a one-line pointer and `ACTIVITY.md` with the `▶ RESUMED BY A HUMAN` banner (`03-mission-lifecycle.md` §4a); ancestor mirrors under `upstream/` never carry it.
 
 ```markdown
 # {mission_key}: {title}

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -936,6 +936,14 @@ until that run exists, field evidence below stays operator-self-reported.
   ADR-0009, CHANGELOG.
 ### Field evidence (receipted)
 
+- **The containing project is upstream** (2026-09-10, ADR-0036 addendum):
+  an issue a person placed in a project got nothing from the project —
+  the ancestor offer followed only the decomposition marker. The offer now
+  walks `family_graph.upstream_chain`: decomposition ancestors, then the
+  containing project (`Mission.parent_ref`, trusted from the vendor's
+  record, read live when unlabeled), mirrored last under
+  `upstream/{PROJECT-KEY}/` with the relation and title in the banner;
+  an unreadable project is a named gap. Docs 02, 07 §2, playbook note.
 - **The feed for readers: step cards** (2026-09-09, ADR-0042 PR-1..4):
   a three-step mission read as fifteen comments, a third of them
   markers, the answer posted twice, an HTML marker rendered as text on

--- a/docs/adr/0036-upstream-activity-ancestor-offer.md
+++ b/docs/adr/0036-upstream-activity-ancestor-offer.md
@@ -87,3 +87,43 @@ deselection from Dev Types where the operator still has it selected.
 - Activity payload builders and the dispatch strict gate share one chokepoint
   (`activity_payload` → `upstream_gaps`).
 - No new config field; reuses `context_sourcing_strict` and attachment caps.
+
+## Addendum — the containing project is upstream too (2026-09-10)
+
+**Context.** The ancestor walk above follows only the decomposition marker,
+which DevCake writes when it splits a mission. An issue a person places in a
+project by hand carries no marker, so its Dev received nothing from the
+project: not the brief, not the project updates, not the documents. The
+founder ruled that this is a mistake: a mission inside a project must know
+the project's activity repository is there for consulting and that it is
+the upstream work the mission belongs to. It need not ride in the prompt;
+it must be in the workspace, named for what it is.
+
+**Decision.**
+
+- The offer walks the **upstream chain** (`family_graph.upstream_chain`):
+  the decomposition ancestors as before, then the **containing project** of
+  the chain's last issue (the mission itself when there is no chain). The
+  project is the farthest upstream, so it is mirrored last and truncates
+  first under the byte cap. A chain that already ends at the project by
+  marker gains nothing twice.
+- The containment edge is read from the vendor's own record
+  (`Mission.parent_ref`, the project's id on vendors with projects). It is
+  trusted **without** the `DEVCAKE-CREATED` gate that guards the marker:
+  membership is set by a person or by DevCake on the vendor, never by
+  description text, so it cannot be forged. `family_of` and the family gate
+  do not change — the project edge is context, not ordering.
+- A containing project the board snapshot does not hold (a project without
+  the managed label is never polled) is read live once, under the
+  dispatch's call class. An unreadable project is a named `⚠ UPSTREAM GAP`
+  like any ancestor, so a strict board defers the dispatch rather than
+  launching blind.
+- The ACTIVITY.md offer banner names each mirror's relation
+  (`decomposition parent` / `containing project`) and the upstream
+  mission's title, and the playbooks' workspace note says the project's
+  brief and feed are the context the mission is part of.
+
+**Consequences.** Any issue in a project sees the project's MISSION.md,
+ACTIVITY.md (its updates) and documents under `upstream/{PROJECT-KEY}/`.
+One extra full read per dispatch for such issues, under the existing cap.
+`blocked_by` feeds stay out (§3); widening that remains a separate decision.


### PR DESCRIPTION
## What

An issue a person places in a project now receives the project's activity under `upstream/{PROJECT-KEY}/` in its Dev workspace, the same way a decomposition child receives its parent's (ADR-0036 addendum).

## Why

The upstream offer followed only the decomposition marker DevCake writes when it splits a mission. A hand-made issue inside a project has no marker, so its Dev got nothing from the project: not the brief, not the project updates, not the documents. The project is the upstream work the issue belongs to; the Dev must know its activity repository is there for consulting.

## How

- `family_graph.upstream_chain`: the decomposition ancestors as before, then the containing project of the chain's last issue (`Mission.parent_ref`, the vendor's own record). Trusted without the `DEVCAKE-CREATED` gate: membership is set on the vendor by a person or by DevCake, never by description text. `family_of` and the family gate are untouched — this edge is context, not ordering.
- `_offer_upstream` walks the chain. The project is mirrored last (farthest upstream, truncates first under the byte cap). A project the board snapshot does not hold (unlabeled projects are never polled) is read live once; an unreadable one is a named `⚠ UPSTREAM GAP`, so a strict board defers instead of launching blind. A chain that already ends at the project by marker gains nothing twice.
- The ACTIVITY.md banner names each mirror's relation (`decomposition parent` / `containing project`) and the upstream mission's title; the playbooks' workspace note and upstream section say the project's brief and feed are the context the mission is part of.
- Docs: ADR-0036 addendum, 07 §2 tree and folder text, 02 field table, roadmap log, changelog.

## Tests

`test_upstream_activity.py`: chain rules (issue in project; marker chain ending at the project not doubled; issue chain then its project; project absent from the snapshot offered unresolved; nothing without a project or marker; containment is issue-only), payload rules (hand-made issue mirrors the project from the snapshot with no live read; unlabeled project read live once; unreadable project is a gap with no upstream files; a marker child of a project mirrors it once as the decomposition parent). Existing ancestor, truncation and strict-gate tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVp9ty5CFCjT6PphDe24MH
