### PR TITLE
feat(upstream): upstream folders are copies of the record; finished blockers included (ADR-0043 stage 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ See the living log and open candidates in
   uploaded and linked, through the same chokepoint issues use (ADR-0043,
   stage 2 of 3).
 
+- **Changed — a Dev's upstream folders are copies of the record, and
+  finished blockers are among them.** The upstream folders in a Dev's
+  workspace were rebuilt from the vendor at every dispatch and covered
+  the decomposition ancestors and the containing project only; a mission
+  this one was blocked by contributed a repository clone and a short
+  handoff excerpt, so an attachment on a blocker's ticket never reached
+  the dependent. Each upstream folder is now a copy of that mission's
+  activity repository, and every direct blocker that finished has one.
+  The byte budget is decided from the record's sizes before anything is
+  fetched; a mission that never ran is rebuilt from the vendor as before;
+  an unreadable blocker is disclosed, never a reason to hold a dispatch
+  (ADR-0043, stage 3 of 3).
+
 ## v0.6.1 (2026-09-10)
 
 Patch release in the v0.6 "Kentucky Butter" line. `devcake-cli` stays at 0.1.8.

--- a/app/devcake/domain/orchestrator/activity_payload.py
+++ b/app/devcake/domain/orchestrator/activity_payload.py
@@ -201,18 +201,25 @@ def _nested_snapshot_bytes(payload: dict) -> list[tuple[str, bytes]]:
 
 async def _offer_upstream(mgr, mission, used: set[str]
                           ) -> tuple[list[dict], list[dict], list[str], list[str]]:
-    """CAKE-124 / ADR-0036 (+ addendum): mirror each upstream mission —
-    every decomposition ancestor, then the containing project — under
-    upstream/{KEY}/. Packs nearest-parent-first into a total byte budget
-    equal to `_attachment_cap()`; the farthest (root-ward) ones truncate
-    first. A containing project the board snapshot does not hold (it may
-    carry no managed label) is read live; an unreadable one is a gap like
-    any ancestor. Returns (attachment_dicts, gaps, truncated_keys,
-    banner_lines)."""
+    """ADR-0043 §3-4 (CAKE-124 / ADR-0036 lineage): mirror each upstream
+    mission — every decomposition ancestor, the containing project, then
+    every direct done blocker — under upstream/{KEY}/. Each folder is a
+    COPY OF THE RECORD: the upstream mission's activity repository, read
+    through the internal forge (its own `upstream/` subtree excluded; the
+    chain lays every folder out flat). A mission with no record (never
+    dispatched) falls back to the vendor rebuild. Packs nearest-first into
+    a total byte budget equal to `_attachment_cap()`, decided from the
+    tree's sizes before a byte is fetched; the farthest truncate first.
+    An unreadable ancestor or project is a strict-gate gap; an unreadable
+    blocker is a disclosed gap that never defers a dispatch (no dispatch
+    was ever gated on blocker context). Returns (attachment_dicts,
+    gating_gaps, truncated_keys, banner_lines)."""
     # Lazy import: family_graph → dispatch → activity_payload (cycle).
     from . import family_graph
+    from ...ports.internal_forge import activity_repo_name
     missions = await _missions_snapshot(mgr)
     chain = family_graph.upstream_chain(mission, missions)
+    outside = family_graph.blockers_outside(mission, missions)
     # A trusted parent_ref that does not resolve in the snapshot is a gap —
     # the Dev must not start believing the chain is empty when it is not.
     pref = decomposition_parent_ref(mission)
@@ -234,7 +241,8 @@ async def _offer_upstream(mgr, mission, used: set[str]
         budget = 25 * 1024 * 1024
 
     files: list[dict] = []
-    gaps: list[dict] = []
+    gaps: list[dict] = []            # gating (ancestor / project)
+    soft_gaps: list[dict] = []       # disclosed only (blocker)
     truncated: list[str] = []
     banners: list[str] = []
     included: list[str] = []
@@ -249,6 +257,13 @@ async def _offer_upstream(mgr, mission, used: set[str]
         return (u.mission.key if u.mission is not None and u.mission.key
                 else u.ref)
 
+    def _gap(up, key, pmo_id, reason):
+        entry = {"key": key, "pmo_id": pmo_id, "reason": reason}
+        (soft_gaps if up.relation == family_graph.RELATION_BLOCKER
+         else gaps).append(entry)
+
+    forge = getattr(mgr, "internal_forge", None)
+
     for i, up in enumerate(chain):
         anc = up.mission
         if anc is None:
@@ -257,34 +272,64 @@ async def _offer_upstream(mgr, mission, used: set[str]
             try:
                 anc = await mgr.pmo.get(MissionRef(up.ref, up.kind))
             except Exception as e:  # noqa: BLE001 — unreadable upstream = gap, never silent
-                reason = (f"{up.relation} unreadable: "
-                          f"{type(e).__name__}: {str(e)[:160]}")
-                gaps.append({"key": up.ref, "pmo_id": up.ref,
-                             "reason": reason})
+                _gap(up, up.ref, up.ref, f"{up.relation} unreadable: "
+                     f"{type(e).__name__}: {str(e)[:160]}")
                 continue
         key = anc.key or anc.pmo_id
         seg = _safe_upstream_key(key)
         if seg is None:
-            gaps.append({"key": key, "pmo_id": anc.pmo_id,
-                         "reason": "unsafe mission key for upstream path"})
-            continue
-        try:
-            nested = await activity_payload(
-                mgr, anc.pmo_id, anc.pmo_kind or up.kind,
-                include_upstream=False)
-        except Exception as e:  # noqa: BLE001 — one ancestor failure must not abort the offer
-            reason = (f"{up.relation} activity unreadable: "
-                      f"{type(e).__name__}: {str(e)[:160]}")
-            gaps.append({"key": key, "pmo_id": anc.pmo_id, "reason": reason})
+            _gap(up, key, anc.pmo_id, "unsafe mission key for upstream path")
             continue
 
-        pairs = _nested_snapshot_bytes(nested)
-        size = sum(len(b) for _, b in pairs)
-        if used_bytes + size > budget:
-            # This ancestor and every older (farther) one are omitted.
-            for rest in chain[i:]:
-                truncated.append(_label(rest))
-            break
+        # 1 — the record: the upstream mission's activity repository
+        source = "record"
+        pairs: list[tuple[str, bytes]] | None = None
+        size = 0
+        if forge is not None and anc.key:
+            repo = activity_repo_name(mgr.instance_name, anc.key)
+            try:
+                tree = await forge.activity_snapshot_tree(repo)
+            except Exception as e:  # noqa: BLE001 — the record is unreadable: a gap, never a silent vendor fallback that could cost the budget
+                _gap(up, key, anc.pmo_id, f"{up.relation} record unreadable: "
+                     f"{type(e).__name__}: {str(e)[:160]}")
+                continue
+            if tree is not None:
+                blobs = [t for t in tree
+                         if not t["path"].startswith("upstream/")]
+                size = sum(int(t.get("size") or 0) for t in blobs)
+                if used_bytes + size > budget:
+                    for rest in chain[i:]:
+                        truncated.append(_label(rest))
+                    break
+                try:
+                    pairs = [(t["path"],
+                              await forge.activity_snapshot_file(repo, t["path"]))
+                             for t in blobs]
+                except Exception as e:  # noqa: BLE001 — same: a half-read record is a gap
+                    _gap(up, key, anc.pmo_id,
+                         f"{up.relation} record unreadable: "
+                         f"{type(e).__name__}: {str(e)[:160]}")
+                    continue
+
+        # 2 — no record (the mission never dispatched): the vendor rebuild
+        if pairs is None:
+            source = "vendor"
+            try:
+                nested = await activity_payload(
+                    mgr, anc.pmo_id, anc.pmo_kind or up.kind,
+                    include_upstream=False)
+            except Exception as e:  # noqa: BLE001 — one upstream failure must not abort the offer
+                _gap(up, key, anc.pmo_id,
+                     f"{up.relation} activity unreadable: "
+                     f"{type(e).__name__}: {str(e)[:160]}")
+                continue
+            pairs = _nested_snapshot_bytes(nested)
+            size = sum(len(b) for _, b in pairs)
+            if used_bytes + size > budget:
+                # This one and every farther one are omitted.
+                for rest in chain[i:]:
+                    truncated.append(_label(rest))
+                break
 
         prefix = f"upstream/{seg}"
         for rel, data in pairs:
@@ -295,28 +340,37 @@ async def _offer_upstream(mgr, mission, used: set[str]
             files.append({"filename": full,
                           "content_b64": base64.b64encode(data).decode()})
         used_bytes += size
-        included.append((key, up.relation, anc.title or ""))
+        included.append((key, up.relation, anc.title or "", source))
 
-    if included:
+    if included or outside:
         banners.append(
-            "## Upstream mission activity (decomposition ancestors and "
-            "the containing project)")
+            "## Upstream mission activity (ancestors, the containing "
+            "project, and finished blockers)")
         banners.append(
-            "Upstream activity mirrors live under `upstream/{MISSION-KEY}/` "
-            "(nearest parent first, toward the graph root; the project "
-            "this mission belongs to comes last). Each holds that "
-            "mission's MISSION.md, ACTIVITY.md and attachments — consult "
-            "them for the brief and history this mission is part of. "
-            "Direct `blocked_by` work-repo mounts remain a separate "
-            "contract (ADR-0017) — they are not mirrored here.")
-        for key, relation, title in included:
+            "Upstream activity mirrors live under `upstream/{MISSION-KEY}/`: "
+            "each decomposition ancestor nearest parent first toward the "
+            "graph root, then the project this mission belongs to, then "
+            "every mission this one was blocked by that finished. Each "
+            "folder is a copy of that mission's record — MISSION.md, "
+            "ACTIVITY.md and every attachment — consult them for the brief, "
+            "the history and the files this mission's work is part of. A "
+            "folder marked \"rebuilt from the vendor\" belongs to a mission "
+            "that never ran under DevCake. Direct `blocked_by` work-repo "
+            "clones under `/workspace/repo/` remain a separate contract "
+            "(ADR-0017).")
+        for key, relation, title, source in included:
             seg = _safe_upstream_key(key) or key
             tail = f": {title}" if title else ""
-            banners.append(f"- `upstream/{seg}/` — {relation}{tail}")
+            src = "" if source == "record" else " (rebuilt from the vendor)"
+            banners.append(f"- `upstream/{seg}/` — {relation}{tail}{src}")
+        if outside:
+            banners.append(
+                f"- {outside} blocker(s) on another board are not mirrored "
+                f"here; their handoffs are in MISSION.md.")
         banners.append("")
 
-    if gaps:
-        for g in gaps:
+    if gaps or soft_gaps:
+        for g in gaps + soft_gaps:
             banners.append(
                 f"⚠ UPSTREAM GAP — activity for `{g.get('key')}` is "
                 f"unavailable: {g.get('reason', 'unreadable')}.")

--- a/app/devcake/domain/orchestrator/family_graph.py
+++ b/app/devcake/domain/orchestrator/family_graph.py
@@ -79,6 +79,7 @@ def decomposition_ancestors(source: Mission,
 # each upstream/{KEY}/ folder is there.
 RELATION_PARENT = "decomposition parent"
 RELATION_PROJECT = "containing project"
+RELATION_BLOCKER = "blocker"
 
 
 @dataclass(frozen=True)
@@ -105,26 +106,50 @@ def containing_project_ref(mission: Mission) -> str | None:
 
 def upstream_chain(source: Mission, missions: list[Mission]) -> list[Upstream]:
     """The missions whose activity a dispatched Dev is offered, nearest
-    first (ADR-0036 + addendum): the decomposition ancestors, then the
-    containing project of the chain's last issue (the source itself when
-    there is no chain). An issue a person places in a project therefore
-    gets the project's brief and feed exactly as a decomposition child
-    does; a chain that already ends at the project gains nothing twice.
-    The project is the farthest ancestor, so it truncates first under the
-    byte cap. Cycle-safe by construction of the walk plus the `seen` set."""
+    first (ADR-0036 + addendum, ADR-0043 §4): the decomposition ancestors,
+    then the containing project of the chain's last issue (the source
+    itself when there is no chain), then every DIRECT `blocked_by` mission
+    whose status is done, in relation order. An issue a person places in a
+    project therefore gets the project's brief and feed exactly as a
+    decomposition child does; a chain that already ends at the project
+    gains nothing twice; a dependent sees each finished blocker's whole
+    record, not only its handoff excerpt. Order is priority: the byte cap
+    truncates from the end, so blockers drop before the project and the
+    project before the nearest parent. Blockers are never followed
+    transitively (their own upstream is in their own record). A blocker the
+    snapshot does not hold (another board, ADR-0009) is not listed — see
+    `blockers_outside`. Cycle-safe by construction of the walk plus the
+    `seen` set."""
     chain = [Upstream(m.pmo_id, m.pmo_kind or "issue", RELATION_PARENT, m)
              for m in decomposition_ancestors(source, missions)]
     last = chain[-1].mission if chain else source
     seen = {source.pmo_id} | {u.ref for u in chain}
-    pid = containing_project_ref(last)
-    if not pid or pid in seen:
-        return chain
     by_id = {m.pmo_id: m for m in missions if m.pmo_id}
-    proj = by_id.get(pid)
-    if proj is not None and (proj.pmo_kind or "issue") != "project":
-        return chain          # a parent_ref that is not a project: ignore
-    chain.append(Upstream(pid, "project", RELATION_PROJECT, proj))
+    by_key = {m.key.upper(): m for m in missions if m.key}
+    pid = containing_project_ref(last)
+    if pid and pid not in seen:
+        proj = by_id.get(pid)
+        if proj is None or (proj.pmo_kind or "issue") == "project":
+            chain.append(Upstream(pid, "project", RELATION_PROJECT, proj))
+            seen.add(pid)
+    for ref in source.blocked_by or []:
+        b = _resolve_in_pool(ref, by_id, by_key)
+        if b is None or b.pmo_id in seen or b.status != "done":
+            continue
+        chain.append(Upstream(b.pmo_id, b.pmo_kind or "issue",
+                              RELATION_BLOCKER, b))
+        seen.add(b.pmo_id)
     return chain
+
+
+def blockers_outside(source: Mission, missions: list[Mission]) -> int:
+    """How many of the source's direct blockers the snapshot does not hold
+    (peer-board blockers, ADR-0009): they are counted in the offer banner,
+    never mirrored — the walk runs over ONE board's snapshot."""
+    by_id = {m.pmo_id for m in missions if m.pmo_id}
+    by_key = {m.key.upper() for m in missions if m.key}
+    return sum(1 for ref in (source.blocked_by or [])
+               if ref not in by_id and ref.upper() not in by_key)
 
 
 def family_of(source: Mission, missions: list[Mission]) -> Family:

--- a/app/devcake/prompts/__init__.py
+++ b/app/devcake/prompts/__init__.py
@@ -70,11 +70,12 @@ the EXECUTE step, from the plan you attach.
   brief), ACTIVITY.md (a faithful mirror of the mission's feed — full posts,
   replies, `[attachment: …]` markers), every attached file — including prior
   steps' full session transcripts (`N_TYPE.md`) — and, when this mission is
-  part of larger work, `upstream/{MISSION-KEY}/` mirrors of every upstream
-  mission: each decomposition ancestor toward the graph root (parent,
-  grandparent, …) and the project this mission belongs to. Read upstream
-  context from those folders; do not assume a parent-delivered attachment
-  lands at the activity root. Reference material: grep or read what you need; do not
+  part of larger work, `upstream/{MISSION-KEY}/` copies of every upstream
+  mission's record: each decomposition ancestor toward the graph root
+  (parent, grandparent, …), the project this mission belongs to, and every
+  mission this one was blocked by that finished. Read upstream context from
+  those folders; do not assume a parent-delivered attachment lands at the
+  activity root. Reference material: grep or read what you need; do not
   assume you must read all of it.
 - `/workspace/out/` — where your outputs go.
 
@@ -251,8 +252,8 @@ most recent human comment wins.
 # overrides that keep the epilogues) tells Devs where the context of the
 # larger work lives.
 UPSTREAM_ACTIVITY_NOTE = """
-### Upstream mission activity (decomposition ancestors and the containing project)
-When this mission is part of larger work — a child in a decomposition graph, or an issue that belongs to a project — `/workspace/activity/upstream/{MISSION-KEY}/` holds a mirror of each upstream mission's activity (MISSION.md, ACTIVITY.md, attachments): each ancestor nearest parent first toward the graph root, then the project this mission belongs to. The project's brief and feed are the context this mission is part of: consult them before deciding scope. Parent-delivered attachments (plans, ledgers, handoffs) live there, not necessarily at the activity root. ACTIVITY.md banners disclose gaps and farthest-first truncation under the payload byte cap. Direct `blocked_by` work-repo mounts are a separate contract under `/workspace/repo/`.
+### Upstream mission activity (ancestors, the containing project, and finished blockers)
+When this mission is part of larger work — a child in a decomposition graph, an issue that belongs to a project, or a mission that waited on others — `/workspace/activity/upstream/{MISSION-KEY}/` holds a copy of each upstream mission's record (MISSION.md, ACTIVITY.md, every attachment): each ancestor nearest parent first toward the graph root, then the project this mission belongs to, then every mission this one was blocked by that finished. The project's brief and feed are the context this mission is part of, and a finished blocker's folder holds everything it produced and was given — consult them before deciding scope. Parent-delivered attachments (plans, ledgers, handoffs) live there, not necessarily at the activity root. ACTIVITY.md banners disclose gaps and farthest-first truncation under the payload byte cap. Direct `blocked_by` work-repo clones are a separate contract under `/workspace/repo/`.
 """
 
 # Appended to every playbook that must WRITE result.json (all but PLAN, whose

--- a/app/devcake/prompts/customer_success.py
+++ b/app/devcake/prompts/customer_success.py
@@ -23,9 +23,10 @@ whether it is one deliverable or several.
 - `/workspace/activity/` — the issue's knowledge base: MISSION.md (the
   brief), ACTIVITY.md (a faithful mirror of the issue's feed — posts,
   replies, attachments), every attached file, and — when this issue is part
-  of larger work — `upstream/{MISSION-KEY}/` mirrors of each upstream
-  mission's activity: decomposition ancestors toward the graph root, then
-  the project this issue belongs to. Read what you need.
+  of larger work — `upstream/{MISSION-KEY}/` copies of each upstream
+  mission's record: decomposition ancestors toward the graph root, the
+  project this issue belongs to, and every finished issue this one was
+  blocked by. Read what you need.
 - `/workspace/out/` — where your outputs go.
 
 ### The issue

--- a/app/tests/fakes.py
+++ b/app/tests/fakes.py
@@ -159,6 +159,7 @@ class FakeInternalForge:
         # kept prefixes untouched); the read operations serve from it.
         self.snapshots: dict[str, dict[str, str]] = {}
         self.read_calls: list[tuple[str, str]] = []
+        self.fail_reads: set[str] = set()     # repos whose record is unreadable
 
     async def ensure_activity_repo(self, instance, mission_key):
         from devcake.ports.internal_forge import activity_repo_name
@@ -189,6 +190,8 @@ class FakeInternalForge:
         import base64
         import hashlib
         self.read_calls.append((repo_name, ""))
+        if repo_name in self.fail_reads:
+            raise RuntimeError(f"record unreadable: {repo_name}")
         cur = self.snapshots.get(repo_name)
         if cur is None:
             return None

--- a/app/tests/test_upstream_activity.py
+++ b/app/tests/test_upstream_activity.py
@@ -492,3 +492,161 @@ def test_nonstrict_unreadable_ancestor_dispatches_with_gap(tmp_path):
     assert "ROOT-1" in by_path["ACTIVITY.md"]
     assert "unavailable" in by_path["ACTIVITY.md"].lower() or \
         "UPSTREAM GAP" in by_path["ACTIVITY.md"]
+
+
+# ── ADR-0043 §3-4: folders are copies of the record; blockers included ───
+
+def _blocker(pmo_id: str, key: str, status: str = "done") -> Mission:
+    return _m(pmo_id, key, status=status)
+
+
+def test_upstream_chain_appends_direct_done_blockers_in_order():
+    a = _blocker("a", "BLK-A"); b = _blocker("b", "BLK-B")
+    c = _blocker("c", "BLK-C", status="in_progress")
+    proj = _project("p", "PRJ-1")
+    issue = _m("i", "ISSUE-1"); issue.parent_ref = "p"
+    issue.blocked_by = ["b", "c", "a"]
+    got = family_graph.upstream_chain(issue, [a, b, c, proj, issue])
+    assert [(u.ref, u.relation) for u in got] == [
+        ("p", family_graph.RELATION_PROJECT),
+        ("b", family_graph.RELATION_BLOCKER),
+        ("a", family_graph.RELATION_BLOCKER)]      # c is not done: skipped
+
+
+def test_upstream_chain_never_lists_a_blocker_twice_or_transitively():
+    root = _m("r", "ROOT-1"); root.blocked_by = ["x"]
+    x = _blocker("x", "BLK-X")
+    child = _m("c", "CHILD-1", parent="r", depth=1)
+    child.blocked_by = ["r", "x"]                   # parent doubles as blocker
+    got = family_graph.upstream_chain(child, [root, x, child])
+    assert [(u.ref, u.relation) for u in got] == [
+        ("r", family_graph.RELATION_PARENT),
+        ("x", family_graph.RELATION_BLOCKER)]
+    # x's own blocker (none here) and r's blockers are never followed
+
+
+def test_blockers_outside_the_snapshot_are_counted():
+    issue = _m("i", "ISSUE-1"); issue.blocked_by = ["peer-1", "a"]
+    a = _blocker("a", "BLK-A")
+    assert family_graph.blockers_outside(issue, [issue, a]) == 1
+    assert [u.ref for u in family_graph.upstream_chain(issue, [issue, a])] == ["a"]
+
+
+def _forge_with_record(repo: str, files: dict[str, bytes]):
+    from fakes import FakeInternalForge
+    forge = FakeInternalForge()
+    forge.seed_snapshot(repo, files)
+    return forge
+
+
+def test_upstream_folder_is_copied_from_the_record_not_the_vendor(tmp_path):
+    """The parent's activity repo is the source: its files land verbatim
+    (its own upstream/ subtree excluded) and the vendor is not read."""
+    root = _m("r", "ROOT-1")
+    child = _m("c", "CHILD-1", parent="r", depth=1)
+    activities = {"c": _act(child, "child feed"),
+                  "r": _act(root, "VENDOR VIEW — must not be used")}
+    pmo = MultiActivityPMO([root, child], activities)
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [root, child]
+    mgr.internal_forge = _forge_with_record("activity-linear-root-1", {
+        "MISSION.md": b"# ROOT-1 record brief",
+        "ACTIVITY.md": b"record feed with the 1_ONBOARD card",
+        "1_ONBOARD.md": b"full transcript bytes",
+        "spec.pdf": b"%PDF starting attachment",
+        "upstream/GRAND-1/MISSION.md": b"not nested again"})
+    payload = run_coro(mgr.activity_payload("c"))
+    by_name = {a["filename"]: base64.b64decode(a["content_b64"])
+               for a in payload["attachments"]}
+    assert by_name["upstream/ROOT-1/MISSION.md"] == b"# ROOT-1 record brief"
+    assert by_name["upstream/ROOT-1/1_ONBOARD.md"] == b"full transcript bytes"
+    assert by_name["upstream/ROOT-1/spec.pdf"] == b"%PDF starting attachment"
+    assert "upstream/ROOT-1/upstream/GRAND-1/MISSION.md" not in by_name
+    assert not any(pid == "r" for pid, _full in pmo.activity_calls)
+    assert "(rebuilt from the vendor)" not in payload["activity_md"]
+    assert payload["upstream_gaps"] == []
+
+
+def test_upstream_without_a_record_is_rebuilt_from_the_vendor(tmp_path):
+    from fakes import FakeInternalForge
+    root = _m("r", "ROOT-1")
+    child = _m("c", "CHILD-1", parent="r", depth=1)
+    pmo = MultiActivityPMO([root, child], {
+        "c": _act(child, "child feed"), "r": _act(root, "root vendor feed")})
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [root, child]
+    mgr.internal_forge = FakeInternalForge()         # no record for ROOT-1
+    payload = run_coro(mgr.activity_payload("c"))
+    by_name = {a["filename"]: base64.b64decode(a["content_b64"])
+               for a in payload["attachments"]}
+    assert b"root vendor feed" in by_name["upstream/ROOT-1/ACTIVITY.md"]
+    assert "ROOT-1 (rebuilt from the vendor)" in payload["activity_md"]
+
+
+def test_done_blocker_record_is_mirrored_and_labeled(tmp_path):
+    blk = _blocker("b", "BLK-1")
+    issue = _m("i", "ISSUE-1"); issue.blocked_by = ["b"]
+    pmo = MultiActivityPMO([blk, issue], {"i": _act(issue, "issue feed")})
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [blk, issue]
+    mgr.internal_forge = _forge_with_record("activity-linear-blk-1", {
+        "MISSION.md": b"blocker brief", "ACTIVITY.md": b"blocker feed",
+        "findings.csv": b"a,b\n1,2\n"})
+    payload = run_coro(mgr.activity_payload("i"))
+    by_name = {a["filename"]: base64.b64decode(a["content_b64"])
+               for a in payload["attachments"]}
+    assert by_name["upstream/BLK-1/findings.csv"] == b"a,b\n1,2\n"
+    assert "`upstream/BLK-1/` — blocker" in payload["activity_md"]
+
+
+def test_unreadable_blocker_record_is_a_disclosed_non_gating_gap(tmp_path):
+    blk = _blocker("b", "BLK-1")
+    issue = _m("i", "ISSUE-1"); issue.blocked_by = ["b"]
+    pmo = MultiActivityPMO([blk, issue], {"i": _act(issue, "issue feed")})
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [blk, issue]
+    forge = _forge_with_record("activity-linear-blk-1", {"MISSION.md": b"x"})
+    forge.fail_reads.add("activity-linear-blk-1")
+    mgr.internal_forge = forge
+    payload = run_coro(mgr.activity_payload("i"))
+    assert payload["upstream_gaps"] == []            # never gates a dispatch
+    assert "UPSTREAM GAP" in payload["activity_md"]
+    assert "BLK-1" in payload["activity_md"]
+    assert not any(a["filename"].startswith("upstream/")
+                   for a in payload["attachments"])
+
+
+def test_unreadable_ancestor_record_still_gates(tmp_path):
+    root = _m("r", "ROOT-1")
+    child = _m("c", "CHILD-1", parent="r", depth=1)
+    pmo = MultiActivityPMO([root, child], {"c": _act(child, "child feed")})
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [root, child]
+    forge = _forge_with_record("activity-linear-root-1", {"MISSION.md": b"x"})
+    forge.fail_reads.add("activity-linear-root-1")
+    mgr.internal_forge = forge
+    payload = run_coro(mgr.activity_payload("c"))
+    assert [g["key"] for g in payload["upstream_gaps"]] == ["ROOT-1"]
+    assert "record unreadable" in payload["upstream_gaps"][0]["reason"]
+
+
+def test_budget_is_decided_from_record_sizes_before_download(tmp_path):
+    """Blockers are last, so they truncate first; an over-budget record is
+    never downloaded (only its tree was read)."""
+    root = _m("r", "ROOT-1")
+    child = _m("c", "CHILD-1", parent="r", depth=1)
+    blk = _blocker("b", "BLK-1"); child.blocked_by = ["b"]
+    pmo = MultiActivityPMO([root, child, blk], {"c": _act(child, "c")})
+    mgr = make_mgr(tmp_path, pmo)
+    mgr._upstream_missions = [root, child, blk]
+    forge = _forge_with_record("activity-linear-root-1",
+                               {"MISSION.md": b"r" * 100})
+    forge.seed_snapshot("activity-linear-blk-1", {"big.bin": b"b" * 5000})
+    mgr.internal_forge = forge
+    mgr._attachment_cap = lambda: 1000
+    payload = run_coro(mgr.activity_payload("c"))
+    names = [a["filename"] for a in payload["attachments"]]
+    assert "upstream/ROOT-1/MISSION.md" in names
+    assert not any(n.startswith("upstream/BLK-1/") for n in names)
+    assert "BLK-1" in payload["upstream_truncated"]
+    assert ("activity-linear-blk-1", "big.bin") not in forge.read_calls

--- a/docs/07-dev-runtime.md
+++ b/docs/07-dev-runtime.md
@@ -43,14 +43,17 @@ Devs are **pure functions from (workspace, prompt) to artifacts**: they never wr
                          #   truncation banners
                          #   when this mission has upstream work (ADR-0036)
     upstream/
-      {MISSION-KEY}/     # ZERO OR MORE upstream mirrors (ADR-0036 / CAKE-124 +
-                         #   addendum): each decomposition ancestor, then the
-                         #   project this mission belongs to; each holds that
-                         #   mission's MISSION.md, ACTIVITY.md, and attachments.
-                         #   Nearest parent first toward the graph root, the
-                         #   project last; farthest truncated first under the
-                         #   attachment byte cap. Direct blocked_by work-repo
-                         #   mounts stay on ADR-0017 — they are not mirrored here.
+      {MISSION-KEY}/     # ZERO OR MORE upstream folders (ADR-0043 §3-4; lineage
+                         #   ADR-0036 / CAKE-124): each decomposition ancestor,
+                         #   then the project this mission belongs to, then every
+                         #   direct done blocker. Each is a COPY OF THAT MISSION'S
+                         #   RECORD (its activity repo: MISSION.md, ACTIVITY.md,
+                         #   every attachment; its own upstream/ not nested), or a
+                         #   vendor rebuild when it never ran. Nearest parent first,
+                         #   project, blockers last; farthest truncated first under
+                         #   the attachment byte cap, decided from the record's
+                         #   sizes. Direct blocked_by work-repo clones stay on
+                         #   ADR-0017 under /workspace/repo/.
     {attachment files}   # every attachment from the feed — including prior steps' full
                          #   session transcripts (`N_TYPE.md`, `PLAN_N.md`). When the
                          #   PMO cannot attach files, paginated `Part i of n` comments
@@ -90,7 +93,7 @@ The workspace is prepared entirely by the container **entrypoint** (not the app)
 
 ## 2. `ACTIVITY.md` format
 
-**Intent (confirmed decision, revised by ADR-0014; amended by ADR-0036):** the `activity/` folder is a mini **knowledge base the harness taps into as needed** — queryable, greppable reference material. It is *never* inlined into the prompt; the playbook prompt carries only the mission title/description and points here (`03-mission-lifecycle.md` §7). The folder is four parts: **`MISSION.md`** (the brief — key/title/meta/labels, the FULL description, and mission-level attachments: description-embedded assets + the vendor's native attachment list, files downloaded / links rendered as links), **`ACTIVITY.md`** (a **faithful mirror of the feed as seen in the PMO** — every post and reply inline with its full body, `↳ reply to` nesting for people's replies (DevCake's own step bookkeeping is threaded on the board for readability and mirrored flat — the same file whether the vendor threads or not, `03-mission-lifecycle.md` §8), `[attachment: name]` markers at their feed positions; heavy content is naturally attachment-borne because DevCake's own long posts externalize at post time), the **sibling files** (every attachment's bytes, including prior steps' full session transcripts), and — when this mission is part of larger work — **`upstream/{MISSION-KEY}/`** mirrors of every upstream mission: each decomposition ancestor toward the graph root, then the project the mission belongs to (ADR-0036 / CAKE-124 + addendum; nearest parent first, the project last; farthest truncated first under the attachment byte cap; an issue a person places in a project gets the project's brief and feed this way; `blocked_by` work-repo mounts stay on ADR-0017). If the adapter's full-history hard stop ever trips, `ACTIVITY.md` opens with a loud `⚠ FEED TRUNCATED` banner — never silent. Upstream gaps and truncation use the same honest-banner doctrine (`⚠ UPSTREAM GAP` / `⚠ UPSTREAM TRUNCATED`). After a hand-off released by a person, `MISSION.md` opens with a one-line pointer and `ACTIVITY.md` with the `▶ RESUMED BY A HUMAN` banner (`03-mission-lifecycle.md` §4a); ancestor mirrors under `upstream/` never carry it.
+**Intent (confirmed decision, revised by ADR-0014; amended by ADR-0036):** the `activity/` folder is a mini **knowledge base the harness taps into as needed** — queryable, greppable reference material. It is *never* inlined into the prompt; the playbook prompt carries only the mission title/description and points here (`03-mission-lifecycle.md` §7). The folder is four parts: **`MISSION.md`** (the brief — key/title/meta/labels, the FULL description, and mission-level attachments: description-embedded assets + the vendor's native attachment list, files downloaded / links rendered as links), **`ACTIVITY.md`** (a **faithful mirror of the feed as seen in the PMO** — every post and reply inline with its full body, `↳ reply to` nesting for people's replies (DevCake's own step bookkeeping is threaded on the board for readability and mirrored flat — the same file whether the vendor threads or not, `03-mission-lifecycle.md` §8), `[attachment: name]` markers at their feed positions; heavy content is naturally attachment-borne because DevCake's own long posts externalize at post time), the **sibling files** (every attachment's bytes, including prior steps' full session transcripts), and — when this mission is part of larger work — **`upstream/{MISSION-KEY}/`** copies of every upstream mission's record: each decomposition ancestor toward the graph root, the project the mission belongs to, and every direct blocker that finished (ADR-0043 §3-4, lineage ADR-0036 / CAKE-124; each folder is the upstream mission's activity repository read back — MISSION.md, ACTIVITY.md, every attachment — or a vendor rebuild for a mission that never ran; nearest parent first, project, blockers last; farthest truncated first under the attachment byte cap; an unreadable ancestor or project is a strict-gate gap, an unreadable blocker a disclosed one; `blocked_by` work-repo clones stay on ADR-0017). If the adapter's full-history hard stop ever trips, `ACTIVITY.md` opens with a loud `⚠ FEED TRUNCATED` banner — never silent. Upstream gaps and truncation use the same honest-banner doctrine (`⚠ UPSTREAM GAP` / `⚠ UPSTREAM TRUNCATED`). After a hand-off released by a person, `MISSION.md` opens with a one-line pointer and `ACTIVITY.md` with the `▶ RESUMED BY A HUMAN` banner (`03-mission-lifecycle.md` §4a); ancestor mirrors under `upstream/` never carry it.
 
 ```markdown
 # {mission_key}: {title}

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -936,6 +936,15 @@ until that run exists, field evidence below stays operator-self-reported.
   ADR-0009, CHANGELOG.
 ### Field evidence (receipted)
 
+- **Upstream folders are copies of the record, stage 3** (2026-09-10,
+  ADR-0043 §3-4): `_offer_upstream` reads each upstream mission's activity
+  repo through `activity_snapshot_tree` (budget decided from sizes) and
+  `activity_snapshot_file`, vendor rebuild only when no record exists;
+  `family_graph.upstream_chain` appends every direct done blocker
+  (`RELATION_BLOCKER`, never transitive; `blockers_outside` counts
+  peer-board ones for the banner); blocker gaps are disclosed, never
+  gating; banner names the source per folder. Prompts, docs/07, ADR-0017
+  and ADR-0036 pointers.
 - **Project runs write their record, stage 2** (2026-09-10, ADR-0043 §2):
   `feed._feed`/`_edit` no longer suppress project kind — posts and edits go
   to the project-native feed (no threads); `_post_step_card` /

--- a/docs/adr/0017-blocker-work-ro-mounts-and-optional-pmo-zip.md
+++ b/docs/adr/0017-blocker-work-ro-mounts-and-optional-pmo-zip.md
@@ -38,3 +38,5 @@ Canceled blockers do not mount. A blocker repo with **no read credential at disp
 - Dependents on internal pipelines can read upstream trees without Linear archaeology.
 - Operators can opt into PMO file visibility for configured repos without changing zero-repo guarantees.
 - Docs/14: blocker RO tokens (other mission’s read token) enter the Dev under Zone B trust — documented, same class as reference repos.
+
+> Amended by ADR-0043 §4: beside the work-repo mount, a direct done blocker's whole record is now copied under `upstream/{KEY}/` in the dependent's activity folder. The mount contract above is unchanged.

--- a/docs/adr/0036-upstream-activity-ancestor-offer.md
+++ b/docs/adr/0036-upstream-activity-ancestor-offer.md
@@ -1,6 +1,6 @@
 # ADR-0036 — Offer every decomposition ancestor's activity to dispatched Devs
 
-- **Status:** accepted (2026-08-19)
+- **Status:** accepted (2026-08-19); §2's vendor rebuild and §3's blocker exclusion superseded by ADR-0043 (folders are copies of the record; direct done blockers included)
 - **Amends:** ADR-0014 (activity payload / activity repos), cross-references
   ADR-0012 (decomposition-depth bound) and ADR-0017 (blocker-mount contract)
 - **Ticket:** CAKE-124


### PR DESCRIPTION
## What

Stage 3 of ADR-0043: every upstream folder in a Dev's workspace is a copy of that mission's activity repository, and every direct blocker that finished has one, beside the ancestors and the containing project.

## Why

A done blocker used to contribute its work-repository clone and a 700-character handoff excerpt only, so an attachment on a blocker's ticket never reached the dependent. Rebuilding blockers from the vendor at dispatch would cost one full feed read per blocker; a mission gated on hundreds of siblings would burn the hourly budget. Reading the record from the internal forge costs nothing against that budget, which is what makes "every direct blocker, no count cap" affordable.

## How

- `family_graph.upstream_chain`: after the ancestors and the containing project, every direct `blocked_by` mission with status done, in relation order, marked `blocker`. Never transitive; a mission already in the chain is not listed twice. `blockers_outside` counts blockers the board snapshot does not hold (peer boards) for the banner.
- `_offer_upstream`: for each upstream mission, read its activity repository's tree through `activity_snapshot_tree`; the sizes decide the byte budget before a file is fetched; files are read through `activity_snapshot_file`, the repository's own `upstream/` subtree excluded. No repository (the mission never dispatched) → the vendor rebuild of ADR-0036, marked in the banner. An unreadable ancestor or project record is a strict-gate gap as before; an unreadable blocker record is a disclosed gap that never defers a dispatch.
- Banner: heading and explanation cover the three relations; each folder line carries relation, title and source; peer-board blockers are counted in one line.
- Prompts: the workspace preamble and the upstream note tell the Dev that finished blockers' records are there and what a vendor-rebuilt folder means. Docs 07 tree and §2, ADR-0017 and ADR-0036 pointers, roadmap, changelog.

## Tests

`test_upstream_activity.py` (+10): blockers appended in order and only when done; a parent that doubles as a blocker is listed once; peer-board blockers counted; a folder is copied from the record with the vendor never read and nested upstream excluded; no record → vendor rebuild marked; a done blocker's record lands with its files and the `blocker` label; an unreadable blocker record is a disclosed non-gating gap; an unreadable ancestor record still gates; the budget is decided from sizes and an over-budget blocker is never downloaded. Full suite identical to main apart from the 70 environment-only failures.

Stacked on #455 (stage 2), which is stacked on #454 (stage 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVp9ty5CFCjT6PphDe24MH
