### PR TITLE
fix(apparmor): user-defined networks inside the Dev's engine work on AppArmor hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ added here without copying the full roadmap.
 See the living log and open candidates in
 [`docs/16-roadmap.md`](docs/16-roadmap.md).
 
+- **Fixed — user-defined networks inside the Dev's engine work on AppArmor
+  hosts.** The Dev-container profile denied every write under `/proc/sys`,
+  which broke `docker network create` and any compose project with
+  published ports: the engine's network helper writes a bridge sysctl in
+  the network namespace it owns. The profile now leaves `/proc/sys/net/*`
+  to the kernel's own per-namespace ownership check (the container's own
+  network sysctls stay refused, measured), the nested-engine probe
+  exercises a user-defined network with a published port as part of its
+  verdict, and the baker re-measures when the installed profile's bytes
+  change. Re-run the two profile commands after upgrading; the doctor
+  reports the old copy as outdated.
+
 ## v0.6.5 (2026-09-11)
 
 Patch release in the v0.6 "Kentucky Butter" line. Ships with `devcake-cli` 0.1.9 — upgrade the CLI before `devcake up --release`.

--- a/app/tests/test_dev_factory.py
+++ b/app/tests/test_dev_factory.py
@@ -2370,6 +2370,9 @@ def test_nested_receipt_projection_and_when_the_probe_is_due(tmp_path):
     assert due(engine="30.0")
     assert not due(kernel="7.0", engine="29.7")
     assert not due(kernel="", engine="")
+    # a re-installed profile (same name, new bytes) re-measures too
+    assert due(receipt={**new, "apparmor_profile_sha256": "old"}, profile_sha256="new")
+    assert not due(receipt={**new, "apparmor_profile_sha256": "same"}, profile_sha256="same")
 
     # the fact rides every status until a tick sets it anew
     previous = {"state": "ready", "nested": proj}

--- a/docs/adr/0023-dev-toolchain-floor.md
+++ b/docs/adr/0023-dev-toolchain-floor.md
@@ -183,7 +183,12 @@ Measured recipe (feasibility matrix + live probes, 2026-08-13):
    `userns`, `mount`, `umount` and `pivot_root` allowed, which grant nothing
    to a uid-1000 process in the initial namespace (no capabilities there)
    and apply only inside a user namespace it creates, exactly the rootless
-   engine's case. Hosts without AppArmor ignore the name (Docker drops it),
+   engine's case. The profile's write denial under `/proc/sys` leaves
+   `/proc/sys/net/*` to the kernel's own per-namespace ownership check:
+   the engine's network helper writes a bridge sysctl in every network
+   namespace it creates (a user-defined network or a compose project with
+   published ports fails without it — measured), while the container's own
+   network sysctls stay refused to the uid-1000 Dev (measured). Hosts without AppArmor ignore the name (Docker drops it),
    and a host that has not loaded the profile runs under `docker-default`
    with the engine unavailable — never a refusal to launch. Both Dev steps
    also launch with Docker's masked and read-only system paths removed

--- a/scripts/apparmor/devcake-nested
+++ b/scripts/apparmor/devcake-nested
@@ -1,5 +1,5 @@
 # devcake-nested — AppArmor profile for DevCake Dev containers.
-# version: 2026-09-11.2
+# version: 2026-09-11.3
 #
 # Docker's default container profile with three additions, so the rootless
 # engine inside a Dev container can create user namespaces and mount inside
@@ -41,7 +41,16 @@ profile devcake-nested flags=(attach_disconnected,mediate_deleted) {
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9/]*}/** w,
-  deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
+  # deny /proc/sys writes except /proc/sys/kernel/* (shm*, below) and
+  # /proc/sys/net/*: network sysctls are per network namespace and the
+  # kernel lets only that namespace's owner write them — root-owned in
+  # this container's own namespace (a uid-1000 Dev is refused), the
+  # rootless engine's in the namespaces it creates (netavark sets
+  # route_localnet on every bridge it makes; measured 2026-09-11)
+  deny @{PROC}/sys/[^kn]** w,
+  deny @{PROC}/sys/n[^e]** w,
+  deny @{PROC}/sys/ne[^t]** w,
+  deny @{PROC}/sys/net[^/]** w,
   deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
   deny @{PROC}/sysrq-trigger rwklx,
   deny @{PROC}/kcore rwklx,

--- a/scripts/check_apparmor_masks.py
+++ b/scripts/check_apparmor_masks.py
@@ -79,8 +79,10 @@ def deny_rules(profile_text: str) -> list[tuple[str, str]]:
 # purpose (inherited from Docker's own profile): each entry names why.
 PARTIAL_READONLY = {
     "/proc/sys": "Docker's own profile leaves /proc/sys/kernel/shm* writable "
-                 "(POSIX shared memory sizing); everything else under /proc/sys "
-                 "is denied by the class rules",
+                 "(POSIX shared memory sizing) and this one leaves /proc/sys/net/* "
+                 "to the kernel's per-namespace ownership check (the rootless "
+                 "engine's bridges need it; the container's own stay root-only); "
+                 "everything else under /proc/sys is denied by the class rules",
 }
 
 

--- a/scripts/dev_factory/core.py
+++ b/scripts/dev_factory/core.py
@@ -466,10 +466,12 @@ def nested_projection(receipt: Mapping | None) -> dict | None:
 
 def nested_probe_due(*, baked_now: bool, receipt: Mapping | None,
                      apparmor_profile: str, seccomp_sha256: str,
-                     kernel: str = "", engine: str = "") -> bool:
+                     kernel: str = "", engine: str = "",
+                     profile_sha256: str = "") -> bool:
     """Run the probe after a green harness bake, and whenever the newest
     receipt measured a different contract than the stack now runs — the
-    profile name, the seccomp blob, the host kernel or the engine version
+    profile name, the installed profile's bytes, the seccomp blob, the host
+    kernel or the engine version
     (an unattended kernel or Docker upgrade changes what the same contract
     does) — red or green, so loading the profile and running devcake up
     re-measures on the next tick. A receipt that matches the contract is
@@ -485,7 +487,10 @@ def nested_probe_due(*, baked_now: bool, receipt: Mapping | None,
     pairs = ((str(receipt.get("apparmor_profile") or ""), apparmor_profile),
              (str(receipt.get("seccomp_sha256") or ""), seccomp_sha256),
              (str(host.get("kernel") or ""), kernel),
-             (str(host.get("engine") or ""), engine))
+             (str(host.get("engine") or ""), engine),
+             # the installed profile's bytes (a re-installed profile is a
+             # new contract with the same name)
+             (str(receipt.get("apparmor_profile_sha256") or ""), profile_sha256))
     return any(now and was != now for was, now in pairs)
 
 

--- a/scripts/dev_factory/watch.py
+++ b/scripts/dev_factory/watch.py
@@ -669,6 +669,15 @@ def profile_still_applies(now: float | None = None) -> bool | None:
     return value
 
 
+def _installed_profile_sha256() -> str:
+    """sha256 of /etc/apparmor.d/devcake-nested, empty when absent."""
+    import hashlib
+    try:
+        return hashlib.sha256(Path("/etc/apparmor.d/devcake-nested").read_bytes()).hexdigest()
+    except OSError:
+        return ""
+
+
 def _host_facts() -> tuple[str, str]:
     """(kernel, engine) as the probe records them; empty when unreadable."""
     out = []
@@ -704,7 +713,8 @@ def nested_drift_pending(now: float | None = None) -> bool:
         value = nested_probe_due(
             baked_now=False, receipt=receipt,
             apparmor_profile=resolve_apparmor_profile(REPO, os.environ),
-            seccomp_sha256=_dag_seccomp_sha256(), kernel=kernel, engine=engine)
+            seccomp_sha256=_dag_seccomp_sha256(), kernel=kernel, engine=engine,
+            profile_sha256=_installed_profile_sha256())
         if value and t < _PROBE_BACKOFF["until"]:
             value = False
     except Exception:  # noqa: BLE001 — a drift check must never kill the loop
@@ -748,7 +758,8 @@ def publish_nested(*, work: Path, previous, status: dict, baked: list[str],
     due = nested_probe_due(baked_now=bool(baked), receipt=receipt,
                            apparmor_profile=profile,
                            seccomp_sha256=_dag_seccomp_sha256(),
-                           kernel=kernel, engine=engine)
+                           kernel=kernel, engine=engine,
+                           profile_sha256=_installed_profile_sha256())
     candidates = probe_image_candidates(local_images, tag=tag)
     image = baked[-1] if baked else (candidates[0] if candidates else "")
     # a probe that produced no receipt (script error, timeout) must not

--- a/scripts/harness_probe/nested_probe.sh
+++ b/scripts/harness_probe/nested_probe.sh
@@ -117,6 +117,19 @@ printf '%s\n' "$out" | sed 's/^/NP_NESTED_OUT: /'
 out="$(podman run --rm --user 4321 -v /workspace:/w "$NP_TEST_IMAGE" sh -c 'echo x > /w/np_write_subuid' 2>&1)"; rc=$?
 echo "NP_SUBUID_RC=$rc"
 [ "$rc" -eq 0 ] || printf '%s\n' "$out" | sed 's/^/NP_SUBUID_ERR: /'
+# A user-defined network with a published port: netavark writes a bridge
+# sysctl for it, which the default network never needs (the AppArmor rule
+# that broke this was measured only through this path). Part of the rig
+# verdict: `docker network create` is table stakes.
+podman network rm -f np_net >/dev/null 2>&1
+out="$(podman network create np_net 2>&1 && podman run --rm --network np_net -p 18080:80 "$NP_TEST_IMAGE" sh -c 'echo network-ok' 2>&1)"; rc=$?
+podman network rm -f np_net >/dev/null 2>&1
+if [ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -q "network-ok"; then
+  echo "NP_NETWORK_RC=0"
+else
+  echo "NP_NETWORK_RC=${rc:-1}"
+  printf '%s\n' "$out" | tail -3 | sed 's/^/NP_NETWORK_ERR: /'
+fi
 # Compose through the docker symlink (podman's compose subcommand → the
 # image's pinned provider): a compose-created network exercises netavark,
 # which a bare `podman run` never does. Recorded, not part of rig_ok.
@@ -197,6 +210,7 @@ GRAPH="$(val NP_GRAPH)"
 NESTED_RC="$(val NP_NESTED_RC)"
 SUBUID_RC="$(val NP_SUBUID_RC)"
 COMPOSE_RC="$(val NP_COMPOSE_RC)"
+NETWORK_RC="$(val NP_NETWORK_RC)"
 INNER_KERNEL="$(val NP_UNAME)"
 INNER_UID="$(val NP_UID)"
 
@@ -210,7 +224,7 @@ fi
 # anything else means WorkspaceStore leaks trees on this rig.
 RIG_OK=false
 if [[ "$NESTED_OK" = true && "${SUBUID_RC:-1}" = "0" \
-      && "$RECLAIM_SUBUID_UID" = "1000" ]]; then
+      && "${NETWORK_RC:-1}" = "0" && "$RECLAIM_SUBUID_UID" = "1000" ]]; then
   RIG_OK=true
 fi
 
@@ -237,6 +251,9 @@ if [[ "$RIG_OK" != true ]]; then
     FIRST_RED_DETAIL="$(grep -m1 '^NP_NESTED_OUT: ' "$LOG" | cut -d' ' -f2- | cut -c1-300 || true)"
   elif [[ "${SUBUID_RC:-1}" != "0" ]]; then
     FIRST_RED="a nested non-root user could not write the workspace bind"
+  elif [[ "${NETWORK_RC:-1}" != "0" ]]; then
+    FIRST_RED="a user-defined network could not be created or used"
+    FIRST_RED_DETAIL="$(grep -m1 '^NP_NETWORK_ERR: ' "$LOG" | cut -d' ' -f2- | cut -c1-300 || true)"
   elif [[ "$RECLAIM_SUBUID_UID" != "1000" ]]; then
     FIRST_RED="the workspace reclaim left a nested write at uid ${RECLAIM_SUBUID_UID}"
   else
@@ -254,7 +271,8 @@ NP_INNER_KERNEL="${INNER_KERNEL:-}" NP_UIDMAP_RC="${UIDMAP_RC:-}" \
 NP_UIDMAP="${UIDMAP:-}" NP_GRAPH_RC="${GRAPH_RC:-}" NP_GRAPH="${GRAPH:-}" \
 NP_NESTED_RC="${NESTED_RC:-}" NP_NESTED_OK="$NESTED_OK" \
 NP_SUBUID_RC="${SUBUID_RC:-}" NP_SUBUID_WRITE_UID="$SUBUID_WRITE_UID" \
-NP_COMPOSE_RC="${COMPOSE_RC:-}" \
+NP_COMPOSE_RC="${COMPOSE_RC:-}" NP_NETWORK_RC="${NETWORK_RC:-}" \
+NP_PROFILE_SHA="$( [[ -f /etc/apparmor.d/devcake-nested ]] && sha256sum /etc/apparmor.d/devcake-nested | cut -d' ' -f1 || echo '')" \
 NP_RECLAIM_SUBUID_UID="$RECLAIM_SUBUID_UID" NP_RIG_OK="$RIG_OK" \
 NP_WRITE_UID="$WRITE_UID" NP_RECLAIM_UID="$RECLAIM_UID" \
 NP_RECLAIM_RC="$RECLAIM_RC" \
@@ -283,6 +301,9 @@ receipt = {
     "nested_run": {"rc": e["NP_NESTED_RC"], "ok": e["NP_NESTED_OK"] == "true"},
     # `docker compose up` through the symlink — recorded, not part of rig_ok
     "compose": {"rc": e["NP_COMPOSE_RC"], "ok": e["NP_COMPOSE_RC"] == "0"},
+    "network": {"rc": e["NP_NETWORK_RC"], "ok": e["NP_NETWORK_RC"] == "0"},
+    # the installed profile's bytes: a re-installed profile is a new contract
+    "apparmor_profile_sha256": e["NP_PROFILE_SHA"],
     "workspace_bind": {
         # nested ROOT maps back to the dev uid; the subuid row is the
         # foreign-uid case the B1 reclaim handler exists for
@@ -306,7 +327,7 @@ if [[ "$RIG_OK" = true ]]; then
 else
   echo "── nested_probe: FAIL — first red NP_ step above; log: $LOG" >&2
 fi
-echo "matrix row: $STAMP | ${HOST_OS} kernel=${KERNEL} engine=${ENGINE} ${ARCH} apparmor=${APPARMOR_PROFILE} | graph=${GRAPH:-?} | uid_map_rc=${UIDMAP_RC:-?} nested_ok=${NESTED_OK} compose_rc=${COMPOSE_RC:-?} | ws uid root ${WRITE_UID}→${RECLAIM_UID} subuid ${SUBUID_WRITE_UID}→${RECLAIM_SUBUID_UID}"
+echo "matrix row: $STAMP | ${HOST_OS} kernel=${KERNEL} engine=${ENGINE} ${ARCH} apparmor=${APPARMOR_PROFILE} | graph=${GRAPH:-?} | uid_map_rc=${UIDMAP_RC:-?} nested_ok=${NESTED_OK} network_rc=${NETWORK_RC:-?} compose_rc=${COMPOSE_RC:-?} | ws uid root ${WRITE_UID}→${RECLAIM_UID} subuid ${SUBUID_WRITE_UID}→${RECLAIM_SUBUID_UID}"
 rm -rf "$WS" 2>/dev/null \
   || echo "nested_probe: scratch left behind (foreign uids — reclaim red?): $WS" >&2
 # Keep the newest five receipts (with their logs and sent profiles); the


### PR DESCRIPTION
A Dev on the reference host reported the same afternoon v0.6.5 went live: `docker network create` then a run on that network fails with `netavark: set sysctl net/ipv4/conf/podman1/route_localnet: Permission denied`. Reproduced under the shipped profile; the cause is the profile's blanket write denial under `/proc/sys`, inherited from Docker's default profile, which the engine's network helper trips on for every bridge it creates (the probe's compose step happened not to). Network sysctls are per network namespace and the kernel lets only that namespace's owner write them, so the deny now excludes `/proc/sys/net`.

Measured on the host with a temporary test profile: a user-defined network with and without a published port works; `echo 1 > /proc/sys/net/ipv4/ip_forward` from the Dev's own shell stays "Permission denied". The mask checker's documented partial for `/proc/sys` names the new exception. The probe now creates a user-defined network and runs a container on it with a published port as part of the rig verdict (green locally on WSL2), and records the installed profile's digest so the baker re-measures when the profile is re-installed (drift key; test). Profile version 2026-09-11.3 — operators re-run the two profile commands; the doctor reports the old copy as outdated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoFYUSEMk4bQ4gYuosePBs