### PR TITLE
feat(discovery): deliveries carry every finding in full; the status comment gathers discoveries and leads (ADR-0042 addendum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ added here without copying the full roadmap.
 See the living log and open candidates in
 [`docs/16-roadmap.md`](docs/16-roadmap.md).
 
+- **Fixed — routed discoveries reach the mission they were sent to, in
+  full.** A leads delivery carried excerpts, and a long one carried
+  nothing but a pointer to a file on the source mission that the
+  recipient's Dev never receives. The delivery's record now carries every
+  finding in full, with no inline ceiling; the head quotes an excerpt of
+  each. The recipient's Dev reads them from its own activity folder.
+
+- **Added — one place to read a mission's discoveries.** The status
+  comment's fold gains a Discoveries section: what the mission reported,
+  with the record-file link, and every lead it received, in full. It is a
+  view over the feed with no marker, no file token and no provenance line,
+  so nothing that scans the feed counts it, the freshness check ignores
+  it, and no Dev sees it. The status refresh now reads the feed once and
+  the record push at the same boundary reuses that read.
+
 ## v0.6.3 (2026-09-10)
 
 Patch release in the v0.6 "Kentucky Butter" line. `devcake-cli` stays at 0.1.8.

--- a/app/devcake/domain/orchestrator/activity_payload.py
+++ b/app/devcake/domain/orchestrator/activity_payload.py
@@ -424,7 +424,7 @@ RECORD_KEEP_PREFIXES = ("upstream/",)
 
 
 async def record_activity(mgr, pmo_id: str, kind: str, mission_key: str,
-                          reason: str) -> None:
+                          reason: str, act=None) -> None:
     """ADR-0043 §1: the activity repository is the record of the mission's
     run. Called at every run boundary (step close, completion, hand-off,
     PR closed unmerged, conflict routed) after the feed writes of that
@@ -437,7 +437,7 @@ async def record_activity(mgr, pmo_id: str, kind: str, mission_key: str,
         return
     try:
         payload = await activity_payload(mgr, pmo_id, kind,
-                                         include_upstream=False)
+                                         include_upstream=False, act=act)
         name = await mgr.internal_forge.ensure_activity_repo(
             mgr.instance_name, mission_key)
         await mgr.internal_forge.push_activity_snapshot(
@@ -495,7 +495,8 @@ def _discovery_lines(entries) -> list[str]:
             ts = getattr(e, "ts", None)
             date = f" · {ts:%Y-%m-%d}" if ts else ""
             out.append(f"{len(out) + 1}. [{src} · step {step}{date}] — the "
-                       f"routed delivery is in ACTIVITY.md; full record: "
+                       f"findings, in full, are in ACTIVITY.md under "
+                       f"\"Leads from {src}, step {step}\"; source record: "
                        f"`DISCOVERY_{step}.md` on {src}.")
     return out
 
@@ -511,7 +512,8 @@ def _doc_filename(title: str) -> str:
 
 async def activity_payload(mgr, pmo_id: str, kind: str = "issue",
                            blocker_notes: list[dict] | None = None,
-                           *, include_upstream: bool = True) -> dict:
+                           *, include_upstream: bool = True,
+                           act=None) -> dict:
     """ADR-0014 D3: MISSION.md = the brief; ACTIVITY.md = a faithful MIRROR
     of the feed — full bodies inline (never externalized), attachments by
     name in feed order, reply nesting; every attachment's bytes ride as
@@ -528,7 +530,8 @@ async def activity_payload(mgr, pmo_id: str, kind: str = "issue",
     under the attachment byte cap). Gaps land in `upstream_gaps` and as
     honest banners — never silent. Nested rebuilds pass
     `include_upstream=False` to avoid recursion."""
-    act = await mgr.pmo.get_activity(MissionRef(pmo_id, kind), full=True)
+    if act is None:
+        act = await mgr.pmo.get_activity(MissionRef(pmo_id, kind), full=True)
     m = act.mission
     attachments = []
     used: set[str] = {"ACTIVITY.md", "MISSION.md"}   # docs/07 §2 dedupe seed

--- a/app/devcake/domain/orchestrator/completion.py
+++ b/app/devcake/domain/orchestrator/completion.py
@@ -162,14 +162,13 @@ async def complete_merged(mgr, cause: MergedCause, *, ref: MissionRef,
             # ADR-0042 §5 — the status comment reads "done" (a view; never
             # a gate; inside the write-back class so a starved key does
             # not refuse it)
-            await status_comment.refresh(
+            act = await status_comment.refresh(
                 mgr, ref.pmo_id, reason=spec.audit_action, run=run,
                 mission=mission, pr_url=pr_url)
-            # ADR-0043 §1 — the record follows the close
+            # ADR-0043 §1 — the record follows the close, on the same read
             await activity_payload.record_activity(
-                mgr, ref.pmo_id, ref.kind,
-                mission_key,
-                spec.audit_action)
+                mgr, ref.pmo_id, ref.kind, mission_key, spec.audit_action,
+                act=act)
         anchor = posted[0] if posted else None
         try:
             if run is not None:
@@ -246,10 +245,11 @@ async def route_conflict_to_execute(mgr, pmo_id: str, key: str, pr_url: str,
         mgr._audit(pmo_id, "conflict_resolve_dispatched",
                     f"attempt {n + 1} ({pr_url})")
         with write_back_class():
-            await status_comment.refresh(mgr, pmo_id, reason="conflict_routed",
-                                         pr_url=pr_url)
+            act = await status_comment.refresh(mgr, pmo_id,
+                                               reason="conflict_routed",
+                                               pr_url=pr_url)
             await activity_payload.record_activity(
-                mgr, pmo_id, "issue", key, "conflict_routed")
+                mgr, pmo_id, "issue", key, "conflict_routed", act=act)
         return True
     except Exception:  # noqa: BLE001 — degrade with record: conflict routing failure is logged; caller keeps the mission parked for a human
         log.exception("conflict auto-resolve routing failed for %s", key)

--- a/app/devcake/domain/orchestrator/discovery.py
+++ b/app/devcake/domain/orchestrator/discovery.py
@@ -16,6 +16,7 @@ must never wedge a close.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 
 from ...security import redact
@@ -526,3 +527,97 @@ async def discovery_sweep(mgr, m) -> None:
         except Exception as ex:  # noqa: BLE001 — retried next sweep
             mgr._audit(m.pmo_id, "discovery_label_failed", str(ex)[:200])
         mgr._discoveries_pending.discard(m.pmo_id)
+
+
+# ── the Discoveries digest (ADR-0042 §5 addendum: one place for a reader) ──
+
+DIGEST_BUDGET = 24_000     # chars; older deliveries drop first, said so
+
+_RECORD_LINK_RE = re.compile(r"Full record attached: \[[^\]]+\]\(([^)]+)\)")
+
+
+def _section_or_body(body: str, title: str) -> str:
+    """The fold section `title` of a card/notice, or the whole body when
+    the entry predates folds (a legacy harvest / delivery comment)."""
+    from .feed import fold_sections, strip_fold
+    head, inner = strip_fold(body)
+    if inner is not None:
+        for s in fold_sections(inner):
+            if s.title == title:
+                return s.body
+        return ""
+    return body
+
+
+def _quoted_blocks(text: str) -> list[str]:
+    """The finding blocks of a record: numbering lines, `>`-quoted text and
+    steward notes — never a backticked marker line, never a bare
+    provenance line (the digest is a VIEW: no scan may count it)."""
+    out: list[str] = []
+    for para in text.split("\n\n"):
+        s = para.strip()
+        if not s or s.startswith("`") or s.startswith("🔎") or s == "---":
+            continue
+        if s.startswith("Full record attached") or s.startswith("(attachment"):
+            continue
+        out.append(s)
+    return out
+
+
+def digest_lines(entries) -> list[str]:
+    """What this mission discovered and what it was handed, gathered from
+    the feed for the status comment's `Discoveries` section — a reader's
+    one place. Pure over the entries; carries no backticked marker and no
+    step-file token, so no scan counts it and the Freshness Gate ignores
+    it like the rest of the status comment. Outgoing: per step, the count,
+    the record file link and the excerpts the card carries. Incoming: per
+    (source, step), every finding in full as the delivery carried it.
+    Over the budget, the oldest deliveries are dropped and the line says
+    so — the record above always has them."""
+    from .feed import unquoted
+    from .markers import DISCOVERY_IN_MARKER_RE, DISCOVERY_MARKER_RE
+    from .feed import SECTION_DISCOVERIES, SECTION_RECORD
+    reported: list[str] = []
+    received: list[list[str]] = []
+    seen_in: set[tuple[str, int]] = set()
+    for e in entries:
+        body = e.body or ""
+        plain = unquoted(body)
+        for step, n in DISCOVERY_MARKER_RE.findall(plain):
+            section = _section_or_body(body, SECTION_DISCOVERIES)
+            m = _RECORD_LINK_RE.search(section)
+            link = f" · [record file]({m.group(1)})" if m else ""
+            reported.append(f"step {step} · {n} finding{'' if n == '1' else 's'}{link}")
+            reported.extend(_quoted_blocks(section))
+        for src, step in DISCOVERY_IN_MARKER_RE.findall(plain):
+            key = (src, int(step))
+            if key in seen_in:
+                continue
+            seen_in.add(key)
+            record = _section_or_body(body, SECTION_RECORD)
+            # one `---`-separated part per (source, step) in a bundled delivery
+            part = next((pt for pt in record.split("\n\n---\n\n")
+                         if f"src={src} step={step}`" in pt), record)
+            ts = getattr(e, "ts", None)
+            when = f" · {ts:%Y-%m-%d}" if ts else ""
+            received.append([f"from {src}, step {step}{when}",
+                             *_quoted_blocks(part)])
+    if not reported and not received:
+        return []
+    lines: list[str] = []
+    if reported:
+        lines += ["**Reported by this mission**", *reported]
+    if received:
+        kept = list(received)
+        dropped = 0
+        while kept and sum(len("\n\n".join(b)) for b in kept) > DIGEST_BUDGET:
+            kept.pop(0)
+            dropped += 1
+        lines += ["", "**Leads received**"] if lines else ["**Leads received**"]
+        if dropped:
+            lines.append(f"{dropped} older deliver{'y' if dropped == 1 else 'ies'} "
+                         f"omitted here — the record above has them.")
+        for block in kept:
+            lines += block
+    return lines
+

--- a/app/devcake/domain/orchestrator/finalize.py
+++ b/app/devcake/domain/orchestrator/finalize.py
@@ -215,9 +215,10 @@ async def _finalize(mgr, run: Run, payload: dict) -> None:
                 await restore_after_failure(mgr, run)
             log.warning("run %s failed (exit %s, attempt %d)",
                         run.run_id, exit_code, run.attempt_of_step)
-            await status_comment.refresh(mgr, pmo_id, reason="failed", run=run)
+            act = await status_comment.refresh(mgr, pmo_id, reason="failed",
+                                               run=run)
             await activity_payload_mod.record_activity(
-                mgr, pmo_id, run.pmo_kind, run.mission_key, "failed")
+                mgr, pmo_id, run.pmo_kind, run.mission_key, "failed", act=act)
             return
 
         # 2b — ADR-0033 harvest bookkeeping (label, pending set, routing
@@ -266,10 +267,11 @@ async def _finalize(mgr, run: Run, payload: dict) -> None:
                     await restore_after_failure(mgr, run)
                 log.warning("run %s failed with DEV_BAD_OUTPUT: %s",
                             run.run_id, e)
-                await status_comment.refresh(mgr, pmo_id, reason="bad_output",
-                                             run=run)
+                act = await status_comment.refresh(
+                    mgr, pmo_id, reason="bad_output", run=run)
                 await activity_payload_mod.record_activity(
-                    mgr, pmo_id, run.pmo_kind, run.mission_key, "bad_output")
+                    mgr, pmo_id, run.pmo_kind, run.mission_key, "bad_output",
+                    act=act)
                 return
             if _pre_wipe(mgr, run):
                 return
@@ -290,11 +292,12 @@ async def _finalize(mgr, run: Run, payload: dict) -> None:
         log.info("finalized %s (%s)", run.run_id, outcome)
         # ADR-0042 §5 — the LAST statement of the close: the status comment
         # says what the record now says (best-effort, never a gate)
-        await status_comment.refresh(mgr, pmo_id, reason="finalize", run=run)
+        act = await status_comment.refresh(mgr, pmo_id, reason="finalize",
+                                           run=run)
         # ADR-0043 §1 — then the record: the activity repository holds what
-        # the feed now holds (best-effort, never a gate)
+        # the feed now holds (best-effort, never a gate); the same read
         await activity_payload_mod.record_activity(
-            mgr, pmo_id, run.pmo_kind, run.mission_key, "finalize")
+            mgr, pmo_id, run.pmo_kind, run.mission_key, "finalize", act=act)
 
 
 def dev_failure_error(mgr, run: Run, payload: dict) -> str:

--- a/app/devcake/domain/orchestrator/stalls.py
+++ b/app/devcake/domain/orchestrator/stalls.py
@@ -352,13 +352,12 @@ async def _status(mgr, m: Mission, waiting: str | None) -> None:
     """Create the status comment when none exists (one full read to find
     an existing one), else edit it in place with the waiting line."""
     runs = status_comment.runs_of(mgr, m.pmo_id)
-    entry = status_comment._known_entry(mgr, m.pmo_id, None)
-    if not entry:
-        act = await mgr.pmo.get_activity(MissionRef(m.pmo_id, "issue"), full=True)
-        entry = feed.find_status_entry(act.entries) or ""
+    act = await mgr.pmo.get_activity(MissionRef(m.pmo_id, "issue"), full=True)
+    entry = (status_comment._known_entry(mgr, m.pmo_id, None)
+             or feed.find_status_entry(act.entries) or "")
     body = status_comment.render(mgr, m, runs, pr_url=None,
                                  collapsible=feed.collapsible_of(mgr),
-                                 waiting=waiting)
+                                 waiting=waiting, entries=act.entries)
     if entry:
         await mgr._edit(m.pmo_id, "issue", entry, body)
     else:

--- a/app/devcake/domain/orchestrator/status_comment.py
+++ b/app/devcake/domain/orchestrator/status_comment.py
@@ -25,8 +25,8 @@ from ..model import (LABEL_EXECUTE, LABEL_FAILED, LABEL_MERGE,
                      LABEL_NEEDS_HUMAN, LABEL_PLAN, LABEL_REVIEW, LABEL_SKIP,
                      Mission, MissionRef)
 from ..run import Run, aware, utcnow
-from .feed import (SECTION_RECORD, FoldSection, collapsible_of, format_duration,
-                   render_fold)
+from .feed import (SECTION_DISCOVERIES, SECTION_RECORD, FoldSection,
+                   collapsible_of, format_duration, render_fold)
 from .markers import STATUS_MARKER, decomposition_parent_ref
 
 log = logging.getLogger("devcake.missions")
@@ -117,7 +117,8 @@ def _now_line(mission: Mission, runs: list[Run], pr_url: str,
 
 
 def render(mgr, mission: Mission, runs: list[Run], *, pr_url: str | None,
-           collapsible: str, waiting: str | None = None) -> str:
+           collapsible: str, waiting: str | None = None,
+           entries=None) -> str:
     """The comment body (sentinel-free; the chokepoints seal it). Pure —
     everything comes from the record. Never a file token, never a
     `Part i of n` line, no marker but the status marker (each pinned)."""
@@ -154,10 +155,19 @@ def render(mgr, mission: Mission, runs: list[Run], *, pr_url: str | None,
             c = run_cost(mgr, r)
             lines.append(f"| {seq} · {r.mission_type} | {glyph} {word}{attempt} "
                          f"| {dur} | {'$%.2f' % c if c is not None else '—'} |")
-    record = FoldSection(SECTION_RECORD, (
+    sections = []
+    if entries:
+        # ADR-0042 §5 addendum — one place for what this mission discovered
+        # and was handed (a view over the record: no marker, no scan)
+        from .discovery import digest_lines
+        digest = digest_lines(entries)
+        if digest:
+            sections.append(FoldSection(SECTION_DISCOVERIES, "\n\n".join(digest)))
+    sections.append(FoldSection(SECTION_RECORD, (
         f"{STATUS_MARKER}\nupdated {utcnow():%Y-%m-%d %H:%M} UTC · instance "
-        f"{getattr(mgr, 'instance_name', '')}"))
-    lines += ["", render_fold([record], collapsible=collapsible, summary="Record")]
+        f"{getattr(mgr, 'instance_name', '')}")))
+    summary = "Discoveries · record" if len(sections) > 1 else "Record"
+    lines += ["", render_fold(sections, collapsible=collapsible, summary=summary)]
     return "\n".join(lines)
 
 
@@ -222,11 +232,14 @@ def _known_entry(mgr, pmo_id: str, run: Run | None) -> str:
 
 async def refresh(mgr, pmo_id: str, *, reason: str, run: Run | None = None,
                   mission: Mission | None = None,
-                  pr_url: str | None = None) -> None:
-    """Rebuild the body from the record and edit it in place. At most ONE
-    cheap `pmo.get` when the caller has no fresh mission. Catches
-    everything: a refused budget, a transient, a vanished entry (the
-    cached id is dropped so the next dispatch re-creates it)."""
+                  pr_url: str | None = None, act=None):
+    """Rebuild the body from the record and edit it in place. ONE full
+    feed read (the Discoveries section is a view over the feed) unless the
+    caller hands over the Activity it already read (`act`); the read is
+    returned so the boundary's record push (ADR-0043) reuses it — one read
+    per boundary. Catches everything: a refused budget, a transient, a
+    vanished entry (the cached id is dropped so the next dispatch
+    re-creates it). Returns the Activity read, None when nothing was."""
     entry_id = _known_entry(mgr, pmo_id, run)
     if not entry_id:
         seen = getattr(mgr, "_status_unknown", None)
@@ -239,15 +252,18 @@ async def refresh(mgr, pmo_id: str, *, reason: str, run: Run | None = None,
         if pmo_id not in seen:
             seen.add(pmo_id)
             mgr._audit(pmo_id, "status_comment_unknown", reason)
-        return
+        return act
     try:
+        if act is None:
+            act = await mgr.pmo.get_activity(MissionRef(pmo_id, "issue"),
+                                             full=True)
         if mission is None:
-            mission = await mgr.pmo.get(MissionRef(pmo_id, "issue"))
+            mission = act.mission
         runs = runs_of(mgr, pmo_id)
         if run is not None and all(r.run_id != run.run_id for r in runs):
             runs.append(run)
         body = render(mgr, mission, runs, pr_url=pr_url,
-                      collapsible=collapsible_of(mgr))
+                      collapsible=collapsible_of(mgr), entries=act.entries)
         await mgr._edit(pmo_id, "issue", entry_id, body)
         _cache(mgr)[pmo_id] = entry_id
     except PMOTransient as e:
@@ -262,3 +278,4 @@ async def refresh(mgr, pmo_id: str, *, reason: str, run: Run | None = None,
             except Exception:  # noqa: BLE001 — best-effort bookkeeping
                 log.debug("status entry reset not saved for %s", run.run_id,
                           exc_info=True)
+    return act

--- a/app/devcake/domain/orchestrator/steward.py
+++ b/app/devcake/domain/orchestrator/steward.py
@@ -612,30 +612,38 @@ async def apply_discovery_routes(mgr, run: Run, routes: list) -> tuple[int, int]
             head = [f"`devcake:discovery-in:v1 src={skey} step={step}`",
                     f"🔎 [{skey} · step {step} · {utcnow():%Y-%m-%d}] — "
                     f"leads, not truths: verify against the source before "
-                    f"relying. Full record: `DISCOVERY_{step}.md` on "
+                    f"relying. Source record: `DISCOVERY_{step}.md` on "
                     f"{skey}.",
                     *(f"`devcake:finding:v1 sha="
                       f"{finding_fingerprint(x['entry'])}`" for x in fresh)]
+            # the Record carries every finding IN FULL (finding, evidence,
+            # scope) — the recipient's Dev reads it from its own folder and
+            # never sees the source mission's file; the head quotes an
+            # excerpt of each for the reader
             body_lines: list[str] = []
+            excerpts: list[str] = []
             for x in fresh:
-                body_lines += render_entry_lines(
+                body_lines += render_entry_lines([x["entry"]], full=True)
+                excerpts += render_entry_lines(
                     [x["entry"]], cap=DISCOVERY_IN_EXCERPT_MAX)
                 if x["because"]:
-                    body_lines.append(f"*— steward: {defang(x['because'])}*")
-            parts.append((skey, step, head, body_lines, fresh))
+                    note = f"*— steward: {defang(x['because'])}*"
+                    body_lines.append(note)
+                    excerpts.append(note)
+            parts.append((skey, step, head, body_lines, fresh, excerpts))
             landed.extend(fresh)
         if not parts:
             continue
-        body = _leads_notice(mgr, parts, findings=True)
-        if len(body) > FEED_INLINE_MAX:
-            # marker + provenance must stay inline — re-render from the
-            # parts with the findings dropped from head and record alike;
-            # the marker, pointer and fingerprint lines stay (never
-            # externalize a counted marker)
-            body = _leads_notice(mgr, parts, findings=False)
+        # never externalized (a counted marker stays in the feed body); a
+        # vendor with a comment cap pages it, markers on part 1
+        body = _leads_notice(mgr, parts)
         try:
             await mgr._feed(tgt_id, "issue", body, externalize=False)
             delivered += len(landed)
+            # the recipient's status comment gathers what it was handed
+            # (ADR-0042 §5 addendum) — best-effort, never gates the delivery
+            from . import status_comment
+            await status_comment.refresh(mgr, tgt_id, reason="leads_delivered")
         except Exception as ex:  # noqa: BLE001 — nothing landed; hold the
             # batch so phase 3 cannot stamp to=- (the sweep re-drives)
             for x in landed:
@@ -707,39 +715,34 @@ async def apply_discovery_routes(mgr, run: Run, routes: list) -> tuple[int, int]
     return delivered, rejected
 
 
-def _leads_notice(mgr, parts, *, findings: bool) -> str:
+def _leads_notice(mgr, parts) -> str:
     """The delivery as a notice (ADR-0042 §6): `📨 Leads from KEY, step N.`
-    with the findings quoted in the head, and the Record the delivery
-    comment as it was — one `---`-separated section per (source, step):
-    the elevated pair marker, the pointer line, the fingerprints, then the
-    finding blocks. `findings=False` is the inline-ceiling fallback: the
-    finding blocks are dropped from head and record alike while every
-    marker line stays, so the elevated marker, the pair dedup and the
-    content dedup all survive a truncated delivery."""
+    with an excerpt of each finding quoted in the head, and the Record —
+    one `---`-separated section per (source, step): the elevated pair
+    marker, the provenance line, the fingerprints, then every finding IN
+    FULL (finding, evidence, scope). There is no inline ceiling: the
+    notice is never externalized (a counted marker stays in the feed
+    body) and a capped vendor pages it, so a long delivery loses nothing
+    — the recipient's Dev reads the findings from its own ACTIVITY.md."""
     record = "\n\n---\n\n".join(
-        "\n\n".join(head + (body_lines if findings else []))
-        for _skey, _step, head, body_lines, _fresh in parts)
+        "\n\n".join(head + body_lines)
+        for _skey, _step, head, body_lines, _fresh, _ex in parts)
     skey, step = parts[0][0], parts[0][1]
-    others = [f"{s} step {n}" for s, n, _h, _b, _f in parts[1:]]
-    n_leads = sum(len(fresh) for _s, _n, _h, _b, fresh in parts)
+    others = [f"{s} step {n}" for s, n, _h, _b, _f, _e in parts[1:]]
+    n_leads = sum(len(fresh) for _s, _n, _h, _b, fresh, _e in parts)
     what = (f"{n_leads} lead{'' if n_leads == 1 else 's'}"
             + (f", also from {', '.join(others)}" if others else "")
             + " — leads, not truths: verify against the source before "
-            "relying on them; the full record is the DISCOVERY file on the "
-            "source mission.")
-    if not findings:
-        what += (" The findings were over the inline budget and are not "
-                 "repeated here.")
+            "relying on them. The findings are in full in the record below.")
     quoted: list[str] = []
-    if findings:
-        for _s, _n, _head, body_lines, _fresh in parts:
-            for block in body_lines:
-                if block.startswith("**"):
-                    continue                    # the numbering line
-                if block.startswith("*— steward:"):
-                    quoted.append(feed.blockquote(block.strip("*")))
-                    continue
-                quoted.append(block)            # already `>`-quoted
+    for _s, _n, _head, _body, _fresh, excerpts in parts:
+        for block in excerpts:
+            if block.startswith("**"):
+                continue                        # the numbering line
+            if block.startswith("*— steward:"):
+                quoted.append(feed.blockquote(block.strip("*")))
+                continue
+            quoted.append(block)                # already `>`-quoted
     head_text = what + ("\n\n" + "\n\n".join(quoted) if quoted else "")
     return feed.notice(mgr, feed.leads_lead(skey, step), head_text, record)
 

--- a/app/devcake/domain/orchestrator/sweeps.py
+++ b/app/devcake/domain/orchestrator/sweeps.py
@@ -255,12 +255,12 @@ async def merge_sweep(mgr, m: Mission) -> None:
                             f"mission canceled (merge sweep)."))
                 mgr._audit(m.pmo_id, "merge_sweep_canceled", state.url)
                 with completion.write_back_class():
-                    await status_comment.refresh(
+                    act = await status_comment.refresh(
                         mgr, m.pmo_id, reason="merge_sweep_canceled",
                         pr_url=state.url)
                     await activity_payload.record_activity(
                         mgr, m.pmo_id, m.pmo_kind or "issue", m.key,
-                        "merge_sweep_canceled")
+                        "merge_sweep_canceled", act=act)
     else:
         # advisory banner (docs/11): an open PR on DEVCAKE-MERGE awaits a
         # human — unless the deferred-retry window is actively running
@@ -454,12 +454,12 @@ async def _deferred_merge_retry(mgr, m: Mission, pr,
                     mgr.merge_handoffs[m.pmo_id] = (
                         f"{m.key}: awaiting human merge — {pr_url}")
                     with completion.write_back_class():
-                        await status_comment.refresh(
+                        act = await status_comment.refresh(
                             mgr, m.pmo_id, reason="conflict_handoff",
                             mission=m, pr_url=pr_url)
                         await activity_payload.record_activity(
                             mgr, m.pmo_id, m.pmo_kind or "issue", m.key,
-                            "conflict_handoff")
+                            "conflict_handoff", act=act)
             elif elapsed:
                 # a closing attempt that did not merge and was no conflict:
                 # the second in a row hands off
@@ -506,10 +506,11 @@ async def _hand_off_exhausted(mgr, m: Mission, pr_url: str,
     mgr._audit(m.pmo_id, "merge_retry_exhausted", pr_url)
     mgr._merge_window_closed.add(m.pmo_id)
     with completion.write_back_class():
-        await status_comment.refresh(mgr, m.pmo_id, reason="merge_handoff",
-                                     mission=m, pr_url=pr_url)
+        act = await status_comment.refresh(mgr, m.pmo_id, reason="merge_handoff",
+                                           mission=m, pr_url=pr_url)
         await activity_payload.record_activity(
-            mgr, m.pmo_id, m.pmo_kind or "issue", m.key, "merge_handoff")
+            mgr, m.pmo_id, m.pmo_kind or "issue", m.key, "merge_handoff",
+            act=act)
 
 
 async def _closing_attempt_failed(mgr, m: Mission, pr_url: str, window: int,

--- a/app/tests/test_status_comment.py
+++ b/app/tests/test_status_comment.py
@@ -121,18 +121,129 @@ def test_ensure_creates_once_and_adopts_a_found_entry(tmp_path):
     assert run_coro(status_comment.ensure(mgr, m, run, found="")) == ""
 
 
-def test_refresh_edits_in_place_without_a_feed_read(tmp_path):
+def test_refresh_reads_the_feed_once_and_edits_in_place(tmp_path):
+    """ADR-0042 §5 addendum: the Discoveries section is a view over the
+    feed, so a refresh reads it ONCE (full) — and hands that read back so
+    the boundary's record push reuses it instead of reading again."""
     m, mgr, fake, store = _mgr(tmp_path)
     fake.activity_entries = [ActivityEntry(ts=NOW, author="cake", kind="comment",
                                            body="old `devcake:status:v1`\n\n`devcake:v1`",
                                            entry_id="s1")]
     run = _run(store, 1, "ONBOARD", outcome="plan_needed", status_entry_id="s1")
-    before = getattr(fake, "get_activity_full_calls", 0)
-    run_coro(status_comment.refresh(mgr, "p1", reason="finalize", run=run, mission=m))
+    before = getattr(fake, "get_activity_calls", 0)
+    act = run_coro(status_comment.refresh(mgr, "p1", reason="finalize", run=run, mission=m))
     (_pid, eid, body), = fake.edits
     assert eid == "s1" and "📋 triaged" in body and body.endswith("`devcake:v1`")
-    assert getattr(fake, "get_activity_full_calls", 0) == before
+    assert getattr(fake, "get_activity_calls", 0) == before + 1
+    assert act is not None and [e.entry_id for e in act.entries] == ["s1"]
     assert fake.activity_entries[0].ts == NOW                # the entry never moves
+    # a caller's own read is reused: no second read
+    run_coro(status_comment.refresh(mgr, "p1", reason="again", run=run, mission=m, act=act))
+    assert getattr(fake, "get_activity_calls", 0) == before + 1
+
+
+# ── the Discoveries section: one place, a view, no scan counts it ──────────
+
+LEADS = ("📨 **Leads from T-S, step 2.** 1 lead — leads, not truths: verify against "
+         "the source before relying on them. The findings are in full in the record below.\n\n"
+         "> the config default changed to 5\n> Evidence: src/x.py:0\n\n"
+         "<details>\n<summary>Details — record</summary>\n\n▸ **Record**\n\n"
+         "`devcake:discovery-in:v1 src=T-S step=2`\n\n"
+         "🔎 [T-S · step 2 · 2026-09-10] — leads, not truths: verify against the source "
+         "before relying. Source record: `DISCOVERY_2.md` on T-S.\n\n"
+         "`devcake:finding:v1 sha=e3ebbc098dc6`\n\n**1.**\n\n"
+         "> Finding: the config default changed to 5\n>\n> Evidence: src/x.py:0; repro: pytest -k f0"
+         "\n>\n> Scope: scope 0\n\n*— steward: target touches the same config*\n\n"
+         "</details>\n\n`devcake:v1`")
+CARD = ("🔀 Step 1 · EXECUTE · executed · 3 min · $0.10\n\n**Result:** pr\n**Next:** DevCake — REVIEW.\n\n"
+        "<details>\n<summary>Details — token report · discoveries · run</summary>\n\n"
+        "▸ **Discoveries**\n\n`devcake:discovery:v1 step=1 n=1`\n\n"
+        "🔎 1 discovery from step 1 (EXECUTE) — leads for related missions, routed separately.\n\n"
+        "`devcake:finding:v1 sha=bd26fc37be01`\n\nFull record attached: [DISCOVERY_1.md](https://files.example/DISCOVERY_1.md)\n\n"
+        "**1.**\n\n> the regression suite already covers public_api\n> Evidence: tests/suites/regression.txt line 78\n\n"
+        "▸ **Run**\n\n`T-1-1-EXECUTE-AAAAAA`\n\n</details>\n\n`devcake:v1`")
+
+
+def _feed_with_discoveries():
+    return [ActivityEntry(ts=NOW, author="cake", kind="comment", body=CARD, entry_id="c1"),
+            ActivityEntry(ts=NOW + timedelta(minutes=5), author="cake", kind="comment",
+                          body=LEADS, entry_id="c2"),
+            ActivityEntry(ts=NOW + timedelta(minutes=9), author="cake", kind="comment",
+                          body="old `devcake:status:v1`\n\n`devcake:v1`", entry_id="s1")]
+
+
+def test_status_comment_gathers_discoveries_and_leads(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path)
+    _run(store, 1, "EXECUTE", outcome="executed")
+    body = status_comment.render(mgr, m, status_comment.runs_of(mgr, "p1"), pr_url=None,
+                                 collapsible="details", entries=_feed_with_discoveries())
+    assert "▸ **Discoveries**" in body
+    assert "**Reported by this mission**" in body
+    assert "step 1 · 1 finding · [record file](https://files.example/DISCOVERY_1.md)" in body
+    assert "> the regression suite already covers public_api" in body
+    assert "**Leads received**" in body
+    assert "from T-S, step 2 · 2026-09-09" in body
+    assert "> Finding: the config default changed to 5" in body     # in full
+    assert "> Scope: scope 0" in body
+    assert "*— steward: target touches the same config*" in body
+    # a VIEW: no scan counts it, no step-file token, no provenance line
+    plain = unquoted(body)
+    from devcake.domain.orchestrator.markers import (discovery_in_keys, discovery_posts,
+                                                     finding_fingerprints)
+    assert discovery_posts(plain) == [] and discovery_in_keys(plain) == set()
+    assert finding_fingerprints(plain) == set()
+    assert STEP_MARKER.search(plain) is None and "`DISCOVERY_" not in body
+    assert "🔎 [" not in body
+    sealed = body + "\n\n`devcake:v1`"
+    assert sealed.count(STATUS_MARKER) == 1 and unquoted(sealed).count("`devcake:") == 2
+    assert not freshness._is_material(sealed)
+    assert is_devcake_comment(sealed) and feed.is_status_comment(sealed)
+    entry = ActivityEntry(ts=NOW, author="cake", kind="comment", body=sealed, entry_id="s9")
+    assert dispatch._derive_seq(Activity(mission=m, entries=[entry])) == 1
+    # and the projection still drops it whole — nothing of it reaches a Dev
+    assert [p.body for p in feed.unfold_entries([entry])] == []
+
+
+def test_status_comment_without_discoveries_has_no_section(tmp_path):
+    m, mgr, fake, store = _mgr(tmp_path)
+    body = status_comment.render(mgr, m, [], pr_url=None, collapsible="details",
+                                 entries=[ActivityEntry(ts=NOW, author="felipe", kind="comment",
+                                                        body="hi", entry_id="h")])
+    assert "Discoveries" not in body and "Record" in body
+
+
+def test_digest_budget_drops_oldest_deliveries_and_says_so(tmp_path, monkeypatch):
+    from devcake.domain.orchestrator import discovery
+    monkeypatch.setattr(discovery, "DIGEST_BUDGET", 400)
+    entries = []
+    for i in range(4):
+        entries.append(ActivityEntry(ts=NOW + timedelta(minutes=i), author="cake", kind="comment",
+                                     body=LEADS.replace("T-S step=2", f"T-{i} step=2")
+                                               .replace("from T-S,", f"from T-{i},")
+                                               .replace("[T-S · step 2", f"[T-{i} · step 2"),
+                                     entry_id=f"c{i}"))
+    lines = discovery.digest_lines(entries)
+    text = "\n\n".join(lines)
+    assert "older deliveries omitted here" in text or "older delivery omitted here" in text
+    assert "from T-3, step 2" in text                      # the newest survives
+    assert "from T-0, step 2" not in text
+
+
+def test_steward_delivery_refreshes_the_recipient_status(tmp_path):
+    from test_steward import _apply, _route, _route_setup
+    pmo, mgr, run = _route_setup(tmp_path)
+    from devcake.domain.orchestrator import status_comment as sc
+    calls = []
+    async def fake_refresh(mgr_, pmo_id, **kw):
+        calls.append((pmo_id, kw.get("reason")))
+    import devcake.domain.orchestrator.steward as steward_mod
+    orig = sc.refresh
+    sc.refresh = fake_refresh
+    try:
+        assert _apply(mgr, run, [_route(finding=1)]) == (1, 0)
+    finally:
+        sc.refresh = orig
+    assert ("tgt", "leads_delivered") in calls
 
 
 def test_refresh_without_an_id_audits_once_and_never_edits(tmp_path):

--- a/app/tests/test_steward.py
+++ b/app/tests/test_steward.py
@@ -995,7 +995,9 @@ def test_apply_routes_delivers_receipts_and_drops_label(tmp_path):
     rec = assert_notice(body, "📨 **Leads from T-S, step 2.** 1 lead — leads, not truths",
                         record_has=["`devcake:discovery-in:v1 src=T-S step=2`",
                                     "🔎 [T-S · step 2 ·", "**1.**",
-                                    "> finding 0 about the config",
+                                    "> Finding: finding 0 about the config",
+                                    "> Evidence: src/x.py:0",
+                                    "> Scope: scope 0",
                                     "*— steward: target touches the same config*"])
     assert rec.startswith("`devcake:discovery-in:v1 src=T-S step=2`\n\n🔎 [T-S")
     assert "> finding 0 about the config" in strip_fold(body)[0]
@@ -1425,33 +1427,35 @@ def test_apply_routes_skips_a_finding_already_on_the_recipient(tmp_path):
     assert sha not in stamped
 
 
-def test_delivery_over_the_inline_ceiling_keeps_fingerprints(
-        tmp_path, monkeypatch):
-    """The ceiling fallback drops finding bodies but never a counted marker;
-    the per-finding fingerprints ride the head so content dedup survives a
-    truncated delivery."""
+def test_long_delivery_keeps_every_finding_in_full(tmp_path, monkeypatch):
+    """Founder ruling 2026-09-10: no inline ceiling on a delivery — the
+    recipient's Dev reads the findings from its own folder and never sees
+    the source mission's file, so the Record carries every finding in
+    full (finding, evidence, scope) however long, the head an excerpt,
+    the markers and fingerprints on the head lines as before."""
     from devcake.domain.orchestrator.markers import (
         FINDING_MARKER_RE, finding_fingerprint)
-    monkeypatch.setattr(steward, "FEED_INLINE_MAX", 240)
+    monkeypatch.setattr(steward, "FEED_INLINE_MAX", 240)   # no longer consulted
     pmo, mgr, run = _route_setup(tmp_path)
     delivered, rejected = _apply(mgr, run, [_route(finding=1),
                                             _route(finding=2)])
     assert (delivered, rejected) == (2, 0)
     body = next(md for pid, md in pmo.comments if pid == "tgt")
+    assert len(body) > 240                                # nothing dropped
     assert "`devcake:discovery-in:v1 src=T-S step=2`" in body
-    assert "about the config" not in body                 # bodies dropped
     assert sorted(FINDING_MARKER_RE.findall(body)) == sorted(
         finding_fingerprint({"finding": f"finding {i} about the config"})
         for i in (0, 1))
-    # re-rendered from the parts, not string-split: the lead survives, the
-    # head says the findings are not repeated, the Record keeps the
-    # marker, the pointer and the fingerprints and nothing else
     from fakes import assert_notice
     rec = assert_notice(body, "📨 **Leads from T-S, step 2.** 2 leads",
-                        record_has=["🔎 [T-S · step 2 ·", "`devcake:finding:v1 sha="])
-    assert "not repeated here" in body
-    assert "**1.**" not in rec and "— steward:" not in body
-    # ...and a re-route of either finding is now a content duplicate
+                        record_has=["🔎 [T-S · step 2 ·", "`devcake:finding:v1 sha=",
+                                    "> Finding: finding 0 about the config",
+                                    "> Finding: finding 1 about the config",
+                                    "> Evidence: src/x.py:1", "> Scope: scope 1"])
+    assert "not repeated here" not in body
+    assert "in full in the record below" in body
+    assert rec.count("**1.**") == 2                       # one block per finding, per source
+    # ...and a re-route of either finding is a content duplicate
     pmo2, mgr2, run2 = _route_setup(tmp_path / "b", recipient_bodies=[body])
     assert _apply(mgr2, run2, [_route(finding=2)]) == (0, 0)
     assert not any(pid == "tgt" for pid, _ in pmo2.comments)

--- a/docs/03-mission-lifecycle.md
+++ b/docs/03-mission-lifecycle.md
@@ -189,7 +189,7 @@ every site: a fixed lead — `✋ **Needs you.**` when a person must act,
 `⚠️ **For the record.**` for a disclosure, `ℹ️` for a status note, a
 directive lead (`🧩 **Conflict-resolve directive.**`,
 `🔄 **Freshness re-review N/cap.**`) for the next Dev,
-`📨 **Leads from KEY, step N.**` for a discovery delivery — then one
+`📨 **Leads from KEY, step N.**` for a discovery delivery (its head quotes an excerpt of each finding; its `Record` carries every finding in full — finding, evidence, scope — with no inline ceiling, since the recipient's Dev reads them from its own folder and never sees the source mission's file; a capped vendor pages it, markers on the first page — ADR-0042 addendum) — then one
 sentence saying what, then the what-to-do (the §5 merge command on a
 hand-off), then the fold whose `Record` section is the comment text of the
 pre-notice build, verbatim, markers included on their own lines. The head
@@ -226,7 +226,7 @@ by `DEVCAKE-SKIP`; ⏳ awaiting merge of the PR; ✅ done; 🚫 canceled;
 **parent** when there is one, and the step ladder — one row per step from
 the mission's runs, latest attempt per step, glyph · outcome · duration ·
 cost. A mission that entered at REVIEW by label shows one row; the ladder is
-the runs, never the label history.
+the runs, never the label history. Its fold also carries a **`Discoveries`** section (ADR-0042 addendum): what the mission reported (per step: count, the record-file link, the card's excerpts) and every lead it received (per source and step, the findings in full) — a view over the feed (`discovery.digest_lines`) with no marker, no file token and no provenance line, so no scan counts it and no Dev sees it; oldest deliveries drop first past a byte budget, and the section says so. Building it costs the refresh one full feed read, which the ADR-0043 record push at the same boundary reuses; a discovery delivery refreshes the recipient's comment so the section is current when the leads land.
 
 It is **created by whichever dispatch finds the feed without one** — there
 is no privileged entry point — or by a **stalled deferral** (a dispatch refused or deferred for longer than `stall_after_seconds` for a reason a person can act on: the Now line then reads "waiting to start since <date> — <why>", and one ✋ notice per block per episode is posted beside it; both carry a marker the Dev's folder drops — ADR-0042 addendum, `stalls.py`) — found again by the `` `devcake:status:v1` ``

--- a/docs/16-roadmap.md
+++ b/docs/16-roadmap.md
@@ -936,6 +936,17 @@ until that run exists, field evidence below stays operator-self-reported.
   ADR-0009, CHANGELOG.
 ### Field evidence (receipted)
 
+- **Discoveries in full + the status comment's Discoveries section**
+  (2026-09-10, ADR-0042 addendum): the steward's leads notice lost its
+  inline ceiling — `Record` carries every finding in full (`render_entry_lines
+  (full=True)`), head quotes excerpts, `_feed(externalize=False)` pages on
+  capped vendors; the card's outgoing section unchanged (golden folder
+  byte-identical). `discovery.digest_lines(entries)` builds the status
+  comment's `Discoveries` section (no markers, no file tokens, budgeted);
+  `status_comment.refresh` reads the feed once (full) and returns the
+  `Activity`, which the ADR-0043 `record_activity(act=)` reuses at all 8
+  boundaries; the steward refreshes the recipient after a delivery;
+  `stalls._status` renders with entries too.
 - **Stalled dispatches surfaced** (2026-09-10, ADR-0042 addendum): a
   decomposition child sat 8 days because its archived original made the
   ancestor walk gap and strict sourcing deferred every cycle — visible in

--- a/docs/adr/0042-feed-for-readers.md
+++ b/docs/adr/0042-feed-for-readers.md
@@ -317,3 +317,43 @@ shown on the panel but never written to (its feed is its children's
 context). The ledger persists under `/data/state/stalls.json` so a restart
 keeps the clocks.
 
+## Addendum — discoveries in full, and one place to read them (2026-09-10)
+
+**Context.** A routed discovery delivery (`📨 Leads from KEY, step N`)
+carried its findings as 700-character excerpts, and when the whole notice
+passed the 2 KB inline ceiling it was re-rendered with the findings dropped
+altogether and a pointer to the source mission's `DISCOVERY_N.md` — a file
+the recipient's Dev never receives. The findings were lost exactly where
+they were meant to land. And a reader had to open every card and every
+delivery to know what a mission discovered and was handed.
+
+**Decision.**
+
+- **The delivery's `Record` carries every finding in full** — finding,
+  evidence, scope — however long; the head quotes an excerpt of each. There
+  is no inline ceiling any more: a delivery is never externalized (its
+  counted markers stay in the feed body) and a vendor with a comment cap
+  pages it, markers on the first page. The recipient's Dev reads the
+  findings from its own ACTIVITY.md; MISSION.md's leads list points there.
+  The card's own `Discoveries` section is unchanged (excerpts + the record
+  file): the mission's Dev already holds `DISCOVERY_N.md`, and the golden
+  projection stays byte-identical.
+- **The status comment gains a `Discoveries` section** in its fold: what
+  the mission reported (per step: count, the record-file link, the card's
+  excerpts) and every lead it received (per source and step: the findings
+  in full as the delivery carried them). It is a **view over the feed** —
+  `discovery.digest_lines` — and keeps every §5 invariant: no backticked
+  marker, no step-file token, no provenance line, sentinel-signed, dropped
+  by the projection, so no scan counts it, the Freshness Gate ignores it,
+  and no Dev sees it. Over a byte budget the oldest deliveries drop first
+  and the section says so; the record above always has them.
+- **One feed read per boundary.** The refresh reads the feed once (full)
+  to build the section — the ADR-0043 record push at the same boundary
+  reuses that read — and a delivery refreshes the recipient's status
+  comment so the section is current the moment the leads land.
+
+**Consequences.** Nothing a Dev receives changes except that a recipient
+now receives the findings it was promised. One full read replaces the
+status refresh's cheap read at each boundary (the record push already paid
+it). Linear has no comment cap; a capped vendor pages long deliveries.
+


### PR DESCRIPTION
## What

Two things Felipe found on a live ticket: routed discovery deliveries were losing their findings, and there was no single place to read what a mission discovered and was handed.

## Why

A leads delivery carried 700-character excerpts of each finding, and when the whole notice passed the 2 KB inline ceiling it was re-rendered with the findings dropped and a pointer to `DISCOVERY_N.md` on the source mission — a file the recipient's Dev never receives. The findings were lost exactly where they were meant to land.

## How

- **Deliveries in full.** The delivery's `Record` carries every finding (finding, evidence, scope) with no inline ceiling: the notice is never externalized (its counted markers stay in the feed body) and a capped vendor pages it, markers on the first page. The head quotes an excerpt of each. MISSION.md's leads list now says the findings are in ACTIVITY.md under the delivery. The card's own Discoveries section is unchanged: the mission's Dev already holds the record file, and the golden projection stays byte-identical.
- **The status comment's Discoveries section.** `discovery.digest_lines(entries)` gathers what the mission reported (per step: count, record-file link, the card's excerpts) and every lead it received (per source and step, in full) into a section of the status fold. A view over the feed, keeping every ADR-0042 §5 invariant: no backticked marker, no step-file token, no provenance line, sentinel-signed, dropped by the projection — no scan counts it, the Freshness Gate ignores it, no Dev sees it. Oldest deliveries drop first past a byte budget, and the section says so.
- **One read per boundary.** `status_comment.refresh` reads the feed once (full) and returns the `Activity`; the ADR-0043 `record_activity(act=)` reuses it at all eight boundaries; the steward refreshes the recipient's status comment after a delivery; the stall status renders with entries.
- Docs: ADR-0042 addendum, 03 §4c and §5b, roadmap, changelog.

## Tests

Steward: a delivery's record carries every finding in full (evidence and scope included), a long delivery loses nothing, dedup on re-route survives, a delivery refreshes the recipient's status. Status comment: refresh reads once and reuses a caller's read; the Discoveries section renders reported and received leads and passes every view invariant (no scan counts it, not material, projection drops it, `_derive_seq` unaffected); no section without discoveries; the budget drops the oldest and says so. Golden projection unchanged. Full suite identical to main apart from the 70 environment-only failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVp9ty5CFCjT6PphDe24MH
